### PR TITLE
fix(storage): reference schema_url in users CHECK constraint

### DIFF
--- a/internal/storage/database/dialect/postgres/migration/001_users/up.sql
+++ b/internal/storage/database/dialect/postgres/migration/001_users/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE zitadel_nextgen.users(
     instance_id TEXT NOT NULL
     , id TEXT NOT NULL CHECK (id <> '')
-    , schema_url TEXT NOT NULL CHECK (schema <> '')
+    , schema_url TEXT NOT NULL CHECK (schema_url <> '')
     , data_blob JSONB
 
     , PRIMARY KEY (instance_id, id)


### PR DESCRIPTION
## Summary
- One-character fix in [internal/storage/database/dialect/postgres/migration/001_users/up.sql](internal/storage/database/dialect/postgres/migration/001_users/up.sql): the `schema_url` column's `CHECK` constraint referenced a non-existent column `schema`, causing `CREATE TABLE` to fail on Postgres 16 with `ERROR: column "schema" does not exist (SQLSTATE 42703)`.
- Introduced in #5 (commit 7a0f872, "feat(storage): define user tables"). The `internal/storage/database/repository` tests, which boot an embedded Postgres via `fergusstrange/embedded-postgres`, have been broken on `main` since that landed; reproduced from a pristine clone.

## Test plan
- [x] `go test ./internal/storage/database/repository/...` — passes (previously failed with SQLSTATE 42703)
- [x] `go test ./...` — passes