### PR TITLE
ci: update CI and release docs for pnpm 10

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,6 +1,6 @@
 # Changesets
 
-This directory holds [changesets](https://github.com/changesets/changesets) for the npm-published packages in this monorepo (`apps/cli`, `packages/components`, `packages/sdk-*`).
+This directory holds [changesets](https://github.com/changesets/changesets) for the npm-published packages in this monorepo (`apps/cli`, `packages/sdk-*`).
 
 When you make a user-visible change to one of those packages, run:
 
@@ -10,9 +10,9 @@ corepack pnpm changeset
 
 Pick the affected packages, the bump type (patch / minor / major), and write a one-line summary. A markdown file appears in this directory and gets committed with your PR.
 
-The `changesets` GitHub Action opens a "Version Packages" PR aggregating all pending changesets. Merging that PR bumps versions, updates `CHANGELOG.md` files, tags the affected packages, and publishes them to npm.
+The future `changesets` GitHub Action should open a "Version Packages" PR aggregating all pending changesets. Merging that PR will bump versions, update `CHANGELOG.md` files, tag the affected packages, and publish them to npm once package ownership and npm tokens are in place. No npm publishing workflow is enabled yet.
 
-The Go server binary is **not** managed by changesets — it is released with `goreleaser` on `v*` tags. See [docs/adrs/002-multi-package-release-strategy.md](../docs/adrs/002-multi-package-release-strategy.md).
+The Go server binary is **not** managed by changesets — it is released with `goreleaser` through the manual release workflow while the repo is pre-release. See [docs/adrs/002-multi-package-release-strategy.md](../docs/adrs/002-multi-package-release-strategy.md).
 
 ## Licensing reminder
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,89 @@ jobs:
       - run: go vet ./...
       - run: go test -v -timeout=10m ./...
 
+  node-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: corepack pnpm -r typecheck
+
+      - name: Test
+        run: corepack pnpm -r test
+
+      - name: Build
+        run: corepack pnpm -r build
+
+  npm-pack-smoke:
+    runs-on: ubuntu-latest
+    needs: node-check
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: corepack pnpm -r build
+
+      - name: Smoke test built CLI
+        run: |
+          node apps/cli/dist/zitadel.js --version
+          node apps/cli/dist/zitadel.js capabilities --json
+
+      - name: Dry-run npm packs
+        run: |
+          for dir in apps/cli packages/sdk-core packages/sdk-next; do
+            (cd "$dir" && npm pack --dry-run)
+          done
+
+      - name: Create npm package artifacts
+        run: |
+          mkdir -p "$RUNNER_TEMP/zitadel-npm-packages"
+          for dir in apps/cli packages/sdk-core packages/sdk-next; do
+            (cd "$dir" && npm pack --pack-destination "$RUNNER_TEMP/zitadel-npm-packages")
+          done
+          ls -lh "$RUNNER_TEMP/zitadel-npm-packages"
+
+      - name: Upload npm package artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: npm-packages
+          path: ${{ runner.temp }}/zitadel-npm-packages/*.tgz
+          if-no-files-found: error
+          retention-days: 7
+
   goreleaser-snapshot:
     runs-on: ubuntu-latest
+    needs: [go-test, node-check]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -43,13 +124,15 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+          run_install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          # cache: pnpm is intentionally omitted until pnpm-lock.yaml exists
-          # in the repo (lands with the frontend workspace).
+          cache: pnpm
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -65,3 +148,11 @@ jobs:
           args: release --snapshot --clean --skip=publish,sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload GoReleaser snapshot artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: goreleaser-snapshot
+          path: dist/**
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,17 @@
 name: release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git tag or ref to release, for example v0.1.0.'
+        required: true
+        type: string
+      snapshot:
+        description: 'Run a non-publishing snapshot instead of a real release.'
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -17,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -27,13 +36,15 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+          run_install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          # cache: pnpm is intentionally omitted until pnpm-lock.yaml exists
-          # in the repo (lands with the frontend workspace).
+          cache: pnpm
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -42,13 +53,25 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
+        if: ${{ ! inputs.snapshot }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Run GoReleaser (snapshot)
+        if: ${{ inputs.snapshot }}
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --snapshot --clean --skip=publish,sign
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
+        if: ${{ ! inputs.snapshot }}
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser

--- a/README.md
+++ b/README.md
@@ -2,6 +2,55 @@
 
 Next iteration of the Zitadel identity platform.
 
+## Current status
+
+This repository is pre-release. The Go server release path is wired through
+GoReleaser, but `main.go` is still a placeholder and the embedded console
+directory contains only `apps/console/dist/.gitkeep` in clean checkouts. The
+CLI and SDK packages are also pre-release; CI produces installable snapshots for
+review, not official releases.
+
+## Local checks
+
+Use Node.js from [.nvmrc](.nvmrc) and the pinned pnpm 10 workspace manager from
+`package.json`.
+
+```sh
+corepack pnpm --version
+corepack pnpm install --frozen-lockfile
+corepack pnpm -r typecheck
+corepack pnpm -r test
+corepack pnpm -r build
+
+go vet ./...
+go test ./...
+```
+
+Package smoke checks:
+
+```sh
+node apps/cli/dist/zitadel.js --version
+node apps/cli/dist/zitadel.js capabilities --json
+
+(cd apps/cli && npm pack --dry-run)
+(cd packages/sdk-core && npm pack --dry-run)
+(cd packages/sdk-next && npm pack --dry-run)
+```
+
+## CI
+
+Pull requests and pushes to `main` run:
+
+- Go vet and tests.
+- pnpm install, typecheck, tests, and builds.
+- Built CLI smoke checks.
+- npm package dry-run/pack checks.
+- A non-publishing GoReleaser snapshot.
+
+CI uploads short-lived workflow artifacts for review: GoReleaser snapshot output
+and npm package tarballs. These artifacts expire after 7 days and are not
+release artifacts.
+
 ## Build & release
 
 This monorepo ships three artifact families on independent cadences. The full rationale lives in [docs/adrs/002-multi-package-release-strategy.md](docs/adrs/002-multi-package-release-strategy.md).
@@ -19,17 +68,24 @@ goreleaser release --snapshot --clean --skip=publish,sign
 docker run --rm ghcr.io/zitadel/nextgen:<snapshot-tag>-amd64
 ```
 
-Tagged releases (`v*`) trigger `.github/workflows/release.yml`, which produces multi-arch tarballs and pushes a multi-arch image manifest to `ghcr.io/zitadel/nextgen`.
+The publish-capable release workflow is currently manual-only via
+`.github/workflows/release.yml` (`workflow_dispatch`). It can run a dry snapshot
+or, when intentionally invoked for a release tag, produce multi-arch tarballs and
+push a multi-arch image manifest to `ghcr.io/zitadel/nextgen`.
 
 ### npm packages (`changesets`)
 
-`apps/cli`, `packages/components`, and `packages/sdk-*` are published to npm via [changesets](https://github.com/changesets/changesets). On any user-visible change to those packages:
+`apps/cli` and `packages/sdk-*` are intended to be published to npm via
+[changesets](https://github.com/changesets/changesets). On any user-visible
+change to those packages:
 
 ```sh
 corepack pnpm changeset
 ```
 
-The bot opens a "Version Packages" PR; merging it tags and publishes the affected packages.
+The future changesets workflow should open a "Version Packages" PR; merging it
+will tag and publish the affected packages once npm ownership and tokens are in
+place. No npm publishing workflow is enabled yet.
 
 ### Local development
 

--- a/apps/cli/LICENSE
+++ b/apps/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ZITADEL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,11 +1,42 @@
 # zitadel
 
-Agent-friendly Zitadel CLI.
+Agent-friendly Zitadel CLI for the next generation Zitadel project.
 
 ```sh
 npx zitadel@latest
 ```
 
-V1 supports Next.js App Router projects and creates a pre-claim local Zitadel setup with mock-backed login and registration routes. Repo config is the source of truth: edit `zitadel.json` or `.zitadel/**`, then run `npx zitadel@latest plan` or `npx zitadel@latest apply`.
+## Status
 
-Agents should use the generated contract in `AGENTS.md` and call commands with `--non-interactive --json`.
+The CLI is still pre-release. It supports the mock-backed golden path for Next.js
+App Router projects, but it is not yet a complete live platform client.
+
+V1 creates a pre-claim local Zitadel setup with mock-backed login and
+registration routes. Repo config is the source of truth: edit `zitadel.json` or
+`.zitadel/**`, then run `zitadel plan` or `zitadel apply`.
+
+## Golden path
+
+```sh
+npx zitadel@latest setup --framework next
+npx zitadel@latest doctor
+npx zitadel@latest plan
+npx zitadel@latest apply
+npx zitadel@latest claim
+npx zitadel@latest claim status --challenge-id <id>
+```
+
+Agents should use the generated contract in `AGENTS.md` and call commands with
+`--non-interactive --json`:
+
+```sh
+npx zitadel@latest capabilities --json
+npx zitadel@latest <command> --non-interactive --json
+```
+
+## Release readiness
+
+Before npm publishing is enabled, the package still needs the CI smoke checks to
+stay green, live API coverage to catch up with the mock contract, and the
+changesets publishing workflow to be enabled with confirmed npm ownership and
+tokens. CI package tarballs are review artifacts only.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -2,6 +2,16 @@
   "name": "zitadel",
   "version": "0.0.0",
   "description": "Agent-friendly Zitadel CLI",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zitadel/nextgen.git",
+    "directory": "apps/cli"
+  },
+  "homepage": "https://github.com/zitadel/nextgen/tree/main/apps/cli#readme",
+  "bugs": {
+    "url": "https://github.com/zitadel/nextgen/issues"
+  },
   "type": "module",
   "bin": {
     "zitadel": "dist/zitadel.js"

--- a/apps/cli/tests/integration/setup-next.test.ts
+++ b/apps/cli/tests/integration/setup-next.test.ts
@@ -132,6 +132,96 @@ describe("Next setup integration", () => {
     const productionAfterClaim = await runCliForTest(["apply", "--cwd", cwd, "--json", "--mock", "--environment", "production"]);
     expect(productionAfterClaim.exitCode).toBe(0);
   });
+
+  it("plans identity resource counts and fails apply clearly for missing env refs", async () => {
+    const cwd = await createNextProject();
+    await runCliForTest([
+      "setup",
+      "--cwd",
+      cwd,
+      "--non-interactive",
+      "--json",
+      "--mock",
+      "--skip-deploy-platform",
+    ]);
+
+    const idp = await runCliForTest([
+      "idp",
+      "add",
+      "--cwd",
+      cwd,
+      "--json",
+      "--preset",
+      "google",
+      "--client-id",
+      "abc.apps.googleusercontent.com",
+      "--env-secret",
+      "ZITADEL_IDP_GOOGLE_SECRET",
+    ]);
+    expect(idp.exitCode).toBe(0);
+
+    const app = await runCliForTest([
+      "app",
+      "add",
+      "--cwd",
+      cwd,
+      "--json",
+      "--preset",
+      "spa",
+      "--slug",
+      "web",
+      "--redirect-uri",
+      "http://localhost:3000/callback",
+    ]);
+    expect(app.exitCode).toBe(0);
+
+    const plan = await runCliForTest(["plan", "--cwd", cwd, "--json", "--mock"], {
+      ZITADEL_IDP_GOOGLE_SECRET: "secret",
+    });
+    expect(plan.exitCode).toBe(0);
+    const planJson = parseJson(plan.stdout) as {
+      data: { resources: { idps: number; apps: number }; env_refs: { missing: string[] } };
+    };
+    expect(planJson.data.resources.idps).toBe(1);
+    expect(planJson.data.resources.apps).toBe(1);
+    expect(planJson.data.env_refs.missing).toEqual([]);
+
+    const apply = await runCliForTest(["apply", "--cwd", cwd, "--json", "--mock"]);
+    expect(apply.exitCode).toBe(3);
+    const applyJson = parseJson(apply.stdout) as {
+      code: string;
+      message: string;
+      details: { env_refs: { missing: string[] } };
+    };
+    expect(applyJson.code).toBe("E_VALIDATION");
+    expect(applyJson.message).toContain("Missing environment variables");
+    expect(applyJson.details.env_refs.missing).toEqual(["ZITADEL_IDP_GOOGLE_SECRET"]);
+  });
+
+  it("rejects invalid Liquid templates before recording apply state", async () => {
+    const cwd = await createNextProject();
+    await runCliForTest([
+      "setup",
+      "--cwd",
+      cwd,
+      "--non-interactive",
+      "--json",
+      "--mock",
+      "--skip-deploy-platform",
+    ]);
+    const stateBefore = await readFile(join(cwd, ".zitadel/state.json"), "utf8");
+    await mkdir(join(cwd, ".zitadel/templates"), { recursive: true });
+    await writeFile(join(cwd, ".zitadel/templates/bad.liquid"), "<div>{{ value | raw }}</div>\n");
+
+    const apply = await runCliForTest(["apply", "--cwd", cwd, "--json", "--mock"]);
+
+    expect(apply.exitCode).toBe(3);
+    const envelope = parseJson(apply.stdout) as { code: string; message: string; hint?: string };
+    expect(envelope.code).toBe("E_VALIDATION");
+    expect(envelope.message).toContain("Liquid templates");
+    expect(envelope.hint).toContain("raw");
+    expect(await readFile(join(cwd, ".zitadel/state.json"), "utf8")).toBe(stateBefore);
+  });
 });
 
 async function createNextProject(): Promise<string> {

--- a/apps/cli/tests/unit/resources.test.ts
+++ b/apps/cli/tests/unit/resources.test.ts
@@ -74,7 +74,7 @@ describe("identity resources", () => {
     expect(listAfterEnv.data.idps).toHaveLength(0);
   });
 
-  it("app add writes a spa preset with redirect URIs", async () => {
+  it("app add/list/show/remove round-trips through .zitadel/apps", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "zitadel-app-"));
     const result = await runCliForTest([
       "app",
@@ -100,6 +100,26 @@ describe("identity resources", () => {
     expect(contents.protocol).toBe("oidc");
     expect((contents.oidc as { client_type: string }).client_type).toBe("spa");
     expect((contents.oidc as { redirect_uris: string[] }).redirect_uris).toContain("http://localhost:3000/callback");
+
+    const list = await runCliForTest(["app", "list", "--cwd", cwd, "--json"]);
+    const listEnv = parseJson(list.stdout) as { data: { apps: Array<{ slug: string; protocol: string }> } };
+    expect(listEnv.data.apps).toHaveLength(1);
+    expect(listEnv.data.apps[0].slug).toBe("web");
+
+    const show = await runCliForTest(["app", "show", "web", "--cwd", cwd, "--json"]);
+    expect(show.exitCode).toBe(0);
+    const showEnv = parseJson(show.stdout) as { data: { app: { slug: string } } };
+    expect(showEnv.data.app.slug).toBe("web");
+
+    const remove = await runCliForTest(["app", "remove", "web", "--cwd", cwd, "--json"]);
+    expect(remove.exitCode).toBe(0);
+    const removeEnv = parseJson(remove.stdout) as { status: string; data: { slug: string } };
+    expect(removeEnv.status).toBe("ok");
+    expect(removeEnv.data.slug).toBe("web");
+
+    const listAfter = await runCliForTest(["app", "list", "--cwd", cwd, "--json"]);
+    const listAfterEnv = parseJson(listAfter.stdout) as { data: { apps: unknown[] } };
+    expect(listAfterEnv.data.apps).toHaveLength(0);
   });
 
   it("does not advertise GitHub as an OIDC IdP preset", async () => {

--- a/docs/adrs/002-multi-package-release-strategy.md
+++ b/docs/adrs/002-multi-package-release-strategy.md
@@ -8,8 +8,8 @@
 
 Release the three artifact families produced by this monorepo with two complementary tools, on independent cadences:
 
-1. **Go server binary + embedded React console**: released by `goreleaser` on `v*` tags. Produces multi-arch archives (linux/darwin/windows × amd64/arm64, minus windows/arm64), per-arch Docker images, and a `ghcr.io/zitadel/nextgen` manifest list. The console SPA is built by Vite during goreleaser's `before.hooks` and embedded into the binary via `//go:embed`.
-2. **TypeScript packages** (`apps/cli/`, `packages/components/`, `packages/sdk-*/`): released by `changesets` + `pnpm publish -r`. Each PR adds a `.changeset/*.md` describing the bump; the `changesets` GitHub Action opens a "Version Packages" PR aggregating pending changes; merging it tags per-package versions and publishes to npm.
+1. **Go server binary + embedded React console**: released by `goreleaser` against an explicit release tag. While this repository is pre-release, the publish-capable workflow is `workflow_dispatch` only; automatic `v*` tag releases can be enabled when the server is ready. The release produces multi-arch archives (linux/darwin/windows × amd64/arm64, minus windows/arm64), per-arch Docker images, and a `ghcr.io/zitadel/nextgen` manifest list. The console SPA is built by Vite during goreleaser's `before.hooks` and embedded into the binary via `//go:embed`.
+2. **TypeScript packages** (`apps/cli/`, `packages/sdk-*/`): released by `changesets` + `pnpm publish -r`. Each PR adds a `.changeset/*.md` describing the bump. The `changesets` GitHub Action is not enabled yet; once npm ownership and tokens are ready, it should open a "Version Packages" PR aggregating pending changes, then tag per-package versions and publish to npm when that PR is merged.
 3. **The console SPA is intentionally not a separately versioned npm package.** It is the Go server's UI; it ships embedded in the server binary at the server's version. If a future use case calls for a standalone console library, it becomes a new entry under `packages/` managed by changesets, and the Go server pins a specific version.
 
 Cross-package coordination is handled via changeset notes and peer-dep ranges, not unified tags.
@@ -33,7 +33,7 @@ Positive:
 - Each tool is used for its strength. `goreleaser` is the de facto standard for Go binary + multi-arch Docker releases. `changesets` is what most pnpm-workspace projects (Astro, Remix, Vercel SDKs) converge on.
 - Release cadences stay independent. A bug fix in `@zitadel/cli` does not require a server release; a server patch does not bump CLI versions.
 - New contributors recognize both workflows from prior projects.
-- The `.changeset/*.md` files in PRs make user-visible changes self-documenting before release.
+- The `.changeset/*.md` files in PRs make user-visible changes self-documenting before release, even before npm publishing automation is enabled.
 
 Trade-offs:
 
@@ -56,6 +56,8 @@ Trade-offs:
 
 ## Follow-up
 
-- Claim the `@zitadel` npm scope (org admin precondition for changesets to publish).
+- Claim the `@zitadel` npm scope and configure npm publishing credentials (org admin preconditions for changesets to publish).
+- Enable the changesets publishing workflow after npm package ownership is confirmed.
+- Decide when to switch the Go release workflow from manual `workflow_dispatch` to automatic `v*` tag releases.
 - Draft a `CONTRIBUTING.md` section pointing contributors at `pnpm changeset` for npm changes and conventional commit prefixes for the goreleaser changelog.
 - Decide ADR 003 territory: should server config schemas or other stable contracts have their own release/versioning policy that crosses both tools?

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zitadel-nextgen-workspace",
   "private": true,
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@10.33.2",
   "scripts": {
     "build": "corepack pnpm -r build",
     "typecheck": "corepack pnpm -r typecheck",
@@ -13,5 +13,11 @@
     "tsup": "^8.3.5",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }

--- a/packages/sdk-core/LICENSE
+++ b/packages/sdk-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ZITADEL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -2,6 +2,16 @@
   "name": "@zitadel/sdk-core",
   "version": "0.0.0",
   "description": "Core types and mock runtime helpers for Zitadel",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zitadel/nextgen.git",
+    "directory": "packages/sdk-core"
+  },
+  "homepage": "https://github.com/zitadel/nextgen/tree/main/packages/sdk-core#readme",
+  "bugs": {
+    "url": "https://github.com/zitadel/nextgen/issues"
+  },
   "type": "module",
   "exports": {
     ".": {
@@ -10,6 +20,9 @@
     }
   },
   "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean",
     "typecheck": "tsc --noEmit",

--- a/packages/sdk-next/LICENSE
+++ b/packages/sdk-next/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ZITADEL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sdk-next/package.json
+++ b/packages/sdk-next/package.json
@@ -2,6 +2,16 @@
   "name": "@zitadel/sdk-next",
   "version": "0.0.0",
   "description": "Next.js helpers and mock auth UI for Zitadel",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zitadel/nextgen.git",
+    "directory": "packages/sdk-next"
+  },
+  "homepage": "https://github.com/zitadel/nextgen/tree/main/packages/sdk-next#readme",
+  "bugs": {
+    "url": "https://github.com/zitadel/nextgen/issues"
+  },
   "type": "module",
   "exports": {
     ".": {
@@ -10,6 +20,9 @@
     }
   },
   "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup src/index.tsx --format esm --dts --clean",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Upgrade the workspace to pnpm 10 and allow known build-time dependencies
- Add Node CI jobs for typecheck, tests, builds, built-CLI smoke checks, npm pack smoke, and short-lived artifacts
- Make the release workflow manual-only behind `workflow_dispatch` with snapshot mode
- Add CLI coverage for app CRUD, resource planning, missing env refs, and invalid Liquid templates
- Refresh README, changeset, and ADR docs for the current pre-release and release posture

## Testing
- Added and ran CLI unit and integration tests for the new resource and apply behavior
- Verified pnpm 10 install, typecheck, test, and build succeed locally
- Verified built CLI smoke checks, npm pack dry-runs, Go vet/tests, and a GoReleaser snapshot run