### PR TITLE
chore(ci): set semantic rules

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,63 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true
+
+# Allowed types — the PR title type must be one of these.
+# This list is the single source of truth referenced by AGENTS.md and CONTRIBUTING.md.
+types:
+  - feat      # new feature
+  - fix       # bug fix
+  - docs      # documentation only (no code change)
+  - refactor  # code restructuring without behaviour change
+  - perf      # performance improvement
+  - test      # adding or fixing tests
+  - build     # build system or tooling
+  - ci        # CI/CD pipeline
+  - chore     # maintenance (deps, config, etc.)
+  - revert    # reverts a previous commit
+
+# Allowed scopes — if a scope is provided it must match one of these.
+# Scopes are optional; omit rather than invent one not on this list.
+# Note: 'docs' is a type, not a scope — use the type 'docs' for documentation changes.
+# This list is the single source of truth referenced by AGENTS.md and CONTRIBUTING.md.
+scopes:
+  # Backend — domain areas
+  - api
+  - session
+  - authz
+  - command
+  - query
+  - eventstore
+  - actions
+  - crypto
+  - domain
+  - feature
+  - idp
+  - notification
+  - oidc
+  - saml
+  - webauthn
+  # Backend — infrastructure
+  - cache
+  - config
+  - database
+  - migration
+  - setup
+  - telemetry
+  - queue
+  # Frontend
+  - console
+  - login
+  # API layer
+  - grpc
+  - proto
+  # Deployment
+  - deploy
+  # Cross-cutting
+  - build
+  - ci
+  - deps
+  - i18n
+  - integration
+  - perf
+  - security
+  - test

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,8 @@ go.work.sum
 .claude/
 
 # Editor/IDE
-# .idea/
-# .vscode/
+.idea/
+.vscode/
 
 # JavaScript / TypeScript
 node_modules/


### PR DESCRIPTION
Copied from: https://github.com/zitadel/zitadel/blob/main/.github/semantic.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to repository/CI configuration and gitignore patterns, with no runtime code paths affected.
> 
> **Overview**
> Adds `.github/semantic.yml` to enforce **semantic PR title** validation (title-only) with an allowlist of accepted `types` and optional `scopes`.
> 
> Updates `.gitignore` to actually ignore IDE project folders (`.idea/`, `.vscode/`) instead of leaving them commented out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf0841def86953d815e0c4af3d7c0f2d8eb1af8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->