### PR TITLE
docs: clarify .zitadel/ vs. runtime-API ownership rule

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -37,6 +37,10 @@ Agents do not claim projects. `zitadel claim` returns a human `claim_url`; after
 
 Generated routes use `ZitadelFlow({ purpose, projectId, issuer, environment })` so the future `<zitadel-flow>` web component can replace the React shim without changing the app-level contract.
 
+## CLI vs. Runtime API
+
+This CLI manages the dev-owned shape of a Zitadel deployment: default IdPs, app definitions, schemas, flows, locales, templates. For per-customer-org configuration (e.g. a B2B customer's own SSO), end-user CRUD, or any unbounded set, route to the runtime Admin/Org API instead — not `zitadel` commands or `.zitadel/` files. Subordinate config (claim mappings, redirect URIs, role bindings) lives wherever its parent resource lives. See `docs/design/cli/README.md` § *What lives in `.zitadel/`* for the ownership rule and the resource-by-resource split.
+
 <!-- generated:capabilities:begin -->
 
 Envelope schema version: `1`. Every envelope carries `cli_version`, `command`, `source` at the top level.

--- a/apps/cli/scripts/gen-agents-md.ts
+++ b/apps/cli/scripts/gen-agents-md.ts
@@ -148,7 +148,11 @@ Agents do not claim projects. \`zitadel claim\` returns a human \`claim_url\`; a
 
 ## Renderer Direction
 
-Generated routes use \`ZitadelFlow({ purpose, projectId, issuer, environment })\` so the future \`<zitadel-flow>\` web component can replace the React shim without changing the app-level contract.`;
+Generated routes use \`ZitadelFlow({ purpose, projectId, issuer, environment })\` so the future \`<zitadel-flow>\` web component can replace the React shim without changing the app-level contract.
+
+## CLI vs. Runtime API
+
+This CLI manages the dev-owned shape of a Zitadel deployment: default IdPs, app definitions, schemas, flows, locales, templates. For per-customer-org configuration (e.g. a B2B customer's own SSO), end-user CRUD, or any unbounded set, route to the runtime Admin/Org API instead — not \`zitadel\` commands or \`.zitadel/\` files. Subordinate config (claim mappings, redirect URIs, role bindings) lives wherever its parent resource lives. See \`docs/design/cli/README.md\` § *What lives in \`.zitadel/\`* for the ownership rule and the resource-by-resource split.`;
 }
 
 main().catch((error) => {

--- a/docs/design/cli/README.md
+++ b/docs/design/cli/README.md
@@ -11,6 +11,38 @@ Two conceptual commitments before we write more code:
 - **[Identity Surface](identity-surface.md)** — how the CLI exposes IdPs, external auth factors, and apps (Zitadel-as-IdP/OIDC/SAML server) as separately-managed, GitOps-reconciled resources. Biggest open shape question: what lives in `.zitadel/` vs. what is purely server-side state.
 - **[BDUI Renderer](bdui-renderer.md)** — how the Lit-based login UI integrates with framework adapters. Biggest open shape question: is the renderer a single `<zitadel-flow>` web component that consumes the flow engine directly, or does the adapter-scaffolded page wrap it per-framework?
 
+## What lives in `.zitadel/` (and what doesn't)
+
+**Ownership decides the surface.** The CLI is for resources the dev owns — bounded, deliberate, reproducible across environments. The runtime API is for resources someone else owns: end users, B2B customer-org admins, registration / SSO / SCIM, and any unbounded set the deployment produces over time. The split isn't architectural — every CLI `apply` ultimately hits the same API a runtime caller would — but ownership and cardinality decide which surface is the right entry point.
+
+A quick test: *"Would I want a PR for each one of these?"* If yes, it's a CLI resource. If no — if the count grows with traffic, with customer organizations, or with anyone-but-the-dev — it belongs on the runtime API.
+
+**Subordinate config follows its parent.** Claim mappings, redirect URIs, role bindings, and similar attached config live wherever the resource they belong to lives. A default Google IdP defined in `.zitadel/idps/google.json` carries its claim mapping in that file. A B2B customer's runtime-created Okta IdP carries its claim mapping in the API call that creates it. There is no separate "claim-mapping registry" per surface — the child config rides with the parent.
+
+The six resource kinds the CLI manages, each with a runtime-API counterpart where one exists:
+
+| Resource | `.zitadel/<dir>/` | Runtime-API counterpart |
+|---|---|---|
+| IdP | `idps/` — your default sign-in sources | per-customer-org SSO from your B2B admin UI |
+| App | `apps/` — your first-party apps and machine clients | customer-managed apps, dynamic client registration |
+| User schema | `schemas/` — what a user looks like on your platform | dev-owned only |
+| Flow | `flows/` — login / register / recovery definitions | dev-owned only |
+| Locale | `locales/` — translation dictionaries | dev-owned only |
+| Template | `templates/` — Liquid templates | tenant-editable after eject; see [template-security.md](../flowengine/template-security.md) |
+
+The canonical directory list is read at [apps/cli/src/commands/apply.ts:144-150](../../../apps/cli/src/commands/apply.ts) (templates are loaded separately as `.liquid` files, not `.json` resources).
+
+**Things that intentionally have no `.zitadel/` directory** — users, sessions, audit events, per-customer-org IdPs and apps. They're unbounded or owned by someone other than the dev. To bootstrap a small set (e.g. a first admin user in staging), use one-shot imperative CLI commands like `zitadel user create --owner` that hit the API but don't get tracked in git.
+
+**Worked examples** matching the recurring B2B questions:
+
+- *"Default Google SSO for my login page."* → `.zitadel/idps/google.json`, applied via `zitadel apply`.
+- *"My B2B customers each wire up their own Okta."* → Your B2B admin UI calls the runtime IdP API per customer-org. Not the CLI.
+- *"Bootstrap a couple of admin users in staging."* → Imperative command, not a file in `.zitadel/`.
+- *"Map `groups` from my customer's runtime-created IdP into a role claim."* → Subordinate config follows the parent: the IdP was created via API, so its claim mapping lives in that API call. Dev-side flow actions can transform claims after the fact, but they don't live in `.zitadel/idps/`.
+
+The per-resource sections in [identity-surface.md](identity-surface.md) carry a *Scope* callout restating this for each kind. AI agents reading [apps/cli/AGENTS.md](../../../apps/cli/AGENTS.md) see the same rule in the "CLI vs. runtime API" section.
+
 ## Plan
 
 The gap analysis against the product vision is tracked in [PLAN.md](PLAN.md). Ordering rationale:

--- a/docs/design/cli/README.md
+++ b/docs/design/cli/README.md
@@ -32,13 +32,13 @@ The six resource kinds the CLI manages, each with a runtime-API counterpart wher
 
 The canonical directory list is read at [apps/cli/src/commands/apply.ts:144-150](../../../apps/cli/src/commands/apply.ts) (templates are loaded separately as `.liquid` files, not `.json` resources).
 
-**Things that intentionally have no `.zitadel/` directory** — users, sessions, audit events, per-customer-org IdPs and apps. They're unbounded or owned by someone other than the dev. To bootstrap a small set (e.g. a first admin user in staging), use one-shot imperative CLI commands like `zitadel user create --owner` that hit the API but don't get tracked in git.
+**Things that intentionally have no `.zitadel/` directory** — users, sessions, audit events, per-customer-org IdPs and apps. They're unbounded or owned by someone other than the dev. Bootstrapping a small set (e.g. a first admin user in staging) is the job of a *planned* one-shot imperative CLI surface that hits the API but doesn't get tracked in git. Concrete command names are deliberately absent here until the surface ships in the registry.
 
 **Worked examples** matching the recurring B2B questions:
 
 - *"Default Google SSO for my login page."* → `.zitadel/idps/google.json`, applied via `zitadel apply`.
 - *"My B2B customers each wire up their own Okta."* → Your B2B admin UI calls the runtime IdP API per customer-org. Not the CLI.
-- *"Bootstrap a couple of admin users in staging."* → Imperative command, not a file in `.zitadel/`.
+- *"Bootstrap a couple of admin users in staging."* → Planned imperative bootstrap surface (not yet in the registry), not a file in `.zitadel/`.
 - *"Map `groups` from my customer's runtime-created IdP into a role claim."* → Subordinate config follows the parent: the IdP was created via API, so its claim mapping lives in that API call. Dev-side flow actions can transform claims after the fact, but they don't live in `.zitadel/idps/`.
 
 The per-resource sections in [identity-surface.md](identity-surface.md) carry a *Scope* callout restating this for each kind. AI agents reading [apps/cli/AGENTS.md](../../../apps/cli/AGENTS.md) see the same rule in the "CLI vs. runtime API" section.

--- a/docs/design/cli/identity-surface.md
+++ b/docs/design/cli/identity-surface.md
@@ -20,6 +20,8 @@ Treating these as one noun conflates credentials, lifecycles, and UX. Treating t
 
 ### IdP — `.zitadel/idps/<slug>.json`
 
+> **Scope.** This is for your platform's default sign-in sources — Google, your corporate Okta, your default SAML IdP. For per-customer-org SSO (a B2B customer configuring their own Okta through your admin UI), use the runtime IdP API, not the CLI. Subordinate config (claim mapping, scopes) rides with the IdP itself: dev-owned IdPs carry it in the file; runtime-created IdPs carry it in the API call that creates them. See [What lives in `.zitadel/`](README.md) for the full ownership rule.
+
 A trust relationship with an external identity provider. Zitadel redirects the user there, receives claims, provisions or links a local user.
 
 ```json
@@ -70,11 +72,15 @@ zitadel idp test google   # dry-run discovery + token exchange (mockable)
 
 ### External factor provider — reserved (deferred)
 
+> **Scope (when this lands).** Same rule as IdPs: dev-owned default factor providers (your platform's default Duo or YubiKey integration) belong in `.zitadel/external-factors/`; customer-owned per-org factor providers go through the runtime API. See [What lives in `.zitadel/`](README.md) for the ownership rule.
+
 Placeholder. The upstream design for external MFA providers is currently unpublished: the prior research document was removed on `frontend-adr-001` pending consolidation of step types, protocol adapters, and ACR semantics. Until that design resurfaces, this CLI does not expose an external-factor resource directory, command, or schema. Built-in factors (password, passkey, captcha gates) remain available through flow steps and `gates`.
 
 When upstream is ready, the resurrected surface is expected to live at `.zitadel/external-factors/<slug>.json` with `zitadel external-factor add|list|show|remove` commands — but the concrete shape (protocol adapters, patterns, ACR properties) will track the upstream decision rather than the prior prototype.
 
 ### App — `.zitadel/apps/<slug>.json`
+
+> **Scope.** This is for your platform's first-party apps (your web frontend, your mobile app) and machine clients. For customer-managed apps and dynamic client registration — common in B2B platforms where each customer brings their own consumer of your APIs — use the runtime apps API, not the CLI. See [What lives in `.zitadel/`](README.md) for the ownership rule.
 
 A consumer of Zitadel's OIDC/SAML server. This is "the thing with a client_id that receives tokens." Also optionally the seat of Zitadel-as-IdP scenarios where the customer is running a SAML server for their own customers.
 
@@ -125,7 +131,7 @@ zitadel app metadata web-frontend   # emits metadata for the counterparty (SAML)
 { "kind": "app", "role": "server", "protocol": "saml", ... }
 ```
 
-…but this stretches what "app" means. Alternative is a separate `.zitadel/providers/` directory. Current leaning: keep it as `app` with `role` to avoid two near-identical resource types, and reassess if customer confusion surfaces.
+…but this stretches what "app" means. Alternative is a separate `.zitadel/providers/` directory. The ownership lens resolves this: if the dev owns the SAML-server config (one for their whole platform), it's a `.zitadel/apps/<slug>.json` with `role: "server"` — a small, deliberate, dev-owned resource. If the customer owns it (one per customer-org, configured via a B2B admin UI), it doesn't belong in `.zitadel/` at all and goes through the runtime API. Current leaning: keep `role: "server"` on `app` for the dev-owned case to avoid two near-identical resource types; per-customer SAML servers don't get a CLI surface.
 
 ## How they plug into flow definitions
 


### PR DESCRIPTION
## Summary

Codify the line between resources managed via `.zitadel/` config and resources managed via the runtime API. Came out of a brainstorm about recurring B2B confusion: default Google SSO (CLI) vs. per-customer-org SSO (runtime API); bootstrap admin users (one-shot CLI command) vs. registration/SCIM users (runtime); claim mapping for default IdPs (in the file) vs. runtime-created IdPs (in the API call).

The locked framing: **ownership decides the surface**. Bounded, dev-owned, reproducible-across-environments → CLI. Unbounded or owned by someone else (end users, customer-org admins, runtime processes) → runtime API. Subordinate config (claim mappings, redirect URIs, role bindings) lives wherever its parent resource lives.

## Changes

- **`docs/design/cli/README.md`** — new "What lives in `.zitadel/` (and what doesn't)" section with the ownership rule, PR-per-instance test, subordinate-config-follows-parent principle, six-row resource table, and four worked B2B examples.
- **`docs/design/cli/identity-surface.md`** — *Scope* callouts on IdP, External-factor (reserved), and App sections. Re-frames the existing `role: "server"` open question through the ownership lens — it resolves cleanly once you ask "who owns this config?"
- **`apps/cli/scripts/gen-agents-md.ts`** — `handwrittenHeader()` now emits a "CLI vs. Runtime API" routing section so AI consumers see the rule in the agent contract before the command capabilities table.
- **`apps/cli/AGENTS.md`** — regenerated; diff is exactly the 4 new lines, generated capabilities block byte-identical otherwise.

## Out of scope (flagged for follow-up)

- The CLI's `audience.scope` envelope (e.g. `{ "scope": "team", "team_id": "acme" }`) vs. the flow engine's `Audience { org_ids[], app_ids[], schema_ids[] }` shape don't line up — real misalignment surfaced during exploration.
- `ResourceKind` in `apps/cli/src/resources/types.ts` covers only `idp` + `app` while `apply.ts:144-150` knows about all six directories — worth consolidating.

## Test plan

- [x] `corepack pnpm --filter zitadel typecheck` — clean
- [x] `corepack pnpm --filter zitadel test --run` — 44/44 pass
- [x] `corepack pnpm --filter zitadel gen:agents-md` — output diff is only the new section; generated capabilities block byte-identical
- [ ] Reviewer cold-read of `docs/design/cli/README.md` § "What lives in `.zitadel/` (and what doesn't)" — does each of the four B2B examples land?
- [ ] Cold-read of `apps/cli/AGENTS.md` "CLI vs. Runtime API" — clear enough that an agent routes per-customer SSO requests to the runtime API rather than `.zitadel/idps/`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)