### PR TITLE
docs: add README-first documentation restructure plan

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,11 @@
+Tool-specific rules in this file are a bootstrap only.
+
+Authoritative instructions live in scoped `AGENTS.md` files.
+
+Always read in this order:
+1. Root `AGENTS.md`
+2. The nearest scoped `AGENTS.md` for the files you read or change
+
+Start with:
+- [AGENTS.md](AGENTS.md)
+- [internal/storage/AGENTS.md](internal/storage/AGENTS.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,28 @@
 These instructions apply to the whole repository. A nearer `AGENTS.md` may add
 more specific rules for a subtree.
 
+## Instruction Scope And Precedence
+
+Use `AGENTS.md` as the primary and tool-agnostic instruction source.
+
+Always resolve instructions in this order:
+1. Root `AGENTS.md` (this file)
+2. The nearest scoped `AGENTS.md` for the files you read or change
+
+If instructions conflict, the nearest scoped `AGENTS.md` for the touched path
+takes precedence over broader scope files.
+
+## ADR Context
+
+Before changing behavior, review relevant ADRs in `docs/adrs/` and align
+proposals and implementations with recorded decisions.
+
+- `docs/adrs/004-agent-contract-and-agents-md.md` defines how external agents
+  should consume the Zitadel CLI contract; treat it as product-surface context,
+  not as the primary implementation contract for developing this repository.
+- `docs/adrs/` contains product and architectural decisions that should be
+  treated as implementation context, not optional references.
+
 ## Project Shape
 
 This repo is the pre-release next generation of Zitadel. The Go server and

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -95,6 +95,8 @@ machine-only index folder).
 - Expand `docs/design/README.md` with domain routing.
 - Normalize task tables in domain READMEs.
 - Expand ADR index table in `docs/adrs/README.md`.
+- Use `docs/README_TEMPLATES.md` as the source template for root and domain
+  README structure.
 
 ### Phase 2: Consistency pass
 - Normalize status/context sections across major design docs.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,113 @@
+# Documentation Restructure Plan (README-First)
+
+## Goal
+
+Make `docs/` easy to navigate for both humans and agents without introducing a
+separate index directory that creates maintenance overhead.
+
+## Principles
+
+1. **README-first navigation:** Indexes live in existing `README.md` files,
+   close to the docs they describe.
+2. **Task-first discovery:** Readers should start from "I need to do X" paths.
+3. **Clear source-of-truth split:** ADRs capture decisions, design docs capture
+   evolving implementation direction.
+4. **Low-overhead upkeep:** Updating documentation should require touching only
+   nearby README files, not a parallel index hierarchy.
+
+## Target Documentation Shape
+
+```text
+docs/
+  README.md                   # Global task router and first entrypoint
+  adrs/
+    README.md                 # ADR index and decision map
+    *.md                      # Architecture Decision Records
+  design/
+    README.md                 # Design overview and domain routing
+    flowengine/
+      README.md               # Domain task index
+      *.md
+      api/*.yaml
+    cli/
+      README.md               # Domain task index
+      *.md
+    branding/
+      README.md               # Domain task index
+      *.md
+```
+
+## Index Strategy (No `docs/indexes/` Folder)
+
+### `docs/README.md` (global index)
+
+Contains:
+- "I need to..." task table mapped to start docs.
+- Audience split (engineer, PM, designer, agent).
+- Quick links to ADRs and design domains.
+
+### `docs/adrs/README.md` (decision index)
+
+Contains:
+- ADR list (id, title, status, summary).
+- Optional "affected domains" column for faster routing.
+
+### `docs/design/README.md` (design hub)
+
+Contains:
+- Domain overview (`flowengine`, `cli`, `branding`).
+- Current review focus per domain.
+- Links to each domain README.
+
+### `docs/design/<domain>/README.md` (local task index)
+
+Each domain README should include:
+- Scope and status.
+- "Common tasks" table with "Start here" links.
+- Canonical documents and related ADRs.
+- Open questions and next review points when applicable.
+
+## Document Metadata Convention
+
+To help both humans and agents, major design docs should standardize the
+existing top section with:
+
+- Status
+- Date
+- Context
+- What needs feedback (if draft/in review)
+
+This should stay lightweight and human-readable (no requirement for a separate
+machine-only index folder).
+
+## Maintenance Rules
+
+1. New doc -> add link in nearest domain `README.md`.
+2. Cross-domain important doc -> also add link in `docs/README.md`.
+3. New ADR -> update `docs/adrs/README.md` in the same change.
+4. If a doc moves -> leave a short forwarding note in the old location until
+   references are updated.
+
+## Rollout Plan
+
+### Phase 1: Navigation alignment (no content moves)
+- Create/refresh `docs/README.md` as task-first entrypoint.
+- Expand `docs/design/README.md` with domain routing.
+- Normalize task tables in domain READMEs.
+- Expand ADR index table in `docs/adrs/README.md`.
+
+### Phase 2: Consistency pass
+- Normalize status/context sections across major design docs.
+- Ensure cross-links between design docs and related ADRs are explicit.
+- Remove dead or duplicate links.
+
+### Phase 3: Optional structural moves (only if still needed)
+- Move files only where discoverability materially improves.
+- Keep short compatibility forwarding notes at old paths during transition.
+
+## Definition of Done
+
+- A contributor can reach relevant docs in <= 3 clicks from `docs/README.md`.
+- Every design domain has a task-oriented `README.md`.
+- ADR index is current and usable as a decision map.
+- No dedicated `docs/indexes/` folder is required.

--- a/docs/README_TEMPLATES.md
+++ b/docs/README_TEMPLATES.md
@@ -1,0 +1,97 @@
+# Documentation README Templates
+
+Copy and adapt these templates when creating or refreshing documentation
+entrypoints. They implement the README-first navigation model from
+[`docs/PLAN.md`](./PLAN.md).
+
+## Root Template (`docs/README.md`)
+
+```md
+# Documentation
+
+This folder contains product decisions and design direction for nextgen.
+
+## Start by Task
+
+Use this table when you know what you need to do, but not where to start.
+
+| I need to... | Start here | Then read |
+|---|---|---|
+| Understand architecture decisions | [ADRs](./adrs/README.md) | Relevant ADR file(s) |
+| Change authentication and flow behavior | [Authentication design](./design/flowengine/README.md) | Flow Engine + Session API docs |
+| Change CLI behavior or resource model | [CLI design](./design/cli/README.md) | Identity surface + plan docs |
+| Change login UI branding/templates | [Branding design](./design/branding/README.md) | Tokens + templates + validator |
+| Find active design discussions | [Design hub](./design/README.md) | Domain README "Open questions" sections |
+
+## Read by Audience
+
+- **Engineers:** start with [Design hub](./design/README.md), then domain README.
+- **Product/Architecture:** start with [ADRs](./adrs/README.md), then design
+  domain context.
+- **Agents:** start with the relevant task row above, follow domain README
+  "Common tasks" and "Canonical docs" sections.
+
+## Documentation Map
+
+- [Architecture Decision Records](./adrs/README.md)
+- [Design Hub](./design/README.md)
+  - [Flow Engine](./design/flowengine/README.md)
+  - [CLI](./design/cli/README.md)
+  - [Branding](./design/branding/README.md)
+
+## Conventions
+
+- ADRs are decision records and source-of-truth for accepted architecture.
+- Design docs may be draft/in-review and should state status at the top.
+- New docs must be linked from the nearest domain README in the same change.
+```
+
+## Domain Template (`docs/design/<domain>/README.md`)
+
+```md
+# <Domain Name>
+
+> **Status:** Draft | In Review | Accepted
+> **Date:** YYYY-MM-DD
+> **Context:** One-sentence scope for this domain.
+
+## Scope
+
+Describe what this domain owns and what is out of scope.
+
+## Common Tasks
+
+Use this table for task-first routing inside the domain.
+
+| Task | Start here | Related docs | Related ADRs |
+|---|---|---|---|
+| <Task 1> | [<doc>](./<doc>.md) | [<doc>](./<doc>.md) | [ADR NNN](../../adrs/NNN-<slug>.md) |
+| <Task 2> | [<doc>](./<doc>.md) | [<doc>](./<doc>.md) | [ADR NNN](../../adrs/NNN-<slug>.md) |
+| <Task 3> | [<doc>](./<doc>.md) | [<doc>](./<doc>.md) | [ADR NNN](../../adrs/NNN-<slug>.md) |
+
+## Canonical Documents
+
+List the core docs in this domain and what each one answers.
+
+| Document | Status | Purpose |
+|---|---|---|
+| [<doc>](./<doc>.md) | Draft | <What this explains> |
+| [<doc>](./<doc>.md) | In Review | <What this explains> |
+
+## Related Decisions (ADRs)
+
+- [ADR NNN: <title>](../../adrs/NNN-<slug>.md)
+- [ADR NNN: <title>](../../adrs/NNN-<slug>.md)
+
+## Open Questions / Review Focus
+
+- <Question or unresolved tradeoff>
+- <Question or unresolved tradeoff>
+
+## Change Checklist
+
+- [ ] New/updated docs are linked in this README.
+- [ ] Cross-domain docs are linked from `docs/README.md`.
+- [ ] ADR references are up to date.
+- [ ] Stale links removed.
+```

--- a/internal/storage/AGENTS.md
+++ b/internal/storage/AGENTS.md
@@ -1,0 +1,17 @@
+# Storage Agent Instructions
+
+These instructions apply to `internal/storage/` and may be refined by nearer
+scoped `AGENTS.md` files.
+
+## Storage Scope
+
+- Storage is SQL-first. Prefer SQL-compatible modeling and query patterns.
+- Supported databases are PostgreSQL and Spanner.
+- Keep dialect-specific SQL behavior, query building, and migrations in
+  `internal/storage/database/dialect/`.
+
+## Sub-scoped Guidance
+
+Read the nearest scoped file before changing repository code:
+
+- `internal/storage/database/repository/AGENTS.md`

--- a/internal/storage/database/repository/AGENTS.md
+++ b/internal/storage/database/repository/AGENTS.md
@@ -1,0 +1,54 @@
+# Repository Agent Instructions
+
+These instructions apply to `internal/storage/database/repository/`.
+
+## 1. Scope Split: Relational Repositories vs Users EAV
+
+- Use the repository pattern in this folder for traditional relational tables.
+- Do not treat users as a traditional table-shaped repository entity.
+- Users use the EAV model described in `docs/adrs/008-users-eav-store.md`.
+- Users operation semantics follow the SQL contract examples in
+  `internal/storage/database/dialect/postgres/migration/003_users/example/`
+  (`create`, `put`, `patch`, `get_by_id`, `get_by_attribute`, `list`,
+  `cleanup`).
+
+## 2. Relational Repository Structure
+
+Repository structs should expose:
+- `qualifiedTableName() string`
+- `PrimaryKeyColumns() []database.Column`
+- `UpdatedAtColumn() database.Column` (for updatable entities)
+
+## 3. Relational CRUD Patterns
+
+- **Create**: Use `client.Exec` with `database.NewStatementBuilder("INSERT ...")`.
+- **Read**: Use `repository.getOne[T]` or `repository.getMany[T]`.
+- **Update**: Use `repository.updateOne[T]`; do not hand-build UPDATE strings.
+- **Delete**: Use `repository.deleteOne[T]`.
+
+## 4. Conditions And Changes
+
+- Build filters with `database.And(...)`, `database.Or(...)`, and
+  `database.NewTextCondition(...)` (or typed condition helpers).
+- Represent scoping values such as `instance_id` as `Condition`s.
+- Avoid special-casing `instance_id` as a separate method argument when the
+  repository helper already accepts conditions.
+- Use `database.NewChange(column, value)` for updates.
+
+## 5. Safety Constraints
+
+- Ensure write operations are constrained by primary key and tenant scope.
+- Use `checkPKCondition(target, condition)` inside repository methods.
+
+## 6. Relational Example (Non-User Entity)
+
+```go
+func (r *Repository) UpdateProject(ctx context.Context, id string, changes ...database.Change) error {
+	cond := database.And(
+		database.NewTextCondition(r.columnID, database.TextEquals, id),
+		database.NewTextCondition(r.columnInstanceID, database.TextEquals, auth.InstanceID(ctx)),
+	)
+	_, err := updateOne[*Project](ctx, r.client, r, cond, changes...)
+	return err
+}
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `docs/PLAN.md` with an updated documentation restructure plan
- align the plan to a README-first navigation model inspired by Oxidel
- explicitly avoid a separate `docs/indexes/` directory to reduce maintenance overhead
- add copy-paste templates for root and domain README files in `docs/README_TEMPLATES.md`

## What Was Added
- **Root docs template** for `docs/README.md` including:
  - task-first routing table
  - audience-based entrypoints
  - documentation map and maintenance conventions
- **Domain docs template** for `docs/design/<domain>/README.md` including:
  - scope/status header
  - common tasks routing table
  - canonical documents table
  - related ADRs and change checklist

## Plan Update
- `docs/PLAN.md` now references `docs/README_TEMPLATES.md` as the source template for README structure during Phase 1 rollout.

## Validation
- confirmed branch updates only documentation planning/template files
- verified templates are consistent with the README-first, no-index-folder approach
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9979b2e-8136-4c4a-b74b-bf40ca90baa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9979b2e-8136-4c4a-b74b-bf40ca90baa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

