### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,43 @@ human `claim_url`; only a human completes claim, after which agents may run
 - Server and console application paths are AGPL-3.0-only by default.
 - Keep local secrets, private keys, tokens, and `.zitadel/secret`-style files out
   of source control and browser-safe runtime metadata.
+
+## Cursor Cloud specific instructions
+
+### Environment prerequisites
+
+- **Node.js 24** (from `.nvmrc`) via nvm; **Go 1.26** installed to `/usr/local/go`.
+- pnpm is managed through corepack (`packageManager` field in root `package.json`).
+- Go must be on `PATH`: `export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"`.
+
+### Running services
+
+| Service | Command | Default URL |
+|---------|---------|-------------|
+| Console (Vite dev) | `corepack pnpm nx dev @zitadel-nextgen/console` | `http://localhost:5173` |
+| Go server (placeholder) | `go build -o /tmp/nextgen . && /tmp/nextgen --help` | N/A (server subcommand still being wired) |
+| CLI smoke check | `node apps/cli/dist/zitadel.mjs --version` | N/A |
+
+### Lint / typecheck / build / test
+
+All standard commands are in the `README.md` "Local checks" section and the
+`AGENTS.md` "Local Checks" section. Summary:
+
+```sh
+corepack pnpm nx run-many -t lint,typecheck,build,test   # TS workspace
+go vet ./...                                              # Go lint
+go test ./...                                             # Go tests
+```
+
+### Known caveats
+
+- `pnpm install` may warn about ignored build scripts for `@swc/core` and `nx`.
+  These do not affect normal operation; `pnpm.onlyBuiltDependencies` in the root
+  `package.json` controls which packages are allowed to run install scripts.
+- Go tests use `embedded-postgres` and spin up a temporary Postgres instance
+  automatically; no external database is needed for `go test ./...`.
+- The Go server binary (`main.go`) is a placeholder; `--help` works but the
+  `server` subcommand is still being wired up.
+- Console E2E tests (`apps/console-e2e/`) use Playwright and require a running
+  console preview server; they are not part of the standard `go test` / `nx test`
+  targets.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with environment prerequisites, service startup commands, and known caveats for Cloud Agent sessions.

## What's included

- **Environment prerequisites**: Node.js 24 (`.nvmrc`), Go 1.26, pnpm via corepack
- **Service startup table**: Console dev server, Go server placeholder, CLI smoke check
- **Lint/test commands reference**: Points to existing Local Checks section
- **Known caveats**: pnpm build script warnings, embedded-postgres for Go tests, placeholder server status, E2E test requirements

## Walkthrough

[console-app-demo.mp4](https://cursor.com/agents/bc-328d7f77-5a5b-4e39-a66f-9b76bd5e8852/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole-app-demo.mp4)
Console app running in dev mode at localhost:5173, demonstrating interactive sign-in flow.

[Console sign-in page](https://cursor.com/agents/bc-328d7f77-5a5b-4e39-a66f-9b76bd5e8852/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole-signin-page.webp)
[Console password screen](https://cursor.com/agents/bc-328d7f77-5a5b-4e39-a66f-9b76bd5e8852/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole-password-screen.webp)
[Console sign-in success](https://cursor.com/agents/bc-328d7f77-5a5b-4e39-a66f-9b76bd5e8852/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole-signin-success.webp)

## Testing

- **TS workspace**: `corepack pnpm nx run-many -t lint,typecheck,build,test` — all 8 projects passed
- **Go vet**: `go vet ./...` — clean
- **Go tests**: `go test ./...` — all pass except one pre-existing test failure in `internal/storage/database/repository` (JSON schema encoding assertion)
- **Console dev**: Vite dev server runs and serves the app at localhost:5173
- **CLI**: `node apps/cli/dist/zitadel.mjs --version` outputs `0.0.0`
- **Go build**: `go build` succeeds, binary runs with `--help`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-328d7f77-5a5b-4e39-a66f-9b76bd5e8852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-328d7f77-5a5b-4e39-a66f-9b76bd5e8852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

