### PR TITLE
feat: require project_id on POST /flow

### DIFF
--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -889,6 +889,46 @@ func (s *ChallengeID) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes ChallengeNonce as json.
+func (s ChallengeNonce) Encode(e *jx.Encoder) {
+	unwrapped := string(s)
+
+	e.Str(unwrapped)
+}
+
+// Decode decodes ChallengeNonce from json.
+func (s *ChallengeNonce) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ChallengeNonce to nil")
+	}
+	var unwrapped string
+	if err := func() error {
+		v, err := d.Str()
+		unwrapped = string(v)
+		if err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = ChallengeNonce(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ChallengeNonce) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ChallengeNonce) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode implements json.Marshaler.
 func (s *ChallengeResponse) Encode(e *jx.Encoder) {
 	e.ObjStart()
@@ -1305,6 +1345,10 @@ func (s *CreateFlowRequest) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *CreateFlowRequest) encodeFields(e *jx.Encoder) {
 	{
+		e.FieldStart("project_id")
+		s.ProjectID.Encode(e)
+	}
+	{
 		e.FieldStart("purpose")
 		s.Purpose.Encode(e)
 	}
@@ -1352,15 +1396,16 @@ func (s *CreateFlowRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfCreateFlowRequest = [8]string{
-	0: "purpose",
-	1: "slug",
-	2: "schema_version",
-	3: "challenge_nonce",
-	4: "session_id",
-	5: "auth_request_id",
-	6: "redirect_uri",
-	7: "hint",
+var jsonFieldsNameOfCreateFlowRequest = [9]string{
+	0: "project_id",
+	1: "purpose",
+	2: "slug",
+	3: "schema_version",
+	4: "challenge_nonce",
+	5: "session_id",
+	6: "auth_request_id",
+	7: "redirect_uri",
+	8: "hint",
 }
 
 // Decode decodes CreateFlowRequest from json.
@@ -1368,12 +1413,22 @@ func (s *CreateFlowRequest) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode CreateFlowRequest to nil")
 	}
-	var requiredBitSet [1]uint8
+	var requiredBitSet [2]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "purpose":
+		case "project_id":
 			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.ProjectID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"project_id\"")
+			}
+		case "purpose":
+			requiredBitSet[0] |= 1 << 1
 			if err := func() error {
 				if err := s.Purpose.Decode(d); err != nil {
 					return err
@@ -1461,8 +1516,9 @@ func (s *CreateFlowRequest) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [1]uint8{
-		0b00000001,
+	for i, mask := range [2]uint8{
+		0b00000011,
+		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -8492,6 +8548,39 @@ func (s OptBrandingLayout) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptBrandingLayout) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ChallengeNonce as json.
+func (o OptChallengeNonce) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes ChallengeNonce from json.
+func (o *OptChallengeNonce) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptChallengeNonce to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptChallengeNonce) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptChallengeNonce) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -404,6 +404,8 @@ func (s *CaptchaProofCaptcha) SetToken(val string) {
 
 type ChallengeID string
 
+type ChallengeNonce string
+
 // A factor challenge issued within an authentication attempt.
 // A challenge presents a single-factor verification prompt (password entry, TOTP code, passkey
 // assertion, etc.).
@@ -547,10 +549,8 @@ func (*CreateAuthAttemptBadRequest) createAuthAttemptRes() {}
 // Request to create a new authentication attempt.
 // Ref: #
 type CreateAuthAttemptRequest struct {
-	ProjectID ProjectID `json:"project_id"`
-	// Optional. The challenge nonce from POST /bootstrap/challenge.
-	// This nonce is origin-bound (for browser clients) and single-use.
-	ChallengeNonce OptString `json:"challenge_nonce"`
+	ProjectID      ProjectID         `json:"project_id"`
+	ChallengeNonce OptChallengeNonce `json:"challenge_nonce"`
 	// Optional. If provided, this attempt adds factors to an existing session (step-up auth).
 	// If omitted, a new session is created implicitly on successful handoff.
 	SessionID OptNilSessionID `json:"session_id"`
@@ -562,7 +562,7 @@ func (s *CreateAuthAttemptRequest) GetProjectID() ProjectID {
 }
 
 // GetChallengeNonce returns the value of ChallengeNonce.
-func (s *CreateAuthAttemptRequest) GetChallengeNonce() OptString {
+func (s *CreateAuthAttemptRequest) GetChallengeNonce() OptChallengeNonce {
 	return s.ChallengeNonce
 }
 
@@ -577,7 +577,7 @@ func (s *CreateAuthAttemptRequest) SetProjectID(val ProjectID) {
 }
 
 // SetChallengeNonce sets the value of ChallengeNonce.
-func (s *CreateAuthAttemptRequest) SetChallengeNonce(val OptString) {
+func (s *CreateAuthAttemptRequest) SetChallengeNonce(val OptChallengeNonce) {
 	s.ChallengeNonce = val
 }
 
@@ -592,18 +592,16 @@ func (*CreateAuthAttemptUnauthorized) createAuthAttemptRes() {}
 
 // Ref: #
 type CreateFlowRequest struct {
-	Purpose CreateFlowRequestPurpose `json:"purpose"`
+	ProjectID ProjectID                `json:"project_id"`
+	Purpose   CreateFlowRequestPurpose `json:"purpose"`
 	// Human-readable identifier of a specific flow definition to use.
 	// When omitted, the engine selects the best-matching definition
 	// based on purpose + audience context.
 	Slug OptString `json:"slug"`
 	// Semver version of the flow definition JSON Schema to use.
 	// When omitted, the latest version is used.
-	SchemaVersion OptString `json:"schema_version"`
-	// Origin-bound nonce obtained from `POST /bootstrap/challenge`.
-	// Binds the flow to the browser that requested it, preventing
-	// cross-origin replay of flow cookies.
-	ChallengeNonce OptString `json:"challenge_nonce"`
+	SchemaVersion  OptString         `json:"schema_version"`
+	ChallengeNonce OptChallengeNonce `json:"challenge_nonce"`
 	// Existing session to attach to (for step-up / reauth).
 	// Omit to let the flow create a new session implicitly.
 	SessionID OptString `json:"session_id"`
@@ -611,6 +609,11 @@ type CreateFlowRequest struct {
 	AuthRequestID OptString   `json:"auth_request_id"`
 	RedirectURI   OptURI      `json:"redirect_uri"`
 	Hint          OptFlowHint `json:"hint"`
+}
+
+// GetProjectID returns the value of ProjectID.
+func (s *CreateFlowRequest) GetProjectID() ProjectID {
+	return s.ProjectID
 }
 
 // GetPurpose returns the value of Purpose.
@@ -629,7 +632,7 @@ func (s *CreateFlowRequest) GetSchemaVersion() OptString {
 }
 
 // GetChallengeNonce returns the value of ChallengeNonce.
-func (s *CreateFlowRequest) GetChallengeNonce() OptString {
+func (s *CreateFlowRequest) GetChallengeNonce() OptChallengeNonce {
 	return s.ChallengeNonce
 }
 
@@ -653,6 +656,11 @@ func (s *CreateFlowRequest) GetHint() OptFlowHint {
 	return s.Hint
 }
 
+// SetProjectID sets the value of ProjectID.
+func (s *CreateFlowRequest) SetProjectID(val ProjectID) {
+	s.ProjectID = val
+}
+
 // SetPurpose sets the value of Purpose.
 func (s *CreateFlowRequest) SetPurpose(val CreateFlowRequestPurpose) {
 	s.Purpose = val
@@ -669,7 +677,7 @@ func (s *CreateFlowRequest) SetSchemaVersion(val OptString) {
 }
 
 // SetChallengeNonce sets the value of ChallengeNonce.
-func (s *CreateFlowRequest) SetChallengeNonce(val OptString) {
+func (s *CreateFlowRequest) SetChallengeNonce(val OptChallengeNonce) {
 	s.ChallengeNonce = val
 }
 
@@ -4226,6 +4234,52 @@ func (o OptBrandingLayout) Get() (v BrandingLayout, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptBrandingLayout) Or(d BrandingLayout) BrandingLayout {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptChallengeNonce returns new OptChallengeNonce with value set to v.
+func NewOptChallengeNonce(v ChallengeNonce) OptChallengeNonce {
+	return OptChallengeNonce{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptChallengeNonce is optional ChallengeNonce.
+type OptChallengeNonce struct {
+	Value ChallengeNonce
+	Set   bool
+}
+
+// IsSet returns true if OptChallengeNonce was set.
+func (o OptChallengeNonce) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptChallengeNonce) Reset() {
+	var v ChallengeNonce
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptChallengeNonce) SetTo(v ChallengeNonce) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptChallengeNonce) Get() (v ChallengeNonce, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptChallengeNonce) Or(d ChallengeNonce) ChallengeNonce {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/api/generated/oas_validators_gen.go
+++ b/api/generated/oas_validators_gen.go
@@ -403,6 +403,17 @@ func (s *CreateFlowRequest) Validate() error {
 
 	var failures []validate.FieldError
 	if err := func() error {
+		if err := s.ProjectID.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "project_id",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := s.Purpose.Validate(); err != nil {
 			return err
 		}

--- a/api/openapi/components/flows/create-flow-request.yaml
+++ b/api/openapi/components/flows/create-flow-request.yaml
@@ -1,6 +1,8 @@
 type: object
-required: [purpose]
+required: [project_id, purpose]
 properties:
+  project_id:
+    $ref: ../schemas/project-id.yaml
   purpose:
     type: string
     enum: [login, register, recovery, profiling, reauth, link_account]
@@ -20,11 +22,7 @@ properties:
     pattern: '^\d+\.\d+\.\d+$'
     example: "1.0.0"
   challenge_nonce:
-    type: string
-    description: |
-      Origin-bound nonce obtained from `POST /bootstrap/challenge`.
-      Binds the flow to the browser that requested it, preventing
-      cross-origin replay of flow cookies.
+    $ref: ../schemas/challenge-nonce.yaml
   session_id:
     type: string
     description: |

--- a/api/openapi/components/schemas/challenge-nonce.yaml
+++ b/api/openapi/components/schemas/challenge-nonce.yaml
@@ -1,0 +1,6 @@
+type: string
+description: |
+  Origin-bound, single-use nonce obtained from `POST /bootstrap/challenge`.
+  Binds the request to the browser that initiated the flow, preventing
+  cross-origin replay.
+example: nonce_abc123def456

--- a/api/openapi/endpoints/auth_attempts/create-auth-attempt-request.yaml
+++ b/api/openapi/endpoints/auth_attempts/create-auth-attempt-request.yaml
@@ -6,11 +6,7 @@ properties:
   project_id:
     $ref: "../../components/schemas/project-id.yaml"
   challenge_nonce:
-    type: string
-    description: |
-      Optional. The challenge nonce from POST /bootstrap/challenge.
-      This nonce is origin-bound (for browser clients) and single-use.
-    example: nonce_abc123def456
+    $ref: "../../components/schemas/challenge-nonce.yaml"
   session_id:
     description: |
       Optional. If provided, this attempt adds factors to an existing session (step-up auth).


### PR DESCRIPTION
## Summary

- Add `project_id` (required) to `CreateFlowRequest`, mirroring `CreateAuthAttemptRequest`.
- Extract `challenge_nonce` to `components/schemas/challenge-nonce.yaml`; both `POST /flow` and `POST /auth-attempts` now `$ref` it. No behavior change — still optional on both.

## Why

`POST /flow` is `security: []` and the gateway doesn't yet inject a tenant context, so the handler has no way to derive `project_id`. The selector work on `flow-engine-selector` needs a project scope to run. The explicit body field is the smallest unblock that matches the convention already established by `POST /auth-attempts`.

## Implications

- **Tenant identifier on a browser-facing surface**: callers must know and send their project id from JS. We accept this for now; the long-term plan is to resolve the tenant at the edge (host/path) and inject it via middleware, at which point `project_id` becomes redundant and can be dropped from the body.
- **Forward-compat with `/auth-attempts`**: `challenge_nonce` and `project_id` now share generated types across both endpoints, so the flow handler can pass them through unchanged when creating an auth attempt.

## Test plan

- [ ] \`go generate ./api/...\` produces no further diff
- [ ] \`go build ./...\` is green
- [ ] OpenAPI bundle renders without lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)