### PR TITLE
feat: add UserSchema and align FlowDefinition API ↔ domain shapes

### DIFF
--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -5277,15 +5277,7 @@ func (s *FlowDefinition) encodeFields(e *jx.Encoder) {
 	}
 	{
 		e.FieldStart("purposes")
-		e.ArrStart()
-		for _, elem := range s.Purposes {
-			elem.Encode(e)
-		}
-		e.ArrEnd()
-	}
-	{
-		e.FieldStart("initial_steps")
-		s.InitialSteps.Encode(e)
+		s.Purposes.Encode(e)
 	}
 	{
 		if s.Audience.Set {
@@ -5303,13 +5295,12 @@ func (s *FlowDefinition) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFlowDefinition = [6]string{
+var jsonFieldsNameOfFlowDefinition = [5]string{
 	0: "name",
 	1: "user_schema",
 	2: "purposes",
-	3: "initial_steps",
-	4: "audience",
-	5: "steps",
+	3: "audience",
+	4: "steps",
 }
 
 // Decode decodes FlowDefinition from json.
@@ -5348,30 +5339,12 @@ func (s *FlowDefinition) Decode(d *jx.Decoder) error {
 		case "purposes":
 			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
-				s.Purposes = make([]FlowDefinitionPurposesItem, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem FlowDefinitionPurposesItem
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.Purposes = append(s.Purposes, elem)
-					return nil
-				}); err != nil {
+				if err := s.Purposes.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"purposes\"")
-			}
-		case "initial_steps":
-			requiredBitSet[0] |= 1 << 3
-			if err := func() error {
-				if err := s.InitialSteps.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"initial_steps\"")
 			}
 		case "audience":
 			if err := func() error {
@@ -5384,7 +5357,7 @@ func (s *FlowDefinition) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"audience\"")
 			}
 		case "steps":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				s.Steps = make([]FlowDefinitionStep, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -5411,7 +5384,7 @@ func (s *FlowDefinition) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00101111,
+		0b00010111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -5602,15 +5575,7 @@ func (s *FlowDefinitionDetailResponse) encodeFields(e *jx.Encoder) {
 	}
 	{
 		e.FieldStart("purposes")
-		e.ArrStart()
-		for _, elem := range s.Purposes {
-			elem.Encode(e)
-		}
-		e.ArrEnd()
-	}
-	{
-		e.FieldStart("initial_steps")
-		s.InitialSteps.Encode(e)
+		s.Purposes.Encode(e)
 	}
 	{
 		if s.Audience.Set {
@@ -5652,19 +5617,18 @@ func (s *FlowDefinitionDetailResponse) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFlowDefinitionDetailResponse = [12]string{
+var jsonFieldsNameOfFlowDefinitionDetailResponse = [11]string{
 	0:  "name",
 	1:  "user_schema",
 	2:  "purposes",
-	3:  "initial_steps",
-	4:  "audience",
-	5:  "steps",
-	6:  "id",
-	7:  "project_id",
-	8:  "schema_uri",
-	9:  "status",
-	10: "created_at",
-	11: "updated_at",
+	3:  "audience",
+	4:  "steps",
+	5:  "id",
+	6:  "project_id",
+	7:  "schema_uri",
+	8:  "status",
+	9:  "created_at",
+	10: "updated_at",
 }
 
 // Decode decodes FlowDefinitionDetailResponse from json.
@@ -5703,30 +5667,12 @@ func (s *FlowDefinitionDetailResponse) Decode(d *jx.Decoder) error {
 		case "purposes":
 			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
-				s.Purposes = make([]FlowDefinitionDetailResponsePurposesItem, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem FlowDefinitionDetailResponsePurposesItem
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.Purposes = append(s.Purposes, elem)
-					return nil
-				}); err != nil {
+				if err := s.Purposes.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"purposes\"")
-			}
-		case "initial_steps":
-			requiredBitSet[0] |= 1 << 3
-			if err := func() error {
-				if err := s.InitialSteps.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"initial_steps\"")
 			}
 		case "audience":
 			if err := func() error {
@@ -5739,7 +5685,7 @@ func (s *FlowDefinitionDetailResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"audience\"")
 			}
 		case "steps":
-			requiredBitSet[0] |= 1 << 5
+			requiredBitSet[0] |= 1 << 4
 			if err := func() error {
 				s.Steps = make([]FlowDefinitionStep, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -5757,7 +5703,7 @@ func (s *FlowDefinitionDetailResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"steps\"")
 			}
 		case "id":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Str()
 				s.ID = string(v)
@@ -5769,7 +5715,7 @@ func (s *FlowDefinitionDetailResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"id\"")
 			}
 		case "project_id":
-			requiredBitSet[0] |= 1 << 7
+			requiredBitSet[0] |= 1 << 6
 			if err := func() error {
 				v, err := d.Str()
 				s.ProjectID = string(v)
@@ -5781,7 +5727,7 @@ func (s *FlowDefinitionDetailResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"project_id\"")
 			}
 		case "schema_uri":
-			requiredBitSet[1] |= 1 << 0
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeURI(d)
 				s.SchemaURI = v
@@ -5793,7 +5739,7 @@ func (s *FlowDefinitionDetailResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"schema_uri\"")
 			}
 		case "status":
-			requiredBitSet[1] |= 1 << 1
+			requiredBitSet[1] |= 1 << 0
 			if err := func() error {
 				v, err := d.Str()
 				s.Status = string(v)
@@ -5805,7 +5751,7 @@ func (s *FlowDefinitionDetailResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "created_at":
-			requiredBitSet[1] |= 1 << 2
+			requiredBitSet[1] |= 1 << 1
 			if err := func() error {
 				v, err := json.DecodeDateTime(d)
 				s.CreatedAt = v
@@ -5817,7 +5763,7 @@ func (s *FlowDefinitionDetailResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"created_at\"")
 			}
 		case "updated_at":
-			requiredBitSet[1] |= 1 << 3
+			requiredBitSet[1] |= 1 << 2
 			if err := func() error {
 				v, err := json.DecodeDateTime(d)
 				s.UpdatedAt = v
@@ -5838,8 +5784,8 @@ func (s *FlowDefinitionDetailResponse) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
-		0b11101111,
-		0b00001111,
+		0b11110111,
+		0b00000111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -5886,14 +5832,14 @@ func (s *FlowDefinitionDetailResponse) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s FlowDefinitionDetailResponseInitialSteps) Encode(e *jx.Encoder) {
+func (s FlowDefinitionDetailResponsePurposes) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
 	e.ObjEnd()
 }
 
 // encodeFields implements json.Marshaler.
-func (s FlowDefinitionDetailResponseInitialSteps) encodeFields(e *jx.Encoder) {
+func (s FlowDefinitionDetailResponsePurposes) encodeFields(e *jx.Encoder) {
 	for k, elem := range s {
 		e.FieldStart(k)
 
@@ -5901,10 +5847,10 @@ func (s FlowDefinitionDetailResponseInitialSteps) encodeFields(e *jx.Encoder) {
 	}
 }
 
-// Decode decodes FlowDefinitionDetailResponseInitialSteps from json.
-func (s *FlowDefinitionDetailResponseInitialSteps) Decode(d *jx.Decoder) error {
+// Decode decodes FlowDefinitionDetailResponsePurposes from json.
+func (s *FlowDefinitionDetailResponsePurposes) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode FlowDefinitionDetailResponseInitialSteps to nil")
+		return errors.New("invalid: unable to decode FlowDefinitionDetailResponsePurposes to nil")
 	}
 	m := s.init()
 	var propertiesCount int
@@ -5924,7 +5870,7 @@ func (s *FlowDefinitionDetailResponseInitialSteps) Decode(d *jx.Decoder) error {
 		m[string(k)] = elem
 		return nil
 	}); err != nil {
-		return errors.Wrap(err, "decode FlowDefinitionDetailResponseInitialSteps")
+		return errors.Wrap(err, "decode FlowDefinitionDetailResponsePurposes")
 	}
 	// Validate properties count.
 	if err := (validate.Object{
@@ -5940,129 +5886,14 @@ func (s *FlowDefinitionDetailResponseInitialSteps) Decode(d *jx.Decoder) error {
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s FlowDefinitionDetailResponseInitialSteps) MarshalJSON() ([]byte, error) {
+func (s FlowDefinitionDetailResponsePurposes) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *FlowDefinitionDetailResponseInitialSteps) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes FlowDefinitionDetailResponsePurposesItem as json.
-func (s FlowDefinitionDetailResponsePurposesItem) Encode(e *jx.Encoder) {
-	e.Str(string(s))
-}
-
-// Decode decodes FlowDefinitionDetailResponsePurposesItem from json.
-func (s *FlowDefinitionDetailResponsePurposesItem) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode FlowDefinitionDetailResponsePurposesItem to nil")
-	}
-	v, err := d.StrBytes()
-	if err != nil {
-		return err
-	}
-	// Try to use constant string.
-	switch FlowDefinitionDetailResponsePurposesItem(v) {
-	case FlowDefinitionDetailResponsePurposesItemLogin:
-		*s = FlowDefinitionDetailResponsePurposesItemLogin
-	case FlowDefinitionDetailResponsePurposesItemRegister:
-		*s = FlowDefinitionDetailResponsePurposesItemRegister
-	case FlowDefinitionDetailResponsePurposesItemRecovery:
-		*s = FlowDefinitionDetailResponsePurposesItemRecovery
-	case FlowDefinitionDetailResponsePurposesItemProfiling:
-		*s = FlowDefinitionDetailResponsePurposesItemProfiling
-	case FlowDefinitionDetailResponsePurposesItemReauth:
-		*s = FlowDefinitionDetailResponsePurposesItemReauth
-	case FlowDefinitionDetailResponsePurposesItemLinkAccount:
-		*s = FlowDefinitionDetailResponsePurposesItemLinkAccount
-	default:
-		*s = FlowDefinitionDetailResponsePurposesItem(v)
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s FlowDefinitionDetailResponsePurposesItem) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *FlowDefinitionDetailResponsePurposesItem) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s FlowDefinitionInitialSteps) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s FlowDefinitionInitialSteps) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		e.Str(elem)
-	}
-}
-
-// Decode decodes FlowDefinitionInitialSteps from json.
-func (s *FlowDefinitionInitialSteps) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode FlowDefinitionInitialSteps to nil")
-	}
-	m := s.init()
-	var propertiesCount int
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		propertiesCount++
-		var elem string
-		if err := func() error {
-			v, err := d.Str()
-			elem = string(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode FlowDefinitionInitialSteps")
-	}
-	// Validate properties count.
-	if err := (validate.Object{
-		MinProperties:    1,
-		MinPropertiesSet: true,
-		MaxProperties:    0,
-		MaxPropertiesSet: false,
-	}).ValidateProperties(propertiesCount); err != nil {
-		return errors.Wrap(err, "object")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s FlowDefinitionInitialSteps) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *FlowDefinitionInitialSteps) UnmarshalJSON(data []byte) error {
+func (s *FlowDefinitionDetailResponsePurposes) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -6190,50 +6021,69 @@ func (s *FlowDefinitionListResponse) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes FlowDefinitionPurposesItem as json.
-func (s FlowDefinitionPurposesItem) Encode(e *jx.Encoder) {
-	e.Str(string(s))
+// Encode implements json.Marshaler.
+func (s FlowDefinitionPurposes) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
 }
 
-// Decode decodes FlowDefinitionPurposesItem from json.
-func (s *FlowDefinitionPurposesItem) Decode(d *jx.Decoder) error {
+// encodeFields implements json.Marshaler.
+func (s FlowDefinitionPurposes) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
+
+		e.Str(elem)
+	}
+}
+
+// Decode decodes FlowDefinitionPurposes from json.
+func (s *FlowDefinitionPurposes) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode FlowDefinitionPurposesItem to nil")
+		return errors.New("invalid: unable to decode FlowDefinitionPurposes to nil")
 	}
-	v, err := d.StrBytes()
-	if err != nil {
-		return err
+	m := s.init()
+	var propertiesCount int
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		propertiesCount++
+		var elem string
+		if err := func() error {
+			v, err := d.Str()
+			elem = string(v)
+			if err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode FlowDefinitionPurposes")
 	}
-	// Try to use constant string.
-	switch FlowDefinitionPurposesItem(v) {
-	case FlowDefinitionPurposesItemLogin:
-		*s = FlowDefinitionPurposesItemLogin
-	case FlowDefinitionPurposesItemRegister:
-		*s = FlowDefinitionPurposesItemRegister
-	case FlowDefinitionPurposesItemRecovery:
-		*s = FlowDefinitionPurposesItemRecovery
-	case FlowDefinitionPurposesItemProfiling:
-		*s = FlowDefinitionPurposesItemProfiling
-	case FlowDefinitionPurposesItemReauth:
-		*s = FlowDefinitionPurposesItemReauth
-	case FlowDefinitionPurposesItemLinkAccount:
-		*s = FlowDefinitionPurposesItemLinkAccount
-	default:
-		*s = FlowDefinitionPurposesItem(v)
+	// Validate properties count.
+	if err := (validate.Object{
+		MinProperties:    1,
+		MinPropertiesSet: true,
+		MaxProperties:    0,
+		MaxPropertiesSet: false,
+	}).ValidateProperties(propertiesCount); err != nil {
+		return errors.Wrap(err, "object")
 	}
 
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s FlowDefinitionPurposesItem) MarshalJSON() ([]byte, error) {
+func (s FlowDefinitionPurposes) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *FlowDefinitionPurposesItem) UnmarshalJSON(data []byte) error {
+func (s *FlowDefinitionPurposes) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -7086,19 +6936,9 @@ func (s *FlowDefinitionUpdateRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.Purposes != nil {
+		if s.Purposes.Set {
 			e.FieldStart("purposes")
-			e.ArrStart()
-			for _, elem := range s.Purposes {
-				elem.Encode(e)
-			}
-			e.ArrEnd()
-		}
-	}
-	{
-		if s.InitialSteps.Set {
-			e.FieldStart("initial_steps")
-			s.InitialSteps.Encode(e)
+			s.Purposes.Encode(e)
 		}
 	}
 	{
@@ -7119,12 +6959,11 @@ func (s *FlowDefinitionUpdateRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFlowDefinitionUpdateRequest = [5]string{
+var jsonFieldsNameOfFlowDefinitionUpdateRequest = [4]string{
 	0: "user_schema",
 	1: "purposes",
-	2: "initial_steps",
-	3: "audience",
-	4: "steps",
+	2: "audience",
+	3: "steps",
 }
 
 // Decode decodes FlowDefinitionUpdateRequest from json.
@@ -7147,30 +6986,13 @@ func (s *FlowDefinitionUpdateRequest) Decode(d *jx.Decoder) error {
 			}
 		case "purposes":
 			if err := func() error {
-				s.Purposes = make([]FlowDefinitionUpdateRequestPurposesItem, 0)
-				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem FlowDefinitionUpdateRequestPurposesItem
-					if err := elem.Decode(d); err != nil {
-						return err
-					}
-					s.Purposes = append(s.Purposes, elem)
-					return nil
-				}); err != nil {
+				s.Purposes.Reset()
+				if err := s.Purposes.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"purposes\"")
-			}
-		case "initial_steps":
-			if err := func() error {
-				s.InitialSteps.Reset()
-				if err := s.InitialSteps.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"initial_steps\"")
 			}
 		case "audience":
 			if err := func() error {
@@ -7224,14 +7046,14 @@ func (s *FlowDefinitionUpdateRequest) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s FlowDefinitionUpdateRequestInitialSteps) Encode(e *jx.Encoder) {
+func (s FlowDefinitionUpdateRequestPurposes) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
 	e.ObjEnd()
 }
 
 // encodeFields implements json.Marshaler.
-func (s FlowDefinitionUpdateRequestInitialSteps) encodeFields(e *jx.Encoder) {
+func (s FlowDefinitionUpdateRequestPurposes) encodeFields(e *jx.Encoder) {
 	for k, elem := range s {
 		e.FieldStart(k)
 
@@ -7239,10 +7061,10 @@ func (s FlowDefinitionUpdateRequestInitialSteps) encodeFields(e *jx.Encoder) {
 	}
 }
 
-// Decode decodes FlowDefinitionUpdateRequestInitialSteps from json.
-func (s *FlowDefinitionUpdateRequestInitialSteps) Decode(d *jx.Decoder) error {
+// Decode decodes FlowDefinitionUpdateRequestPurposes from json.
+func (s *FlowDefinitionUpdateRequestPurposes) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode FlowDefinitionUpdateRequestInitialSteps to nil")
+		return errors.New("invalid: unable to decode FlowDefinitionUpdateRequestPurposes to nil")
 	}
 	m := s.init()
 	var propertiesCount int
@@ -7262,7 +7084,7 @@ func (s *FlowDefinitionUpdateRequestInitialSteps) Decode(d *jx.Decoder) error {
 		m[string(k)] = elem
 		return nil
 	}); err != nil {
-		return errors.Wrap(err, "decode FlowDefinitionUpdateRequestInitialSteps")
+		return errors.Wrap(err, "decode FlowDefinitionUpdateRequestPurposes")
 	}
 	// Validate properties count.
 	if err := (validate.Object{
@@ -7278,62 +7100,14 @@ func (s *FlowDefinitionUpdateRequestInitialSteps) Decode(d *jx.Decoder) error {
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s FlowDefinitionUpdateRequestInitialSteps) MarshalJSON() ([]byte, error) {
+func (s FlowDefinitionUpdateRequestPurposes) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *FlowDefinitionUpdateRequestInitialSteps) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes FlowDefinitionUpdateRequestPurposesItem as json.
-func (s FlowDefinitionUpdateRequestPurposesItem) Encode(e *jx.Encoder) {
-	e.Str(string(s))
-}
-
-// Decode decodes FlowDefinitionUpdateRequestPurposesItem from json.
-func (s *FlowDefinitionUpdateRequestPurposesItem) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode FlowDefinitionUpdateRequestPurposesItem to nil")
-	}
-	v, err := d.StrBytes()
-	if err != nil {
-		return err
-	}
-	// Try to use constant string.
-	switch FlowDefinitionUpdateRequestPurposesItem(v) {
-	case FlowDefinitionUpdateRequestPurposesItemLogin:
-		*s = FlowDefinitionUpdateRequestPurposesItemLogin
-	case FlowDefinitionUpdateRequestPurposesItemRegister:
-		*s = FlowDefinitionUpdateRequestPurposesItemRegister
-	case FlowDefinitionUpdateRequestPurposesItemRecovery:
-		*s = FlowDefinitionUpdateRequestPurposesItemRecovery
-	case FlowDefinitionUpdateRequestPurposesItemProfiling:
-		*s = FlowDefinitionUpdateRequestPurposesItemProfiling
-	case FlowDefinitionUpdateRequestPurposesItemReauth:
-		*s = FlowDefinitionUpdateRequestPurposesItemReauth
-	case FlowDefinitionUpdateRequestPurposesItemLinkAccount:
-		*s = FlowDefinitionUpdateRequestPurposesItemLinkAccount
-	default:
-		*s = FlowDefinitionUpdateRequestPurposesItem(v)
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s FlowDefinitionUpdateRequestPurposesItem) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *FlowDefinitionUpdateRequestPurposesItem) UnmarshalJSON(data []byte) error {
+func (s *FlowDefinitionUpdateRequestPurposes) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -14026,21 +13800,21 @@ func (s *OptFlowDefinitionStepTransitions) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes FlowDefinitionUpdateRequestInitialSteps as json.
-func (o OptFlowDefinitionUpdateRequestInitialSteps) Encode(e *jx.Encoder) {
+// Encode encodes FlowDefinitionUpdateRequestPurposes as json.
+func (o OptFlowDefinitionUpdateRequestPurposes) Encode(e *jx.Encoder) {
 	if !o.Set {
 		return
 	}
 	o.Value.Encode(e)
 }
 
-// Decode decodes FlowDefinitionUpdateRequestInitialSteps from json.
-func (o *OptFlowDefinitionUpdateRequestInitialSteps) Decode(d *jx.Decoder) error {
+// Decode decodes FlowDefinitionUpdateRequestPurposes from json.
+func (o *OptFlowDefinitionUpdateRequestPurposes) Decode(d *jx.Decoder) error {
 	if o == nil {
-		return errors.New("invalid: unable to decode OptFlowDefinitionUpdateRequestInitialSteps to nil")
+		return errors.New("invalid: unable to decode OptFlowDefinitionUpdateRequestPurposes to nil")
 	}
 	o.Set = true
-	o.Value = make(FlowDefinitionUpdateRequestInitialSteps)
+	o.Value = make(FlowDefinitionUpdateRequestPurposes)
 	if err := o.Value.Decode(d); err != nil {
 		return err
 	}
@@ -14048,14 +13822,14 @@ func (o *OptFlowDefinitionUpdateRequestInitialSteps) Decode(d *jx.Decoder) error
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s OptFlowDefinitionUpdateRequestInitialSteps) MarshalJSON() ([]byte, error) {
+func (s OptFlowDefinitionUpdateRequestPurposes) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptFlowDefinitionUpdateRequestInitialSteps) UnmarshalJSON(data []byte) error {
+func (s *OptFlowDefinitionUpdateRequestPurposes) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -2397,13 +2397,12 @@ type FlowDefinition struct {
 	// defined in this schema. The engine resolves field types, validation,
 	// and implicit outcomes from schema annotations at runtime.
 	UserSchema url.URL `json:"user_schema"`
-	// Which flow purposes this definition handles. A definition can serve
-	// multiple purposes (e.g. a combined login/register flow).
-	Purposes []FlowDefinitionPurposesItem `json:"purposes"`
-	// Maps each purpose to the step name that starts the flow for that purpose.
-	// Keys must be a subset of `purposes`.
-	InitialSteps FlowDefinitionInitialSteps `json:"initial_steps"`
-	Audience     OptFlowAudience            `json:"audience"`
+	// Maps each purpose this definition handles to its entry-point step.
+	// Keys are purpose names; values must match a `name` in `steps`. A
+	// definition can serve multiple purposes (e.g. a combined login/register
+	// flow) by listing one entry per purpose.
+	Purposes FlowDefinitionPurposes `json:"purposes"`
+	Audience OptFlowAudience        `json:"audience"`
 	// Ordered list of steps in this flow. The order is for human readability —
 	// actual step sequencing is determined by transitions.
 	Steps []FlowDefinitionStep `json:"steps"`
@@ -2420,13 +2419,8 @@ func (s *FlowDefinition) GetUserSchema() url.URL {
 }
 
 // GetPurposes returns the value of Purposes.
-func (s *FlowDefinition) GetPurposes() []FlowDefinitionPurposesItem {
+func (s *FlowDefinition) GetPurposes() FlowDefinitionPurposes {
 	return s.Purposes
-}
-
-// GetInitialSteps returns the value of InitialSteps.
-func (s *FlowDefinition) GetInitialSteps() FlowDefinitionInitialSteps {
-	return s.InitialSteps
 }
 
 // GetAudience returns the value of Audience.
@@ -2450,13 +2444,8 @@ func (s *FlowDefinition) SetUserSchema(val url.URL) {
 }
 
 // SetPurposes sets the value of Purposes.
-func (s *FlowDefinition) SetPurposes(val []FlowDefinitionPurposesItem) {
+func (s *FlowDefinition) SetPurposes(val FlowDefinitionPurposes) {
 	s.Purposes = val
-}
-
-// SetInitialSteps sets the value of InitialSteps.
-func (s *FlowDefinition) SetInitialSteps(val FlowDefinitionInitialSteps) {
-	s.InitialSteps = val
 }
 
 // SetAudience sets the value of Audience.
@@ -2518,13 +2507,12 @@ type FlowDefinitionDetailResponse struct {
 	// defined in this schema. The engine resolves field types, validation,
 	// and implicit outcomes from schema annotations at runtime.
 	UserSchema url.URL `json:"user_schema"`
-	// Which flow purposes this definition handles. A definition can serve
-	// multiple purposes (e.g. a combined login/register flow).
-	Purposes []FlowDefinitionDetailResponsePurposesItem `json:"purposes"`
-	// Maps each purpose to the step name that starts the flow for that purpose.
-	// Keys must be a subset of `purposes`.
-	InitialSteps FlowDefinitionDetailResponseInitialSteps `json:"initial_steps"`
-	Audience     OptFlowAudience                          `json:"audience"`
+	// Maps each purpose this definition handles to its entry-point step.
+	// Keys are purpose names; values must match a `name` in `steps`. A
+	// definition can serve multiple purposes (e.g. a combined login/register
+	// flow) by listing one entry per purpose.
+	Purposes FlowDefinitionDetailResponsePurposes `json:"purposes"`
+	Audience OptFlowAudience                      `json:"audience"`
 	// Ordered list of steps in this flow. The order is for human readability —
 	// actual step sequencing is determined by transitions.
 	Steps []FlowDefinitionStep `json:"steps"`
@@ -2553,13 +2541,8 @@ func (s *FlowDefinitionDetailResponse) GetUserSchema() url.URL {
 }
 
 // GetPurposes returns the value of Purposes.
-func (s *FlowDefinitionDetailResponse) GetPurposes() []FlowDefinitionDetailResponsePurposesItem {
+func (s *FlowDefinitionDetailResponse) GetPurposes() FlowDefinitionDetailResponsePurposes {
 	return s.Purposes
-}
-
-// GetInitialSteps returns the value of InitialSteps.
-func (s *FlowDefinitionDetailResponse) GetInitialSteps() FlowDefinitionDetailResponseInitialSteps {
-	return s.InitialSteps
 }
 
 // GetAudience returns the value of Audience.
@@ -2613,13 +2596,8 @@ func (s *FlowDefinitionDetailResponse) SetUserSchema(val url.URL) {
 }
 
 // SetPurposes sets the value of Purposes.
-func (s *FlowDefinitionDetailResponse) SetPurposes(val []FlowDefinitionDetailResponsePurposesItem) {
+func (s *FlowDefinitionDetailResponse) SetPurposes(val FlowDefinitionDetailResponsePurposes) {
 	s.Purposes = val
-}
-
-// SetInitialSteps sets the value of InitialSteps.
-func (s *FlowDefinitionDetailResponse) SetInitialSteps(val FlowDefinitionDetailResponseInitialSteps) {
-	s.InitialSteps = val
 }
 
 // SetAudience sets the value of Audience.
@@ -2666,93 +2644,13 @@ func (*FlowDefinitionDetailResponse) createFlowDefinitionRes() {}
 func (*FlowDefinitionDetailResponse) getFlowDefinitionRes()    {}
 func (*FlowDefinitionDetailResponse) updateFlowDefinitionRes() {}
 
-// Maps each purpose to the step name that starts the flow for that purpose.
-// Keys must be a subset of `purposes`.
-type FlowDefinitionDetailResponseInitialSteps map[string]string
+// Maps each purpose this definition handles to its entry-point step.
+// Keys are purpose names; values must match a `name` in `steps`. A
+// definition can serve multiple purposes (e.g. a combined login/register
+// flow) by listing one entry per purpose.
+type FlowDefinitionDetailResponsePurposes map[string]string
 
-func (s *FlowDefinitionDetailResponseInitialSteps) init() FlowDefinitionDetailResponseInitialSteps {
-	m := *s
-	if m == nil {
-		m = map[string]string{}
-		*s = m
-	}
-	return m
-}
-
-type FlowDefinitionDetailResponsePurposesItem string
-
-const (
-	FlowDefinitionDetailResponsePurposesItemLogin       FlowDefinitionDetailResponsePurposesItem = "login"
-	FlowDefinitionDetailResponsePurposesItemRegister    FlowDefinitionDetailResponsePurposesItem = "register"
-	FlowDefinitionDetailResponsePurposesItemRecovery    FlowDefinitionDetailResponsePurposesItem = "recovery"
-	FlowDefinitionDetailResponsePurposesItemProfiling   FlowDefinitionDetailResponsePurposesItem = "profiling"
-	FlowDefinitionDetailResponsePurposesItemReauth      FlowDefinitionDetailResponsePurposesItem = "reauth"
-	FlowDefinitionDetailResponsePurposesItemLinkAccount FlowDefinitionDetailResponsePurposesItem = "link_account"
-)
-
-// AllValues returns all FlowDefinitionDetailResponsePurposesItem values.
-func (FlowDefinitionDetailResponsePurposesItem) AllValues() []FlowDefinitionDetailResponsePurposesItem {
-	return []FlowDefinitionDetailResponsePurposesItem{
-		FlowDefinitionDetailResponsePurposesItemLogin,
-		FlowDefinitionDetailResponsePurposesItemRegister,
-		FlowDefinitionDetailResponsePurposesItemRecovery,
-		FlowDefinitionDetailResponsePurposesItemProfiling,
-		FlowDefinitionDetailResponsePurposesItemReauth,
-		FlowDefinitionDetailResponsePurposesItemLinkAccount,
-	}
-}
-
-// MarshalText implements encoding.TextMarshaler.
-func (s FlowDefinitionDetailResponsePurposesItem) MarshalText() ([]byte, error) {
-	switch s {
-	case FlowDefinitionDetailResponsePurposesItemLogin:
-		return []byte(s), nil
-	case FlowDefinitionDetailResponsePurposesItemRegister:
-		return []byte(s), nil
-	case FlowDefinitionDetailResponsePurposesItemRecovery:
-		return []byte(s), nil
-	case FlowDefinitionDetailResponsePurposesItemProfiling:
-		return []byte(s), nil
-	case FlowDefinitionDetailResponsePurposesItemReauth:
-		return []byte(s), nil
-	case FlowDefinitionDetailResponsePurposesItemLinkAccount:
-		return []byte(s), nil
-	default:
-		return nil, errors.Errorf("invalid value: %q", s)
-	}
-}
-
-// UnmarshalText implements encoding.TextUnmarshaler.
-func (s *FlowDefinitionDetailResponsePurposesItem) UnmarshalText(data []byte) error {
-	switch FlowDefinitionDetailResponsePurposesItem(data) {
-	case FlowDefinitionDetailResponsePurposesItemLogin:
-		*s = FlowDefinitionDetailResponsePurposesItemLogin
-		return nil
-	case FlowDefinitionDetailResponsePurposesItemRegister:
-		*s = FlowDefinitionDetailResponsePurposesItemRegister
-		return nil
-	case FlowDefinitionDetailResponsePurposesItemRecovery:
-		*s = FlowDefinitionDetailResponsePurposesItemRecovery
-		return nil
-	case FlowDefinitionDetailResponsePurposesItemProfiling:
-		*s = FlowDefinitionDetailResponsePurposesItemProfiling
-		return nil
-	case FlowDefinitionDetailResponsePurposesItemReauth:
-		*s = FlowDefinitionDetailResponsePurposesItemReauth
-		return nil
-	case FlowDefinitionDetailResponsePurposesItemLinkAccount:
-		*s = FlowDefinitionDetailResponsePurposesItemLinkAccount
-		return nil
-	default:
-		return errors.Errorf("invalid value: %q", data)
-	}
-}
-
-// Maps each purpose to the step name that starts the flow for that purpose.
-// Keys must be a subset of `purposes`.
-type FlowDefinitionInitialSteps map[string]string
-
-func (s *FlowDefinitionInitialSteps) init() FlowDefinitionInitialSteps {
+func (s *FlowDefinitionDetailResponsePurposes) init() FlowDefinitionDetailResponsePurposes {
 	m := *s
 	if m == nil {
 		m = map[string]string{}
@@ -2790,73 +2688,19 @@ func (s *FlowDefinitionListResponse) SetNextPageToken(val OptNilPageToken) {
 
 func (*FlowDefinitionListResponse) listFlowDefinitionsRes() {}
 
-type FlowDefinitionPurposesItem string
+// Maps each purpose this definition handles to its entry-point step.
+// Keys are purpose names; values must match a `name` in `steps`. A
+// definition can serve multiple purposes (e.g. a combined login/register
+// flow) by listing one entry per purpose.
+type FlowDefinitionPurposes map[string]string
 
-const (
-	FlowDefinitionPurposesItemLogin       FlowDefinitionPurposesItem = "login"
-	FlowDefinitionPurposesItemRegister    FlowDefinitionPurposesItem = "register"
-	FlowDefinitionPurposesItemRecovery    FlowDefinitionPurposesItem = "recovery"
-	FlowDefinitionPurposesItemProfiling   FlowDefinitionPurposesItem = "profiling"
-	FlowDefinitionPurposesItemReauth      FlowDefinitionPurposesItem = "reauth"
-	FlowDefinitionPurposesItemLinkAccount FlowDefinitionPurposesItem = "link_account"
-)
-
-// AllValues returns all FlowDefinitionPurposesItem values.
-func (FlowDefinitionPurposesItem) AllValues() []FlowDefinitionPurposesItem {
-	return []FlowDefinitionPurposesItem{
-		FlowDefinitionPurposesItemLogin,
-		FlowDefinitionPurposesItemRegister,
-		FlowDefinitionPurposesItemRecovery,
-		FlowDefinitionPurposesItemProfiling,
-		FlowDefinitionPurposesItemReauth,
-		FlowDefinitionPurposesItemLinkAccount,
+func (s *FlowDefinitionPurposes) init() FlowDefinitionPurposes {
+	m := *s
+	if m == nil {
+		m = map[string]string{}
+		*s = m
 	}
-}
-
-// MarshalText implements encoding.TextMarshaler.
-func (s FlowDefinitionPurposesItem) MarshalText() ([]byte, error) {
-	switch s {
-	case FlowDefinitionPurposesItemLogin:
-		return []byte(s), nil
-	case FlowDefinitionPurposesItemRegister:
-		return []byte(s), nil
-	case FlowDefinitionPurposesItemRecovery:
-		return []byte(s), nil
-	case FlowDefinitionPurposesItemProfiling:
-		return []byte(s), nil
-	case FlowDefinitionPurposesItemReauth:
-		return []byte(s), nil
-	case FlowDefinitionPurposesItemLinkAccount:
-		return []byte(s), nil
-	default:
-		return nil, errors.Errorf("invalid value: %q", s)
-	}
-}
-
-// UnmarshalText implements encoding.TextUnmarshaler.
-func (s *FlowDefinitionPurposesItem) UnmarshalText(data []byte) error {
-	switch FlowDefinitionPurposesItem(data) {
-	case FlowDefinitionPurposesItemLogin:
-		*s = FlowDefinitionPurposesItemLogin
-		return nil
-	case FlowDefinitionPurposesItemRegister:
-		*s = FlowDefinitionPurposesItemRegister
-		return nil
-	case FlowDefinitionPurposesItemRecovery:
-		*s = FlowDefinitionPurposesItemRecovery
-		return nil
-	case FlowDefinitionPurposesItemProfiling:
-		*s = FlowDefinitionPurposesItemProfiling
-		return nil
-	case FlowDefinitionPurposesItemReauth:
-		*s = FlowDefinitionPurposesItemReauth
-		return nil
-	case FlowDefinitionPurposesItemLinkAccount:
-		*s = FlowDefinitionPurposesItemLinkAccount
-		return nil
-	default:
-		return errors.Errorf("invalid value: %q", data)
-	}
+	return m
 }
 
 // Response object for a flow definition after creation.
@@ -3287,20 +3131,18 @@ func (s *FlowDefinitionStepTransitionsItemAction) UnmarshalText(data []byte) err
 
 // Partial update for a flow definition. Only provided fields are replaced;
 // omitted fields retain their current server-side values.
-// Array fields (`steps`, `purposes`, `initial_steps`) are treated atomically:
-// if provided, the entire array/object is replaced. If omitted, the current
+// Collection fields (`steps`, `purposes`) are treated atomically: if
+// provided, the entire array/object is replaced. If omitted, the current
 // value is preserved unchanged.
 // `name` is a stable identifier and cannot be changed after creation.
 // Ref: #
 type FlowDefinitionUpdateRequest struct {
 	// User schema this flow operates on. Replaces the current value if provided.
 	UserSchema OptURI `json:"user_schema"`
-	// Replaces the full list of purposes this definition handles if provided.
-	Purposes []FlowDefinitionUpdateRequestPurposesItem `json:"purposes"`
-	// Replaces the full map of purpose-to-initial-step if provided.
-	// Keys must be a subset of `purposes`.
-	InitialSteps OptFlowDefinitionUpdateRequestInitialSteps `json:"initial_steps"`
-	Audience     OptFlowAudience                            `json:"audience"`
+	// Replaces the full purpose-to-entry-step map if provided. Keys are
+	// purpose names; values must match a `name` in `steps`.
+	Purposes OptFlowDefinitionUpdateRequestPurposes `json:"purposes"`
+	Audience OptFlowAudience                        `json:"audience"`
 	// Replaces the full steps array if provided. Partial step lists are not
 	// supported — supply all steps when updating this field.
 	Steps []FlowDefinitionStep `json:"steps"`
@@ -3312,13 +3154,8 @@ func (s *FlowDefinitionUpdateRequest) GetUserSchema() OptURI {
 }
 
 // GetPurposes returns the value of Purposes.
-func (s *FlowDefinitionUpdateRequest) GetPurposes() []FlowDefinitionUpdateRequestPurposesItem {
+func (s *FlowDefinitionUpdateRequest) GetPurposes() OptFlowDefinitionUpdateRequestPurposes {
 	return s.Purposes
-}
-
-// GetInitialSteps returns the value of InitialSteps.
-func (s *FlowDefinitionUpdateRequest) GetInitialSteps() OptFlowDefinitionUpdateRequestInitialSteps {
-	return s.InitialSteps
 }
 
 // GetAudience returns the value of Audience.
@@ -3337,13 +3174,8 @@ func (s *FlowDefinitionUpdateRequest) SetUserSchema(val OptURI) {
 }
 
 // SetPurposes sets the value of Purposes.
-func (s *FlowDefinitionUpdateRequest) SetPurposes(val []FlowDefinitionUpdateRequestPurposesItem) {
+func (s *FlowDefinitionUpdateRequest) SetPurposes(val OptFlowDefinitionUpdateRequestPurposes) {
 	s.Purposes = val
-}
-
-// SetInitialSteps sets the value of InitialSteps.
-func (s *FlowDefinitionUpdateRequest) SetInitialSteps(val OptFlowDefinitionUpdateRequestInitialSteps) {
-	s.InitialSteps = val
 }
 
 // SetAudience sets the value of Audience.
@@ -3356,86 +3188,17 @@ func (s *FlowDefinitionUpdateRequest) SetSteps(val []FlowDefinitionStep) {
 	s.Steps = val
 }
 
-// Replaces the full map of purpose-to-initial-step if provided.
-// Keys must be a subset of `purposes`.
-type FlowDefinitionUpdateRequestInitialSteps map[string]string
+// Replaces the full purpose-to-entry-step map if provided. Keys are
+// purpose names; values must match a `name` in `steps`.
+type FlowDefinitionUpdateRequestPurposes map[string]string
 
-func (s *FlowDefinitionUpdateRequestInitialSteps) init() FlowDefinitionUpdateRequestInitialSteps {
+func (s *FlowDefinitionUpdateRequestPurposes) init() FlowDefinitionUpdateRequestPurposes {
 	m := *s
 	if m == nil {
 		m = map[string]string{}
 		*s = m
 	}
 	return m
-}
-
-type FlowDefinitionUpdateRequestPurposesItem string
-
-const (
-	FlowDefinitionUpdateRequestPurposesItemLogin       FlowDefinitionUpdateRequestPurposesItem = "login"
-	FlowDefinitionUpdateRequestPurposesItemRegister    FlowDefinitionUpdateRequestPurposesItem = "register"
-	FlowDefinitionUpdateRequestPurposesItemRecovery    FlowDefinitionUpdateRequestPurposesItem = "recovery"
-	FlowDefinitionUpdateRequestPurposesItemProfiling   FlowDefinitionUpdateRequestPurposesItem = "profiling"
-	FlowDefinitionUpdateRequestPurposesItemReauth      FlowDefinitionUpdateRequestPurposesItem = "reauth"
-	FlowDefinitionUpdateRequestPurposesItemLinkAccount FlowDefinitionUpdateRequestPurposesItem = "link_account"
-)
-
-// AllValues returns all FlowDefinitionUpdateRequestPurposesItem values.
-func (FlowDefinitionUpdateRequestPurposesItem) AllValues() []FlowDefinitionUpdateRequestPurposesItem {
-	return []FlowDefinitionUpdateRequestPurposesItem{
-		FlowDefinitionUpdateRequestPurposesItemLogin,
-		FlowDefinitionUpdateRequestPurposesItemRegister,
-		FlowDefinitionUpdateRequestPurposesItemRecovery,
-		FlowDefinitionUpdateRequestPurposesItemProfiling,
-		FlowDefinitionUpdateRequestPurposesItemReauth,
-		FlowDefinitionUpdateRequestPurposesItemLinkAccount,
-	}
-}
-
-// MarshalText implements encoding.TextMarshaler.
-func (s FlowDefinitionUpdateRequestPurposesItem) MarshalText() ([]byte, error) {
-	switch s {
-	case FlowDefinitionUpdateRequestPurposesItemLogin:
-		return []byte(s), nil
-	case FlowDefinitionUpdateRequestPurposesItemRegister:
-		return []byte(s), nil
-	case FlowDefinitionUpdateRequestPurposesItemRecovery:
-		return []byte(s), nil
-	case FlowDefinitionUpdateRequestPurposesItemProfiling:
-		return []byte(s), nil
-	case FlowDefinitionUpdateRequestPurposesItemReauth:
-		return []byte(s), nil
-	case FlowDefinitionUpdateRequestPurposesItemLinkAccount:
-		return []byte(s), nil
-	default:
-		return nil, errors.Errorf("invalid value: %q", s)
-	}
-}
-
-// UnmarshalText implements encoding.TextUnmarshaler.
-func (s *FlowDefinitionUpdateRequestPurposesItem) UnmarshalText(data []byte) error {
-	switch FlowDefinitionUpdateRequestPurposesItem(data) {
-	case FlowDefinitionUpdateRequestPurposesItemLogin:
-		*s = FlowDefinitionUpdateRequestPurposesItemLogin
-		return nil
-	case FlowDefinitionUpdateRequestPurposesItemRegister:
-		*s = FlowDefinitionUpdateRequestPurposesItemRegister
-		return nil
-	case FlowDefinitionUpdateRequestPurposesItemRecovery:
-		*s = FlowDefinitionUpdateRequestPurposesItemRecovery
-		return nil
-	case FlowDefinitionUpdateRequestPurposesItemProfiling:
-		*s = FlowDefinitionUpdateRequestPurposesItemProfiling
-		return nil
-	case FlowDefinitionUpdateRequestPurposesItemReauth:
-		*s = FlowDefinitionUpdateRequestPurposesItemReauth
-		return nil
-	case FlowDefinitionUpdateRequestPurposesItemLinkAccount:
-		*s = FlowDefinitionUpdateRequestPurposesItemLinkAccount
-		return nil
-	default:
-		return errors.Errorf("invalid value: %q", data)
-	}
 }
 
 // Ref: #
@@ -7591,38 +7354,38 @@ func (o OptFlowDefinitionStepTransitions) Or(d FlowDefinitionStepTransitions) Fl
 	return d
 }
 
-// NewOptFlowDefinitionUpdateRequestInitialSteps returns new OptFlowDefinitionUpdateRequestInitialSteps with value set to v.
-func NewOptFlowDefinitionUpdateRequestInitialSteps(v FlowDefinitionUpdateRequestInitialSteps) OptFlowDefinitionUpdateRequestInitialSteps {
-	return OptFlowDefinitionUpdateRequestInitialSteps{
+// NewOptFlowDefinitionUpdateRequestPurposes returns new OptFlowDefinitionUpdateRequestPurposes with value set to v.
+func NewOptFlowDefinitionUpdateRequestPurposes(v FlowDefinitionUpdateRequestPurposes) OptFlowDefinitionUpdateRequestPurposes {
+	return OptFlowDefinitionUpdateRequestPurposes{
 		Value: v,
 		Set:   true,
 	}
 }
 
-// OptFlowDefinitionUpdateRequestInitialSteps is optional FlowDefinitionUpdateRequestInitialSteps.
-type OptFlowDefinitionUpdateRequestInitialSteps struct {
-	Value FlowDefinitionUpdateRequestInitialSteps
+// OptFlowDefinitionUpdateRequestPurposes is optional FlowDefinitionUpdateRequestPurposes.
+type OptFlowDefinitionUpdateRequestPurposes struct {
+	Value FlowDefinitionUpdateRequestPurposes
 	Set   bool
 }
 
-// IsSet returns true if OptFlowDefinitionUpdateRequestInitialSteps was set.
-func (o OptFlowDefinitionUpdateRequestInitialSteps) IsSet() bool { return o.Set }
+// IsSet returns true if OptFlowDefinitionUpdateRequestPurposes was set.
+func (o OptFlowDefinitionUpdateRequestPurposes) IsSet() bool { return o.Set }
 
 // Reset unsets value.
-func (o *OptFlowDefinitionUpdateRequestInitialSteps) Reset() {
-	var v FlowDefinitionUpdateRequestInitialSteps
+func (o *OptFlowDefinitionUpdateRequestPurposes) Reset() {
+	var v FlowDefinitionUpdateRequestPurposes
 	o.Value = v
 	o.Set = false
 }
 
 // SetTo sets value to v.
-func (o *OptFlowDefinitionUpdateRequestInitialSteps) SetTo(v FlowDefinitionUpdateRequestInitialSteps) {
+func (o *OptFlowDefinitionUpdateRequestPurposes) SetTo(v FlowDefinitionUpdateRequestPurposes) {
 	o.Set = true
 	o.Value = v
 }
 
 // Get returns value and boolean that denotes whether value was set.
-func (o OptFlowDefinitionUpdateRequestInitialSteps) Get() (v FlowDefinitionUpdateRequestInitialSteps, ok bool) {
+func (o OptFlowDefinitionUpdateRequestPurposes) Get() (v FlowDefinitionUpdateRequestPurposes, ok bool) {
 	if !o.Set {
 		return v, false
 	}
@@ -7630,7 +7393,7 @@ func (o OptFlowDefinitionUpdateRequestInitialSteps) Get() (v FlowDefinitionUpdat
 }
 
 // Or returns value if set, or given parameter if does not.
-func (o OptFlowDefinitionUpdateRequestInitialSteps) Or(d FlowDefinitionUpdateRequestInitialSteps) FlowDefinitionUpdateRequestInitialSteps {
+func (o OptFlowDefinitionUpdateRequestPurposes) Or(d FlowDefinitionUpdateRequestPurposes) FlowDefinitionUpdateRequestPurposes {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -2348,14 +2348,15 @@ func (s *FieldValidation) SetMaxLength(val OptInt) {
 	s.MaxLength = val
 }
 
-// Scopes which teams, apps, or projects this flow definition applies to.
-// When all fields are empty/omitted, the definition is a project-wide default.
-// The engine picks the most specific matching definition: app > team > project.
+// Scopes which teams or apps this flow definition applies to. Empty or
+// omitted fields mean "no restriction"; when both are empty the definition
+// matches every request in the project. The engine picks the most specific
+// matching definition: app > team > project-wide.
 // Ref: #
 type FlowAudience struct {
-	// Restrict to specific teams (organizations).
+	// Restrict to specific teams (organizations). Empty means no team restriction.
 	TeamIds []string `json:"team_ids"`
-	// Restrict to specific applications.
+	// Restrict to specific applications. Empty means no app restriction.
 	AppIds []string `json:"app_ids"`
 }
 

--- a/api/generated/oas_validators_gen.go
+++ b/api/generated/oas_validators_gen.go
@@ -749,52 +749,13 @@ func (s *FlowDefinition) Validate() error {
 		})
 	}
 	if err := func() error {
-		if s.Purposes == nil {
-			return errors.New("nil is invalid value")
-		}
-		if err := (validate.Array{
-			MinLength:    1,
-			MinLengthSet: true,
-			MaxLength:    0,
-			MaxLengthSet: false,
-		}).ValidateLength(len(s.Purposes)); err != nil {
-			return errors.Wrap(err, "array")
-		}
-		if err := validate.UniqueItems(s.Purposes); err != nil {
-			return errors.Wrap(err, "array")
-		}
-		var failures []validate.FieldError
-		for i, elem := range s.Purposes {
-			if err := func() error {
-				if err := elem.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				failures = append(failures, validate.FieldError{
-					Name:  fmt.Sprintf("[%d]", i),
-					Error: err,
-				})
-			}
-		}
-		if len(failures) > 0 {
-			return &validate.Error{Fields: failures}
-		}
-		return nil
-	}(); err != nil {
-		failures = append(failures, validate.FieldError{
-			Name:  "purposes",
-			Error: err,
-		})
-	}
-	if err := func() error {
-		if err := s.InitialSteps.Validate(); err != nil {
+		if err := s.Purposes.Validate(); err != nil {
 			return err
 		}
 		return nil
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
-			Name:  "initial_steps",
+			Name:  "purposes",
 			Error: err,
 		})
 	}
@@ -904,52 +865,13 @@ func (s *FlowDefinitionDetailResponse) Validate() error {
 		})
 	}
 	if err := func() error {
-		if s.Purposes == nil {
-			return errors.New("nil is invalid value")
-		}
-		if err := (validate.Array{
-			MinLength:    1,
-			MinLengthSet: true,
-			MaxLength:    0,
-			MaxLengthSet: false,
-		}).ValidateLength(len(s.Purposes)); err != nil {
-			return errors.Wrap(err, "array")
-		}
-		if err := validate.UniqueItems(s.Purposes); err != nil {
-			return errors.Wrap(err, "array")
-		}
-		var failures []validate.FieldError
-		for i, elem := range s.Purposes {
-			if err := func() error {
-				if err := elem.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				failures = append(failures, validate.FieldError{
-					Name:  fmt.Sprintf("[%d]", i),
-					Error: err,
-				})
-			}
-		}
-		if len(failures) > 0 {
-			return &validate.Error{Fields: failures}
-		}
-		return nil
-	}(); err != nil {
-		failures = append(failures, validate.FieldError{
-			Name:  "purposes",
-			Error: err,
-		})
-	}
-	if err := func() error {
-		if err := s.InitialSteps.Validate(); err != nil {
+		if err := s.Purposes.Validate(); err != nil {
 			return err
 		}
 		return nil
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
-			Name:  "initial_steps",
+			Name:  "purposes",
 			Error: err,
 		})
 	}
@@ -995,35 +917,7 @@ func (s *FlowDefinitionDetailResponse) Validate() error {
 	return nil
 }
 
-func (s FlowDefinitionDetailResponseInitialSteps) Validate() error {
-	var failures []validate.FieldError
-
-	if len(failures) > 0 {
-		return &validate.Error{Fields: failures}
-	}
-	return nil
-}
-
-func (s FlowDefinitionDetailResponsePurposesItem) Validate() error {
-	switch s {
-	case "login":
-		return nil
-	case "register":
-		return nil
-	case "recovery":
-		return nil
-	case "profiling":
-		return nil
-	case "reauth":
-		return nil
-	case "link_account":
-		return nil
-	default:
-		return errors.Errorf("invalid value: %v", s)
-	}
-}
-
-func (s FlowDefinitionInitialSteps) Validate() error {
+func (s FlowDefinitionDetailResponsePurposes) Validate() error {
 	var failures []validate.FieldError
 
 	if len(failures) > 0 {
@@ -1072,23 +966,13 @@ func (s *FlowDefinitionListResponse) Validate() error {
 	return nil
 }
 
-func (s FlowDefinitionPurposesItem) Validate() error {
-	switch s {
-	case "login":
-		return nil
-	case "register":
-		return nil
-	case "recovery":
-		return nil
-	case "profiling":
-		return nil
-	case "reauth":
-		return nil
-	case "link_account":
-		return nil
-	default:
-		return errors.Errorf("invalid value: %v", s)
+func (s FlowDefinitionPurposes) Validate() error {
+	var failures []validate.FieldError
+
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
 	}
+	return nil
 }
 
 func (s *FlowDefinitionResponse) Validate() error {
@@ -1324,46 +1208,7 @@ func (s *FlowDefinitionUpdateRequest) Validate() error {
 
 	var failures []validate.FieldError
 	if err := func() error {
-		if s.Purposes == nil {
-			return nil // optional
-		}
-		if err := (validate.Array{
-			MinLength:    1,
-			MinLengthSet: true,
-			MaxLength:    0,
-			MaxLengthSet: false,
-		}).ValidateLength(len(s.Purposes)); err != nil {
-			return errors.Wrap(err, "array")
-		}
-		if err := validate.UniqueItems(s.Purposes); err != nil {
-			return errors.Wrap(err, "array")
-		}
-		var failures []validate.FieldError
-		for i, elem := range s.Purposes {
-			if err := func() error {
-				if err := elem.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				failures = append(failures, validate.FieldError{
-					Name:  fmt.Sprintf("[%d]", i),
-					Error: err,
-				})
-			}
-		}
-		if len(failures) > 0 {
-			return &validate.Error{Fields: failures}
-		}
-		return nil
-	}(); err != nil {
-		failures = append(failures, validate.FieldError{
-			Name:  "purposes",
-			Error: err,
-		})
-	}
-	if err := func() error {
-		if value, ok := s.InitialSteps.Get(); ok {
+		if value, ok := s.Purposes.Get(); ok {
 			if err := func() error {
 				if err := value.Validate(); err != nil {
 					return err
@@ -1376,7 +1221,7 @@ func (s *FlowDefinitionUpdateRequest) Validate() error {
 		return nil
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
-			Name:  "initial_steps",
+			Name:  "purposes",
 			Error: err,
 		})
 	}
@@ -1422,32 +1267,13 @@ func (s *FlowDefinitionUpdateRequest) Validate() error {
 	return nil
 }
 
-func (s FlowDefinitionUpdateRequestInitialSteps) Validate() error {
+func (s FlowDefinitionUpdateRequestPurposes) Validate() error {
 	var failures []validate.FieldError
 
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
-}
-
-func (s FlowDefinitionUpdateRequestPurposesItem) Validate() error {
-	switch s {
-	case "login":
-		return nil
-	case "register":
-		return nil
-	case "recovery":
-		return nil
-	case "profiling":
-		return nil
-	case "reauth":
-		return nil
-	case "link_account":
-		return nil
-	default:
-		return errors.Errorf("invalid value: %v", s)
-	}
 }
 
 func (s *FlowEventRequest) Validate() error {

--- a/api/openapi/components/flows/flow-audience.yaml
+++ b/api/openapi/components/flows/flow-audience.yaml
@@ -1,18 +1,19 @@
 type: object
 description: |
-  Scopes which teams, apps, or projects this flow definition applies to.
-  When all fields are empty/omitted, the definition is a project-wide default.
-  The engine picks the most specific matching definition: app > team > project.
+  Scopes which teams or apps this flow definition applies to. Empty or
+  omitted fields mean "no restriction"; when both are empty the definition
+  matches every request in the project. The engine picks the most specific
+  matching definition: app > team > project-wide.
 properties:
   team_ids:
     type: array
     items:
       type: string
-    description: Restrict to specific teams (organizations).
+    description: Restrict to specific teams (organizations). Empty means no team restriction.
     example: ["team_acme"]
   app_ids:
     type: array
     items:
       type: string
-    description: Restrict to specific applications.
+    description: Restrict to specific applications. Empty means no app restriction.
     example: ["app_saas"]

--- a/api/openapi/components/flows/flow-definition-update-request.yaml
+++ b/api/openapi/components/flows/flow-definition-update-request.yaml
@@ -3,8 +3,8 @@ description: |
   Partial update for a flow definition. Only provided fields are replaced;
   omitted fields retain their current server-side values.
 
-  Array fields (`steps`, `purposes`, `initial_steps`) are treated atomically:
-  if provided, the entire array/object is replaced. If omitted, the current
+  Collection fields (`steps`, `purposes`) are treated atomically: if
+  provided, the entire array/object is replaced. If omitted, the current
   value is preserved unchanged.
 
   `name` is a stable identifier and cannot be changed after creation.
@@ -17,20 +17,10 @@ properties:
     example: https://raw.githubusercontent.com/zitadel/nextgen/refs/heads/main/api/openapi/endpoints/schemas/human-user.yaml
 
   purposes:
-    type: array
-    items:
-      type: string
-      enum: [login, register, recovery, profiling, reauth, link_account]
-    minItems: 1
-    uniqueItems: true
-    description: |
-      Replaces the full list of purposes this definition handles if provided.
-
-  initial_steps:
     type: object
     description: |
-      Replaces the full map of purpose-to-initial-step if provided.
-      Keys must be a subset of `purposes`.
+      Replaces the full purpose-to-entry-step map if provided. Keys are
+      purpose names; values must match a `name` in `steps`.
     minProperties: 1
     propertyNames:
       type: string

--- a/api/openapi/components/flows/flow-definition.yaml
+++ b/api/openapi/components/flows/flow-definition.yaml
@@ -1,5 +1,5 @@
 type: object
-required: [name, user_schema, purposes, initial_steps, steps]
+required: [name, user_schema, purposes, steps]
 description: |
   A flow definition is the server-side configuration that describes a complete
   authentication or identity flow. It is NOT sent to the frontend — the flow
@@ -30,21 +30,12 @@ properties:
     example: https://raw.githubusercontent.com/zitadel/nextgen/refs/heads/main/api/openapi/endpoints/schemas/human-user.yaml
 
   purposes:
-    type: array
-    items:
-      type: string
-      enum: [login, register, recovery, profiling, reauth, link_account]
-    minItems: 1
-    uniqueItems: true
-    description: |
-      Which flow purposes this definition handles. A definition can serve
-      multiple purposes (e.g. a combined login/register flow).
-
-  initial_steps:
     type: object
     description: |
-      Maps each purpose to the step name that starts the flow for that purpose.
-      Keys must be a subset of `purposes`.
+      Maps each purpose this definition handles to its entry-point step.
+      Keys are purpose names; values must match a `name` in `steps`. A
+      definition can serve multiple purposes (e.g. a combined login/register
+      flow) by listing one entry per purpose.
     minProperties: 1
     propertyNames:
       type: string

--- a/api/openapi/endpoints/schemas/examples/login.yaml
+++ b/api/openapi/endpoints/schemas/examples/login.yaml
@@ -10,9 +10,8 @@
 
 name: standard-login
 user_schema: https://raw.githubusercontent.com/zitadel/nextgen/refs/heads/main/api/openapi/endpoints/schemas/human-user.yaml
-purposes: [login]
 
-initial_steps:
+purposes:
   login: identify
 
 steps:

--- a/api/openapi/endpoints/schemas/flow-definition.json
+++ b/api/openapi/endpoints/schemas/flow-definition.json
@@ -7,7 +7,6 @@
     "name",
     "user_schema",
     "purposes",
-    "initial_steps",
     "steps"
   ],
   "additionalProperties": false,
@@ -30,24 +29,6 @@
       "description": "URL of the user schema this flow operates on. Step `fields` reference property names defined in that schema; the engine resolves field type, validation, and implicit transition outcomes from the schema's `x-*` annotations at runtime. URLs follow the same publishing convention as this document."
     },
     "purposes": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/$defs/Purpose"
-      },
-      "examples": [
-        [
-          "login"
-        ],
-        [
-          "login",
-          "register"
-        ]
-      ],
-      "description": "Which intents this definition can serve. A definition may handle more than one purpose by exposing a different entry-point step per purpose (see `initial_steps`)."
-    },
-    "initial_steps": {
       "type": "object",
       "minProperties": 1,
       "propertyNames": {
@@ -66,7 +47,7 @@
           "register": "identify"
         }
       ],
-      "description": "Maps each purpose to the step that begins the flow for that purpose. Every key must also appear in `purposes`; every value must match a `name` in `steps`. Both checks are enforced by the engine, not by this schema."
+      "description": "Maps each purpose this definition handles to the step that begins the flow for that purpose. Every value must match a `name` in `steps`; the check is enforced by the engine, not by this schema."
     },
     "audience": {
       "$ref": "#/$defs/Audience",
@@ -141,7 +122,7 @@
             "authenticate",
             "done"
           ],
-          "description": "Unique step identifier within this definition. Slug-shaped so it is safe to use as a transition `target` and as a key in `initial_steps`. Referenced by other steps in the same definition."
+          "description": "Unique step identifier within this definition. Slug-shaped so it is safe to use as a transition `target` and as a value in `purposes`. Referenced by other steps in the same definition."
         },
         "fields": {
           "type": "array",

--- a/api/openapi/endpoints/schemas/flow-definition.json
+++ b/api/openapi/endpoints/schemas/flow-definition.json
@@ -51,7 +51,7 @@
     },
     "audience": {
       "$ref": "#/$defs/Audience",
-      "description": "Scopes which requests this definition applies to. Omitted or empty means project-wide default. The engine ranks matches by specificity (app > team > schema > project default)."
+      "description": "Scopes which requests this definition applies to. Omitted or empty arrays mean project-wide. The engine ranks matches by specificity (app > team > project-wide)."
     },
     "steps": {
       "type": "array",

--- a/internal/domain/flow_definition.go
+++ b/internal/domain/flow_definition.go
@@ -63,11 +63,9 @@ type FlowDefinition struct {
 	UpdatedAt     time.Time
 	// UserSchema is the URL of the JSON schema this flow operates on.
 	UserSchema string
-	// Purposes collapses the OpenAPI `purposes` array and `initial_steps`
-	// map into a single slice of (Purpose, InitialStep) tuples.
-	Purposes []FlowDefinitionPurposeEntry
-	Audience FlowDefinitionAudience
-	Steps    []FlowDefinitionStep
+	Purposes   []FlowDefinitionPurposeEntry
+	Audience   FlowDefinitionAudience
+	Steps      []FlowDefinitionStep
 }
 
 // FlowDefinitionPurposeEntry maps a purpose to its entry-point step within the definition.

--- a/internal/domain/flow_definition.go
+++ b/internal/domain/flow_definition.go
@@ -75,12 +75,11 @@ type FlowDefinitionPurposeEntry struct {
 }
 
 // FlowDefinitionAudience describes which requests this definition should be selected for.
-// Fields are applied with specificity: AppID > TeamID > UserSchemaID > IsProjectDefault.
+// Empty slices (or nil) mean "no restriction". Specificity for resolution
+// is app > team > project-wide (both empty).
 type FlowDefinitionAudience struct {
-	AppID            *string
-	TeamID           *string
-	UserSchemaID     *string
-	IsProjectDefault bool
+	AppIDs  []string
+	TeamIDs []string
 }
 
 // FlowDefinitionStep is a single node in the step graph.

--- a/internal/domain/flow_definition.go
+++ b/internal/domain/flow_definition.go
@@ -61,9 +61,13 @@ type FlowDefinition struct {
 	Status        FlowDefinitionStatus
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
-	Purposes      []FlowDefinitionPurposeEntry
-	Audience      FlowDefinitionAudience
-	Steps         []FlowDefinitionStep
+	// UserSchema is the URL of the JSON schema this flow operates on.
+	UserSchema string
+	// Purposes collapses the OpenAPI `purposes` array and `initial_steps`
+	// map into a single slice of (Purpose, InitialStep) tuples.
+	Purposes []FlowDefinitionPurposeEntry
+	Audience FlowDefinitionAudience
+	Steps    []FlowDefinitionStep
 }
 
 // FlowDefinitionPurposeEntry maps a purpose to its entry-point step within the definition.

--- a/internal/service/flow.go
+++ b/internal/service/flow.go
@@ -112,8 +112,8 @@ func (s *flowService) resolveByName(ctx context.Context, req ResolveFlowRequest)
 //
 // TODO: honor [ResolveFlowRequest.Hint]. The MVP returns whichever row the
 // repository yields first; once admin UX produces multiple audience-targeted
-// definitions per purpose, score candidates by AppID > TeamID > UserSchemaID
-// > IsProjectDefault and tie-break by created_at DESC.
+// definitions per purpose, score candidates by AppIDs > TeamIDs >
+// project-wide (both empty) and tie-break by created_at DESC.
 func (s *flowService) resolveByAudience(ctx context.Context, req ResolveFlowRequest) (*domain.FlowDefinition, error) {
 	opts := []domain.FlowDefinitionListOption{
 		domain.WithFlowDefinitionStatus(domain.FlowDefinitionStatusActive),

--- a/internal/service/flow_test.go
+++ b/internal/service/flow_test.go
@@ -80,8 +80,8 @@ func newDef(name, version string, audience domain.FlowDefinitionAudience, purpos
 }
 
 func TestResolve_ResolveByName_ExactVersion(t *testing.T) {
-	want := newDef("login", "1.2.3", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
-	other := newDef("login", "1.0.0", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
+	want := newDef("login", "1.2.3", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	other := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{other, want})
 
 	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
@@ -99,7 +99,7 @@ func TestResolve_ResolveByName_ExactVersion(t *testing.T) {
 }
 
 func TestResolve_ResolveByName_FiltersWithRequestedOptions(t *testing.T) {
-	def := newDef("login", "1.2.3", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
+	def := newDef("login", "1.2.3", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 
 	ctrl := gomock.NewController(t)
 	repo := domainmock.NewMockFlowDefinitionRepository(ctrl)
@@ -131,9 +131,9 @@ func TestResolve_ResolveByName_FiltersWithRequestedOptions(t *testing.T) {
 }
 
 func TestResolve_ResolveByName_LatestActiveWhenVersionNil(t *testing.T) {
-	v1 := newDef("login", "1.0.0", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
-	v2 := newDef("login", "2.4.1", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
-	v15 := newDef("login", "1.5.0", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
+	v1 := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	v2 := newDef("login", "2.4.1", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	v15 := newDef("login", "1.5.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{v1, v2, v15})
 
 	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
@@ -163,7 +163,7 @@ func TestResolve_ResolveByName_NotFound(t *testing.T) {
 }
 
 func TestResolve_ResolveByName_PurposeMismatch(t *testing.T) {
-	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{def})
 
 	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
@@ -177,8 +177,8 @@ func TestResolve_ResolveByName_PurposeMismatch(t *testing.T) {
 }
 
 func TestResolve_ResolveByAudience_ReturnsFirstMatchingPurpose(t *testing.T) {
-	first := newDef("login", "1.0.0", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
-	second := newDef("alt", "1.0.0", domain.FlowDefinitionAudience{AppID: ptr("app-1")}, domain.FlowDefinitionPurposeLogin)
+	first := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	second := newDef("alt", "1.0.0", domain.FlowDefinitionAudience{AppIDs: []string{"app-1"}}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{first, second})
 
 	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
@@ -194,7 +194,7 @@ func TestResolve_ResolveByAudience_ReturnsFirstMatchingPurpose(t *testing.T) {
 }
 
 func TestResolve_ResolveByAudience_NoMatch(t *testing.T) {
-	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{def})
 
 	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
@@ -207,8 +207,8 @@ func TestResolve_ResolveByAudience_NoMatch(t *testing.T) {
 }
 
 func TestResolve_ResolveByAudience_ExactVersionFiltersOlder(t *testing.T) {
-	v1 := newDef("login", "1.0.0", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
-	v2 := newDef("login", "2.0.0", domain.FlowDefinitionAudience{IsProjectDefault: true}, domain.FlowDefinitionPurposeLogin)
+	v1 := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	v2 := newDef("login", "2.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{v1, v2})
 
 	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{

--- a/internal/storage/database/repository/flow_definition.go
+++ b/internal/storage/database/repository/flow_definition.go
@@ -30,9 +30,10 @@ type flowDefinitionRow struct {
 
 // flowDefinitionContent is the structure stored inside the definition JSONB column.
 type flowDefinitionContent struct {
-	Purposes []flowDefinitionPurposeJSON `json:"purposes"`
-	Audience flowDefinitionAudienceJSON  `json:"audience"`
-	Steps    []flowDefinitionStepJSON    `json:"steps"`
+	UserSchema string                      `json:"user_schema"`
+	Purposes   []flowDefinitionPurposeJSON `json:"purposes"`
+	Audience   flowDefinitionAudienceJSON  `json:"audience"`
+	Steps      []flowDefinitionStepJSON    `json:"steps"`
 }
 
 type flowDefinitionPurposeJSON struct {
@@ -267,9 +268,10 @@ func marshalFlowDefinitionContent(def *domain.FlowDefinition) ([]byte, error) {
 	}
 
 	return json.Marshal(flowDefinitionContent{
-		Purposes: purposes,
-		Audience: audience,
-		Steps:    steps,
+		UserSchema: def.UserSchema,
+		Purposes:   purposes,
+		Audience:   audience,
+		Steps:      steps,
 	})
 }
 
@@ -324,6 +326,7 @@ func rowToFlowDefinition(row flowDefinitionRow) (*domain.FlowDefinition, error) 
 		Status:        row.Status,
 		CreatedAt:     row.CreatedAt,
 		UpdatedAt:     row.UpdatedAt,
+		UserSchema:    content.UserSchema,
 		Purposes:      purposes,
 		Audience: domain.FlowDefinitionAudience{
 			AppID:            content.Audience.AppID,

--- a/internal/storage/database/repository/flow_definition.go
+++ b/internal/storage/database/repository/flow_definition.go
@@ -42,10 +42,8 @@ type flowDefinitionPurposeJSON struct {
 }
 
 type flowDefinitionAudienceJSON struct {
-	AppID            *string `json:"app_id,omitempty"`
-	TeamID           *string `json:"team_id,omitempty"`
-	UserSchemaID     *string `json:"user_schema_id,omitempty"`
-	IsProjectDefault bool    `json:"is_project_default"`
+	AppIDs  []string `json:"app_ids,omitempty"`
+	TeamIDs []string `json:"team_ids,omitempty"`
 }
 
 type flowDefinitionStepJSON struct {
@@ -243,10 +241,8 @@ func marshalFlowDefinitionContent(def *domain.FlowDefinition) ([]byte, error) {
 	}
 
 	audience := flowDefinitionAudienceJSON{
-		AppID:            def.Audience.AppID,
-		TeamID:           def.Audience.TeamID,
-		UserSchemaID:     def.Audience.UserSchemaID,
-		IsProjectDefault: def.Audience.IsProjectDefault,
+		AppIDs:  def.Audience.AppIDs,
+		TeamIDs: def.Audience.TeamIDs,
 	}
 
 	steps := make([]flowDefinitionStepJSON, len(def.Steps))
@@ -329,10 +325,8 @@ func rowToFlowDefinition(row flowDefinitionRow) (*domain.FlowDefinition, error) 
 		UserSchema:    content.UserSchema,
 		Purposes:      purposes,
 		Audience: domain.FlowDefinitionAudience{
-			AppID:            content.Audience.AppID,
-			TeamID:           content.Audience.TeamID,
-			UserSchemaID:     content.Audience.UserSchemaID,
-			IsProjectDefault: content.Audience.IsProjectDefault,
+			AppIDs:  content.Audience.AppIDs,
+			TeamIDs: content.Audience.TeamIDs,
 		},
 		Steps: steps,
 	}, nil

--- a/internal/storage/database/repository/flow_definition_test.go
+++ b/internal/storage/database/repository/flow_definition_test.go
@@ -27,6 +27,7 @@ func TestFlowDefinitionRepository_CreateAndGet(t *testing.T) {
 	assert.Equal(t, def.Name, got.Name)
 	assert.Equal(t, def.SchemaVersion, got.SchemaVersion)
 	assert.Equal(t, def.Status, got.Status)
+	assert.Equal(t, def.UserSchema, got.UserSchema)
 	assert.WithinDuration(t, time.Now(), got.CreatedAt, 5*time.Second)
 	assert.WithinDuration(t, time.Now(), got.UpdatedAt, 5*time.Second)
 
@@ -232,6 +233,7 @@ func sampleFlowDefinition(projectID, id string) *domain.FlowDefinition {
 		Name:          "Default Login",
 		SchemaVersion: "1.0.0",
 		Status:        domain.FlowDefinitionStatusDraft,
+		UserSchema:    "https://example.com/schemas/human-user.json",
 		Purposes: []domain.FlowDefinitionPurposeEntry{
 			{Purpose: domain.FlowDefinitionPurposeLogin, InitialStep: "identifier"},
 		},

--- a/internal/storage/database/repository/flow_definition_test.go
+++ b/internal/storage/database/repository/flow_definition_test.go
@@ -35,9 +35,8 @@ func TestFlowDefinitionRepository_CreateAndGet(t *testing.T) {
 	assert.Equal(t, domain.FlowDefinitionPurposeLogin, got.Purposes[0].Purpose)
 	assert.Equal(t, "identifier", got.Purposes[0].InitialStep)
 
-	assert.Equal(t, def.Audience.AppID, got.Audience.AppID)
-	assert.Nil(t, got.Audience.TeamID)
-	assert.False(t, got.Audience.IsProjectDefault)
+	assert.Equal(t, def.Audience.AppIDs, got.Audience.AppIDs)
+	assert.Empty(t, got.Audience.TeamIDs)
 
 	require.Len(t, got.Steps, 3)
 	stepsByName := make(map[string]domain.FlowDefinitionStep)
@@ -226,7 +225,6 @@ func TestFlowDefinitionRepository_ProjectIsolation(t *testing.T) {
 
 func sampleFlowDefinition(projectID, id string) *domain.FlowDefinition {
 	pivotAction := domain.Pivot
-	appID := "app-1"
 	return &domain.FlowDefinition{
 		ProjectID:     projectID,
 		ID:            id,
@@ -238,8 +236,7 @@ func sampleFlowDefinition(projectID, id string) *domain.FlowDefinition {
 			{Purpose: domain.FlowDefinitionPurposeLogin, InitialStep: "identifier"},
 		},
 		Audience: domain.FlowDefinitionAudience{
-			AppID:            &appID,
-			IsProjectDefault: false,
+			AppIDs: []string{"app-1"},
 		},
 		Steps: []domain.FlowDefinitionStep{
 			{


### PR DESCRIPTION
## Summary

Closes the gaps between the OpenAPI contract and `domain.FlowDefinition` so handler work can proceed against a single coherent shape.

- **`UserSchema` on `domain.FlowDefinition`** — OpenAPI required `user_schema`; the domain aggregate didn't carry it. 
- **Collapsed `purposes` array + `initial_steps` map into one map.**  Replaced with a single `purposes` map
  (purpose → entry-point step), matching the domain's `[]FlowDefinitionPurposeEntry`.
- **Aligned audience with the API.** Domain audience becomes `AppIDs []string` / `TeamIDs []string`. Dropped `UserSchemaID` (the top-level `UserSchema` already scopes which users a flow applies to)
and `IsProjectDefault` (now implicit: both arrays empty = unrestricted).
