### PR TITLE
feat: wire flow engine through HTTP handler

### DIFF
--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -7120,8 +7120,10 @@ func (s *FlowEventRequest) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *FlowEventRequest) encodeFields(e *jx.Encoder) {
 	{
-		e.FieldStart("session_token")
-		e.Str(s.SessionToken)
+		if s.SessionToken.Set {
+			e.FieldStart("session_token")
+			s.SessionToken.Encode(e)
+		}
 	}
 	{
 		e.FieldStart("type")
@@ -7151,11 +7153,9 @@ func (s *FlowEventRequest) Decode(d *jx.Decoder) error {
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
 		case "session_token":
-			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				v, err := d.Str()
-				s.SessionToken = string(v)
-				if err != nil {
+				s.SessionToken.Reset()
+				if err := s.SessionToken.Decode(d); err != nil {
 					return err
 				}
 				return nil
@@ -7192,7 +7192,7 @@ func (s *FlowEventRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000010,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -7468,8 +7468,10 @@ func (s *FlowResponse) encodeFields(e *jx.Encoder) {
 		e.Str(s.SessionID)
 	}
 	{
-		e.FieldStart("session_token")
-		e.Str(s.SessionToken)
+		if s.SessionToken.Set {
+			e.FieldStart("session_token")
+			s.SessionToken.Encode(e)
+		}
 	}
 	{
 		e.FieldStart("step")
@@ -7546,11 +7548,9 @@ func (s *FlowResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"session_id\"")
 			}
 		case "session_token":
-			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
-				v, err := d.Str()
-				s.SessionToken = string(v)
-				if err != nil {
+				s.SessionToken.Reset()
+				if err := s.SessionToken.Decode(d); err != nil {
 					return err
 				}
 				return nil
@@ -7617,7 +7617,7 @@ func (s *FlowResponse) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00001111,
+		0b00001011,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -8113,8 +8113,10 @@ func (s *FlowSubmitRequest) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *FlowSubmitRequest) encodeFields(e *jx.Encoder) {
 	{
-		e.FieldStart("session_token")
-		e.Str(s.SessionToken)
+		if s.SessionToken.Set {
+			e.FieldStart("session_token")
+			s.SessionToken.Encode(e)
+		}
 	}
 	{
 		e.FieldStart("action")
@@ -8158,11 +8160,9 @@ func (s *FlowSubmitRequest) Decode(d *jx.Decoder) error {
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
 		case "session_token":
-			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				v, err := d.Str()
-				s.SessionToken = string(v)
-				if err != nil {
+				s.SessionToken.Reset()
+				if err := s.SessionToken.Decode(d); err != nil {
 					return err
 				}
 				return nil
@@ -8221,7 +8221,7 @@ func (s *FlowSubmitRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000010,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -3195,14 +3195,17 @@ func (s *FlowDefinitionUpdateRequestPurposes) init() FlowDefinitionUpdateRequest
 
 // Ref: #
 type FlowEventRequest struct {
-	SessionToken string               `json:"session_token"`
+	// Reserved for future session-token rotation; not consumed in MVP.
+	// The flow id on the URL path and the `_zflow` cookie are
+	// authoritative.
+	SessionToken OptString            `json:"session_token"`
 	Type         FlowEventRequestType `json:"type"`
 	// Event payload (fingerprint hash, timing data, etc.).
 	Payload OptFlowEventRequestPayload `json:"payload"`
 }
 
 // GetSessionToken returns the value of SessionToken.
-func (s *FlowEventRequest) GetSessionToken() string {
+func (s *FlowEventRequest) GetSessionToken() OptString {
 	return s.SessionToken
 }
 
@@ -3217,7 +3220,7 @@ func (s *FlowEventRequest) GetPayload() OptFlowEventRequestPayload {
 }
 
 // SetSessionToken sets the value of SessionToken.
-func (s *FlowEventRequest) SetSessionToken(val string) {
+func (s *FlowEventRequest) SetSessionToken(val OptString) {
 	s.SessionToken = val
 }
 
@@ -3344,9 +3347,10 @@ type FlowResponse struct {
 	ID string `json:"id"`
 	// Underlying session ID. Stable across all stacked flows.
 	SessionID string `json:"session_id"`
-	// Rotated on every response. Required for the next request.
-	SessionToken string   `json:"session_token"`
-	Step         FlowStep `json:"step"`
+	// Reserved for future session-token rotation; not emitted in MVP.
+	// Cookie + flow id binding is authoritative.
+	SessionToken OptString `json:"session_token"`
+	Step         FlowStep  `json:"step"`
 	// Resolved branding inherited from the app → team → project hierarchy.
 	// Determined at flow creation based on audience context. Does not change between steps.
 	Branding OptBranding `json:"branding"`
@@ -3372,7 +3376,7 @@ func (s *FlowResponse) GetSessionID() string {
 }
 
 // GetSessionToken returns the value of SessionToken.
-func (s *FlowResponse) GetSessionToken() string {
+func (s *FlowResponse) GetSessionToken() OptString {
 	return s.SessionToken
 }
 
@@ -3412,7 +3416,7 @@ func (s *FlowResponse) SetSessionID(val string) {
 }
 
 // SetSessionToken sets the value of SessionToken.
-func (s *FlowResponse) SetSessionToken(val string) {
+func (s *FlowResponse) SetSessionToken(val OptString) {
 	s.SessionToken = val
 }
 
@@ -3681,7 +3685,10 @@ func (s *FlowStepGates) init() FlowStepGates {
 
 // Ref: #
 type FlowSubmitRequest struct {
-	SessionToken string `json:"session_token"`
+	// Reserved for future session-token rotation; not consumed in MVP.
+	// The flow id on the URL path and the `_zflow` cookie are
+	// authoritative.
+	SessionToken OptString `json:"session_token"`
 	// Which action to take. Either:
 	// - A key from the step's `actions` dictionary (e.g., "submit", "register", "back")
 	// - The reserved value "sso" — triggers SSO redirect (requires `sso_provider_id`).
@@ -3697,7 +3704,7 @@ type FlowSubmitRequest struct {
 }
 
 // GetSessionToken returns the value of SessionToken.
-func (s *FlowSubmitRequest) GetSessionToken() string {
+func (s *FlowSubmitRequest) GetSessionToken() OptString {
 	return s.SessionToken
 }
 
@@ -3722,7 +3729,7 @@ func (s *FlowSubmitRequest) GetSSOProviderID() OptString {
 }
 
 // SetSessionToken sets the value of SessionToken.
-func (s *FlowSubmitRequest) SetSessionToken(val string) {
+func (s *FlowSubmitRequest) SetSessionToken(val OptString) {
 	s.SessionToken = val
 }
 

--- a/api/openapi/components/flows/flow-event-request.yaml
+++ b/api/openapi/components/flows/flow-event-request.yaml
@@ -1,8 +1,12 @@
 type: object
-required: [session_token, type]
+required: [type]
 properties:
   session_token:
     type: string
+    description: |
+      Reserved for future session-token rotation; not consumed in MVP.
+      The flow id on the URL path and the `_zflow` cookie are
+      authoritative.
   type:
     type: string
     enum: [fingerprint, telemetry]

--- a/api/openapi/components/flows/flow-response.yaml
+++ b/api/openapi/components/flows/flow-response.yaml
@@ -1,5 +1,5 @@
 type: object
-required: [id, session_id, session_token, step]
+required: [id, session_id, step]
 properties:
   id:
     type: string
@@ -13,7 +13,9 @@ properties:
     description: Underlying session ID. Stable across all stacked flows.
   session_token:
     type: string
-    description: Rotated on every response. Required for the next request.
+    description: |
+      Reserved for future session-token rotation; not emitted in MVP.
+      Cookie + flow id binding is authoritative.
   step:
     $ref: flow-step.yaml
   branding:

--- a/api/openapi/components/flows/flow-submit-request.yaml
+++ b/api/openapi/components/flows/flow-submit-request.yaml
@@ -1,8 +1,12 @@
 type: object
-required: [session_token, action]
+required: [action]
 properties:
   session_token:
     type: string
+    description: |
+      Reserved for future session-token rotation; not consumed in MVP.
+      The flow id on the URL path and the `_zflow` cookie are
+      authoritative.
   action:
     type: string
     description: |

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -11,4 +11,8 @@ type Config struct {
 
 type ServerConfig struct {
 	Address string `mapstructure:"address"`
+	// CookieSealerKey is the 32-byte (hex-encoded, 64 chars) symmetric
+	// key used to seal flow cookies. Required — the server refuses to
+	// boot without it. Bind via NEXTGEN_SERVER_COOKIE_SEALER_KEY.
+	CookieSealerKey string `mapstructure:"cookie_sealer_key"`
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
@@ -11,16 +12,26 @@ import (
 	"syscall"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/ianlancetaylor/jsonschema"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	oasapi "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/api"
+	"github.com/zitadel/nextgen/internal/cookie"
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/domain/idgen"
 	"github.com/zitadel/nextgen/internal/service"
 	"github.com/zitadel/nextgen/internal/storage/database"
 	_ "github.com/zitadel/nextgen/internal/storage/database/dialect/all"
 	"github.com/zitadel/nextgen/internal/storage/database/repository"
 )
+
+// flowSchemaCacheSize bounds the JSONSchemaResolver's in-memory LRU.
+// 128 entries is enough headroom for MVP customer schema counts; tune
+// later if cache miss rates rise.
+const flowSchemaCacheSize = 128
 
 func NewCommand() *cobra.Command {
 	var configPath string
@@ -48,6 +59,29 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
+// buildCookieSealer decodes a hex-encoded sealer key and constructs
+// the [cookie.Sealer]. The key must be exactly [cookie.KeySize] bytes
+// after decoding; anything else is a configuration error.
+func buildCookieSealer(hexKey string) (*cookie.Sealer, error) {
+	if hexKey == "" {
+		return nil, errors.New("server: cookie_sealer_key is required (set NEXTGEN_SERVER_COOKIE_SEALER_KEY)")
+	}
+	raw, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("server: decode cookie_sealer_key: %w", err)
+	}
+	if len(raw) != cookie.KeySize {
+		return nil, fmt.Errorf("server: cookie_sealer_key must decode to %d bytes, got %d", cookie.KeySize, len(raw))
+	}
+	var key cookie.Key
+	copy(key[:], raw)
+	sealer, err := cookie.NewSealer(key)
+	if err != nil {
+		return nil, fmt.Errorf("server: build cookie sealer: %w", err)
+	}
+	return sealer, nil
+}
+
 func startDatabase(ctx context.Context, config database.Config) (database.Pool, error) {
 	connector, err := config.Build()
 	if err != nil {
@@ -71,6 +105,11 @@ func run(ctx context.Context, cfg Config, pool database.Pool) error {
 		}
 	}()
 
+	sealer, err := buildCookieSealer(cfg.Server.CookieSealerKey)
+	if err != nil {
+		return err
+	}
+
 	// ── Repositories ─────────────────
 	projectRepo := repository.NewProjectRepository(pool)
 	userRepo := repository.NewUserRepository()
@@ -79,9 +118,9 @@ func run(ctx context.Context, cfg Config, pool database.Pool) error {
 	sessionRepo := repository.NewSessionRepository(pool)
 	flowRepo := repository.NewFlowDefinitionRepository(pool)
 	attemptRepo := repository.NewAuthAttemptRepository(pool)
+	schemaRepo := repository.NewJSONSchemaRepository(pool)
 
-	// ── Services ─────────────────────
-	flowService := service.NewFlowService(pool, flowRepo)
+	// ── Auth attempt service ─────────
 	authAttemptSvc := service.NewAuthAttemptService(
 		pool,
 		attemptRepo,
@@ -92,13 +131,32 @@ func run(ctx context.Context, cfg Config, pool database.Pool) error {
 		userPasskeyRepo,
 	)
 
+	// ── Flow engine ──────────────────
+	ids := idgen.NewULID()
+	schemaCache, err := lru.New2Q[string, *jsonschema.Schema](flowSchemaCacheSize)
+	if err != nil {
+		return fmt.Errorf("build schema cache: %w", err)
+	}
+	schemas := domain.NewJSONSchemaResolver(schemaRepo, schemaCache, 0, 0, nil, nil)
+	fields := domain.NewSchemaFieldResolver(schemas)
+
+	// create_user requires a password hasher; argon2id wiring lands in
+	// a follow-up PR. Until then the handler is nil — flows that try to
+	// invoke `create_user` (registration) will fail with ErrIntegrity.
+	// Login does not need it.
+	var createUser *domain.FlowCreateUserHandler
+	flowAuth := service.NewFlowAuthAttemptAdapter(authAttemptSvc)
+	stateMachine := domain.NewFlowStateMachine(fields, createUser, flowAuth, time.Now)
+
+	flowService := service.NewFlowService(pool, flowRepo, stateMachine, ids)
+
 	// ── HTTP Server ─────────────────
 
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	oasServer, err := oasapi.NewServer(
-		api.NewHandler(flowService, authAttemptSvc),
+		api.NewHandler(flowService, authAttemptSvc, sealer, time.Now),
 		api.NewSecurityHandler(),
 		oasapi.WithErrorHandler(api.OgenErrorHandler))
 	if err != nil {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -59,6 +59,15 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
+// mustBindEnv panics on viper's documented "this can't fail in
+// normal use" BindEnv error path. Keeps the env wiring readable
+// without sprinkling error handling at every binding.
+func mustBindEnv(v *viper.Viper, key string) {
+	if err := v.BindEnv(key); err != nil {
+		panic(fmt.Errorf("bind env %q: %w", key, err))
+	}
+}
+
 // buildCookieSealer decodes a hex-encoded sealer key and constructs
 // the [cookie.Sealer]. The key must be exactly [cookie.KeySize] bytes
 // after decoding; anything else is a configuration error.
@@ -145,7 +154,11 @@ func run(ctx context.Context, cfg Config, pool database.Pool) error {
 	// invoke `create_user` (registration) will fail with ErrIntegrity.
 	// Login does not need it.
 	var createUser *domain.FlowCreateUserHandler
-	flowAuth := service.NewFlowAuthAttemptAdapter(authAttemptSvc)
+
+	//flowAuth := service.NewFlowAuthAttemptAdapter(authAttemptSvc)
+	// TODO: replace back to the real adapter
+	flowAuth := service.NewDummyFlowAuthAttemptAdapter(authAttemptSvc)
+
 	stateMachine := domain.NewFlowStateMachine(fields, createUser, flowAuth, time.Now)
 
 	flowService := service.NewFlowService(pool, flowRepo, stateMachine, ids)
@@ -201,6 +214,11 @@ func loadConfig(configPath string) (Config, error) {
 	v.AutomaticEnv()
 
 	v.SetDefault("server.address", ":8080")
+
+	// AutomaticEnv only resolves nested keys viper already knows about
+	// (via default, config file, or explicit BindEnv). Anything without
+	// a default needs to be bound by hand.
+	mustBindEnv(v, "server.cookie_sealer_key")
 
 	if configPath != "" {
 		v.SetConfigFile(configPath)

--- a/docs/design/flowengine/seed-flow.sql
+++ b/docs/design/flowengine/seed-flow.sql
@@ -1,0 +1,371 @@
+-- Seed data for manually testing the flow engine end-to-end.
+--
+-- Usage:
+--   psql "postgresql://postgres:postgres@127.0.0.1:<PORT>/postgres?sslmode=disable" \
+--     -f docs/design/flowengine/seed-flow.sql
+--
+-- After running, exercise the engine with:
+--   curl -s -c /tmp/zflow -X POST http://localhost:8080/flow \
+--     -H 'content-type: application/json' \
+--     -d '{"project_id":"proj-1","purpose":"register"}' | jq
+--
+--   FLOW_ID=...  # from the response.flow.id
+--   curl -s -b /tmp/zflow -c /tmp/zflow -X POST \
+--     http://localhost:8080/flow/$FLOW_ID/step \
+--     -H 'content-type: application/json' \
+--     -d '{"step":"credentials","action":"submit","fields":{"email":"alice@example.com","username":"alice","password":"correct-horse-battery-staple","given_name":"Alice","family_name":"A"}}' | jq
+
+BEGIN;
+
+-- 1. Project ------------------------------------------------------------
+INSERT INTO zitadel_nextgen.projects (id)
+VALUES ('proj-1')
+ON CONFLICT (id) DO NOTHING;
+
+-- 2. User schemas ------------------------------------------------------
+-- Flow definitions reference these by URL; the JSONSchemaResolver looks
+-- them up by (project_id, url) and feeds them to the field resolver.
+INSERT INTO zitadel_nextgen.json_schemas (project_id, url, payload)
+VALUES (
+    'proj-1',
+    'https://example.test/user/v1/default.user.schema.json',
+    $${
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "x-auth-methods": { "password": { "enabled": true } },
+        "required": ["email", "username", "password", "given_name", "family_name"],
+        "properties": {
+            "email":       { "type": "string", "format": "email", "maxLength": 320, "x-identifier": true },
+            "username":    { "type": "string", "minLength": 3, "maxLength": 64, "x-identifier": true },
+            "password":    { "type": "string", "minLength": 8, "x-password": true },
+            "given_name":  { "type": "string", "minLength": 1, "maxLength": 200 },
+            "family_name": { "type": "string", "minLength": 1, "maxLength": 200 }
+        }
+    }$$::json
+)
+ON CONFLICT (project_id, url) DO UPDATE SET payload = EXCLUDED.payload;
+
+INSERT INTO zitadel_nextgen.json_schemas (project_id, url, payload)
+VALUES (
+    'proj-1',
+    'https://example.test/user/v1/saas.user.schema.json',
+    $${
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "x-auth-methods": { "password": { "enabled": true } },
+        "required": ["email", "password", "display_name"],
+        "properties": {
+            "email":        { "type": "string", "format": "email", "maxLength": 320, "x-identifier": true },
+            "password":     { "type": "string", "minLength": 8, "x-password": true },
+            "display_name": { "type": "string", "minLength": 1, "maxLength": 100 },
+            "company":      { "type": "string", "maxLength": 200 }
+        }
+    }$$::json
+)
+ON CONFLICT (project_id, url) DO UPDATE SET payload = EXCLUDED.payload;
+
+-- 3. Register flow ------------------------------------------------------
+-- credentials step → create_user on submit → "done" terminal (show).
+INSERT INTO zitadel_nextgen.flow_definitions
+    (project_id, id, name, schema_version, status, purposes, definition)
+VALUES (
+    'proj-1',
+    'def-register',
+    'standard-register',
+    'v1',
+    'active'::zitadel_nextgen.flow_definition_states,
+    ARRAY['register']::zitadel_nextgen.flow_definition_purposes[],
+    $${
+        "user_schema": "https://example.test/user/v1/default.user.schema.json",
+        "purposes": {"register": "credentials"},
+        "audience": {},
+        "steps": [
+            {
+                "name": "credentials",
+                "fields": ["email", "username", "password", "given_name", "family_name"],
+                "on_success": "create_user",
+                "transitions": {
+                    "submit": {"target": "done"}
+                }
+            },
+            {
+                "name": "done",
+                "complete": "show"
+            }
+        ]
+    }$$::jsonb
+)
+ON CONFLICT (project_id, id) DO UPDATE
+    SET status = EXCLUDED.status,
+        purposes = EXCLUDED.purposes,
+        definition = EXCLUDED.definition,
+        updated_at = NOW();
+
+-- 4. Login flow ---------------------------------------------------------
+-- credentials step dispatches identifier + password challenges (driven
+-- by the schema's x-identifier / x-password annotations); on submit it
+-- terminates at "done". The implicit user_not_found outcome from the
+-- identifier challenge routes to "no_account".
+INSERT INTO zitadel_nextgen.flow_definitions
+    (project_id, id, name, schema_version, status, purposes, definition)
+VALUES (
+    'proj-1',
+    'def-login',
+    'standard-login',
+    'v1',
+    'active'::zitadel_nextgen.flow_definition_states,
+    ARRAY['login']::zitadel_nextgen.flow_definition_purposes[],
+    $${
+        "user_schema": "https://example.test/user/v1/default.user.schema.json",
+        "purposes": {"login": "credentials"},
+        "audience": {},
+        "steps": [
+            {
+                "name": "credentials",
+                "fields": ["email", "password"],
+                "transitions": {
+                    "submit":          {"target": "done"},
+                    "user_not_found":  {"target": "no_account"}
+                }
+            },
+            {
+                "name": "done",
+                "complete": "show"
+            },
+            {
+                "name": "no_account",
+                "complete": "show"
+            }
+        ]
+    }$$::jsonb
+)
+ON CONFLICT (project_id, id) DO UPDATE
+    SET status = EXCLUDED.status,
+        purposes = EXCLUDED.purposes,
+        definition = EXCLUDED.definition,
+        updated_at = NOW();
+
+-- 5. Combined auth flow -----------------------------------------------
+-- Supports both login AND register from the same entry point. The
+-- credentials step verifies credentials via challenge dispatch; on
+-- submit it terminates as a login; on user_not_found it routes to a
+-- profile step that runs create_user.
+--
+-- Note: create_user reads fields from the current submit (not from
+-- FlowState.CollectedData), so the profile step re-declares email +
+-- password and the client must re-submit them. A real UI carries them
+-- over transparently — for curl-based testing, just include them again.
+INSERT INTO zitadel_nextgen.flow_definitions
+    (project_id, id, name, schema_version, status, purposes, definition)
+VALUES (
+    'proj-1',
+    'def-combined',
+    'combined-auth',
+    'v1',
+    'active'::zitadel_nextgen.flow_definition_states,
+    ARRAY['login', 'register']::zitadel_nextgen.flow_definition_purposes[],
+    $${
+        "user_schema": "https://example.test/user/v1/default.user.schema.json",
+        "purposes": {"login": "credentials", "register": "credentials"},
+        "audience": {},
+        "steps": [
+            {
+                "name": "credentials",
+                "fields": ["email", "password"],
+                "transitions": {
+                    "submit":         {"target": "done_login"},
+                    "user_not_found": {"target": "profile"}
+                }
+            },
+            {
+                "name": "profile",
+                "fields": ["email", "username", "password", "given_name", "family_name"],
+                "on_success": "create_user",
+                "transitions": {
+                    "submit": {"target": "done_register"}
+                }
+            },
+            {
+                "name": "done_login",
+                "complete": "show"
+            },
+            {
+                "name": "done_register",
+                "complete": "show"
+            }
+        ]
+    }$$::jsonb
+)
+ON CONFLICT (project_id, id) DO UPDATE
+    SET status = EXCLUDED.status,
+        purposes = EXCLUDED.purposes,
+        definition = EXCLUDED.definition,
+        updated_at = NOW();
+
+-- 6. Multi-step register ----------------------------------------------
+-- Two collection steps before the user is materialized:
+--   profile     – collect identity + names (no create_user yet)
+--   set_password – collect password AND re-collect email; create_user
+--                  runs here because it needs the identifier + password
+--                  in the same submit (it reads in.Fields, not
+--                  FlowState.CollectedData).
+--
+-- For curl-based testing, set_password's submit must include the email
+-- value again. A real UI would prefill it from state.collected_data.
+INSERT INTO zitadel_nextgen.flow_definitions
+    (project_id, id, name, schema_version, status, purposes, definition)
+VALUES (
+    'proj-1',
+    'def-register-multi',
+    'multi-step-register',
+    'v1',
+    'active'::zitadel_nextgen.flow_definition_states,
+    ARRAY['register']::zitadel_nextgen.flow_definition_purposes[],
+    $${
+        "user_schema": "https://example.test/user/v1/default.user.schema.json",
+        "purposes": {"register": "profile"},
+        "audience": {},
+        "steps": [
+            {
+                "name": "profile",
+                "fields": ["email", "username", "given_name", "family_name"],
+                "transitions": {
+                    "submit": {"target": "set_password"}
+                }
+            },
+            {
+                "name": "set_password",
+                "fields": ["email", "password"],
+                "on_success": "create_user",
+                "transitions": {
+                    "submit": {"target": "done"}
+                }
+            },
+            {
+                "name": "done",
+                "complete": "show"
+            }
+        ]
+    }$$::jsonb
+)
+ON CONFLICT (project_id, id) DO UPDATE
+    SET status = EXCLUDED.status,
+        purposes = EXCLUDED.purposes,
+        definition = EXCLUDED.definition,
+        updated_at = NOW();
+
+-- 7. Enterprise login --------------------------------------------------
+-- Three-stage login modelled on the visualizer's "Acme Corp SSO Login":
+--   identify – collect email; identifier challenge dispatched here
+--              (implicit user_not_found routes to the "denied" terminal)
+--   signin   – collect password; password challenge dispatched here
+--   consent  – action-only step (no fields), routes on accept/deny
+--
+-- sso_providers / audience are decorative for now — the state machine
+-- parses them but the response is generated from transitions. Included
+-- to exercise the full JSON shape end-to-end.
+INSERT INTO zitadel_nextgen.flow_definitions
+    (project_id, id, name, schema_version, status, purposes, definition)
+VALUES (
+    'proj-1',
+    'def-enterprise-login',
+    'enterprise-sso-login',
+    'v1',
+    'active'::zitadel_nextgen.flow_definition_states,
+    ARRAY['login']::zitadel_nextgen.flow_definition_purposes[],
+    $${
+        "user_schema": "https://example.test/user/v1/default.user.schema.json",
+        "purposes": {"login": "identify"},
+        "audience": {"team_ids": ["team-acme"], "app_ids": ["app-dashboard"]},
+        "steps": [
+            {
+                "name": "identify",
+                "fields": ["email"],
+                "sso_providers": [
+                    {"id": "okta-acme",  "name": "Acme Okta",      "template": "okta"},
+                    {"id": "azure-acme", "name": "Acme Azure AD", "template": "microsoft"}
+                ],
+                "transitions": {
+                    "submit":         {"target": "signin"},
+                    "user_not_found": {"target": "denied"}
+                }
+            },
+            {
+                "name": "signin",
+                "fields": ["password"],
+                "transitions": {
+                    "submit": {"target": "consent"}
+                }
+            },
+            {
+                "name": "consent",
+                "transitions": {
+                    "accept": {"target": "done"},
+                    "deny":   {"target": "denied"}
+                }
+            },
+            {
+                "name": "denied",
+                "complete": "show"
+            },
+            {
+                "name": "done",
+                "complete": "redirect"
+            }
+        ]
+    }$$::jsonb
+)
+ON CONFLICT (project_id, id) DO UPDATE
+    SET status = EXCLUDED.status,
+        purposes = EXCLUDED.purposes,
+        definition = EXCLUDED.definition,
+        updated_at = NOW();
+
+-- 8. SaaS register ----------------------------------------------------
+-- Single-step register against the saas_user schema. Demonstrates:
+--   - alternate user schema (display_name / company instead of names)
+--   - audience scoping to a single app
+--   - decorative gates + sso_providers (parsed, not yet enforced)
+INSERT INTO zitadel_nextgen.flow_definitions
+    (project_id, id, name, schema_version, status, purposes, definition)
+VALUES (
+    'proj-1',
+    'def-saas-register',
+    'saas-register',
+    'v1',
+    'active'::zitadel_nextgen.flow_definition_states,
+    ARRAY['register']::zitadel_nextgen.flow_definition_purposes[],
+    $${
+        "user_schema": "https://example.test/user/v1/saas.user.schema.json",
+        "purposes": {"register": "profile"},
+        "audience": {"app_ids": ["app-saas"]},
+        "steps": [
+            {
+                "name": "profile",
+                "fields": ["email", "password", "display_name", "company"],
+                "on_success": "create_user",
+                "gates": {
+                    "captcha": {"kind": "captcha", "provider": "altcha"}
+                },
+                "sso_providers": [
+                    {"id": "google-1", "name": "Google", "template": "google"},
+                    {"id": "github-1", "name": "GitHub", "template": "github"}
+                ],
+                "transitions": {
+                    "submit": {"target": "done"}
+                }
+            },
+            {
+                "name": "done",
+                "complete": "show"
+            }
+        ]
+    }$$::jsonb
+)
+ON CONFLICT (project_id, id) DO UPDATE
+    SET status = EXCLUDED.status,
+        purposes = EXCLUDED.purposes,
+        definition = EXCLUDED.definition,
+        updated_at = NOW();
+
+COMMIT;

--- a/internal/api/branding.go
+++ b/internal/api/branding.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	_ "embed"
+
+	api "github.com/zitadel/nextgen/api/generated"
+)
+
+//go:embed branding/default.liquid
+var defaultLiquidTemplate string
+
+// defaultBranding returns the MVP branding payload — a hard-coded
+// centered layout plus the embedded default LiquidJS template. Team /
+// app overrides land later behind the Branding API.
+func defaultBranding() api.Branding {
+	return api.Branding{
+		Layout:         api.NewOptBrandingLayout(api.BrandingLayoutCentered),
+		LiquidTemplate: api.NewOptString(defaultLiquidTemplate),
+	}
+}

--- a/internal/api/branding/default.liquid
+++ b/internal/api/branding/default.liquid
@@ -1,0 +1,52 @@
+{% comment %}
+  Default LiquidJS template for the flow engine MVP. Rendered by the
+  orchestrator into Shadow DOM. Customers can replace it via the
+  Team/App Branding API once that endpoint ships.
+
+  Available context:
+    step.name             - step identifier
+    step.error            - optional error key
+    step.fields           - dictionary of {name -> field}
+    step.actions          - dictionary of {name -> action}
+    step.complete         - "redirect" | "show" | null
+    step.redirect_url     - present when complete == "redirect"
+{% endcomment %}
+
+<section class="zl-flow zl-flow--{{ step.name }}">
+  {% if step.error %}
+    <p class="zl-flow__error" role="alert">{{ step.error | t }}</p>
+  {% endif %}
+
+  {% if step.complete == "show" %}
+    <p class="zl-flow__done">{{ step.name | t }}</p>
+  {% else %}
+    <form class="zl-flow__form">
+      {% for entry in step.fields %}
+        {% assign name = entry[0] %}
+        {% assign field = entry[1] %}
+        <label class="zl-flow__field">
+          <span>{{ field.text_key | t }}</span>
+          <input
+            name="{{ name }}"
+            type="{{ field.type }}"
+            {% if field.required %}required{% endif %}
+            {% if field.value %}value="{{ field.value }}"{% endif %}
+          />
+        </label>
+      {% endfor %}
+
+      <div class="zl-flow__actions">
+        {% for entry in step.actions %}
+          {% assign name = entry[0] %}
+          {% assign action = entry[1] %}
+          <button
+            type="submit"
+            name="action"
+            value="{{ name }}"
+            {% if action.primary %}class="zl-flow__action--primary"{% endif %}
+          >{{ action.text_key | t }}</button>
+        {% endfor %}
+      </div>
+    </form>
+  {% endif %}
+</section>

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -2,13 +2,41 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"time"
 
+	"github.com/go-faster/jx"
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
 )
+
+// flowCookieName is the cookie that carries the sealed [domain.FlowState].
+const flowCookieName = "_zflow"
+
+// flowCookieMaxAgeSeconds bounds how long a sealed [domain.FlowState]
+// remains replayable. Validated on Open via [domain.FlowState.IssuedAt].
+const flowCookieMaxAgeSeconds = 600
+
+// flowCookiePath scopes the cookie to the /flow space; browsers will
+// only resend it for those routes.
+const flowCookiePath = "/flow"
+
+// ─── error sentinels ────────────────────────────────────────────────
+
+var (
+	errFlowCookieMissing = errors.New("flow cookie missing")
+	errFlowCookieInvalid = errors.New("flow cookie invalid")
+	errFlowCookieExpired = errors.New("flow cookie expired")
+	errFlowIDMismatch    = errors.New("flow id does not match cookie")
+	errFlowCompleted     = errors.New("flow already completed")
+)
+
+// ─── CreateFlow ─────────────────────────────────────────────────────
 
 func (h Handler) CreateFlow(ctx context.Context, req *api.CreateFlowRequest) (api.CreateFlowRes, error) {
 	purpose, err := domain.FlowDefinitionPurposeString(string(req.Purpose))
@@ -39,12 +67,329 @@ func (h Handler) CreateFlow(ctx context.Context, req *api.CreateFlowRequest) (ap
 		return errorResponse(err), nil
 	}
 
-	// Execution is intentionally stopped here. The service resolved a
-	// definition; emitting steps + cookies is the next slice of work.
-	return &api.ErrorDetails{
-		Code:    "flow_execution_not_implemented",
-		Message: fmt.Sprintf("selected flow %q (version %s, id %s); execution not yet implemented", def.Name, def.SchemaVersion, def.ID),
+	startReq := service.StartFlowRequest{
+		Definition: def,
+		Purpose:    purpose,
+	}
+	if uri, ok := req.RedirectURI.Get(); ok {
+		// TODO: validate against the RP's redirect_uri allowlist once
+		// the OIDC layer ships.
+		s := uri.String()
+		startReq.RedirectURI = &s
+	}
+	if id, ok := req.AuthRequestID.Get(); ok {
+		// TODO: bind the auth request once OIDC mints them.
+		startReq.AuthRequestID = &id
+	}
+	if id, ok := req.SessionID.Get(); ok {
+		startReq.SessionID = &id
+	}
+
+	result, err := h.flowService.Start(ctx, startReq)
+	if err != nil {
+		return mapFlowErrorStatus(err), nil
+	}
+
+	cookieValue, err := h.sealState(result.State)
+	if err != nil {
+		return internalErrorResponse(err), nil
+	}
+
+	resp := h.buildFlowResponse(result, false)
+	return &api.FlowResponseHeaders{
+		SetCookie: api.NewOptString(flowSetCookie(cookieValue, false)),
+		Response:  resp,
 	}, nil
+}
+
+// ─── SubmitFlowStep ─────────────────────────────────────────────────
+
+func (h Handler) SubmitFlowStep(ctx context.Context, req *api.FlowSubmitRequest, params api.SubmitFlowStepParams) (api.SubmitFlowStepRes, error) {
+	state, err := h.openState(params.Zflow)
+	if err != nil {
+		return mapFlowErrorStatus(err), nil
+	}
+	if state.ID != params.ID {
+		return mapFlowErrorStatus(errFlowIDMismatch), nil
+	}
+
+	submitReq := service.SubmitFlowRequest{
+		State:  state,
+		Action: req.Action,
+	}
+	if fields, ok := req.Fields.Get(); ok {
+		decoded, err := decodeFlowFields(fields)
+		if err != nil {
+			return errorResponseWithStatusCode(http.StatusBadRequest, domain.ErrRequestInvalid().WithMessage(err.Error())), nil
+		}
+		submitReq.Fields = decoded
+	}
+	if proofs, ok := req.GateProofs.Get(); ok {
+		submitReq.GateProofs = proofs
+	}
+	if id, ok := req.SSOProviderID.Get(); ok {
+		submitReq.SSOProviderID = &id
+	}
+
+	result, err := h.flowService.Submit(ctx, submitReq)
+	if err != nil {
+		return mapFlowErrorStatus(err), nil
+	}
+
+	cookieValue, err := h.sealState(result.State)
+	if err != nil {
+		return internalErrorResponse(err), nil
+	}
+
+	terminal := result.Step != nil && result.Step.Complete != nil
+	flowResp := h.buildFlowResponse(result, terminal)
+
+	// On a validation error the state machine returns the step with
+	// `Error` set and a non-terminal completion. Surface it as 400.
+	if result.Step != nil && result.Step.Error != nil {
+		return &api.SubmitFlowStepBadRequest{
+			SetCookie: api.NewOptString(flowSetCookie(cookieValue, false)),
+			Response:  flowResp,
+		}, nil
+	}
+
+	return &api.SubmitFlowStepOK{
+		SetCookie: api.NewOptString(flowSetCookie(cookieValue, terminal)),
+		Response:  flowResp,
+	}, nil
+}
+
+// ─── GetFlowStep ────────────────────────────────────────────────────
+
+func (h Handler) GetFlowStep(ctx context.Context, params api.GetFlowStepParams) (api.GetFlowStepRes, error) {
+	state, err := h.openState(params.Zflow)
+	if err != nil {
+		return mapFlowGetError(err), nil
+	}
+	if state.ID != params.ID {
+		return mapFlowGetError(errFlowIDMismatch), nil
+	}
+
+	result, err := h.flowService.GetStep(ctx, service.GetFlowStepRequest{State: state})
+	if err != nil {
+		return errorResponse(err), nil
+	}
+	if result.Step != nil && result.Step.Complete != nil {
+		return mapFlowGetError(errFlowCompleted), nil
+	}
+
+	resp := h.buildFlowResponse(result, false)
+	return &resp, nil
+}
+
+// ─── SubmitFlowEvent ────────────────────────────────────────────────
+
+func (h Handler) SubmitFlowEvent(ctx context.Context, req *api.FlowEventRequest, params api.SubmitFlowEventParams) (api.SubmitFlowEventRes, error) {
+	state, err := h.openState(params.Zflow)
+	if err != nil {
+		return mapFlowEventError(err), nil
+	}
+	if state.ID != params.ID {
+		return mapFlowEventError(errFlowIDMismatch), nil
+	}
+	// Read-only ack — no state mutation, no Set-Cookie so event
+	// submissions don't act as stealth cookie keep-alives. Concrete
+	// event sinks land later.
+	return &api.SubmitFlowEventNoContent{}, nil
+}
+
+// ─── helpers ────────────────────────────────────────────────────────
+
+// openState decodes and freshness-checks the sealed flow cookie.
+func (h Handler) openState(raw string) (*domain.FlowState, error) {
+	if raw == "" {
+		return nil, errFlowCookieMissing
+	}
+	payload, err := h.sealer.Open(raw)
+	if err != nil {
+		return nil, errFlowCookieInvalid
+	}
+	var state domain.FlowState
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return nil, errFlowCookieInvalid
+	}
+	if h.now().Sub(state.IssuedAt) > flowCookieMaxAgeSeconds*time.Second {
+		return nil, errFlowCookieExpired
+	}
+	return &state, nil
+}
+
+func (h Handler) sealState(state *domain.FlowState) (string, error) {
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("marshal flow state: %w", err)
+	}
+	return h.sealer.Seal(payload)
+}
+
+func flowSetCookie(value string, clear bool) string {
+	if clear {
+		return fmt.Sprintf("%s=; Path=%s; HttpOnly; Secure; SameSite=Strict; Max-Age=0",
+			flowCookieName, flowCookiePath)
+	}
+	return fmt.Sprintf("%s=%s; Path=%s; HttpOnly; Secure; SameSite=Strict; Max-Age=%d",
+		flowCookieName, value, flowCookiePath, flowCookieMaxAgeSeconds)
+}
+
+func (h Handler) buildFlowResponse(result service.FlowStepResult, terminal bool) api.FlowResponse {
+	resp := api.FlowResponse{
+		ID:        result.State.ID,
+		SessionID: result.State.SessionID,
+		Step:      toFlowStep(result.Step),
+		Branding:  api.NewOptBranding(defaultBranding()),
+	}
+	if terminal && result.State.RedirectURI != nil {
+		u, err := parseURI(*result.State.RedirectURI)
+		if err == nil {
+			resp.RedirectURI = api.NewOptURI(u)
+		}
+	}
+	return resp
+}
+
+func toFlowStep(step *domain.FlowStep) api.FlowStep {
+	if step == nil {
+		return api.FlowStep{}
+	}
+	out := api.FlowStep{
+		Name:    step.Name,
+		Fields:  toFlowStepFields(step.Fields),
+		Actions: toFlowStepActions(step.Actions),
+		Gates:   api.FlowStepGates{},
+	}
+	if step.Error != nil {
+		out.Error = api.NewOptNilString(*step.Error)
+	}
+	if step.Complete != nil {
+		out.Complete = api.NewOptFlowStepComplete(toFlowStepComplete(*step.Complete))
+	}
+	if step.RedirectURL != nil {
+		if u, err := parseURI(*step.RedirectURL); err == nil {
+			out.RedirectURL = api.NewOptURI(u)
+		}
+	}
+	return out
+}
+
+func toFlowStepFields(fields map[string]domain.FlowField) api.FlowStepFields {
+	out := make(api.FlowStepFields, len(fields))
+	for name, f := range fields {
+		out[name] = toFlowField(f)
+	}
+	return out
+}
+
+func toFlowField(f domain.FlowField) api.Field {
+	out := api.Field{
+		Type:     api.FieldType(f.Type),
+		TextKey:  f.TextKey,
+		Required: api.NewOptBool(f.Required),
+	}
+	if f.Value != nil {
+		out.Value = jx.Raw(jsonQuoted(*f.Value))
+	}
+	return out
+}
+
+func toFlowStepActions(actions map[string]domain.FlowAction) api.FlowStepActions {
+	out := make(api.FlowStepActions, len(actions))
+	for name, a := range actions {
+		out[name] = api.StepAction{
+			TextKey: api.NewOptString(a.TextKey),
+			Primary: api.NewOptBool(a.Primary),
+		}
+	}
+	return out
+}
+
+func toFlowStepComplete(c domain.FlowStepComplete) api.FlowStepComplete {
+	switch c {
+	case domain.FlowStepCompleteRedirect:
+		return api.FlowStepCompleteRedirect
+	case domain.FlowStepCompleteShow:
+		return api.FlowStepCompleteShow
+	}
+	return api.FlowStepCompleteShow
+}
+
+func decodeFlowFields(raw map[string]jx.Raw) (map[string]any, error) {
+	out := make(map[string]any, len(raw))
+	for k, v := range raw {
+		var decoded any
+		if err := json.Unmarshal(v, &decoded); err != nil {
+			return nil, fmt.Errorf("decode field %q: %w", k, err)
+		}
+		out[k] = decoded
+	}
+	return out, nil
+}
+
+func jsonQuoted(s string) []byte {
+	b, _ := json.Marshal(s)
+	return b
+}
+
+// mapFlowErrorStatus returns the ErrorDetailsStatusCode that satisfies
+// every flow response interface (Create / Submit / Event). Falls
+// through to errorResponse for anything outside the flow-cookie /
+// state-machine vocabulary so domain errors still get their dedicated
+// HTTP mapping.
+func mapFlowErrorStatus(err error) *api.ErrorDetailsStatusCode {
+	switch {
+	case errors.Is(err, errFlowCookieMissing), errors.Is(err, errFlowCookieInvalid):
+		return errorResponseWithStatusCode(http.StatusUnauthorized,
+			domain.Error{Code: "flow_cookie_invalid", Message: "flow cookie is missing or invalid"})
+	case errors.Is(err, errFlowCookieExpired):
+		return errorResponseWithStatusCode(http.StatusUnauthorized,
+			domain.Error{Code: "flow_cookie_expired", Message: "flow cookie has expired"})
+	case errors.Is(err, errFlowIDMismatch):
+		return errorResponseWithStatusCode(http.StatusNotFound,
+			domain.Error{Code: "flow_not_found", Message: "flow id does not match cookie"})
+	case errors.Is(err, errFlowCompleted):
+		return errorResponseWithStatusCode(http.StatusGone,
+			domain.Error{Code: "flow_completed", Message: "flow has already completed"})
+	case errors.Is(err, domain.ErrInvalidAction):
+		return errorResponseWithStatusCode(http.StatusBadRequest,
+			domain.Error{Code: "invalid_action", Message: err.Error()})
+	case errors.Is(err, domain.ErrSessionConflict):
+		return errorResponseWithStatusCode(http.StatusConflict,
+			domain.Error{Code: "session_conflict", Message: err.Error()})
+	case errors.Is(err, domain.ErrUnsupported):
+		return errorResponseWithStatusCode(http.StatusBadRequest,
+			domain.Error{Code: "unsupported", Message: err.Error()})
+	}
+	return errorResponse(err)
+}
+
+func mapFlowGetError(err error) api.GetFlowStepRes {
+	switch {
+	case errors.Is(err, errFlowCookieMissing), errors.Is(err, errFlowCookieInvalid),
+		errors.Is(err, errFlowCookieExpired), errors.Is(err, errFlowIDMismatch):
+		details := api.ErrorDetails{Code: "flow_not_found", Message: "flow not found"}
+		notFound := api.GetFlowStepNotFound(details)
+		return &notFound
+	case errors.Is(err, errFlowCompleted):
+		details := api.ErrorDetails{Code: "flow_completed", Message: "flow has already completed"}
+		gone := api.GetFlowStepGone(details)
+		return &gone
+	}
+	return errorResponse(err)
+}
+
+func mapFlowEventError(err error) api.SubmitFlowEventRes {
+	switch {
+	case errors.Is(err, errFlowCookieMissing), errors.Is(err, errFlowCookieInvalid),
+		errors.Is(err, errFlowCookieExpired), errors.Is(err, errFlowIDMismatch):
+		details := api.ErrorDetails{Code: "flow_not_found", Message: "flow not found"}
+		notFound := api.SubmitFlowEventNotFound(details)
+		return &notFound
+	}
+	return errorResponse(err)
 }
 
 func buildResolveHint(opt api.OptFlowHint) service.ResolveFlowHint {
@@ -74,4 +419,13 @@ func flowDefinitionErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
 	default:
 		return internalErrorResponse(err)
 	}
+}
+
+// parseURI parses a string into the url.URL ogen requires for OptURI.
+func parseURI(s string) (url.URL, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return url.URL{}, err
+	}
+	return *u, nil
 }

--- a/internal/api/flow_test.go
+++ b/internal/api/flow_test.go
@@ -1,0 +1,339 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gen "github.com/zitadel/nextgen/api/generated"
+	"github.com/zitadel/nextgen/internal/api"
+	"github.com/zitadel/nextgen/internal/cookie"
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+)
+
+// ─── fakes ──────────────────────────────────────────────────────────
+
+type fakeFlowSvc struct {
+	def      *domain.FlowDefinition
+	resolveErr error
+
+	startResult  service.FlowStepResult
+	startErr     error
+	submitResult service.FlowStepResult
+	submitErr    error
+	getResult    service.FlowStepResult
+	getErr       error
+
+	gotStartReq  service.StartFlowRequest
+	gotSubmitReq service.SubmitFlowRequest
+	gotGetReq    service.GetFlowStepRequest
+}
+
+func (f *fakeFlowSvc) Resolve(_ context.Context, _ service.ResolveFlowRequest) (*domain.FlowDefinition, error) {
+	return f.def, f.resolveErr
+}
+
+func (f *fakeFlowSvc) Start(_ context.Context, req service.StartFlowRequest) (service.FlowStepResult, error) {
+	f.gotStartReq = req
+	return f.startResult, f.startErr
+}
+
+func (f *fakeFlowSvc) Submit(_ context.Context, req service.SubmitFlowRequest) (service.FlowStepResult, error) {
+	f.gotSubmitReq = req
+	return f.submitResult, f.submitErr
+}
+
+func (f *fakeFlowSvc) GetStep(_ context.Context, req service.GetFlowStepRequest) (service.FlowStepResult, error) {
+	f.gotGetReq = req
+	return f.getResult, f.getErr
+}
+
+var _ service.FlowService = (*fakeFlowSvc)(nil)
+
+// stubAuthAttempt is the bare-minimum implementation needed to satisfy
+// the handler dependency. The flow handlers never call into it
+// directly; the state machine does (and we use a fake FlowService that
+// short-circuits the state machine).
+type stubAuthAttempt struct{}
+
+func (stubAuthAttempt) Create(context.Context, service.CreateAuthAttemptInput) (*domain.AuthAttempt, error) {
+	return nil, errors.New("stub auth attempt")
+}
+func (stubAuthAttempt) GetByID(context.Context, string, string) (*domain.AuthAttempt, error) {
+	return nil, errors.New("stub auth attempt")
+}
+func (stubAuthAttempt) IssueChallenge(context.Context, service.IssueChallengeInput) (*domain.AuthAttempt, error) {
+	return nil, errors.New("stub auth attempt")
+}
+func (stubAuthAttempt) VerifyProof(context.Context, service.VerifyProofInput) (*domain.AuthAttempt, error) {
+	return nil, errors.New("stub auth attempt")
+}
+func (stubAuthAttempt) Handoff(context.Context, service.HandoffInput) (*domain.AuthAttempt, error) {
+	return nil, errors.New("stub auth attempt")
+}
+
+var _ service.AuthAttemptService = stubAuthAttempt{}
+
+// ─── helpers ────────────────────────────────────────────────────────
+
+// fixedKey is a deterministic key for cookie sealing inside tests.
+// Tests never touch real secrets; the sealer just needs a valid key.
+var fixedKey = cookie.Key{
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+	0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+	0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+}
+
+type testServer struct {
+	srv    *httptest.Server
+	sealer *cookie.Sealer
+	fake   *fakeFlowSvc
+	now    func() time.Time
+}
+
+func newTestServer(t *testing.T, now func() time.Time) *testServer {
+	t.Helper()
+	sealer, err := cookie.NewSealer(fixedKey)
+	if err != nil {
+		t.Fatalf("NewSealer: %v", err)
+	}
+	fake := &fakeFlowSvc{}
+	if now == nil {
+		now = time.Now
+	}
+	handler := api.NewHandler(fake, stubAuthAttempt{}, sealer, now)
+	oas, err := gen.NewServer(handler, api.NewSecurityHandler(), gen.WithErrorHandler(api.OgenErrorHandler))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv := httptest.NewServer(oas)
+	t.Cleanup(srv.Close)
+	return &testServer{srv: srv, sealer: sealer, fake: fake, now: now}
+}
+
+// sealCookie marshals a FlowState and seals it the same way the
+// handler does, so tests can craft an inbound cookie for Submit / Get
+// / Event without bootstrapping a full CreateFlow.
+func (ts *testServer) sealCookie(t *testing.T, state *domain.FlowState) string {
+	t.Helper()
+	payload, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	value, err := ts.sealer.Seal(payload)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	return value
+}
+
+func doRequest(t *testing.T, method, url string, body any, cookieValue string) (*http.Response, []byte) {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, url, rdr)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if cookieValue != "" {
+		req.AddCookie(&http.Cookie{Name: "_zflow", Value: cookieValue})
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	return resp, data
+}
+
+// ─── tests ──────────────────────────────────────────────────────────
+
+func TestCreateFlow_ReturnsCookieAndFlowID(t *testing.T) {
+	ts := newTestServer(t, nil)
+	ts.fake.def = &domain.FlowDefinition{ProjectID: "proj_1", ID: "def_1", Purposes: map[domain.FlowDefinitionPurpose]string{domain.FlowDefinitionPurposeLogin: "identify"}}
+	ts.fake.startResult = service.FlowStepResult{
+		State: &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: ts.now()},
+		Step:  &domain.FlowStep{Name: "identify"},
+	}
+
+	resp, body := doRequest(t, http.MethodPost, ts.srv.URL+"/flow", map[string]any{
+		"project_id": "proj_1",
+		"purpose":    "login",
+	}, "")
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(resp.Header.Get("Set-Cookie"), "_zflow=") {
+		t.Errorf("expected Set-Cookie header, got %q", resp.Header.Get("Set-Cookie"))
+	}
+	var fr gen.FlowResponse
+	if err := json.Unmarshal(body, &fr); err != nil {
+		t.Fatalf("unmarshal: %v (body=%s)", err, body)
+	}
+	if fr.ID != "flow_1" {
+		t.Errorf("id = %q, want flow_1", fr.ID)
+	}
+	if b, ok := fr.Branding.Get(); !ok || !b.LiquidTemplate.IsSet() || b.LiquidTemplate.Value == "" {
+		t.Errorf("expected branding.liquid_template to be set, got %+v", fr.Branding)
+	}
+}
+
+func TestSubmitFlowStep_PathIDMismatchReturns404(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{ID: "flow_real", IssuedAt: ts.now()}
+	cookieVal := ts.sealCookie(t, state)
+
+	resp, body := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_wrong/submit", map[string]any{
+		"action": "submit",
+	}, cookieVal)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+}
+
+func TestSubmitFlowStep_TamperedCookieReturns401(t *testing.T) {
+	ts := newTestServer(t, nil)
+	resp, _ := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
+		"action": "submit",
+	}, "garbage")
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestSubmitFlowStep_StaleCookieReturns401(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	ts := newTestServer(t, func() time.Time { return now })
+
+	stale := now.Add(-30 * time.Minute)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: stale}
+	cookieVal := ts.sealCookie(t, state)
+
+	resp, _ := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
+		"action": "submit",
+	}, cookieVal)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 for stale cookie", resp.StatusCode)
+	}
+}
+
+func TestSubmitFlowStep_HappyPath_RotatesCookie(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: ts.now()}
+	cookieVal := ts.sealCookie(t, state)
+
+	advanced := &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: ts.now()}
+	ts.fake.submitResult = service.FlowStepResult{State: advanced, Step: &domain.FlowStep{Name: "password"}}
+
+	resp, body := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
+		"action": "submit",
+		"fields": map[string]any{"identifier": "alice@example.com"},
+	}, cookieVal)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("Set-Cookie"); !strings.Contains(got, "_zflow=") {
+		t.Errorf("expected rotated Set-Cookie, got %q", got)
+	}
+	if got := ts.fake.gotSubmitReq.Fields["identifier"]; got != "alice@example.com" {
+		t.Errorf("decoded identifier = %v, want alice@example.com", got)
+	}
+}
+
+func TestSubmitFlowStep_TerminalClearsCookie(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	cookieVal := ts.sealCookie(t, state)
+
+	complete := domain.FlowStepCompleteShow
+	terminal := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	ts.fake.submitResult = service.FlowStepResult{State: terminal, Step: &domain.FlowStep{Name: "done", Complete: &complete}}
+
+	resp, _ := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
+		"action": "submit",
+	}, cookieVal)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	got := resp.Header.Get("Set-Cookie")
+	if !strings.Contains(got, "Max-Age=0") {
+		t.Errorf("expected Max-Age=0 on terminal, got %q", got)
+	}
+}
+
+func TestGetFlowStep_ReturnsCurrentStep(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{
+		ID:           "flow_1",
+		ProjectID:    "proj_1",
+		SessionID:    "sess_1",
+		IssuedAt:     ts.now(),
+		FlowProgress: domain.FlowProgress{CurrentStep: "identify"},
+	}
+	cookieVal := ts.sealCookie(t, state)
+	ts.fake.getResult = service.FlowStepResult{State: state, Step: &domain.FlowStep{Name: "identify"}}
+
+	resp, body := doRequest(t, http.MethodGet, ts.srv.URL+"/flow/flow_1", nil, cookieVal)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	var fr gen.FlowResponse
+	if err := json.Unmarshal(body, &fr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if fr.Step.Name != "identify" {
+		t.Errorf("step name = %q, want identify", fr.Step.Name)
+	}
+}
+
+func TestGetFlowStep_TerminalReturns410(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	cookieVal := ts.sealCookie(t, state)
+
+	complete := domain.FlowStepCompleteShow
+	ts.fake.getResult = service.FlowStepResult{
+		State: state,
+		Step:  &domain.FlowStep{Name: "done", Complete: &complete},
+	}
+
+	resp, _ := doRequest(t, http.MethodGet, ts.srv.URL+"/flow/flow_1", nil, cookieVal)
+	if resp.StatusCode != http.StatusGone {
+		t.Fatalf("status = %d, want 410", resp.StatusCode)
+	}
+}
+
+func TestSubmitFlowEvent_ReturnsNoContentWithoutSetCookie(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	cookieVal := ts.sealCookie(t, state)
+
+	resp, _ := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/event", map[string]any{
+		"type": "telemetry",
+	}, cookieVal)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Set-Cookie"); got != "" {
+		t.Errorf("expected no Set-Cookie, got %q", got)
+	}
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"context"
+	"time"
 
 	api "github.com/zitadel/nextgen/api/generated"
+	"github.com/zitadel/nextgen/internal/cookie"
 	"github.com/zitadel/nextgen/internal/service"
 )
 
@@ -14,15 +16,24 @@ type Handler struct {
 
 	flowService        service.FlowService
 	authAttemptService service.AuthAttemptService
+	sealer             *cookie.Sealer
+	now                func() time.Time
 }
 
 func NewHandler(
 	flowService service.FlowService,
 	authAttemptService service.AuthAttemptService,
+	sealer *cookie.Sealer,
+	now func() time.Time,
 ) *Handler {
+	if now == nil {
+		now = time.Now
+	}
 	return &Handler{
 		flowService:        flowService,
 		authAttemptService: authAttemptService,
+		sealer:             sealer,
+		now:                now,
 	}
 }
 

--- a/internal/domain/flow_auth_attempt.go
+++ b/internal/domain/flow_auth_attempt.go
@@ -33,26 +33,3 @@ type FlowSubmitPasswordInput struct {
 	AttemptID string
 	Plain     string
 }
-
-// FlowAuthAttemptRuntime is the production [FlowAuthAttemptService].
-// Methods are panic-stubbed until the auth-attempt PR line fleshes out
-// the underlying issue+verify primitives.
-type FlowAuthAttemptRuntime struct{}
-
-func NewFlowAuthAttemptRuntime() *FlowAuthAttemptRuntime {
-	return &FlowAuthAttemptRuntime{}
-}
-
-var _ FlowAuthAttemptService = (*FlowAuthAttemptRuntime)(nil)
-
-func (r *FlowAuthAttemptRuntime) Start(ctx context.Context, in FlowCreateAttemptInput) (string, error) {
-	panic("implement me")
-}
-
-func (r *FlowAuthAttemptRuntime) SubmitIdentifier(ctx context.Context, in FlowSubmitIdentifierInput) (string, error) {
-	panic("implement me")
-}
-
-func (r *FlowAuthAttemptRuntime) SubmitPassword(ctx context.Context, in FlowSubmitPasswordInput) error {
-	panic("implement me")
-}

--- a/internal/domain/flow_state.go
+++ b/internal/domain/flow_state.go
@@ -11,6 +11,11 @@ import "time"
 // live on PivotStack. The remaining fields are session/OIDC context
 // that only makes sense at the top level.
 type FlowState struct {
+	// ID is the flow handle minted at Start. The handler echoes it back
+	// on the path (`/flow/{id}/...`) and verifies it matches the cookie
+	// to reject path/cookie mismatches.
+	ID string
+
 	// ProjectID scopes the flow to a single tenant.
 	ProjectID string
 

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -19,15 +19,19 @@ import (
 type FlowStateMachine interface {
 	Start(ctx context.Context, client database.QueryExecutor, in FlowStartInput) (FlowStepResult, error)
 	Process(ctx context.Context, client database.QueryExecutor, def *FlowDefinition, state *FlowState, in FlowSubmitInput) (FlowStepResult, error)
+	Render(ctx context.Context, client database.QueryExecutor, def *FlowDefinition, state *FlowState) (FlowStepResult, error)
 }
 
 // FlowStartInput carries everything the state machine needs to
-// bootstrap a new flow.
+// bootstrap a new flow. RedirectURI is independent of AuthRequest so
+// standalone flows (no OIDC binding) can still terminate with a
+// redirect target.
 type FlowStartInput struct {
 	Definition    *FlowDefinition
 	Purpose       FlowDefinitionPurpose
 	Session       FlowSessionRef
 	AuthRequest   *FlowAuthRequestRef
+	RedirectURI   *string
 	UserSchemaURL string
 }
 
@@ -87,7 +91,6 @@ type FlowSessionRef struct {
 // is fulfilling.
 type FlowAuthRequestRef struct {
 	ID           string
-	RedirectURI  string
 	RequestedACR *string
 }
 
@@ -146,8 +149,11 @@ func (r *FlowStateMachineRuntime) Start(ctx context.Context, client database.Que
 	}
 	if in.AuthRequest != nil {
 		state.AuthRequestID = &in.AuthRequest.ID
-		state.RedirectURI = &in.AuthRequest.RedirectURI
 		state.RequestedACR = in.AuthRequest.RequestedACR
+	}
+	if in.RedirectURI != nil {
+		uri := *in.RedirectURI
+		state.RedirectURI = &uri
 	}
 
 	if r.authAttempts == nil {
@@ -163,6 +169,22 @@ func (r *FlowStateMachineRuntime) Start(ctx context.Context, client database.Que
 	if err != nil {
 		return FlowStepResult{}, err
 	}
+	return FlowStepResult{State: state, Step: step}, nil
+}
+
+// Render re-emits the current step without advancing. Used by
+// GET /flow/{id} so refresh works without consuming a transition.
+// Refreshes [FlowState.IssuedAt] so the cookie max-age window slides
+// while the user is still on the step.
+func (r *FlowStateMachineRuntime) Render(ctx context.Context, client database.QueryExecutor, def *FlowDefinition, state *FlowState) (FlowStepResult, error) {
+	if def == nil || state == nil {
+		return FlowStepResult{}, fmt.Errorf("%w: render without definition or state", ErrIntegrity)
+	}
+	step, err := r.renderStep(ctx, client, def, state, state.UserSchemaURL, nil)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	state.IssuedAt = r.now()
 	return FlowStepResult{State: state, Step: step}, nil
 }
 

--- a/internal/service/flow.go
+++ b/internal/service/flow.go
@@ -2,15 +2,16 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/domain/idgen"
 	"github.com/zitadel/nextgen/internal/storage/database"
 )
 
-// FlowService is the flow engine's use-case surface. For now only
-// [FlowService.Resolve] is wired; step emission, submission, and session
-// handling will land as additional methods so the API handler keeps a
-// single dependency.
+// FlowService is the flow engine's use-case surface. The API handler
+// depends only on this interface — never on the state machine or
+// repositories directly.
 type FlowService interface {
 	// Resolve returns the [domain.FlowDefinition] to run for an incoming
 	// flow request. Read-only — never touches sessions or cookies.
@@ -28,6 +29,56 @@ type FlowService interface {
 	//     is plumbed through but not yet honored — see TODO on
 	//     resolveByAudience.
 	Resolve(ctx context.Context, req ResolveFlowRequest) (*domain.FlowDefinition, error)
+
+	// Start mints a fresh flow on top of the resolved definition. The
+	// returned [FlowStepResult] carries the initial step plus a
+	// [domain.FlowState] with [domain.FlowState.ID] and
+	// [domain.FlowState.SessionID] populated.
+	Start(ctx context.Context, req StartFlowRequest) (FlowStepResult, error)
+
+	// Submit drives a single client submission through the state
+	// machine. The handler is responsible for opening + resealing the
+	// cookie; this method just re-fetches the definition by
+	// [domain.FlowState.DefinitionID] and calls Process.
+	Submit(ctx context.Context, req SubmitFlowRequest) (FlowStepResult, error)
+
+	// GetStep re-emits the current step without advancing. Backs
+	// `GET /flow/{id}` so page refreshes don't consume transitions.
+	GetStep(ctx context.Context, req GetFlowStepRequest) (FlowStepResult, error)
+}
+
+// FlowStepResult is the service-layer projection of
+// [domain.FlowStepResult]. Handlers receive a single shape regardless
+// of whether the result came from Start, Submit, or GetStep.
+type FlowStepResult struct {
+	State *domain.FlowState
+	Step  *domain.FlowStep
+}
+
+// StartFlowRequest carries the inputs to [FlowService.Start]. The
+// resolved definition is passed back in by the handler so Start does
+// not re-walk the resolution algorithm.
+type StartFlowRequest struct {
+	Definition    *domain.FlowDefinition
+	Purpose       domain.FlowDefinitionPurpose
+	RedirectURI   *string
+	AuthRequestID *string
+	SessionID     *string
+}
+
+// SubmitFlowRequest carries one client submission. State is the cookie
+// payload the handler decoded for this request.
+type SubmitFlowRequest struct {
+	State         *domain.FlowState
+	Action        string
+	Fields        map[string]any
+	GateProofs    map[string]string
+	SSOProviderID *string
+}
+
+// GetFlowStepRequest carries the cookie payload for a refresh.
+type GetFlowStepRequest struct {
+	State *domain.FlowState
 }
 
 // ResolveFlowRequest is the input to [FlowService.Resolve].
@@ -59,16 +110,28 @@ type ResolveFlowHint struct {
 	UserSchemaID *string
 }
 
-// NewFlowService returns a [FlowService] backed by the given
-// [domain.FlowDefinitionRepository]. The pool is used as the
+// NewFlowService returns a [FlowService] composing the definition
+// repository, the state machine, and an ID generator. The pool is the
 // [database.QueryExecutor] for every read.
-func NewFlowService(pool database.Pool, flowDefs domain.FlowDefinitionRepository) FlowService {
-	return &flowService{pool: pool, flowDefs: flowDefs}
+func NewFlowService(
+	pool database.Pool,
+	flowDefs domain.FlowDefinitionRepository,
+	stateMachine domain.FlowStateMachine,
+	ids idgen.Generator,
+) FlowService {
+	return &flowService{
+		pool:         pool,
+		flowDefs:     flowDefs,
+		stateMachine: stateMachine,
+		ids:          ids,
+	}
 }
 
 type flowService struct {
-	pool     database.Pool
-	flowDefs domain.FlowDefinitionRepository
+	pool         database.Pool
+	flowDefs     domain.FlowDefinitionRepository
+	stateMachine domain.FlowStateMachine
+	ids          idgen.Generator
 }
 
 var _ FlowService = (*flowService)(nil)
@@ -131,6 +194,85 @@ func (s *flowService) resolveByAudience(ctx context.Context, req ResolveFlowRequ
 		return nil, domain.ErrFlowDefinitionNotFound()
 	}
 	return defs[0], nil
+}
+
+func (s *flowService) Start(ctx context.Context, req StartFlowRequest) (FlowStepResult, error) {
+	if req.Definition == nil {
+		return FlowStepResult{}, fmt.Errorf("flow service: start without definition")
+	}
+
+	sessionID := ""
+	if req.SessionID != nil {
+		sessionID = *req.SessionID
+	} else {
+		id, err := s.ids.New("sess")
+		if err != nil {
+			return FlowStepResult{}, fmt.Errorf("flow service: mint session id: %w", err)
+		}
+		sessionID = id
+	}
+
+	in := domain.FlowStartInput{
+		Definition:    req.Definition,
+		Purpose:       req.Purpose,
+		Session:       domain.FlowSessionRef{ID: sessionID},
+		RedirectURI:   req.RedirectURI,
+		UserSchemaURL: req.Definition.UserSchema,
+	}
+	if req.AuthRequestID != nil {
+		in.AuthRequest = &domain.FlowAuthRequestRef{ID: *req.AuthRequestID}
+	}
+
+	result, err := s.stateMachine.Start(ctx, s.pool, in)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+
+	flowID, err := s.ids.New("flow")
+	if err != nil {
+		return FlowStepResult{}, fmt.Errorf("flow service: mint flow id: %w", err)
+	}
+	result.State.ID = flowID
+
+	return FlowStepResult{State: result.State, Step: result.Step}, nil
+}
+
+func (s *flowService) Submit(ctx context.Context, req SubmitFlowRequest) (FlowStepResult, error) {
+	if req.State == nil {
+		return FlowStepResult{}, fmt.Errorf("flow service: submit without state")
+	}
+	def, err := s.flowDefs.GetFlowDefinition(ctx, s.pool, req.State.ProjectID, req.State.DefinitionID)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	in := domain.FlowSubmitInput{
+		Action:     req.Action,
+		Fields:     req.Fields,
+		GateProofs: req.GateProofs,
+	}
+	if req.SSOProviderID != nil {
+		in.SSOProvider = &domain.FlowSSOProviderRef{ID: *req.SSOProviderID}
+	}
+	result, err := s.stateMachine.Process(ctx, s.pool, def, req.State, in)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	return FlowStepResult{State: result.State, Step: result.Step}, nil
+}
+
+func (s *flowService) GetStep(ctx context.Context, req GetFlowStepRequest) (FlowStepResult, error) {
+	if req.State == nil {
+		return FlowStepResult{}, fmt.Errorf("flow service: get step without state")
+	}
+	def, err := s.flowDefs.GetFlowDefinition(ctx, s.pool, req.State.ProjectID, req.State.DefinitionID)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	result, err := s.stateMachine.Render(ctx, s.pool, def, req.State)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	return FlowStepResult{State: result.State, Step: result.Step}, nil
 }
 
 func flowServesPurpose(def *domain.FlowDefinition, purpose domain.FlowDefinitionPurpose) bool {

--- a/internal/service/flow_auth_attempt.go
+++ b/internal/service/flow_auth_attempt.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+// FlowAuthAttemptAdapter is the production [domain.FlowAuthAttemptService].
+// It collapses each Submit* call into the underlying [AuthAttemptService]
+// issue+verify pair so the state machine never sees challenge IDs.
+//
+// Identifier no-match and password failure both surface as
+// [domain.ErrAuthAttemptProofRejected]; callers `errors.Is`-match it.
+type FlowAuthAttemptAdapter struct {
+	svc AuthAttemptService
+}
+
+func NewFlowAuthAttemptAdapter(svc AuthAttemptService) *FlowAuthAttemptAdapter {
+	return &FlowAuthAttemptAdapter{svc: svc}
+}
+
+var _ domain.FlowAuthAttemptService = (*FlowAuthAttemptAdapter)(nil)
+
+func (a *FlowAuthAttemptAdapter) Start(ctx context.Context, in domain.FlowCreateAttemptInput) (string, error) {
+	attempt, err := a.svc.Create(ctx, CreateAuthAttemptInput{
+		ProjectID:      in.ProjectID,
+		SessionID:      in.SessionID,
+		RequiredChecks: in.RequiredChecks,
+	})
+	if err != nil {
+		return "", fmt.Errorf("flow auth attempt adapter: create: %w", err)
+	}
+	return attempt.ID, nil
+}
+
+func (a *FlowAuthAttemptAdapter) SubmitIdentifier(ctx context.Context, in domain.FlowSubmitIdentifierInput) (string, error) {
+	issued, err := a.svc.IssueChallenge(ctx, IssueChallengeInput{
+		ProjectID: in.ProjectID,
+		AttemptID: in.AttemptID,
+		Challenge: UserChallenge{},
+	})
+	if err != nil {
+		return "", fmt.Errorf("flow auth attempt adapter: issue user challenge: %w", err)
+	}
+	verified, err := a.svc.VerifyProof(ctx, VerifyProofInput{
+		ProjectID:   in.ProjectID,
+		AttemptID:   in.AttemptID,
+		ChallengeID: challengeIDFor(issued, domain.AuthCheckTypeUser),
+		Proof:       UserProof{LoginName: in.Value},
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrAuthAttemptProofRejected()) {
+			return "", err
+		}
+		return "", fmt.Errorf("flow auth attempt adapter: verify user proof: %w", err)
+	}
+	userCheck, ok := domain.CheckAs[*domain.UserAuthCheck](verified, domain.AuthCheckTypeUser)
+	if !ok || userCheck.Factor == nil {
+		return "", fmt.Errorf("flow auth attempt adapter: user check missing after verify")
+	}
+	return userCheck.Factor.UserID, nil
+}
+
+func (a *FlowAuthAttemptAdapter) SubmitPassword(ctx context.Context, in domain.FlowSubmitPasswordInput) error {
+	issued, err := a.svc.IssueChallenge(ctx, IssueChallengeInput{
+		ProjectID: in.ProjectID,
+		AttemptID: in.AttemptID,
+		Challenge: PasswordChallenge{},
+	})
+	if err != nil {
+		return fmt.Errorf("flow auth attempt adapter: issue password challenge: %w", err)
+	}
+	if _, err := a.svc.VerifyProof(ctx, VerifyProofInput{
+		ProjectID:   in.ProjectID,
+		AttemptID:   in.AttemptID,
+		ChallengeID: challengeIDFor(issued, domain.AuthCheckTypePassword),
+		Proof:       PasswordProof{Password: in.Plain},
+	}); err != nil {
+		if errors.Is(err, domain.ErrAuthAttemptProofRejected()) {
+			return err
+		}
+		return fmt.Errorf("flow auth attempt adapter: verify password proof: %w", err)
+	}
+	return nil
+}
+
+// challengeIDFor extracts the challenge ID for the just-issued check
+// from a returned AuthAttempt. The current [domain.AuthCheck] model on
+// this branch does not carry an ID field; the auth-attempt service
+// implementation will need to surface one (likely on the check itself
+// or a separate challenge value). Returning an empty string keeps the
+// adapter compilable; when the model lands, this helper picks it up.
+//
+// TODO(auth-attempt-impl): replace with the real challenge id once the
+// auth-attempt domain settles.
+func challengeIDFor(attempt *domain.AuthAttempt, typ domain.AuthCheckType) string {
+	if attempt == nil {
+		return ""
+	}
+	if _, ok := attempt.CheckByType(typ); !ok {
+		return ""
+	}
+	return ""
+}

--- a/internal/service/flow_auth_attempt.go
+++ b/internal/service/flow_auth_attempt.go
@@ -105,3 +105,29 @@ func challengeIDFor(attempt *domain.AuthAttempt, typ domain.AuthCheckType) strin
 	}
 	return ""
 }
+
+// ----
+// Dummy implementation while auth_attempt svc is not ready
+// ----
+
+type DummyFlowAuthAttemptAdapter struct {
+	svc AuthAttemptService
+}
+
+func NewDummyFlowAuthAttemptAdapter(_ AuthAttemptService) *DummyFlowAuthAttemptAdapter {
+	return &DummyFlowAuthAttemptAdapter{}
+}
+
+var _ domain.FlowAuthAttemptService = (*DummyFlowAuthAttemptAdapter)(nil)
+
+func (a *DummyFlowAuthAttemptAdapter) Start(ctx context.Context, in domain.FlowCreateAttemptInput) (string, error) {
+	return "attempt.ID", nil
+}
+
+func (a *DummyFlowAuthAttemptAdapter) SubmitIdentifier(ctx context.Context, in domain.FlowSubmitIdentifierInput) (string, error) {
+	return "userCheck.Factor.UserID", nil
+}
+
+func (a *DummyFlowAuthAttemptAdapter) SubmitPassword(ctx context.Context, in domain.FlowSubmitPasswordInput) error {
+	return nil
+}

--- a/internal/service/flow_auth_attempt_test.go
+++ b/internal/service/flow_auth_attempt_test.go
@@ -1,0 +1,189 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+)
+
+// fakeAuthAttemptSvc is a hand-rolled fake of [service.AuthAttemptService]
+// that records calls and lets each test pin per-method behavior.
+type fakeAuthAttemptSvc struct {
+	createFn         func(context.Context, service.CreateAuthAttemptInput) (*domain.AuthAttempt, error)
+	issueChallengeFn func(context.Context, service.IssueChallengeInput) (*domain.AuthAttempt, error)
+	verifyProofFn    func(context.Context, service.VerifyProofInput) (*domain.AuthAttempt, error)
+
+	issueCalls  []service.IssueChallengeInput
+	verifyCalls []service.VerifyProofInput
+}
+
+func (f *fakeAuthAttemptSvc) Create(ctx context.Context, in service.CreateAuthAttemptInput) (*domain.AuthAttempt, error) {
+	return f.createFn(ctx, in)
+}
+
+func (f *fakeAuthAttemptSvc) GetByID(_ context.Context, _, _ string) (*domain.AuthAttempt, error) {
+	panic("unused")
+}
+
+func (f *fakeAuthAttemptSvc) IssueChallenge(ctx context.Context, in service.IssueChallengeInput) (*domain.AuthAttempt, error) {
+	f.issueCalls = append(f.issueCalls, in)
+	return f.issueChallengeFn(ctx, in)
+}
+
+func (f *fakeAuthAttemptSvc) VerifyProof(ctx context.Context, in service.VerifyProofInput) (*domain.AuthAttempt, error) {
+	f.verifyCalls = append(f.verifyCalls, in)
+	return f.verifyProofFn(ctx, in)
+}
+
+func (f *fakeAuthAttemptSvc) Handoff(_ context.Context, _ service.HandoffInput) (*domain.AuthAttempt, error) {
+	panic("unused")
+}
+
+var _ service.AuthAttemptService = (*fakeAuthAttemptSvc)(nil)
+
+func TestFlowAuthAttemptAdapter_Start_DelegatesToCreate(t *testing.T) {
+	called := false
+	svc := &fakeAuthAttemptSvc{
+		createFn: func(_ context.Context, in service.CreateAuthAttemptInput) (*domain.AuthAttempt, error) {
+			called = true
+			if in.ProjectID != "proj-1" {
+				t.Errorf("ProjectID = %q, want proj-1", in.ProjectID)
+			}
+			return &domain.AuthAttempt{ID: "att_1"}, nil
+		},
+	}
+	adapter := service.NewFlowAuthAttemptAdapter(svc)
+
+	id, err := adapter.Start(context.Background(), domain.FlowCreateAttemptInput{ProjectID: "proj-1"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !called {
+		t.Fatal("Create was not invoked")
+	}
+	if id != "att_1" {
+		t.Errorf("attempt id = %q, want att_1", id)
+	}
+}
+
+func TestFlowAuthAttemptAdapter_SubmitIdentifier_HappyPath(t *testing.T) {
+	svc := &fakeAuthAttemptSvc{
+		issueChallengeFn: func(_ context.Context, _ service.IssueChallengeInput) (*domain.AuthAttempt, error) {
+			return &domain.AuthAttempt{
+				Checks: []domain.AuthChecker{
+					&domain.UserAuthCheck{AuthCheck: &domain.AuthCheck{Type: domain.AuthCheckTypeUser}},
+				},
+			}, nil
+		},
+		verifyProofFn: func(_ context.Context, in service.VerifyProofInput) (*domain.AuthAttempt, error) {
+			proof, ok := in.Proof.(service.UserProof)
+			if !ok {
+				t.Fatalf("VerifyProof got %T, want UserProof", in.Proof)
+			}
+			if proof.LoginName != "alice@example.com" {
+				t.Errorf("LoginName = %q, want alice@example.com", proof.LoginName)
+			}
+			return &domain.AuthAttempt{
+				Checks: []domain.AuthChecker{
+					&domain.UserAuthCheck{
+						AuthCheck: &domain.AuthCheck{Type: domain.AuthCheckTypeUser},
+						Factor:    &domain.UserFactor{UserID: "user_42"},
+					},
+				},
+			}, nil
+		},
+	}
+	adapter := service.NewFlowAuthAttemptAdapter(svc)
+
+	userID, err := adapter.SubmitIdentifier(context.Background(), domain.FlowSubmitIdentifierInput{
+		ProjectID: "proj-1",
+		AttemptID: "att_1",
+		Value:     "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("SubmitIdentifier: %v", err)
+	}
+	if userID != "user_42" {
+		t.Errorf("userID = %q, want user_42", userID)
+	}
+	if len(svc.issueCalls) != 1 || len(svc.verifyCalls) != 1 {
+		t.Fatalf("expected 1 issue + 1 verify; got %d / %d", len(svc.issueCalls), len(svc.verifyCalls))
+	}
+}
+
+func TestFlowAuthAttemptAdapter_SubmitIdentifier_PassesThroughProofRejected(t *testing.T) {
+	rejected := domain.ErrAuthAttemptProofRejected()
+	svc := &fakeAuthAttemptSvc{
+		issueChallengeFn: func(_ context.Context, _ service.IssueChallengeInput) (*domain.AuthAttempt, error) {
+			return &domain.AuthAttempt{}, nil
+		},
+		verifyProofFn: func(_ context.Context, _ service.VerifyProofInput) (*domain.AuthAttempt, error) {
+			return nil, rejected
+		},
+	}
+	adapter := service.NewFlowAuthAttemptAdapter(svc)
+
+	_, err := adapter.SubmitIdentifier(context.Background(), domain.FlowSubmitIdentifierInput{
+		ProjectID: "proj-1",
+		AttemptID: "att_1",
+		Value:     "ghost@nowhere",
+	})
+	if !errors.Is(err, rejected) {
+		t.Fatalf("SubmitIdentifier err = %v, want ErrAuthAttemptProofRejected", err)
+	}
+}
+
+func TestFlowAuthAttemptAdapter_SubmitPassword_HappyPath(t *testing.T) {
+	svc := &fakeAuthAttemptSvc{
+		issueChallengeFn: func(_ context.Context, in service.IssueChallengeInput) (*domain.AuthAttempt, error) {
+			if _, ok := in.Challenge.(service.PasswordChallenge); !ok {
+				t.Errorf("Challenge = %T, want PasswordChallenge", in.Challenge)
+			}
+			return &domain.AuthAttempt{}, nil
+		},
+		verifyProofFn: func(_ context.Context, in service.VerifyProofInput) (*domain.AuthAttempt, error) {
+			proof, ok := in.Proof.(service.PasswordProof)
+			if !ok {
+				t.Fatalf("Proof = %T, want PasswordProof", in.Proof)
+			}
+			if proof.Password != "hunter2" {
+				t.Errorf("Password = %q, want hunter2", proof.Password)
+			}
+			return &domain.AuthAttempt{}, nil
+		},
+	}
+	adapter := service.NewFlowAuthAttemptAdapter(svc)
+
+	if err := adapter.SubmitPassword(context.Background(), domain.FlowSubmitPasswordInput{
+		ProjectID: "proj-1",
+		AttemptID: "att_1",
+		Plain:     "hunter2",
+	}); err != nil {
+		t.Fatalf("SubmitPassword: %v", err)
+	}
+}
+
+func TestFlowAuthAttemptAdapter_SubmitPassword_PassesThroughProofRejected(t *testing.T) {
+	rejected := domain.ErrAuthAttemptProofRejected()
+	svc := &fakeAuthAttemptSvc{
+		issueChallengeFn: func(_ context.Context, _ service.IssueChallengeInput) (*domain.AuthAttempt, error) {
+			return &domain.AuthAttempt{}, nil
+		},
+		verifyProofFn: func(_ context.Context, _ service.VerifyProofInput) (*domain.AuthAttempt, error) {
+			return nil, rejected
+		},
+	}
+	adapter := service.NewFlowAuthAttemptAdapter(svc)
+
+	err := adapter.SubmitPassword(context.Background(), domain.FlowSubmitPasswordInput{
+		ProjectID: "proj-1",
+		AttemptID: "att_1",
+		Plain:     "wrong",
+	})
+	if !errors.Is(err, rejected) {
+		t.Fatalf("SubmitPassword err = %v, want ErrAuthAttemptProofRejected", err)
+	}
+}

--- a/internal/service/flow_lifecycle_test.go
+++ b/internal/service/flow_lifecycle_test.go
@@ -1,0 +1,188 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+	"github.com/zitadel/nextgen/internal/storage/database"
+)
+
+// fakeStateMachine is a hand-rolled [domain.FlowStateMachine] that
+// captures inputs and returns the result the test pre-loaded.
+type fakeStateMachine struct {
+	startResult   domain.FlowStepResult
+	startErr      error
+	processResult domain.FlowStepResult
+	processErr    error
+	renderResult  domain.FlowStepResult
+	renderErr     error
+
+	gotStartInput  domain.FlowStartInput
+	gotSubmitInput domain.FlowSubmitInput
+	gotProcessDef  *domain.FlowDefinition
+	gotRenderState *domain.FlowState
+}
+
+func (f *fakeStateMachine) Start(_ context.Context, _ database.QueryExecutor, in domain.FlowStartInput) (domain.FlowStepResult, error) {
+	f.gotStartInput = in
+	return f.startResult, f.startErr
+}
+
+func (f *fakeStateMachine) Process(_ context.Context, _ database.QueryExecutor, def *domain.FlowDefinition, _ *domain.FlowState, in domain.FlowSubmitInput) (domain.FlowStepResult, error) {
+	f.gotProcessDef = def
+	f.gotSubmitInput = in
+	return f.processResult, f.processErr
+}
+
+func (f *fakeStateMachine) Render(_ context.Context, _ database.QueryExecutor, _ *domain.FlowDefinition, state *domain.FlowState) (domain.FlowStepResult, error) {
+	f.gotRenderState = state
+	return f.renderResult, f.renderErr
+}
+
+// stubIDGen returns deterministic IDs prefixed by their resource type.
+type stubIDGen struct {
+	calls int
+}
+
+func (s *stubIDGen) New(prefix string) (string, error) {
+	s.calls++
+	return prefix + "_" + strconv.Itoa(s.calls), nil
+}
+
+func TestFlowService_Start_MintsFlowAndSessionIDs(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	def.UserSchema = "https://example.com/user.json"
+
+	state := &domain.FlowState{ProjectID: def.ProjectID}
+	sm := &fakeStateMachine{startResult: domain.FlowStepResult{State: state, Step: &domain.FlowStep{Name: "start"}}}
+	ids := &stubIDGen{}
+
+	svc := service.NewFlowService(stubPool(), nil, sm, ids)
+
+	res, err := svc.Start(t.Context(), service.StartFlowRequest{
+		Definition: def,
+		Purpose:    domain.FlowDefinitionPurposeLogin,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if res.State == nil || res.State.ID == "" {
+		t.Fatal("flow id was not minted")
+	}
+	if sm.gotStartInput.Session.ID == "" {
+		t.Fatal("session id was not minted")
+	}
+	if sm.gotStartInput.UserSchemaURL != def.UserSchema {
+		t.Errorf("UserSchemaURL = %q, want %q", sm.gotStartInput.UserSchemaURL, def.UserSchema)
+	}
+}
+
+func TestFlowService_Start_PassesRedirectURIThrough(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	state := &domain.FlowState{ProjectID: def.ProjectID}
+	sm := &fakeStateMachine{startResult: domain.FlowStepResult{State: state, Step: &domain.FlowStep{}}}
+
+	svc := service.NewFlowService(stubPool(), nil, sm, &stubIDGen{})
+
+	redirect := "https://rp.example.com/cb"
+	if _, err := svc.Start(t.Context(), service.StartFlowRequest{
+		Definition:  def,
+		Purpose:     domain.FlowDefinitionPurposeLogin,
+		RedirectURI: &redirect,
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if sm.gotStartInput.RedirectURI == nil || *sm.gotStartInput.RedirectURI != redirect {
+		t.Errorf("RedirectURI = %v, want %q", sm.gotStartInput.RedirectURI, redirect)
+	}
+}
+
+func TestFlowService_Start_PreservesProvidedSessionID(t *testing.T) {
+	def := newDef("reauth", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeReauth)
+	state := &domain.FlowState{ProjectID: def.ProjectID}
+	sm := &fakeStateMachine{startResult: domain.FlowStepResult{State: state, Step: &domain.FlowStep{}}}
+
+	svc := service.NewFlowService(stubPool(), nil, sm, &stubIDGen{})
+
+	sessionID := "sess_explicit"
+	if _, err := svc.Start(t.Context(), service.StartFlowRequest{
+		Definition: def,
+		Purpose:    domain.FlowDefinitionPurposeReauth,
+		SessionID:  &sessionID,
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if sm.gotStartInput.Session.ID != sessionID {
+		t.Errorf("Session.ID = %q, want %q", sm.gotStartInput.Session.ID, sessionID)
+	}
+}
+
+func TestFlowService_Start_PropagatesStateMachineError(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	sm := &fakeStateMachine{startErr: errors.New("boom")}
+
+	svc := service.NewFlowService(stubPool(), nil, sm, &stubIDGen{})
+
+	_, err := svc.Start(t.Context(), service.StartFlowRequest{
+		Definition: def,
+		Purpose:    domain.FlowDefinitionPurposeLogin,
+	})
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("Start err = %v, want boom", err)
+	}
+}
+
+func TestFlowService_Submit_RefetchesDefinitionAndCallsProcess(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	repo := stubGetFlowDefinition(t, def)
+	processedState := &domain.FlowState{ID: "flow_1"}
+	sm := &fakeStateMachine{processResult: domain.FlowStepResult{State: processedState, Step: &domain.FlowStep{Name: "next"}}}
+
+	svc := service.NewFlowService(stubPool(), repo, sm, &stubIDGen{})
+
+	state := &domain.FlowState{
+		ID:           "flow_1",
+		ProjectID:    def.ProjectID,
+		FlowProgress: domain.FlowProgress{DefinitionID: def.ID},
+	}
+	if _, err := svc.Submit(t.Context(), service.SubmitFlowRequest{
+		State:  state,
+		Action: "submit",
+	}); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if sm.gotProcessDef == nil || sm.gotProcessDef.ID != def.ID {
+		t.Fatalf("Process was not called with refetched definition")
+	}
+	if sm.gotSubmitInput.Action != "submit" {
+		t.Errorf("Action = %q, want submit", sm.gotSubmitInput.Action)
+	}
+}
+
+func TestFlowService_GetStep_CallsRender(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	repo := stubGetFlowDefinition(t, def)
+	state := &domain.FlowState{
+		ID:           "flow_1",
+		ProjectID:    def.ProjectID,
+		FlowProgress: domain.FlowProgress{DefinitionID: def.ID},
+	}
+	sm := &fakeStateMachine{renderResult: domain.FlowStepResult{State: state, Step: &domain.FlowStep{Name: "identify"}}}
+
+	svc := service.NewFlowService(stubPool(), repo, sm, &stubIDGen{})
+
+	res, err := svc.GetStep(t.Context(), service.GetFlowStepRequest{State: state})
+	if err != nil {
+		t.Fatalf("GetStep: %v", err)
+	}
+	if sm.gotRenderState != state {
+		t.Errorf("Render was called with %p, want %p", sm.gotRenderState, state)
+	}
+	if res.Step == nil || res.Step.Name != "identify" {
+		t.Errorf("Step = %+v, want name identify", res.Step)
+	}
+}

--- a/internal/service/flow_test.go
+++ b/internal/service/flow_test.go
@@ -52,6 +52,24 @@ func stubListFlowDefinitions(t *testing.T, defs []*domain.FlowDefinition) *domai
 	return repo
 }
 
+// stubGetFlowDefinition wires GetFlowDefinition to return def when the
+// id matches and a not-found error otherwise.
+func stubGetFlowDefinition(t *testing.T, def *domain.FlowDefinition) *domainmock.MockFlowDefinitionRepository {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	repo := domainmock.NewMockFlowDefinitionRepository(ctrl)
+	repo.EXPECT().
+		GetFlowDefinition(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ database.QueryExecutor, projectID, id string) (*domain.FlowDefinition, error) {
+			if projectID != def.ProjectID || id != def.ID {
+				return nil, domain.ErrFlowDefinitionNotFound()
+			}
+			return def, nil
+		}).
+		AnyTimes()
+	return repo
+}
+
 func hasPurpose(def *domain.FlowDefinition, purpose domain.FlowDefinitionPurpose) bool {
 	_, ok := def.Purposes[purpose]
 	return ok
@@ -80,7 +98,7 @@ func TestResolve_ResolveByName_ExactVersion(t *testing.T) {
 	other := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{other, want})
 
-	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	got, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID:     "proj",
 		Purpose:       domain.FlowDefinitionPurposeLogin,
 		Name:          ptr("login"),
@@ -115,7 +133,7 @@ func TestResolve_ResolveByName_FiltersWithRequestedOptions(t *testing.T) {
 			return []*domain.FlowDefinition{def}, nil
 		})
 
-	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	_, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID:     "proj",
 		Purpose:       domain.FlowDefinitionPurposeLogin,
 		Name:          ptr("login"),
@@ -132,7 +150,7 @@ func TestResolve_ResolveByName_LatestActiveWhenVersionNil(t *testing.T) {
 	v15 := newDef("login", "1.5.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{v1, v2, v15})
 
-	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	got, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeLogin,
 		Name:      ptr("login"),
@@ -148,7 +166,7 @@ func TestResolve_ResolveByName_LatestActiveWhenVersionNil(t *testing.T) {
 func TestResolve_ResolveByName_NotFound(t *testing.T) {
 	repo := stubListFlowDefinitions(t, nil)
 
-	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	_, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeLogin,
 		Name:      ptr("missing"),
@@ -162,7 +180,7 @@ func TestResolve_ResolveByName_PurposeMismatch(t *testing.T) {
 	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{def})
 
-	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	_, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeRegister,
 		Name:      ptr("login"),
@@ -177,7 +195,7 @@ func TestResolve_ResolveByAudience_ReturnsFirstMatchingPurpose(t *testing.T) {
 	second := newDef("alt", "1.0.0", domain.FlowDefinitionAudience{AppIDs: []string{"app-1"}}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{first, second})
 
-	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	got, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeLogin,
 	})
@@ -193,7 +211,7 @@ func TestResolve_ResolveByAudience_NoMatch(t *testing.T) {
 	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{def})
 
-	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	_, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeRegister,
 	})
@@ -207,7 +225,7 @@ func TestResolve_ResolveByAudience_ExactVersionFiltersOlder(t *testing.T) {
 	v2 := newDef("login", "2.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{v1, v2})
 
-	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	got, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID:     "proj",
 		Purpose:       domain.FlowDefinitionPurposeLogin,
 		SchemaVersion: ptr("1.0.0"),
@@ -228,7 +246,7 @@ func TestResolve_ResolveByAudience_RepoErrorPropagates(t *testing.T) {
 		ListFlowDefinitions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, sentinel)
 
-	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	_, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeLogin,
 	})


### PR DESCRIPTION
 Makes the four flow endpoints actually work end-to-end:

 - `POST /flow` starts a flow and returns the first step plus a sealed `_zflow` cookie carrying the flow state.
 - `POST /flow/{id}/submit` advances the flow, rotating the cookie. On the terminal step the cookie is cleared.
 - `GET /flow/{id}` re-emits the current step without advancing, so page refreshes don't consume transitions.
 - `POST /flow/{id}/event` acknowledges client telemetry without touching state or extending cookie TTL.

Every response carries a default LiquidJS template under `branding.liquid_template`, so the orchestrator has something to render against in MVP.