### PR TITLE
fix: use spec-defined /auth/keys for JWKS lookup

### DIFF
--- a/packages/api-mock/src/server.ts
+++ b/packages/api-mock/src/server.ts
@@ -9,8 +9,8 @@
  *   POST   /sessions/exchange     — exchange handoff_token for session cookie
  *   POST   /logout                — clear session cookies
  *   GET    /auth/end-session      — OIDC-style end-session, clears cookies
- *   GET    /.well-known/jwks.json — JWKS for JWT verification
- *   GET    /oauth/v2/keys         — alias for JWKS
+ *   GET    /.well-known/jwks.json — JWKS for JWT verification (dev convenience)
+ *   GET    /auth/keys             — JWKS, spec-defined endpoint (operation `getKeys`)
  */
 import { type Server } from "node:http";
 
@@ -56,7 +56,7 @@ export function startMockServer(port: number): Server {
   app.get("/.well-known/jwks.json", (_req: express.Request, res: express.Response) => {
     res.json({ keys: [JWK] });
   });
-  app.get("/oauth/v2/keys", (_req: express.Request, res: express.Response) => {
+  app.get("/auth/keys", (_req: express.Request, res: express.Response) => {
     res.json({ keys: [JWK] });
   });
 

--- a/packages/sdk-next/src/lib/jwt.ts
+++ b/packages/sdk-next/src/lib/jwt.ts
@@ -91,7 +91,7 @@
  * during key-rotation incidents where two servers briefly share a key identifier.
  *
  * A cache miss — on first use or after TTL expiry — triggers a fresh fetch
- * from `{issuerUrl}/oauth/v2/keys`.
+ * from `{issuerUrl}/auth/keys`.
  *
  * > **Note (serverless):** the cache is module-level. In serverless environments
  * > each cold start gets a fresh cache; warm instances share it across requests.
@@ -192,7 +192,7 @@ export interface VerifyJwtOptions {
    * Base URL of the auth backend.
    *
    * Serves two purposes:
-   * 1. Determines the JWKS endpoint: `{issuerUrl}/oauth/v2/keys`
+   * 1. Determines the JWKS endpoint: `{issuerUrl}/auth/keys`
    * 2. Is compared against the `iss` claim when present in the token.
    */
   readonly issuerUrl: string;
@@ -529,7 +529,7 @@ export async function verifyJwt(
 
     const kid = header.kid;
     const cryptoKey = await fetchAndCacheJwks(
-      `${issuerUrl}/oauth/v2/keys`,
+      `${issuerUrl}/auth/keys`,
       kid,
       jwksTimeoutMs,
     );

--- a/packages/sdk-nuxt/README.md
+++ b/packages/sdk-nuxt/README.md
@@ -136,7 +136,7 @@ export default defineEventHandler((event) => {
 2. The JWT header is decoded to extract `kid` and `alg`
 3. Tokens with an `alg` not in `allowedAlgorithms` (`RS256`, `ES256` by default) are rejected immediately — no JWKS fetch
 4. Tokens with a `typ` not in `allowedTokenTypes` are rejected immediately
-5. The public key is fetched from `{issuerUrl}/oauth/v2/keys` (JWKS) using the Web Crypto API, with a 5 s timeout, and cached for 5 minutes per `kid`
+5. The public key is fetched from `{issuerUrl}/auth/keys` (JWKS) using the Web Crypto API, with a 5 s timeout, and cached for 5 minutes per `kid`
 6. The signature is verified **before** any claim checks
 7. `iss` must be present and must equal `issuerUrl` — tokens without an issuer are rejected
 8. `exp` must be present and must be in the future (with `clockSkewMs` tolerance) — tokens without an expiry are rejected

--- a/packages/sdk-nuxt/src/runtime/lib/jwt.ts
+++ b/packages/sdk-nuxt/src/runtime/lib/jwt.ts
@@ -91,7 +91,7 @@
  * during key-rotation incidents where two servers briefly share a key identifier.
  *
  * A cache miss — on first use or after TTL expiry — triggers a fresh fetch
- * from `{issuerUrl}/oauth/v2/keys`.
+ * from `{issuerUrl}/auth/keys`.
  *
  * > **Note (serverless):** the cache is module-level. In serverless environments
  * > each cold start gets a fresh cache; warm instances share it across requests.
@@ -193,7 +193,7 @@ export interface VerifyJwtOptions {
    * Base URL of the auth backend.
    *
    * Serves two purposes:
-   * 1. Determines the JWKS endpoint: `{issuerUrl}/oauth/v2/keys`
+   * 1. Determines the JWKS endpoint: `{issuerUrl}/auth/keys`
    * 2. Is compared against the `iss` claim when present in the token.
    */
   readonly issuerUrl: string;
@@ -524,7 +524,7 @@ export async function verifyJwt(
 
     const kid = header.kid;
     const cryptoKey = await fetchAndCacheJwks(
-      `${issuerUrl}/oauth/v2/keys`,
+      `${issuerUrl}/auth/keys`,
       kid,
       jwksTimeoutMs,
     );


### PR DESCRIPTION
sdk-next and sdk-nuxt hardcoded `/oauth/v2/keys` (Zitadel v1 legacy path) for the JWKS lookup. The OAS spec defines `/auth/keys` (operation `getKeys`). Updated both SDKs to match the spec and dropped the api-mock workaround alias that had been masking the mismatch.

## Test plan

- [x] `pnpm nx test sdk-next` — 97/97 pass
- [x] `pnpm nx test sdk-nuxt` — 89/89 pass
- [x] `pnpm nx test api-mock` — 9/9 pass
- [x] Smoke: mock boots, `/auth/keys` returns JWKS, `/oauth/v2/keys` now 404s