### PR TITLE
feat: inline internal deps to ship as a single package

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -55,9 +55,6 @@
     "test:all": "vitest run"
   },
   "dependencies": {
-    "@zitadel-nextgen/api": "workspace:*",
-    "@zitadel-nextgen/design-tokens": "workspace:*",
-    "@zitadel-nextgen/shared-component-styles": "workspace:*",
     "dompurify": "catalog:",
     "liquidjs": "catalog:",
     "lit": "catalog:",
@@ -66,10 +63,14 @@
   "nx": {
     "targets": {
       "build": {
-        "outputs": ["{projectRoot}/dist"]
+        "outputs": [
+          "{projectRoot}/dist"
+        ]
       },
       "typecheck": {
-        "dependsOn": ["build"]
+        "dependsOn": [
+          "build"
+        ]
       }
     }
   },
@@ -85,6 +86,9 @@
     "vite-plugin-web-components-hmr": "catalog:",
     "lightningcss": "catalog:",
     "tsdown": "catalog:",
-    "tslib": "catalog:"
+    "tslib": "catalog:",
+    "@zitadel-nextgen/api": "workspace:*",
+    "@zitadel-nextgen/design-tokens": "workspace:*",
+    "@zitadel-nextgen/shared-component-styles": "workspace:*"
   }
 }

--- a/packages/components/tsdown.config.ts
+++ b/packages/components/tsdown.config.ts
@@ -6,6 +6,12 @@ import { defineConfig } from "tsdown";
  * Each subpath in `package.json` `exports` has its own entry so consumers can
  * `import { ... } from "@zitadel-nextgen/components/atoms"` without dragging
  * in the orchestrator (and its `liquidjs` + `dompurify` dependencies).
+ *
+ * Internal `@zitadel-nextgen/*` workspace packages (`api`, `design-tokens`,
+ * `shared-component-styles`) are inlined into the dist so consumers only
+ * need to install `@zitadel-nextgen/components` itself — no transitive
+ * registry deps. `@zitadel-nextgen/api-mock` stays external because it's a
+ * test-only helper consumers never import.
  */
 export default defineConfig({
   entry: {
@@ -29,12 +35,12 @@ export default defineConfig({
     "dompurify",
     "lucide",
     /^lucide\//,
-    "@zitadel-nextgen/api",
-    /^@zitadel-nextgen\/api\//,
     "@zitadel-nextgen/api-mock",
-    "@zitadel-nextgen/design-tokens",
-    /^@zitadel-nextgen\/design-tokens\//,
   ],
-  /** Surface CSS must inline into dist — demos/Next cannot resolve `?inline` from source. */
-  noExternal: [/^@zitadel-nextgen\/shared-component-styles/],
+  /** Inline internal workspace deps so the published package is self-contained. */
+  noExternal: [
+    /^@zitadel-nextgen\/api(\/|$)/,
+    /^@zitadel-nextgen\/design-tokens(\/|$)/,
+    /^@zitadel-nextgen\/shared-component-styles(\/|$)/,
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,15 +497,6 @@ importers:
 
   packages/components:
     dependencies:
-      '@zitadel-nextgen/api':
-        specifier: workspace:*
-        version: link:../api
-      '@zitadel-nextgen/design-tokens':
-        specifier: workspace:*
-        version: link:../design-tokens
-      '@zitadel-nextgen/shared-component-styles':
-        specifier: workspace:*
-        version: link:../shared-component-styles
       dompurify:
         specifier: 'catalog:'
         version: 3.4.1
@@ -528,9 +519,18 @@ importers:
       '@vitest/browser-playwright':
         specifier: 'catalog:'
         version: 4.1.5(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(playwright@1.59.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@zitadel-nextgen/api':
+        specifier: workspace:*
+        version: link:../api
       '@zitadel-nextgen/api-mock':
         specifier: workspace:*
         version: link:../api-mock
+      '@zitadel-nextgen/design-tokens':
+        specifier: workspace:*
+        version: link:../design-tokens
+      '@zitadel-nextgen/shared-component-styles':
+        specifier: workspace:*
+        version: link:../shared-component-styles
       jsdom:
         specifier: 'catalog:'
         version: 29.0.2


### PR DESCRIPTION
## Summary

`@zitadel-nextgen/components` now bundles `@zitadel-nextgen/api`, `@zitadel-nextgen/design-tokens`, and `@zitadel-nextgen/shared-component-styles` into its dist instead of leaving them as external workspace dependencies. Consumers (SDK, demo apps, registry installers) only need `@zitadel-nextgen/components` itself; npm no longer has to resolve those three packages from the registry.

This shrinks the publishable surface from 7 packages to 4 (`cli`, `sdk-next`, `components`, `sdk-core`) without changing any public API.

## Changes

- `packages/components/tsdown.config.ts` — drop the three packages from `external`, add them under `noExternal`. `@zitadel-nextgen/api-mock` stays external (it's a test-only helper).
- `packages/components/package.json` — move the three from `dependencies` to `devDependencies`.

## Test plan

- [x] `pnpm nx build @zitadel-nextgen/components` — clean build, dist contains no `@zitadel-nextgen/api|design-tokens|shared-component-styles` imports.
- [x] `pnpm nx test @zitadel-nextgen/components` — 93/93 pass.
- [x] `pnpm nx test @zitadel-nextgen/sdk-next` — 97/97 pass.
- [x] `pnpm nx test @nextgen/cli` — 44/44 pass.
- [x] Dist size: ~592 KB esm (was ~480 KB; ~25% growth absorbing the inlined deps).