### PR TITLE
chore: normalize all internal packages to the @zitadel-nextgen scope

### DIFF
--- a/.changeset/components-replace-ui-lit-placeholders.md
+++ b/.changeset/components-replace-ui-lit-placeholders.md
@@ -1,7 +1,7 @@
 ---
 "@zitadel-nextgen/components": minor
 "@zitadel-nextgen/sdk-next": patch
-"@nextgen/sdk-nuxt": patch
+"@zitadel-nextgen/sdk-nuxt": patch
 ---
 
 Replace the `@nextgen/ui-lit` placeholder web components with the real
@@ -24,7 +24,7 @@ Replace the `@nextgen/ui-lit` placeholder web components with the real
   `FlowResponse` with `email` + `password` fields so the existing
   orchestrator + atom pipeline renders against it unchanged.
 - Drop the `@nextgen/ui-lit` package and switch `@zitadel-nextgen/sdk-next`,
-  `@nextgen/sdk-nuxt`, and the `apps/demo-next` / `apps/demo-nuxt` apps to
+  `@zitadel-nextgen/sdk-nuxt`, and the `apps/demo-next` / `apps/demo-nuxt` apps to
   re-export and consume `@zitadel-nextgen/components` instead. Existing
   `<nextgen-login>` / `<nextgen-logout>` tags become `<zitadel-login>` /
   `<zitadel-logout>` with the same `proxy-base` and post-sign-{in,out}-url

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,13 +108,13 @@ jobs:
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: >-
-          corepack pnpm --filter @nextgen/demo-next-e2e
+          corepack pnpm --filter @zitadel-nextgen/demo-next-e2e
           exec playwright install --with-deps chromium
 
       - name: Install Playwright system deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: >-
-          corepack pnpm --filter @nextgen/demo-next-e2e
+          corepack pnpm --filter @zitadel-nextgen/demo-next-e2e
           exec playwright install-deps chromium
 
       # Boots the demo dev servers + api-mock through Playwright's webServer
@@ -127,7 +127,7 @@ jobs:
       - name: End-to-end tests
         run: >-
           corepack pnpm nx run-many -t e2e
-          -p @nextgen/demo-next-e2e,@nextgen/demo-nuxt-e2e
+          -p @zitadel-nextgen/demo-next-e2e,@zitadel-nextgen/demo-nuxt-e2e
 
       - name: Upload Playwright reports on failure
         if: failure()

--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -24,8 +24,8 @@ In development, MSW intercepts flow API calls in the browser (same handlers as
 | ------- | ------- | --- |
 | Lit atoms + login (MSW in browser) | `corepack pnpm nx dev @zitadel-nextgen/components` | [http://localhost:5173/?route=atoms](http://localhost:5173/?route=atoms) · [login](http://localhost:5173/?route=login) |
 | React atoms (this app, MSW in browser) | `corepack pnpm nx dev @zitadel-nextgen/console` | [http://localhost:5174](http://localhost:5174) |
-| Next.js SDK (cookies, middleware, built `dist/`) | `corepack pnpm nx start @zitadel-nextgen/api-mock` then `NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @nextgen/demo-next` | mock [http://localhost:4000](http://localhost:4000) · app [http://localhost:3002/login](http://localhost:3002/login) |
-| Nuxt SDK (cookies, middleware, built `dist/`) | mock as above, then `NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @nextgen/demo-nuxt` | mock `:4000` · app [http://localhost:3001/login](http://localhost:3001/login) |
+| Next.js SDK (cookies, middleware, built `dist/`) | `corepack pnpm nx start @zitadel-nextgen/api-mock` then `NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @zitadel-nextgen/demo-next` | mock [http://localhost:4000](http://localhost:4000) · app [http://localhost:3002/login](http://localhost:3002/login) |
+| Nuxt SDK (cookies, middleware, built `dist/`) | mock as above, then `NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @zitadel-nextgen/demo-nuxt` | mock `:4000` · app [http://localhost:3001/login](http://localhost:3001/login) |
 
 When you change **Lit-only** atom or orchestrator source, prefer the components playground
 (`:5173`) first — it reloads faster. Rebuild components before expecting console or demos

--- a/apps/demo-next-e2e/AGENTS.md
+++ b/apps/demo-next-e2e/AGENTS.md
@@ -35,7 +35,7 @@ this project.
 
 ```sh
 corepack pnpm exec playwright install        # one-time, browsers
-corepack pnpm exec nx run @nextgen/demo-next-e2e:e2e
+corepack pnpm exec nx run @zitadel-nextgen/demo-next-e2e:e2e
 ```
 
 Nx rebuilds `@zitadel-nextgen/components` first via `^build`, then

--- a/apps/demo-next-e2e/package.json
+++ b/apps/demo-next-e2e/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nextgen/demo-next-e2e",
+  "name": "@zitadel-nextgen/demo-next-e2e",
   "version": "0.0.1",
   "private": true,
   "devDependencies": {

--- a/apps/demo-next-e2e/playwright.config.mts
+++ b/apps/demo-next-e2e/playwright.config.mts
@@ -39,7 +39,7 @@ export default defineConfig({
       stderr: "pipe",
     },
     {
-      command: "pnpm --filter @nextgen/demo-next dev",
+      command: "pnpm --filter @zitadel-nextgen/demo-next dev",
       url: "http://localhost:3002/login",
       reuseExistingServer: true,
       cwd: workspaceRoot,

--- a/apps/demo-next/README.md
+++ b/apps/demo-next/README.md
@@ -11,7 +11,7 @@ Use **Nx** from the repo root (`corepack pnpm install` first). Two terminals:
 corepack pnpm nx start @zitadel-nextgen/api-mock
 
 # Terminal 2 — Next.js on port 3002
-NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @nextgen/demo-next
+NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @zitadel-nextgen/demo-next
 ```
 
 Open [http://localhost:3002/login](http://localhost:3002/login). Any email/password combination is accepted by the mock server.

--- a/apps/demo-next/package.json
+++ b/apps/demo-next/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nextgen/demo-next",
+  "name": "@zitadel-nextgen/demo-next",
   "version": "0.0.0",
   "description": "Next.js demo app for Nextgen Auth",
   "homepage": "https://github.com/zitadel/nextgen/tree/main/apps/demo-next#readme",

--- a/apps/demo-nuxt-e2e/AGENTS.md
+++ b/apps/demo-nuxt-e2e/AGENTS.md
@@ -10,7 +10,7 @@ This project covers the boundary that Vitest cannot reach:
 
 - `<zitadel-login>` mounted inside Nuxt's `<ClientOnly>` after the SSR pass.
 - The Lit orchestrator's internal `POST /sessions/exchange` traversing
-  the Nitro `/__nextgen` proxy installed by `@nextgen/sdk-nuxt`.
+  the Nitro `/__nextgen` proxy installed by `@zitadel-nextgen/sdk-nuxt`.
 - The `__nextgen_session` cookie being set on the demo origin and
   surviving the full-page navigation triggered by `post-sign-in-url`.
 - The Nitro auth middleware accepting that cookie on the next request
@@ -40,7 +40,7 @@ belong in this project.
 
 ```sh
 corepack pnpm exec playwright install        # one-time, browsers
-corepack pnpm exec nx run @nextgen/demo-nuxt-e2e:e2e
+corepack pnpm exec nx run @zitadel-nextgen/demo-nuxt-e2e:e2e
 ```
 
 Nx rebuilds `@zitadel-nextgen/components` first via `^build`, then

--- a/apps/demo-nuxt-e2e/package.json
+++ b/apps/demo-nuxt-e2e/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@nextgen/demo-nuxt-e2e",
+  "name": "@zitadel-nextgen/demo-nuxt-e2e",
   "version": "0.0.1",
   "private": true,
   "devDependencies": {
-    "@nextgen/sdk-nuxt": "workspace:*",
+    "@zitadel-nextgen/sdk-nuxt": "workspace:*",
     "@playwright/test": "catalog:",
     "@zitadel-nextgen/api-mock": "workspace:*",
     "eslint-plugin-playwright": "catalog:"

--- a/apps/demo-nuxt-e2e/playwright.config.mts
+++ b/apps/demo-nuxt-e2e/playwright.config.mts
@@ -10,7 +10,7 @@ import { defineConfig, devices } from "@playwright/test";
  *                    → /admin (server-rendered, authenticated)
  *
  * The Vue / Nitro story is structurally similar to demo-next-e2e but the
- * proxy and route-protection layers come from `@nextgen/sdk-nuxt`'s Nitro
+ * proxy and route-protection layers come from `@zitadel-nextgen/sdk-nuxt`'s Nitro
  * middleware rather than `@zitadel-nextgen/sdk-next`'s edge middleware.
  * Running the same scenario on both demos is the only way to catch a
  * regression in one SDK without the other.
@@ -47,7 +47,7 @@ export default defineConfig({
       },
     },
     {
-      command: "pnpm --filter @nextgen/demo-nuxt dev",
+      command: "pnpm --filter @zitadel-nextgen/demo-nuxt dev",
       url: "http://localhost:3001/login",
       reuseExistingServer: true,
       cwd: workspaceRoot,

--- a/apps/demo-nuxt-e2e/src/auth-guard.spec.ts
+++ b/apps/demo-nuxt-e2e/src/auth-guard.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 /**
  * Nitro middleware redirect contract. The Vitest suite stubs the SDK;
- * this test exercises `@nextgen/sdk-nuxt`'s real
+ * this test exercises `@zitadel-nextgen/sdk-nuxt`'s real
  * `createNextgenMiddleware` running inside Nitro, including the JWKS
  * verification short-circuit.
  */

--- a/apps/demo-nuxt-e2e/src/auth.spec.ts
+++ b/apps/demo-nuxt-e2e/src/auth.spec.ts
@@ -8,7 +8,7 @@ import { expect, test } from "@playwright/test";
  *    Nuxt's SSR pass.
  * 2. Form interactions reach the orchestrator across atom shadow roots.
  * 3. The terminal step's internal `POST /sessions/exchange` traverses the
- *    Nitro `/__nextgen` proxy installed by `@nextgen/sdk-nuxt` and the
+ *    Nitro `/__nextgen` proxy installed by `@zitadel-nextgen/sdk-nuxt` and the
  *    api-mock RS256 verification.
  * 4. `__nextgen_session` is set on the demo origin and `<zitadel-login>`'s
  *    full-page navigation lands on the protected `/admin` route.

--- a/apps/demo-nuxt/README.md
+++ b/apps/demo-nuxt/README.md
@@ -11,7 +11,7 @@ Use **Nx** from the repo root (`corepack pnpm install` first). Two terminals:
 corepack pnpm nx start @zitadel-nextgen/api-mock
 
 # Terminal 2 — Nuxt on port 3001
-NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @nextgen/demo-nuxt
+NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @zitadel-nextgen/demo-nuxt
 ```
 
 Open [http://localhost:3001/login](http://localhost:3001/login). Any email/password combination is accepted by the mock server.
@@ -44,7 +44,7 @@ The demo imports the package from `dist/`, not source.
 
 ## How it works
 
-**Server middleware** (`server/middleware/auth.ts`) uses `createNextgenMiddleware` from `@nextgen/sdk-nuxt` to proxy `/__nextgen/*` requests to the auth backend, verify the session JWT on every request, and redirect unauthenticated users away from `/admin`.
+**Server middleware** (`server/middleware/auth.ts`) uses `createNextgenMiddleware` from `@zitadel-nextgen/sdk-nuxt` to proxy `/__nextgen/*` requests to the auth backend, verify the session JWT on every request, and redirect unauthenticated users away from `/admin`.
 
 **Plugin** (`plugins/auth.server.ts`) reads the verified auth context from the server event and writes it into Nuxt's shared `nextgen-auth` state so pages can access it without additional fetches.
 

--- a/apps/demo-nuxt/package.json
+++ b/apps/demo-nuxt/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nextgen/demo-nuxt",
+  "name": "@zitadel-nextgen/demo-nuxt",
   "version": "0.0.0",
   "description": "Nuxt demo app for Nextgen Auth",
   "homepage": "https://github.com/zitadel/nextgen/tree/main/apps/demo-nuxt#readme",
@@ -20,7 +20,7 @@
     "typecheck": "NUXT_BUILD_DIR=.nuxt nuxt prepare && vue-tsc --noEmit -p .nuxt/tsconfig.json"
   },
   "dependencies": {
-    "@nextgen/sdk-nuxt": "workspace:*",
+    "@zitadel-nextgen/sdk-nuxt": "workspace:*",
     "@zitadel-nextgen/components": "workspace:*",
     "@zitadel-nextgen/design-tokens": "workspace:*",
     "@zitadel-nextgen/shared-component-styles": "workspace:*",

--- a/apps/demo-nuxt/pages/admin.vue
+++ b/apps/demo-nuxt/pages/admin.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ClientAuthResult } from "@nextgen/sdk-nuxt";
+import type { ClientAuthResult } from "@zitadel-nextgen/sdk-nuxt";
 
 const auth = useState<ClientAuthResult>("nextgen-auth");
 </script>

--- a/apps/demo-nuxt/pages/login.vue
+++ b/apps/demo-nuxt/pages/login.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ClientAuthResult } from "@nextgen/sdk-nuxt";
+import type { ClientAuthResult } from "@zitadel-nextgen/sdk-nuxt";
 
 const auth = useState<ClientAuthResult>("nextgen-auth");
 if (auth.value?.isAuthenticated) {

--- a/apps/demo-nuxt/plugins/auth.server.ts
+++ b/apps/demo-nuxt/plugins/auth.server.ts
@@ -1,5 +1,5 @@
 import { defineNuxtPlugin, useRequestEvent, useState } from "#imports";
-import type { ClientAuthResult } from "@nextgen/sdk-nuxt";
+import type { ClientAuthResult } from "@zitadel-nextgen/sdk-nuxt";
 
 export default defineNuxtPlugin(() => {
   const event = useRequestEvent();

--- a/apps/demo-nuxt/server/middleware/auth.ts
+++ b/apps/demo-nuxt/server/middleware/auth.ts
@@ -1,4 +1,4 @@
-import { createNextgenMiddleware } from "@nextgen/sdk-nuxt/server";
+import { createNextgenMiddleware } from "@zitadel-nextgen/sdk-nuxt/server";
 
 const { nextgenIssuerUrl } = useRuntimeConfig();
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -127,8 +127,8 @@ have different jobs — keep both:
 | --- | --- | --- | --- |
 | **Lit playground** | `corepack pnpm nx dev @zitadel-nextgen/components` | [login](http://localhost:5173/?route=login) · [atoms](http://localhost:5173/?route=atoms) | Component author surface: branding presets, event log, source TS from `src/`. MSW runs in the browser — no TCP mock server. |
 | **React console playground** | `corepack pnpm nx dev @zitadel-nextgen/console` | [http://localhost:5174](http://localhost:5174) | `@zitadel-nextgen/ui-react` atom matrices in the pre-release console shell. MSW in `import.meta.env.DEV`. Compare against Lit `:5173/?route=atoms` in a second tab. |
-| **demo-next** | `corepack pnpm nx start @zitadel-nextgen/api-mock` + `NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @nextgen/demo-next` | [http://localhost:3002/login](http://localhost:3002/login) (mock on `:4000`) | Next.js SDK, middleware, cookies, built `dist/`. See [`apps/demo-next`](../../apps/demo-next/README.md). |
-| **demo-nuxt** | mock on `:4000`, then `NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @nextgen/demo-nuxt` | [http://localhost:3001/login](http://localhost:3001/login) | Nuxt SDK, middleware, cookies, built `dist/`. See [`apps/demo-nuxt`](../../apps/demo-nuxt/README.md). |
+| **demo-next** | `corepack pnpm nx start @zitadel-nextgen/api-mock` + `NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @zitadel-nextgen/demo-next` | [http://localhost:3002/login](http://localhost:3002/login) (mock on `:4000`) | Next.js SDK, middleware, cookies, built `dist/`. See [`apps/demo-next`](../../apps/demo-next/README.md). |
+| **demo-nuxt** | mock on `:4000`, then `NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @zitadel-nextgen/demo-nuxt` | [http://localhost:3001/login](http://localhost:3001/login) | Nuxt SDK, middleware, cookies, built `dist/`. See [`apps/demo-nuxt`](../../apps/demo-nuxt/README.md). |
 
 The Lit dev playground iterates on `<zl-*>` source; the React console
 playground exercises `@zitadel-nextgen/ui-react` in the internal shell.
@@ -303,8 +303,8 @@ corepack pnpm nx dev @zitadel-nextgen/console
 
 # Framework demos (TCP mock + SDK) — see apps/demo-*/README.md
 # corepack pnpm nx start @zitadel-nextgen/api-mock   # → http://localhost:4000
-# NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @nextgen/demo-next  # → :3002
-# NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @nextgen/demo-nuxt  # → :3001
+# NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @zitadel-nextgen/demo-next  # → :3002
+# NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @zitadel-nextgen/demo-nuxt  # → :3001
 
 # --- Package checks ---
 

--- a/packages/sdk-nuxt/README.md
+++ b/packages/sdk-nuxt/README.md
@@ -1,11 +1,11 @@
-# @nextgen/sdk-nuxt
+# @zitadel-nextgen/sdk-nuxt
 
 Nuxt middleware and helpers for Nextgen Auth.
 
 ## Installation
 
 ```bash
-pnpm add @nextgen/sdk-nuxt
+pnpm add @zitadel-nextgen/sdk-nuxt
 ```
 
 ## Setup
@@ -15,7 +15,7 @@ pnpm add @nextgen/sdk-nuxt
 Create `server/middleware/auth.ts`:
 
 ```ts
-import { createNextgenMiddleware } from '@nextgen/sdk-nuxt/server';
+import { createNextgenMiddleware } from '@zitadel-nextgen/sdk-nuxt/server';
 
 const { nextgenIssuerUrl } = useRuntimeConfig();
 
@@ -106,7 +106,7 @@ Render `<zitadel-login>` inside `<ClientOnly>`:
 ### 6. Reading auth in a server route
 
 ```ts
-import { getAuth } from '@nextgen/sdk-nuxt/server';
+import { getAuth } from '@zitadel-nextgen/sdk-nuxt/server';
 
 export default defineEventHandler((event) => {
   const auth = getAuth(event);

--- a/packages/sdk-nuxt/package.json
+++ b/packages/sdk-nuxt/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nextgen/sdk-nuxt",
+  "name": "@zitadel-nextgen/sdk-nuxt",
   "version": "0.0.0",
   "description": "Nuxt proxy middleware and helpers for Nextgen Auth",
   "homepage": "https://github.com/zitadel/nextgen/tree/main/packages/sdk-nuxt#readme",

--- a/packages/sdk-nuxt/src/module.ts
+++ b/packages/sdk-nuxt/src/module.ts
@@ -10,7 +10,7 @@ import type { NextgenMiddlewareOptions } from './runtime/types';
 
 export default defineNuxtModule<NextgenMiddlewareOptions>({
   meta: {
-    name: '@nextgen/sdk-nuxt',
+    name: '@zitadel-nextgen/sdk-nuxt',
     configKey: 'nextgen',
   },
   defaults: {

--- a/packages/sdk-nuxt/src/runtime/server/handler.ts
+++ b/packages/sdk-nuxt/src/runtime/server/handler.ts
@@ -16,7 +16,7 @@ declare function useRuntimeConfig(): {
 const config = useRuntimeConfig();
 
 /**
- * Default Nitro/H3 event handler registered by the `@nextgen/sdk-nuxt` module
+ * Default Nitro/H3 event handler registered by the `@zitadel-nextgen/sdk-nuxt` module
  * via {@link addServerHandler}. Reads middleware options from Nuxt runtime
  * config (`nuxt.config.ts → nextgen`) so consumers do not need to create
  * their own `server/middleware/auth.ts` when using the module.

--- a/packages/sdk-nuxt/src/runtime/server/middleware.ts
+++ b/packages/sdk-nuxt/src/runtime/server/middleware.ts
@@ -164,7 +164,7 @@ function buildUpstreamHeaders(event: H3Event): Headers {
  * Register it as a Nitro server middleware in `server/middleware/auth.ts`:
  *
  * ```ts
- * import { createNextgenMiddleware } from "@nextgen/sdk-nuxt/server";
+ * import { createNextgenMiddleware } from "@zitadel-nextgen/sdk-nuxt/server";
  *
  * export default createNextgenMiddleware({
  *   issuerUrl: process.env.NEXTGEN_ISSUER_URL,
@@ -421,7 +421,7 @@ async function handleAuth(
  * Call this inside any server route or API handler after the middleware has run:
  *
  * ```ts
- * import { getAuth } from "@nextgen/sdk-nuxt/server";
+ * import { getAuth } from "@zitadel-nextgen/sdk-nuxt/server";
  *
  * export default defineEventHandler((event) => {
  *   const auth = getAuth(event);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,7 +398,7 @@ importers:
 
   apps/demo-nuxt:
     dependencies:
-      '@nextgen/sdk-nuxt':
+      '@zitadel-nextgen/sdk-nuxt':
         specifier: workspace:*
         version: link:../../packages/sdk-nuxt
       '@zitadel-nextgen/components':
@@ -423,7 +423,7 @@ importers:
 
   apps/demo-nuxt-e2e:
     devDependencies:
-      '@nextgen/sdk-nuxt':
+      '@zitadel-nextgen/sdk-nuxt':
         specifier: workspace:*
         version: link:../../packages/sdk-nuxt
       '@playwright/test':


### PR DESCRIPTION
## Summary

Five packages were still on the legacy `@nextgen/*` scope; the rest of the repo was already on `@zitadel-nextgen/*`. Renamed all five so every internal package shares one scope.

- `@nextgen/demo-next` → `@zitadel-nextgen/demo-next`
- `@nextgen/demo-next-e2e` → `@zitadel-nextgen/demo-next-e2e`
- `@nextgen/demo-nuxt` → `@zitadel-nextgen/demo-nuxt`
- `@nextgen/demo-nuxt-e2e` → `@zitadel-nextgen/demo-nuxt-e2e`
- `@nextgen/sdk-nuxt` → `@zitadel-nextgen/sdk-nuxt`

22 files touched: package.jsons, TypeScript imports, READMEs, CI workflow, changeset notes, lockfile. No behavior change.

## Test plan

- [x] `pnpm install --no-frozen-lockfile` clean
- [x] `pnpm nx test @zitadel-nextgen/api-mock` — 9/9
- [x] `pnpm nx test @zitadel-nextgen/components` — 93/93
- [x] `pnpm nx test @zitadel-nextgen/sdk-next` — 97/97
- [x] `pnpm nx test @zitadel-nextgen/cli` — 44/44