### PR TITLE
refactor: unify `Transaction.Begin` with `Beginner` interface

### DIFF
--- a/internal/storage/database/dbmock/tx.mock.go
+++ b/internal/storage/database/dbmock/tx.mock.go
@@ -42,18 +42,18 @@ func (m *MockTransaction) EXPECT() *MockTransactionMockRecorder {
 }
 
 // Begin mocks base method.
-func (m *MockTransaction) Begin(ctx context.Context) (database.Transaction, error) {
+func (m *MockTransaction) Begin(ctx context.Context, opts *database.TransactionOptions) (database.Transaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Begin", ctx)
+	ret := m.ctrl.Call(m, "Begin", ctx, opts)
 	ret0, _ := ret[0].(database.Transaction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Begin indicates an expected call of Begin.
-func (mr *MockTransactionMockRecorder) Begin(ctx any) *gomock.Call {
+func (mr *MockTransactionMockRecorder) Begin(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Begin", reflect.TypeOf((*MockTransaction)(nil).Begin), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Begin", reflect.TypeOf((*MockTransaction)(nil).Begin), ctx, opts)
 }
 
 // Commit mocks base method.

--- a/internal/storage/database/dialect/pgxcommon/tx.go
+++ b/internal/storage/database/dialect/pgxcommon/tx.go
@@ -62,7 +62,8 @@ func (tx *Transaction) Exec(ctx context.Context, sql string, args ...any) (int64
 }
 
 // Begin creates a savepoint to emulate nested transactions.
-func (tx *Transaction) Begin(ctx context.Context) (database.Transaction, error) {
+// opts is ignored because pgx savepoints do not accept per-nested-tx options.
+func (tx *Transaction) Begin(ctx context.Context, _ *database.TransactionOptions) (database.Transaction, error) {
 	savepoint, err := tx.tx.Begin(ctx)
 	if err != nil {
 		return nil, tx.wrapErr(err)

--- a/internal/storage/database/dialect/spanner/tx.go
+++ b/internal/storage/database/dialect/spanner/tx.go
@@ -41,7 +41,7 @@ func (t *Transaction) End(ctx context.Context, err error) error {
 }
 
 // Begin returns an error: Spanner does not support nested transactions or savepoints.
-func (t *Transaction) Begin(_ context.Context) (database.Transaction, error) {
+func (t *Transaction) Begin(_ context.Context, _ *database.TransactionOptions) (database.Transaction, error) {
 	return nil, database.NewUnknownError(errors.New("nested transactions not supported in Spanner"))
 }
 

--- a/internal/storage/database/repository/repository_test.go
+++ b/internal/storage/database/repository/repository_test.go
@@ -113,7 +113,7 @@ func transactionForRollback(t *testing.T) (tx database.Transaction, rollback fun
 
 func savepointForRollback(t *testing.T, tx database.Transaction) (savepoint database.Transaction, rollback func()) {
 	t.Helper()
-	savepoint, err := tx.Begin(t.Context())
+	savepoint, err := tx.Begin(t.Context(), nil)
 	require.NoError(t, err)
 	return savepoint, func() {
 		// context.Background to ensure rollback does not return an error if test is already done

--- a/internal/storage/database/tx.go
+++ b/internal/storage/database/tx.go
@@ -3,6 +3,8 @@ package database
 import "context"
 
 // Transaction is an SQL transaction.
+//
+// [Beginner] on Transaction starts a sub transaction (for example a savepoint).
 type Transaction interface {
 	Beginner
 

--- a/internal/storage/database/tx.go
+++ b/internal/storage/database/tx.go
@@ -4,6 +4,8 @@ import "context"
 
 // Transaction is an SQL transaction.
 type Transaction interface {
+	Beginner
+
 	// Commit marks a transaction as successful and commits it to the database.
 	Commit(ctx context.Context) error
 	// Rollback undoes all changes made in the transaction.
@@ -14,8 +16,6 @@ type Transaction interface {
 	// If err is not nil, and rollback is successful, the original err is returned.
 	// If err is not nil, and rollback fails, the two errors are joined using [errors.Join].
 	End(ctx context.Context, err error) error
-	// Begin starts a sub transaction.
-	Begin(ctx context.Context) (Transaction, error)
 
 	QueryExecutor
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns nested transaction `Begin` with the existing `Beginner` contract so pool, connection, and transaction types share one signature.

## Changes

- Embed `Beginner` on `Transaction` in `internal/storage/database/tx.go` and remove the standalone `Begin(ctx)` method.
- Update PostgreSQL (`pgxcommon`) and Spanner transaction implementations to accept `*TransactionOptions` (options are ignored for savepoints; Spanner still rejects nested transactions).
- Update `savepointForRollback` test helper and regenerate `dbmock` mocks.

## Notes

- Top-level `Pool` / `Connection` `Begin` behavior is unchanged.
- Nested PostgreSQL begins still use pgx savepoints; per-savepoint isolation/access options are not supported by pgx and remain ignored.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32435405-a294-4160-8555-5711629d7c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32435405-a294-4160-8555-5711629d7c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

