### PR TITLE
test: fix cookie tamper test

### DIFF
--- a/internal/cookie/sealer_test.go
+++ b/internal/cookie/sealer_test.go
@@ -2,21 +2,24 @@ package cookie
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func filledKey(fill byte) Key {
-	var k Key
-	for i := range k {
-		k[i] = fill
-	}
-	return k
+func generateKey(t *testing.T) Key {
+	bs := make([]byte, KeySize)
+	_, err := rand.Read(bs)
+	require.NoError(t, err)
+	return Key(bs)
 }
 
 func newSealer(t *testing.T) *Sealer {
 	t.Helper()
-	s, err := NewSealer(filledKey(0xAA))
+	s, err := NewSealer(generateKey(t))
 	if err != nil {
 		t.Fatalf("NewSealer: %v", err)
 	}
@@ -42,24 +45,25 @@ func TestSealer_Roundtrip(t *testing.T) {
 
 func TestSealer_RejectsTamperedCiphertext(t *testing.T) {
 	s := newSealer(t)
-	value, err := s.Seal([]byte("hello"))
+	input := "hello"
+	value, err := s.Seal([]byte(input))
 	if err != nil {
 		t.Fatalf("Seal: %v", err)
 	}
 
-	// JWE compact is `header.cek.iv.ct.tag`. Flip a byte inside the
-	// tag (last segment) so GCM authentication fails.
-	tampered := flipLastByte(value)
+	// JWE compact is `header.cek.iv.ct.tag`. Tampering the tag
+	// (last segment) so GCM authentication fails.
+	tampered := tamperTag(value)
 
-	if _, err := s.Open(tampered); !errors.Is(err, ErrInvalid) {
-		t.Fatalf("Open tampered: err = %v, want ErrInvalid", err)
+	if decoded, err := s.Open(tampered); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("Open tampered: err = %v, want ErrInvalid (input: %s, sealed: %s, tampered: %s, decoded: %s)", err, input, value, tampered, decoded)
 	}
 }
 
 func TestSealer_RejectsForeignKey(t *testing.T) {
 	// A value sealed with a different key must not decrypt — GCM auth
 	// fails and Open returns ErrInvalid.
-	foreign, err := NewSealer(filledKey(0xCC))
+	foreign, err := NewSealer(generateKey(t))
 	if err != nil {
 		t.Fatalf("NewSealer (foreign): %v", err)
 	}
@@ -92,19 +96,18 @@ func TestSealer_RejectsMalformedInput(t *testing.T) {
 	}
 }
 
-// flipLastByte returns value with its final character changed. For a
-// JWE compact serialization the final segment is the GCM tag, so this
-// guarantees authentication failure on Decrypt.
-func flipLastByte(value string) string {
-	if value == "" {
+// tamperTag flips the first character of the authentication-tag segment
+// (the last dot-separated part of a JWE compact serialisation).
+func tamperTag(value string) string {
+	dot := strings.LastIndex(value, ".")
+	if dot < 0 || dot+1 >= len(value) {
 		return value
 	}
 	b := []byte(value)
-	last := b[len(b)-1]
-	if last == 'A' {
-		b[len(b)-1] = 'B'
+	if b[dot+1] == 'A' {
+		b[dot+1] = 'B'
 	} else {
-		b[len(b)-1] = 'A'
+		b[dot+1] = 'A'
 	}
 	return string(b)
 }


### PR DESCRIPTION
Cookie tampering test was flaky. It used a tampering method of tampering the last byte. This is not deterministic because GCM uses base64 encoding. This results some times in padding beeing added to the tag. Because of this, it is possible that the test flipped a byte which is actually only padding. This made the test flaky. 

Fixed this by flipping the first bit instead of the last