### PR TITLE
feat: wire flow engine through HTTP handler

### DIFF
--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -7531,8 +7531,10 @@ func (s *FlowEventRequest) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *FlowEventRequest) encodeFields(e *jx.Encoder) {
 	{
-		e.FieldStart("session_token")
-		e.Str(s.SessionToken)
+		if s.SessionToken.Set {
+			e.FieldStart("session_token")
+			s.SessionToken.Encode(e)
+		}
 	}
 	{
 		e.FieldStart("type")
@@ -7562,11 +7564,9 @@ func (s *FlowEventRequest) Decode(d *jx.Decoder) error {
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
 		case "session_token":
-			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				v, err := d.Str()
-				s.SessionToken = string(v)
-				if err != nil {
+				s.SessionToken.Reset()
+				if err := s.SessionToken.Decode(d); err != nil {
 					return err
 				}
 				return nil
@@ -7603,7 +7603,7 @@ func (s *FlowEventRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000010,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -7879,8 +7879,10 @@ func (s *FlowResponse) encodeFields(e *jx.Encoder) {
 		e.Str(s.SessionID)
 	}
 	{
-		e.FieldStart("session_token")
-		e.Str(s.SessionToken)
+		if s.SessionToken.Set {
+			e.FieldStart("session_token")
+			s.SessionToken.Encode(e)
+		}
 	}
 	{
 		e.FieldStart("step")
@@ -7957,11 +7959,9 @@ func (s *FlowResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"session_id\"")
 			}
 		case "session_token":
-			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
-				v, err := d.Str()
-				s.SessionToken = string(v)
-				if err != nil {
+				s.SessionToken.Reset()
+				if err := s.SessionToken.Decode(d); err != nil {
 					return err
 				}
 				return nil
@@ -8028,7 +8028,7 @@ func (s *FlowResponse) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00001111,
+		0b00001011,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -8734,8 +8734,10 @@ func (s *FlowSubmitRequest) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *FlowSubmitRequest) encodeFields(e *jx.Encoder) {
 	{
-		e.FieldStart("session_token")
-		e.Str(s.SessionToken)
+		if s.SessionToken.Set {
+			e.FieldStart("session_token")
+			s.SessionToken.Encode(e)
+		}
 	}
 	{
 		e.FieldStart("action")
@@ -8786,11 +8788,9 @@ func (s *FlowSubmitRequest) Decode(d *jx.Decoder) error {
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
 		case "session_token":
-			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				v, err := d.Str()
-				s.SessionToken = string(v)
-				if err != nil {
+				s.SessionToken.Reset()
+				if err := s.SessionToken.Decode(d); err != nil {
 					return err
 				}
 				return nil
@@ -8859,7 +8859,7 @@ func (s *FlowSubmitRequest) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000010,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -3312,14 +3312,15 @@ func (s *FlowDefinitionUpdateRequestPurposes) init() FlowDefinitionUpdateRequest
 
 // Ref: #
 type FlowEventRequest struct {
-	SessionToken string               `json:"session_token"`
+	// Reserved for future rotation. The sealed `_zflow` cookie carries the flow state today.
+	SessionToken OptString            `json:"session_token"`
 	Type         FlowEventRequestType `json:"type"`
 	// Event payload (fingerprint hash, timing data, etc.).
 	Payload OptFlowEventRequestPayload `json:"payload"`
 }
 
 // GetSessionToken returns the value of SessionToken.
-func (s *FlowEventRequest) GetSessionToken() string {
+func (s *FlowEventRequest) GetSessionToken() OptString {
 	return s.SessionToken
 }
 
@@ -3334,7 +3335,7 @@ func (s *FlowEventRequest) GetPayload() OptFlowEventRequestPayload {
 }
 
 // SetSessionToken sets the value of SessionToken.
-func (s *FlowEventRequest) SetSessionToken(val string) {
+func (s *FlowEventRequest) SetSessionToken(val OptString) {
 	s.SessionToken = val
 }
 
@@ -3461,9 +3462,9 @@ type FlowResponse struct {
 	ID string `json:"id"`
 	// Underlying session ID. Stable across all stacked flows.
 	SessionID string `json:"session_id"`
-	// Rotated on every response. Required for the next request.
-	SessionToken string   `json:"session_token"`
-	Step         FlowStep `json:"step"`
+	// Reserved for future rotation. The sealed `_zflow` cookie carries the flow state today.
+	SessionToken OptString `json:"session_token"`
+	Step         FlowStep  `json:"step"`
 	// Resolved branding inherited from the app → team → project hierarchy.
 	// Determined at flow creation based on audience context. Does not change between steps.
 	Branding OptBranding `json:"branding"`
@@ -3489,7 +3490,7 @@ func (s *FlowResponse) GetSessionID() string {
 }
 
 // GetSessionToken returns the value of SessionToken.
-func (s *FlowResponse) GetSessionToken() string {
+func (s *FlowResponse) GetSessionToken() OptString {
 	return s.SessionToken
 }
 
@@ -3529,7 +3530,7 @@ func (s *FlowResponse) SetSessionID(val string) {
 }
 
 // SetSessionToken sets the value of SessionToken.
-func (s *FlowResponse) SetSessionToken(val string) {
+func (s *FlowResponse) SetSessionToken(val OptString) {
 	s.SessionToken = val
 }
 
@@ -3914,7 +3915,8 @@ func (s *FlowStepGates) init() FlowStepGates {
 
 // Ref: #
 type FlowSubmitRequest struct {
-	SessionToken string `json:"session_token"`
+	// Reserved for future rotation. The sealed `_zflow` cookie carries the flow state today.
+	SessionToken OptString `json:"session_token"`
 	// Which action to take. Must be a key from the step's `actions` dictionary:
 	// - A regular action (e.g., "submit", "register", "back")
 	// - The reserved value "sso" — triggers SSO redirect (requires `sso_provider_id`).
@@ -3934,7 +3936,7 @@ type FlowSubmitRequest struct {
 }
 
 // GetSessionToken returns the value of SessionToken.
-func (s *FlowSubmitRequest) GetSessionToken() string {
+func (s *FlowSubmitRequest) GetSessionToken() OptString {
 	return s.SessionToken
 }
 
@@ -3964,7 +3966,7 @@ func (s *FlowSubmitRequest) GetSSOProviderID() OptString {
 }
 
 // SetSessionToken sets the value of SessionToken.
-func (s *FlowSubmitRequest) SetSessionToken(val string) {
+func (s *FlowSubmitRequest) SetSessionToken(val OptString) {
 	s.SessionToken = val
 }
 

--- a/api/openapi/components/flows/flow-event-request.yaml
+++ b/api/openapi/components/flows/flow-event-request.yaml
@@ -1,8 +1,9 @@
 type: object
-required: [session_token, type]
+required: [type]
 properties:
   session_token:
     type: string
+    description: Reserved for future rotation. The sealed `_zflow` cookie carries the flow state today.
   type:
     type: string
     enum: [fingerprint, telemetry]

--- a/api/openapi/components/flows/flow-response.yaml
+++ b/api/openapi/components/flows/flow-response.yaml
@@ -1,5 +1,5 @@
 type: object
-required: [id, session_id, session_token, step]
+required: [id, session_id, step]
 properties:
   id:
     type: string
@@ -13,7 +13,7 @@ properties:
     description: Underlying session ID. Stable across all stacked flows.
   session_token:
     type: string
-    description: Rotated on every response. Required for the next request.
+    description: Reserved for future rotation. The sealed `_zflow` cookie carries the flow state today.
   step:
     $ref: flow-step.yaml
   branding:

--- a/api/openapi/components/flows/flow-submit-request.yaml
+++ b/api/openapi/components/flows/flow-submit-request.yaml
@@ -1,8 +1,9 @@
 type: object
-required: [session_token, action]
+required: [action]
 properties:
   session_token:
     type: string
+    description: Reserved for future rotation. The sealed `_zflow` cookie carries the flow state today.
   action:
     type: string
     description: |

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -157,13 +157,8 @@ func run(ctx context.Context, cfg Config, pool database.Pool, userFiles []string
 	// ── Flow engine ──────────────────
 	ids := idgen.NewULID()
 	fields := domain.NewSchemaFieldResolver(storageSchemaResolver)
-
-	// TODO: argon2id wiring lands in a follow-up PR. Until then registration
-	// flows fail with ErrIntegrity; login is unaffected.
-	var createUser *domain.FlowCreateUserHandler
-
 	flowAuth := service.NewFlowAuthAttemptAdapter(authAttemptSvc)
-	stateMachine := domain.NewFlowStateMachine(fields, createUser, flowAuth, time.Now)
+	stateMachine := domain.NewFlowStateMachine(fields, nil, flowAuth, time.Now)
 
 	flowService := service.NewFlowService(pool, flowDefinitionRepo, stateMachine, ids)
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -59,6 +59,15 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
+// mustBindEnv panics on viper's documented "this can't fail in
+// normal use" BindEnv error path. Keeps the env wiring readable
+// without sprinkling error handling at every binding.
+func mustBindEnv(v *viper.Viper, key string) {
+	if err := v.BindEnv(key); err != nil {
+		panic(fmt.Errorf("bind env %q: %w", key, err))
+	}
+}
+
 func startDatabase(ctx context.Context, config database.Config) (database.Pool, error) {
 	connector, err := config.Build()
 	if err != nil {
@@ -129,7 +138,6 @@ func run(ctx context.Context, cfg Config, pool database.Pool, userFiles []string
 	}
 
 	// ── Services ─────────────────────
-	flowService := service.NewFlowService(pool, flowDefinitionRepo)
 	authAttemptSvc := service.NewAuthAttemptService(
 		pool,
 		attemptRepo,
@@ -155,22 +163,26 @@ func run(ctx context.Context, cfg Config, pool database.Pool, userFiles []string
 	)
 	teamService := service.NewTeamService(pool, teamRepo)
 
+	// ── Flow engine ──────────────────
+	ids := idgen.NewULID()
+	fields := domain.NewSchemaFieldResolver(storageSchemaResolver)
+
+	// TODO: argon2id wiring lands in a follow-up PR. Until then registration
+	// flows fail with ErrIntegrity; login is unaffected.
+	var createUser *domain.FlowCreateUserHandler
+
+	flowAuth := service.NewFlowAuthAttemptAdapter(authAttemptSvc)
+	stateMachine := domain.NewFlowStateMachine(fields, createUser, flowAuth, time.Now)
+
+	flowService := service.NewFlowService(pool, flowDefinitionRepo, stateMachine, ids)
+
 	// ── HTTP Server ─────────────────
 
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	oasServer, err := oasapi.NewServer(
-		api.NewHandler(
-			crypter,
-			flowService,
-			authAttemptSvc,
-			sessionService,
-			projectService,
-			schemaService,
-			flowDefinitionSvc,
-			teamService,
-		),
+		api.NewHandler(crypter, flowService, authAttemptSvc, sessionService, projectService, schemaService, flowDefinitionSvc, teamService, time.Now),
 		api.NewSecurityHandler(),
 		oasapi.WithErrorHandler(api.OgenErrorHandler))
 	if err != nil {
@@ -256,28 +268,19 @@ func loadConfig(configPath string) (Config, error) {
 	return cfg, cfg.Validate()
 }
 
-// mustBindEnv panics on viper's documented "this can't fail in
-// normal use" BindEnv error path. Keeps the env wiring readable
-// without sprinkling error handling at every binding.
-func mustBindEnv(v *viper.Viper, key string) {
-	if err := v.BindEnv(key); err != nil {
-		panic(fmt.Errorf("bind env %q: %w", key, err))
-	}
-}
-
 // buildCrypter decodes a hex-encoded crypter key and constructs a
 // [crypto.Crypter]. The key must decode to exactly 32 bytes;
 // anything else is a configuration error.
 func buildCrypter(hexKey string) (crypto.Crypter, error) {
 	if hexKey == "" {
-		return nil, errors.New("server: cookie_sealer_key is required (set NEXTGEN_SERVER_COOKIE_SEALER_KEY)")
+		return nil, errors.New("server: encryption_key is required (set NEXTGEN_SERVER_ENCRYPTION_KEY)")
 	}
 	key, err := hex.DecodeString(hexKey)
 	if err != nil {
-		return nil, fmt.Errorf("server: decode cookie_sealer_key: %w", err)
+		return nil, fmt.Errorf("server: decode encryption_key: %w", err)
 	}
 	if len(key) != 32 {
-		return nil, fmt.Errorf("server: cookie_sealer_key must decode to %d bytes, got %d", 32, len(key))
+		return nil, fmt.Errorf("server: encryption_key must decode to %d bytes, got %d", 32, len(key))
 	}
 	crypter := op.NewAES256GCMCrypto([32]byte(key), "")
 	return crypter, nil

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -59,15 +59,6 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-// mustBindEnv panics on viper's documented "this can't fail in
-// normal use" BindEnv error path. Keeps the env wiring readable
-// without sprinkling error handling at every binding.
-func mustBindEnv(v *viper.Viper, key string) {
-	if err := v.BindEnv(key); err != nil {
-		panic(fmt.Errorf("bind env %q: %w", key, err))
-	}
-}
-
 func startDatabase(ctx context.Context, config database.Config) (database.Pool, error) {
 	connector, err := config.Build()
 	if err != nil {
@@ -182,7 +173,7 @@ func run(ctx context.Context, cfg Config, pool database.Pool, userFiles []string
 	defer stop()
 
 	oasServer, err := oasapi.NewServer(
-		api.NewHandler(crypter, flowService, authAttemptSvc, sessionService, projectService, schemaService, flowDefinitionSvc, teamService, time.Now),
+		api.NewHandler(crypter, flowService, authAttemptSvc, sessionService, projectService, schemaService, flowDefinitionSvc, teamService),
 		api.NewSecurityHandler(),
 		oasapi.WithErrorHandler(api.OgenErrorHandler))
 	if err != nil {
@@ -266,6 +257,15 @@ func loadConfig(configPath string) (Config, error) {
 	}
 
 	return cfg, cfg.Validate()
+}
+
+// mustBindEnv panics on viper's documented "this can't fail in
+// normal use" BindEnv error path. Keeps the env wiring readable
+// without sprinkling error handling at every binding.
+func mustBindEnv(v *viper.Viper, key string) {
+	if err := v.BindEnv(key); err != nil {
+		panic(fmt.Errorf("bind env %q: %w", key, err))
+	}
 }
 
 // buildCrypter decodes a hex-encoded crypter key and constructs a

--- a/internal/api/branding.go
+++ b/internal/api/branding.go
@@ -1,0 +1,18 @@
+package api
+
+import (
+	_ "embed"
+
+	api "github.com/zitadel/nextgen/api/generated"
+)
+
+//go:embed branding/default.liquid
+var defaultLiquidTemplate string
+
+// defaultBranding returns the MVP fallback until the Branding API ships.
+func defaultBranding() api.Branding {
+	return api.Branding{
+		Layout:         api.NewOptBrandingLayout(api.BrandingLayoutCentered),
+		LiquidTemplate: api.NewOptString(defaultLiquidTemplate),
+	}
+}

--- a/internal/api/branding/default.liquid
+++ b/internal/api/branding/default.liquid
@@ -1,52 +1,103 @@
-{% comment %}
-  Default LiquidJS template for the flow engine MVP. Rendered by the
-  orchestrator into Shadow DOM. Customers can replace it via the
-  Team/App Branding API once that endpoint ships.
-
-  Available context:
-    step.name             - step identifier
-    step.error            - optional error key
-    step.fields           - dictionary of {name -> field}
-    step.actions          - dictionary of {name -> action}
-    step.complete         - "redirect" | "show" | null
-    step.redirect_url     - present when complete == "redirect"
-{% endcomment %}
-
-<section class="zl-flow zl-flow--{{ step.name }}">
-  {% if step.error %}
-    <p class="zl-flow__error" role="alert">{{ step.error | t }}</p>
+<zl-page-shell data-zl-template-root>
+  {% if branding.logo_url %}
+    <img slot="header" class="zl-card-logo" src="{{ branding.logo_url }}" alt="" />
   {% endif %}
+  <zl-card>
+    <h1 slot="header" class="zl-card-title">{{ step.texts.title_key | t: identity.display_name }}</h1>
+    {% if step.texts.description_key %}
+      <p slot="header" class="zl-card-subtitle">{{ step.texts.description_key | t: identity.display_name }}</p>
+    {% endif %}
 
-  {% if step.complete == "show" %}
-    <p class="zl-flow__done">{{ step.name | t }}</p>
-  {% else %}
-    <form class="zl-flow__form">
-      {% for entry in step.fields %}
-        {% assign name = entry[0] %}
-        {% assign field = entry[1] %}
-        <label class="zl-flow__field">
-          <span>{{ field.text_key | t }}</span>
-          <input
-            name="{{ name }}"
-            type="{{ field.type }}"
-            {% if field.required %}required{% endif %}
-            {% if field.value %}value="{{ field.value }}"{% endif %}
-          />
-        </label>
+    {% if errors and errors.size > 0 %}
+      {% for err in errors %}
+        {% if err | formLevelError %}
+          {% assign alert_heading = err.text_key | alertHeading %}
+          {% assign alert_body = err.text_key | alertBody %}
+          <zl-alert severity="error"{% if alert_heading != "" %} heading="{{ alert_heading | t }}"{% endif %}>
+            {% if alert_body != "" %}{{ alert_body | t }}{% elsif err.text_key %}{{ err.text_key | t }}{% else %}{{ err.message }}{% endif %}
+          </zl-alert>
+        {% endif %}
       {% endfor %}
+    {% endif %}
 
-      <div class="zl-flow__actions">
-        {% for entry in step.actions %}
-          {% assign name = entry[0] %}
-          {% assign action = entry[1] %}
-          <button
-            type="submit"
-            name="action"
-            value="{{ name }}"
-            {% if action.primary %}class="zl-flow__action--primary"{% endif %}
-          >{{ action.text_key | t }}</button>
-        {% endfor %}
-      </div>
-    </form>
-  {% endif %}
-</section>
+    {% for entry in fields %}
+      {% assign field_placeholder = entry[1].text_key | fieldPlaceholder %}
+      {% assign field_help = entry[1].text_key | fieldHelp %}
+      {% assign field_err = entry[0] | fieldError: errors %}
+      {% assign autocomplete_val = '' %}
+      {% if entry[0] == 'email' %}
+        {% assign autocomplete_val = 'email' %}
+      {% elsif entry[1].type == 'password' and step.name == 'register' %}
+        {% assign autocomplete_val = 'new-password' %}
+      {% elsif entry[1].type == 'password' %}
+        {% assign autocomplete_val = 'current-password' %}
+      {% endif %}
+      <zl-field
+        name="{{ entry[0] }}"
+        label="{{ entry[1].text_key | t }}"
+        type="{{ entry[1].type }}"
+        value="{{ entry[1].value }}"
+        {% if autocomplete_val != '' %}autocomplete="{{ autocomplete_val }}"{% endif %}
+        {% if entry[1].required %}required{% endif %}
+        {% if field_placeholder != "" %}placeholder="{{ field_placeholder }}"{% endif %}
+        {% if field_err != "" %}invalid error="{{ field_err }}"{% endif %}
+      >
+        {% if field_help != "" %}
+          <span slot="help">{{ field_help }}</span>
+        {% endif %}
+      </zl-field>
+    {% endfor %}
+
+    {% if fields.email and fields.password and step.name == 'identifier' %}
+      <p class="zl-card-forgot">
+        <a href="#" class="zl-card-forgot__link" data-action="recover">{{ 'action.forgot_password' | t }}</a>
+      </p>
+    {% endif %}
+
+    {% for entry in actions %}
+      {% if entry[1].primary %}
+        <zl-button
+          hierarchy="primary"
+          size="medium"
+          type="submit"
+          block
+          action="{{ entry[0] }}"
+          label="{{ entry[1].text_key | t }}"
+          {% if loading %}loading{% endif %}
+        ></zl-button>
+      {% endif %}
+    {% endfor %}
+
+    {% if actions.passkey %}
+      <zl-button
+        hierarchy="secondary"
+        size="medium"
+        block
+        action="passkey"
+        label="{{ actions.passkey.text_key | t }}"
+      ></zl-button>
+    {% endif %}
+
+    {% if actions.register %}
+      <p class="zl-card-nav">
+        {{ 'identifier.action.register.lead' | t }}<a href="#" class="zl-card-nav__link" data-action="register">{{ 'identifier.action.register.link' | t }}</a>
+      </p>
+    {% endif %}
+
+    {% if actions.sign_in %}
+      <p class="zl-card-nav">
+        {{ 'register.action.sign_in.lead' | t }}<a href="#" class="zl-card-nav__link" data-action="sign_in">{{ 'register.action.sign_in.link' | t }}</a>
+      </p>
+    {% endif %}
+
+    {% if challenge and challenge.method == "passkey" %}
+      <zl-passkey
+        ceremony="{{ challenge.options.ceremony | default: 'authenticate' }}"
+        challenge-id="{{ challenge.challenge_id }}"
+        options='{{ challenge.options | json }}'
+      ></zl-passkey>
+    {% endif %}
+
+    {% mandatory_gates %}
+  </zl-card>
+</zl-page-shell>

--- a/internal/api/branding/default.liquid
+++ b/internal/api/branding/default.liquid
@@ -1,0 +1,52 @@
+{% comment %}
+  Default LiquidJS template for the flow engine MVP. Rendered by the
+  orchestrator into Shadow DOM. Customers can replace it via the
+  Team/App Branding API once that endpoint ships.
+
+  Available context:
+    step.name             - step identifier
+    step.error            - optional error key
+    step.fields           - dictionary of {name -> field}
+    step.actions          - dictionary of {name -> action}
+    step.complete         - "redirect" | "show" | null
+    step.redirect_url     - present when complete == "redirect"
+{% endcomment %}
+
+<section class="zl-flow zl-flow--{{ step.name }}">
+  {% if step.error %}
+    <p class="zl-flow__error" role="alert">{{ step.error | t }}</p>
+  {% endif %}
+
+  {% if step.complete == "show" %}
+    <p class="zl-flow__done">{{ step.name | t }}</p>
+  {% else %}
+    <form class="zl-flow__form">
+      {% for entry in step.fields %}
+        {% assign name = entry[0] %}
+        {% assign field = entry[1] %}
+        <label class="zl-flow__field">
+          <span>{{ field.text_key | t }}</span>
+          <input
+            name="{{ name }}"
+            type="{{ field.type }}"
+            {% if field.required %}required{% endif %}
+            {% if field.value %}value="{{ field.value }}"{% endif %}
+          />
+        </label>
+      {% endfor %}
+
+      <div class="zl-flow__actions">
+        {% for entry in step.actions %}
+          {% assign name = entry[0] %}
+          {% assign action = entry[1] %}
+          <button
+            type="submit"
+            name="action"
+            value="{{ name }}"
+            {% if action.primary %}class="zl-flow__action--primary"{% endif %}
+          >{{ action.text_key | t }}</button>
+        {% endfor %}
+      </div>
+    </form>
+  {% endif %}
+</section>

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-faster/jx"
+
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
@@ -90,7 +91,7 @@ func (h *Handler) CreateFlow(ctx context.Context, req *api.CreateFlowRequest) (a
 	}, nil
 }
 
-func (h *Handler)SubmitFlowStep(ctx context.Context, req *api.FlowSubmitRequest, params api.SubmitFlowStepParams) (api.SubmitFlowStepRes, error) {
+func (h *Handler) SubmitFlowStep(ctx context.Context, req *api.FlowSubmitRequest, params api.SubmitFlowStepParams) (api.SubmitFlowStepRes, error) {
 	state, err := h.openState(params.Zflow)
 	if err != nil {
 		return mapFlowErrorStatus(err), nil
@@ -144,7 +145,7 @@ func (h *Handler)SubmitFlowStep(ctx context.Context, req *api.FlowSubmitRequest,
 	}, nil
 }
 
-func (h *Handler)GetFlowStep(ctx context.Context, params api.GetFlowStepParams) (api.GetFlowStepRes, error) {
+func (h *Handler) GetFlowStep(ctx context.Context, params api.GetFlowStepParams) (api.GetFlowStepRes, error) {
 	state, err := h.openState(params.Zflow)
 	if err != nil {
 		return mapFlowGetError(err), nil
@@ -207,7 +208,7 @@ func flowSetCookie(value string, clear bool) string {
 	return c.String()
 }
 
-func (h *Handler)buildFlowResponse(result service.FlowStepResult, terminal bool) api.FlowResponse {
+func (h *Handler) buildFlowResponse(result service.FlowStepResult, terminal bool) api.FlowResponse {
 	resp := api.FlowResponse{
 		ID:        result.State.ID,
 		SessionID: result.State.SessionID,

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -178,7 +178,7 @@ func (h *Handler) openState(raw string) (*domain.FlowState, error) {
 	if err := json.Unmarshal([]byte(payload), &state); err != nil {
 		return nil, errFlowCookieInvalid
 	}
-	if h.now().Sub(state.IssuedAt) > flowCookieMaxAgeSeconds*time.Second {
+	if time.Since(state.IssuedAt) > flowCookieMaxAgeSeconds*time.Second {
 		return nil, errFlowCookieExpired
 	}
 	return &state, nil

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	flowCookieName          = "_zflow"
-	flowCookiePath          = "/flow"
 	flowCookieMaxAgeSeconds = 600
 )
 
@@ -195,7 +194,6 @@ func (h *Handler) sealState(state *domain.FlowState) (string, error) {
 func flowSetCookie(value string, clear bool) string {
 	c := &http.Cookie{
 		Name:     flowCookieName,
-		Path:     flowCookiePath,
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
@@ -230,6 +228,7 @@ func toFlowStep(step *domain.FlowStep) api.FlowStep {
 	}
 	out := api.FlowStep{
 		Name:    step.Name,
+		Texts:   api.NewOptStepTexts(toStepTexts(step.Texts)),
 		Fields:  toFlowStepFields(step.Fields),
 		Actions: toFlowStepActions(step.Actions),
 		Gates:   api.FlowStepGates{},
@@ -244,6 +243,17 @@ func toFlowStep(step *domain.FlowStep) api.FlowStep {
 		if u, err := parseURI(*step.RedirectURL); err == nil {
 			out.RedirectURL = api.NewOptURI(u)
 		}
+	}
+	return out
+}
+
+func toStepTexts(t domain.FlowStepTexts) api.StepTexts {
+	out := api.StepTexts{}
+	if t.TitleKey != "" {
+		out.TitleKey = api.NewOptString(t.TitleKey)
+	}
+	if t.DescriptionKey != "" {
+		out.DescriptionKey = api.NewOptNilString(t.DescriptionKey)
 	}
 	return out
 }

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -219,6 +219,10 @@ func (h *Handler)buildFlowResponse(result service.FlowStepResult, terminal bool)
 			resp.RedirectURI = api.NewOptURI(u)
 		}
 	}
+	if terminal && result.HandoffToken != "" {
+		resp.HandoffToken = api.NewOptString(result.HandoffToken)
+		resp.HandoffTokenExpiresAt = api.NewOptDateTime(result.HandoffTokenExpiresAt)
+	}
 	return resp
 }
 

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -2,12 +2,31 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"time"
 
+	"github.com/go-faster/jx"
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
+)
+
+const (
+	flowCookieName          = "_zflow"
+	flowCookiePath          = "/flow"
+	flowCookieMaxAgeSeconds = 600
+)
+
+var (
+	errFlowCookieMissing = errors.New("flow cookie missing")
+	errFlowCookieInvalid = errors.New("flow cookie invalid")
+	errFlowCookieExpired = errors.New("flow cookie expired")
+	errFlowIDMismatch    = errors.New("flow id does not match cookie")
+	errFlowCompleted     = errors.New("flow already completed")
 )
 
 func (h *Handler) CreateFlow(ctx context.Context, req *api.CreateFlowRequest) (api.CreateFlowRes, error) {
@@ -39,12 +58,301 @@ func (h *Handler) CreateFlow(ctx context.Context, req *api.CreateFlowRequest) (a
 		return errorResponse(err), nil
 	}
 
-	// Execution is intentionally stopped here. The service resolved a
-	// definition; emitting steps + cookies is the next slice of work.
-	return &api.ErrorDetails{
-		Code:    "flow_execution_not_implemented",
-		Message: fmt.Sprintf("selected flow %q (version %s, id %s); execution not yet implemented", def.Name, def.SchemaVersion, def.ID),
+	startReq := service.StartFlowRequest{
+		Definition: def,
+		Purpose:    purpose,
+	}
+	if uri, ok := req.RedirectURI.Get(); ok {
+		// TODO: validate against RP's redirect_uri allowlist when OIDC lands.
+		s := uri.String()
+		startReq.RedirectURI = &s
+	}
+	if id, ok := req.AuthRequestID.Get(); ok {
+		startReq.AuthRequestID = &id
+	}
+	if id, ok := req.SessionID.Get(); ok {
+		startReq.SessionID = &id
+	}
+
+	result, err := h.flowService.Start(ctx, startReq)
+	if err != nil {
+		return mapFlowErrorStatus(err), nil
+	}
+
+	cookieValue, err := h.sealState(result.State)
+	if err != nil {
+		return internalErrorResponse(err), nil
+	}
+
+	resp := h.buildFlowResponse(result, false)
+	return &api.FlowResponseHeaders{
+		SetCookie: api.NewOptString(flowSetCookie(cookieValue, false)),
+		Response:  resp,
 	}, nil
+}
+
+func (h *Handler)SubmitFlowStep(ctx context.Context, req *api.FlowSubmitRequest, params api.SubmitFlowStepParams) (api.SubmitFlowStepRes, error) {
+	state, err := h.openState(params.Zflow)
+	if err != nil {
+		return mapFlowErrorStatus(err), nil
+	}
+	if state.ID != params.ID {
+		return mapFlowErrorStatus(errFlowIDMismatch), nil
+	}
+
+	submitReq := service.SubmitFlowRequest{
+		State:  state,
+		Action: req.Action,
+	}
+	if fields, ok := req.Fields.Get(); ok {
+		decoded, err := decodeFlowFields(fields)
+		if err != nil {
+			return errorResponseWithStatusCode(http.StatusBadRequest, domain.ErrRequestInvalid().WithMessage(err.Error())), nil
+		}
+		submitReq.Fields = decoded
+	}
+	if proofs, ok := req.GateProofs.Get(); ok {
+		submitReq.GateProofs = proofs
+	}
+	if id, ok := req.SSOProviderID.Get(); ok {
+		submitReq.SSOProviderID = &id
+	}
+
+	result, err := h.flowService.Submit(ctx, submitReq)
+	if err != nil {
+		return mapFlowErrorStatus(err), nil
+	}
+
+	cookieValue, err := h.sealState(result.State)
+	if err != nil {
+		return internalErrorResponse(err), nil
+	}
+
+	terminal := result.Step != nil && result.Step.Complete != nil
+	flowResp := h.buildFlowResponse(result, terminal)
+
+	// Validation error: state machine keeps the user on the step with Error set.
+	if result.Step != nil && result.Step.Error != nil {
+		return &api.SubmitFlowStepBadRequest{
+			SetCookie: api.NewOptString(flowSetCookie(cookieValue, false)),
+			Response:  flowResp,
+		}, nil
+	}
+
+	return &api.SubmitFlowStepOK{
+		SetCookie: api.NewOptString(flowSetCookie(cookieValue, terminal)),
+		Response:  flowResp,
+	}, nil
+}
+
+func (h *Handler)GetFlowStep(ctx context.Context, params api.GetFlowStepParams) (api.GetFlowStepRes, error) {
+	state, err := h.openState(params.Zflow)
+	if err != nil {
+		return mapFlowGetError(err), nil
+	}
+	if state.ID != params.ID {
+		return mapFlowGetError(errFlowIDMismatch), nil
+	}
+
+	result, err := h.flowService.GetStep(ctx, service.GetFlowStepRequest{State: state})
+	if err != nil {
+		return errorResponse(err), nil
+	}
+	if result.Step != nil && result.Step.Complete != nil {
+		return mapFlowGetError(errFlowCompleted), nil
+	}
+
+	resp := h.buildFlowResponse(result, false)
+	return &resp, nil
+}
+
+func (h *Handler) openState(raw string) (*domain.FlowState, error) {
+	if raw == "" {
+		return nil, errFlowCookieMissing
+	}
+	payload, err := h.crypter.Decrypt(raw)
+	if err != nil {
+		return nil, errFlowCookieInvalid
+	}
+	var state domain.FlowState
+	if err := json.Unmarshal([]byte(payload), &state); err != nil {
+		return nil, errFlowCookieInvalid
+	}
+	if h.now().Sub(state.IssuedAt) > flowCookieMaxAgeSeconds*time.Second {
+		return nil, errFlowCookieExpired
+	}
+	return &state, nil
+}
+
+func (h *Handler) sealState(state *domain.FlowState) (string, error) {
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("marshal flow state: %w", err)
+	}
+	return h.crypter.Encrypt(string(payload))
+}
+
+func flowSetCookie(value string, clear bool) string {
+	c := &http.Cookie{
+		Name:     flowCookieName,
+		Path:     flowCookiePath,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	}
+	if clear {
+		c.MaxAge = -1 // emits "Max-Age=0", instructing browsers to delete
+		return c.String()
+	}
+	c.Value = value
+	c.MaxAge = flowCookieMaxAgeSeconds
+	return c.String()
+}
+
+func (h *Handler)buildFlowResponse(result service.FlowStepResult, terminal bool) api.FlowResponse {
+	resp := api.FlowResponse{
+		ID:        result.State.ID,
+		SessionID: result.State.SessionID,
+		Step:      toFlowStep(result.Step),
+		Branding:  api.NewOptBranding(defaultBranding()),
+	}
+	if terminal && result.State.RedirectURI != nil {
+		if u, err := parseURI(*result.State.RedirectURI); err == nil {
+			resp.RedirectURI = api.NewOptURI(u)
+		}
+	}
+	return resp
+}
+
+func toFlowStep(step *domain.FlowStep) api.FlowStep {
+	if step == nil {
+		return api.FlowStep{}
+	}
+	out := api.FlowStep{
+		Name:    step.Name,
+		Fields:  toFlowStepFields(step.Fields),
+		Actions: toFlowStepActions(step.Actions),
+		Gates:   api.FlowStepGates{},
+	}
+	if step.Error != nil {
+		out.Error = api.NewOptNilString(*step.Error)
+	}
+	if step.Complete != nil {
+		out.Complete = api.NewOptFlowStepComplete(toFlowStepComplete(*step.Complete))
+	}
+	if step.RedirectURL != nil {
+		if u, err := parseURI(*step.RedirectURL); err == nil {
+			out.RedirectURL = api.NewOptURI(u)
+		}
+	}
+	return out
+}
+
+func toFlowStepFields(fields map[string]domain.FlowField) api.FlowStepFields {
+	out := make(api.FlowStepFields, len(fields))
+	for name, f := range fields {
+		out[name] = toFlowField(f)
+	}
+	return out
+}
+
+func toFlowField(f domain.FlowField) api.Field {
+	out := api.Field{
+		Type:     api.FieldType(f.Type),
+		TextKey:  f.TextKey,
+		Required: api.NewOptBool(f.Required),
+	}
+	if f.Value != nil {
+		out.Value = jx.Raw(jsonQuoted(*f.Value))
+	}
+	return out
+}
+
+func toFlowStepActions(actions map[string]domain.FlowAction) api.FlowStepActions {
+	out := make(api.FlowStepActions, len(actions))
+	for name, a := range actions {
+		out[name] = api.StepAction{
+			TextKey: api.NewOptString(a.TextKey),
+			Primary: api.NewOptBool(a.Primary),
+		}
+	}
+	return out
+}
+
+func toFlowStepComplete(c domain.FlowStepComplete) api.FlowStepComplete {
+	switch c {
+	case domain.FlowStepCompleteRedirect:
+		return api.FlowStepCompleteRedirect
+	case domain.FlowStepCompleteShow:
+		return api.FlowStepCompleteShow
+	}
+	return api.FlowStepCompleteShow
+}
+
+func decodeFlowFields(raw map[string]jx.Raw) (map[string]any, error) {
+	out := make(map[string]any, len(raw))
+	for k, v := range raw {
+		var decoded any
+		if err := json.Unmarshal(v, &decoded); err != nil {
+			return nil, fmt.Errorf("decode field %q: %w", k, err)
+		}
+		out[k] = decoded
+	}
+	return out, nil
+}
+
+func jsonQuoted(s string) []byte {
+	b, _ := json.Marshal(s)
+	return b
+}
+
+// isCookieOrIDError matches any sentinel that means "this caller isn't
+// holding a valid flow handle for this path" — either the cookie was
+// missing/tampered/expired, or its embedded id doesn't match the path.
+func isCookieOrIDError(err error) bool {
+	return errors.Is(err, errFlowCookieMissing) ||
+		errors.Is(err, errFlowCookieInvalid) ||
+		errors.Is(err, errFlowCookieExpired) ||
+		errors.Is(err, errFlowIDMismatch)
+}
+
+func mapFlowErrorStatus(err error) *api.ErrorDetailsStatusCode {
+	switch {
+	case errors.Is(err, errFlowCookieMissing), errors.Is(err, errFlowCookieInvalid):
+		return errorResponseWithStatusCode(http.StatusUnauthorized,
+			domain.Error{Code: "flow_cookie_invalid", Message: "flow cookie is missing or invalid"})
+	case errors.Is(err, errFlowCookieExpired):
+		return errorResponseWithStatusCode(http.StatusUnauthorized,
+			domain.Error{Code: "flow_cookie_expired", Message: "flow cookie has expired"})
+	case errors.Is(err, errFlowIDMismatch):
+		return errorResponseWithStatusCode(http.StatusNotFound,
+			domain.Error{Code: "flow_not_found", Message: "flow id does not match cookie"})
+	case errors.Is(err, errFlowCompleted):
+		return errorResponseWithStatusCode(http.StatusGone,
+			domain.Error{Code: "flow_completed", Message: "flow has already completed"})
+	case errors.Is(err, domain.ErrInvalidAction):
+		return errorResponseWithStatusCode(http.StatusBadRequest,
+			domain.Error{Code: "invalid_action", Message: err.Error()})
+	case errors.Is(err, domain.ErrSessionConflict):
+		return errorResponseWithStatusCode(http.StatusConflict,
+			domain.Error{Code: "session_conflict", Message: err.Error()})
+	case errors.Is(err, domain.ErrUnsupported):
+		return errorResponseWithStatusCode(http.StatusBadRequest,
+			domain.Error{Code: "unsupported", Message: err.Error()})
+	}
+	return errorResponse(err)
+}
+
+func mapFlowGetError(err error) api.GetFlowStepRes {
+	switch {
+	case isCookieOrIDError(err):
+		notFound := api.GetFlowStepNotFound{Code: "flow_not_found", Message: "flow not found"}
+		return &notFound
+	case errors.Is(err, errFlowCompleted):
+		gone := api.GetFlowStepGone{Code: "flow_completed", Message: "flow has already completed"}
+		return &gone
+	}
+	return errorResponse(err)
 }
 
 func buildResolveHint(opt api.OptFlowHint) service.ResolveFlowHint {
@@ -65,15 +373,27 @@ func buildResolveHint(opt api.OptFlowHint) service.ResolveFlowHint {
 	return out
 }
 
+var (
+	codeFlowDefinitionNotFound        = domain.ErrFlowDefinitionNotFound().Code
+	codeFlowDefinitionPurposeMismatch = domain.ErrFlowDefinitionPurposeMismatch().Code
+	codeFlowDefinitionInvalid         = domain.ErrFlowDefinitionInvalid(nil, nil).Code
+)
+
 func flowDefinitionErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
 	switch err.Code {
-	case domain.ErrFlowDefinitionNotFound().Code:
+	case codeFlowDefinitionNotFound:
 		return errorResponseWithStatusCode(http.StatusNotFound, err)
-	case domain.ErrFlowDefinitionPurposeMismatch().Code:
-		return errorResponseWithStatusCode(http.StatusBadRequest, err)
-	case domain.ErrFlowDefinitionInvalid(err.Details, err.Parent).Code:
+	case codeFlowDefinitionPurposeMismatch, codeFlowDefinitionInvalid:
 		return errorResponseWithStatusCode(http.StatusBadRequest, err)
 	default:
 		return internalErrorResponse(err)
 	}
+}
+
+func parseURI(s string) (url.URL, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return url.URL{}, err
+	}
+	return *u, nil
 }

--- a/internal/api/flow_test.go
+++ b/internal/api/flow_test.go
@@ -12,9 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/zitadel/oidc/v3/pkg/op"
+
 	gen "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/api"
-	"github.com/zitadel/nextgen/internal/cookie"
+	"github.com/zitadel/nextgen/internal/crypto"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
 )
@@ -80,8 +82,8 @@ func (stubAuthAttempt) Handoff(context.Context, service.HandoffInput) (*domain.A
 
 var _ service.AuthAttemptService = stubAuthAttempt{}
 
-// fixedKey is a deterministic cookie sealer key for tests.
-var fixedKey = cookie.Key{
+// fixedKey is a deterministic crypter key for tests.
+var fixedKey = [32]byte{
 	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
 	0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
 	0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
@@ -89,30 +91,27 @@ var fixedKey = cookie.Key{
 }
 
 type testServer struct {
-	srv    *httptest.Server
-	sealer *cookie.Sealer
-	fake   *fakeFlowSvc
-	now    func() time.Time
+	srv     *httptest.Server
+	crypter crypto.Crypter
+	fake    *fakeFlowSvc
+	now     func() time.Time
 }
 
 func newTestServer(t *testing.T, now func() time.Time) *testServer {
 	t.Helper()
-	sealer, err := cookie.NewSealer(fixedKey)
-	if err != nil {
-		t.Fatalf("NewSealer: %v", err)
-	}
+	crypter := op.NewAES256GCMCrypto(fixedKey, "")
 	fake := &fakeFlowSvc{}
 	if now == nil {
 		now = time.Now
 	}
-	handler := api.NewHandler(sealer, fake, stubAuthAttempt{}, nil, nil, nil, nil, now)
+	handler := api.NewHandler(crypter, fake, stubAuthAttempt{}, nil, nil, nil, nil, now)
 	oas, err := gen.NewServer(handler, api.NewSecurityHandler(), gen.WithErrorHandler(api.OgenErrorHandler))
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
 	srv := httptest.NewServer(oas)
 	t.Cleanup(srv.Close)
-	return &testServer{srv: srv, sealer: sealer, fake: fake, now: now}
+	return &testServer{srv: srv, crypter: crypter, fake: fake, now: now}
 }
 
 // sealCookie matches what the handler emits, so tests can skip CreateFlow.
@@ -122,9 +121,9 @@ func (ts *testServer) sealCookie(t *testing.T, state *domain.FlowState) string {
 	if err != nil {
 		t.Fatalf("marshal state: %v", err)
 	}
-	value, err := ts.sealer.Seal(payload)
+	value, err := ts.crypter.Encrypt(string(payload))
 	if err != nil {
-		t.Fatalf("seal: %v", err)
+		t.Fatalf("encrypt: %v", err)
 	}
 	return value
 }

--- a/internal/api/flow_test.go
+++ b/internal/api/flow_test.go
@@ -271,6 +271,38 @@ func TestSubmitFlowStep_TerminalClearsCookie(t *testing.T) {
 	}
 }
 
+func TestSubmitFlowStep_TerminalSurfacesHandoffToken(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	cookieVal := ts.sealCookie(t, state)
+
+	complete := domain.FlowStepCompleteShow
+	expiresAt := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	ts.fake.submitResult = service.FlowStepResult{
+		State:                 &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()},
+		Step:                  &domain.FlowStep{Name: "done", Complete: &complete},
+		HandoffToken:          "ht_abc",
+		HandoffTokenExpiresAt: expiresAt,
+	}
+
+	resp, body := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
+		"action": "submit",
+	}, cookieVal)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	var fr gen.FlowResponse
+	if err := json.Unmarshal(body, &fr); err != nil {
+		t.Fatalf("unmarshal: %v (body=%s)", err, body)
+	}
+	if got, ok := fr.HandoffToken.Get(); !ok || got != "ht_abc" {
+		t.Errorf("handoff_token = %v (set=%t), want ht_abc", got, ok)
+	}
+	if got, ok := fr.HandoffTokenExpiresAt.Get(); !ok || !got.Equal(expiresAt) {
+		t.Errorf("handoff_token_expires_at = %v (set=%t), want %v", got, ok, expiresAt)
+	}
+}
+
 func TestGetFlowStep_ReturnsCurrentStep(t *testing.T) {
 	ts := newTestServer(t, nil)
 	state := &domain.FlowState{

--- a/internal/api/flow_test.go
+++ b/internal/api/flow_test.go
@@ -94,24 +94,20 @@ type testServer struct {
 	srv     *httptest.Server
 	crypter crypto.Crypter
 	fake    *fakeFlowSvc
-	now     func() time.Time
 }
 
-func newTestServer(t *testing.T, now func() time.Time) *testServer {
+func newTestServer(t *testing.T) *testServer {
 	t.Helper()
 	crypter := op.NewAES256GCMCrypto(fixedKey, "")
 	fake := &fakeFlowSvc{}
-	if now == nil {
-		now = time.Now
-	}
-	handler := api.NewHandler(crypter, fake, stubAuthAttempt{}, nil, nil, nil, nil, now)
+	handler := api.NewHandler(crypter, fake, stubAuthAttempt{}, nil, nil, nil, nil)
 	oas, err := gen.NewServer(handler, api.NewSecurityHandler(), gen.WithErrorHandler(api.OgenErrorHandler))
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
 	srv := httptest.NewServer(oas)
 	t.Cleanup(srv.Close)
-	return &testServer{srv: srv, crypter: crypter, fake: fake, now: now}
+	return &testServer{srv: srv, crypter: crypter, fake: fake}
 }
 
 // sealCookie matches what the handler emits, so tests can skip CreateFlow.
@@ -158,10 +154,10 @@ func doRequest(t *testing.T, method, url string, body any, cookieValue string) (
 }
 
 func TestCreateFlow_ReturnsCookieAndFlowID(t *testing.T) {
-	ts := newTestServer(t, nil)
+	ts := newTestServer(t)
 	ts.fake.def = &domain.FlowDefinition{ProjectID: "proj_1", ID: "def_1", Purposes: map[domain.FlowDefinitionPurpose]string{domain.FlowDefinitionPurposeLogin: "identify"}}
 	ts.fake.startResult = service.FlowStepResult{
-		State: &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: ts.now()},
+		State: &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: time.Now()},
 		Step:  &domain.FlowStep{Name: "identify"},
 	}
 
@@ -188,8 +184,8 @@ func TestCreateFlow_ReturnsCookieAndFlowID(t *testing.T) {
 }
 
 func TestSubmitFlowStep_PathIDMismatchReturns404(t *testing.T) {
-	ts := newTestServer(t, nil)
-	state := &domain.FlowState{ID: "flow_real", IssuedAt: ts.now()}
+	ts := newTestServer(t)
+	state := &domain.FlowState{ID: "flow_real", IssuedAt: time.Now()}
 	cookieVal := ts.sealCookie(t, state)
 
 	resp, body := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_wrong/submit", map[string]any{
@@ -201,7 +197,7 @@ func TestSubmitFlowStep_PathIDMismatchReturns404(t *testing.T) {
 }
 
 func TestSubmitFlowStep_TamperedCookieReturns401(t *testing.T) {
-	ts := newTestServer(t, nil)
+	ts := newTestServer(t)
 	resp, _ := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
 		"action": "submit",
 	}, "garbage")
@@ -211,10 +207,9 @@ func TestSubmitFlowStep_TamperedCookieReturns401(t *testing.T) {
 }
 
 func TestSubmitFlowStep_StaleCookieReturns401(t *testing.T) {
-	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
-	ts := newTestServer(t, func() time.Time { return now })
+	ts := newTestServer(t)
 
-	stale := now.Add(-30 * time.Minute)
+	stale := time.Now().Add(-1 * time.Hour)
 	state := &domain.FlowState{ID: "flow_1", IssuedAt: stale}
 	cookieVal := ts.sealCookie(t, state)
 
@@ -227,11 +222,11 @@ func TestSubmitFlowStep_StaleCookieReturns401(t *testing.T) {
 }
 
 func TestSubmitFlowStep_HappyPath_RotatesCookie(t *testing.T) {
-	ts := newTestServer(t, nil)
-	state := &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: ts.now()}
+	ts := newTestServer(t)
+	state := &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: time.Now()}
 	cookieVal := ts.sealCookie(t, state)
 
-	advanced := &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: ts.now()}
+	advanced := &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: time.Now()}
 	ts.fake.submitResult = service.FlowStepResult{State: advanced, Step: &domain.FlowStep{Name: "password"}}
 
 	resp, body := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
@@ -250,12 +245,12 @@ func TestSubmitFlowStep_HappyPath_RotatesCookie(t *testing.T) {
 }
 
 func TestSubmitFlowStep_TerminalClearsCookie(t *testing.T) {
-	ts := newTestServer(t, nil)
-	state := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	ts := newTestServer(t)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: time.Now()}
 	cookieVal := ts.sealCookie(t, state)
 
 	complete := domain.FlowStepCompleteShow
-	terminal := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	terminal := &domain.FlowState{ID: "flow_1", IssuedAt: time.Now()}
 	ts.fake.submitResult = service.FlowStepResult{State: terminal, Step: &domain.FlowStep{Name: "done", Complete: &complete}}
 
 	resp, _ := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
@@ -271,14 +266,14 @@ func TestSubmitFlowStep_TerminalClearsCookie(t *testing.T) {
 }
 
 func TestSubmitFlowStep_TerminalSurfacesHandoffToken(t *testing.T) {
-	ts := newTestServer(t, nil)
-	state := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	ts := newTestServer(t)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: time.Now()}
 	cookieVal := ts.sealCookie(t, state)
 
 	complete := domain.FlowStepCompleteShow
 	expiresAt := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
 	ts.fake.submitResult = service.FlowStepResult{
-		State:                 &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()},
+		State:                 &domain.FlowState{ID: "flow_1", IssuedAt: time.Now()},
 		Step:                  &domain.FlowStep{Name: "done", Complete: &complete},
 		HandoffToken:          "ht_abc",
 		HandoffTokenExpiresAt: expiresAt,
@@ -303,12 +298,12 @@ func TestSubmitFlowStep_TerminalSurfacesHandoffToken(t *testing.T) {
 }
 
 func TestGetFlowStep_ReturnsCurrentStep(t *testing.T) {
-	ts := newTestServer(t, nil)
+	ts := newTestServer(t)
 	state := &domain.FlowState{
 		ID:           "flow_1",
 		ProjectID:    "proj_1",
 		SessionID:    "sess_1",
-		IssuedAt:     ts.now(),
+		IssuedAt:     time.Now(),
 		FlowProgress: domain.FlowProgress{CurrentStep: "identify"},
 	}
 	cookieVal := ts.sealCookie(t, state)
@@ -328,8 +323,8 @@ func TestGetFlowStep_ReturnsCurrentStep(t *testing.T) {
 }
 
 func TestGetFlowStep_TerminalReturns410(t *testing.T) {
-	ts := newTestServer(t, nil)
-	state := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	ts := newTestServer(t)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: time.Now()}
 	cookieVal := ts.sealCookie(t, state)
 
 	complete := domain.FlowStepCompleteShow

--- a/internal/api/flow_test.go
+++ b/internal/api/flow_test.go
@@ -1,0 +1,315 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gen "github.com/zitadel/nextgen/api/generated"
+	"github.com/zitadel/nextgen/internal/api"
+	"github.com/zitadel/nextgen/internal/cookie"
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+)
+
+// fakeFlowSvc lets handler tests exercise cookie + HTTP plumbing without
+// booting a real state machine.
+type fakeFlowSvc struct {
+	def        *domain.FlowDefinition
+	resolveErr error
+
+	startResult  service.FlowStepResult
+	startErr     error
+	submitResult service.FlowStepResult
+	submitErr    error
+	getResult    service.FlowStepResult
+	getErr       error
+
+	gotStartReq  service.StartFlowRequest
+	gotSubmitReq service.SubmitFlowRequest
+	gotGetReq    service.GetFlowStepRequest
+}
+
+func (f *fakeFlowSvc) Resolve(_ context.Context, _ service.ResolveFlowRequest) (*domain.FlowDefinition, error) {
+	return f.def, f.resolveErr
+}
+
+func (f *fakeFlowSvc) Start(_ context.Context, req service.StartFlowRequest) (service.FlowStepResult, error) {
+	f.gotStartReq = req
+	return f.startResult, f.startErr
+}
+
+func (f *fakeFlowSvc) Submit(_ context.Context, req service.SubmitFlowRequest) (service.FlowStepResult, error) {
+	f.gotSubmitReq = req
+	return f.submitResult, f.submitErr
+}
+
+func (f *fakeFlowSvc) GetStep(_ context.Context, req service.GetFlowStepRequest) (service.FlowStepResult, error) {
+	f.gotGetReq = req
+	return f.getResult, f.getErr
+}
+
+var _ service.FlowService = (*fakeFlowSvc)(nil)
+
+// stubAuthAttempt only exists to satisfy the handler dependency; flow
+// handlers never call it directly.
+type stubAuthAttempt struct{}
+
+func (stubAuthAttempt) Create(context.Context, service.CreateAuthAttemptInput) (*domain.AuthAttempt, error) {
+	return nil, errors.New("stub auth attempt")
+}
+func (stubAuthAttempt) GetByID(context.Context, string, string) (*domain.AuthAttempt, error) {
+	return nil, errors.New("stub auth attempt")
+}
+func (stubAuthAttempt) IssueChallenge(context.Context, service.IssueChallengeInput) (*domain.AuthAttempt, error) {
+	return nil, errors.New("stub auth attempt")
+}
+func (stubAuthAttempt) VerifyProof(context.Context, service.VerifyProofInput) (*domain.AuthAttempt, error) {
+	return nil, errors.New("stub auth attempt")
+}
+func (stubAuthAttempt) Handoff(context.Context, service.HandoffInput) (*domain.AuthAttempt, error) {
+	return nil, errors.New("stub auth attempt")
+}
+
+var _ service.AuthAttemptService = stubAuthAttempt{}
+
+// fixedKey is a deterministic cookie sealer key for tests.
+var fixedKey = cookie.Key{
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+	0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+	0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+}
+
+type testServer struct {
+	srv    *httptest.Server
+	sealer *cookie.Sealer
+	fake   *fakeFlowSvc
+	now    func() time.Time
+}
+
+func newTestServer(t *testing.T, now func() time.Time) *testServer {
+	t.Helper()
+	sealer, err := cookie.NewSealer(fixedKey)
+	if err != nil {
+		t.Fatalf("NewSealer: %v", err)
+	}
+	fake := &fakeFlowSvc{}
+	if now == nil {
+		now = time.Now
+	}
+	handler := api.NewHandler(sealer, fake, stubAuthAttempt{}, nil, nil, nil, nil, now)
+	oas, err := gen.NewServer(handler, api.NewSecurityHandler(), gen.WithErrorHandler(api.OgenErrorHandler))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv := httptest.NewServer(oas)
+	t.Cleanup(srv.Close)
+	return &testServer{srv: srv, sealer: sealer, fake: fake, now: now}
+}
+
+// sealCookie matches what the handler emits, so tests can skip CreateFlow.
+func (ts *testServer) sealCookie(t *testing.T, state *domain.FlowState) string {
+	t.Helper()
+	payload, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	value, err := ts.sealer.Seal(payload)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	return value
+}
+
+func doRequest(t *testing.T, method, url string, body any, cookieValue string) (*http.Response, []byte) {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, url, rdr)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if cookieValue != "" {
+		req.AddCookie(&http.Cookie{Name: "_zflow", Value: cookieValue})
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	return resp, data
+}
+
+func TestCreateFlow_ReturnsCookieAndFlowID(t *testing.T) {
+	ts := newTestServer(t, nil)
+	ts.fake.def = &domain.FlowDefinition{ProjectID: "proj_1", ID: "def_1", Purposes: map[domain.FlowDefinitionPurpose]string{domain.FlowDefinitionPurposeLogin: "identify"}}
+	ts.fake.startResult = service.FlowStepResult{
+		State: &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: ts.now()},
+		Step:  &domain.FlowStep{Name: "identify"},
+	}
+
+	resp, body := doRequest(t, http.MethodPost, ts.srv.URL+"/flow", map[string]any{
+		"project_id": "proj_1",
+		"purpose":    "login",
+	}, "")
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(resp.Header.Get("Set-Cookie"), "_zflow=") {
+		t.Errorf("expected Set-Cookie header, got %q", resp.Header.Get("Set-Cookie"))
+	}
+	var fr gen.FlowResponse
+	if err := json.Unmarshal(body, &fr); err != nil {
+		t.Fatalf("unmarshal: %v (body=%s)", err, body)
+	}
+	if fr.ID != "flow_1" {
+		t.Errorf("id = %q, want flow_1", fr.ID)
+	}
+	if b, ok := fr.Branding.Get(); !ok || !b.LiquidTemplate.IsSet() || b.LiquidTemplate.Value == "" {
+		t.Errorf("expected branding.liquid_template to be set, got %+v", fr.Branding)
+	}
+}
+
+func TestSubmitFlowStep_PathIDMismatchReturns404(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{ID: "flow_real", IssuedAt: ts.now()}
+	cookieVal := ts.sealCookie(t, state)
+
+	resp, body := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_wrong/submit", map[string]any{
+		"action": "submit",
+	}, cookieVal)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+}
+
+func TestSubmitFlowStep_TamperedCookieReturns401(t *testing.T) {
+	ts := newTestServer(t, nil)
+	resp, _ := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
+		"action": "submit",
+	}, "garbage")
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestSubmitFlowStep_StaleCookieReturns401(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	ts := newTestServer(t, func() time.Time { return now })
+
+	stale := now.Add(-30 * time.Minute)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: stale}
+	cookieVal := ts.sealCookie(t, state)
+
+	resp, _ := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
+		"action": "submit",
+	}, cookieVal)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 for stale cookie", resp.StatusCode)
+	}
+}
+
+func TestSubmitFlowStep_HappyPath_RotatesCookie(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: ts.now()}
+	cookieVal := ts.sealCookie(t, state)
+
+	advanced := &domain.FlowState{ID: "flow_1", ProjectID: "proj_1", SessionID: "sess_1", IssuedAt: ts.now()}
+	ts.fake.submitResult = service.FlowStepResult{State: advanced, Step: &domain.FlowStep{Name: "password"}}
+
+	resp, body := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
+		"action": "submit",
+		"fields": map[string]any{"identifier": "alice@example.com"},
+	}, cookieVal)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("Set-Cookie"); !strings.Contains(got, "_zflow=") {
+		t.Errorf("expected rotated Set-Cookie, got %q", got)
+	}
+	if got := ts.fake.gotSubmitReq.Fields["identifier"]; got != "alice@example.com" {
+		t.Errorf("decoded identifier = %v, want alice@example.com", got)
+	}
+}
+
+func TestSubmitFlowStep_TerminalClearsCookie(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	cookieVal := ts.sealCookie(t, state)
+
+	complete := domain.FlowStepCompleteShow
+	terminal := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	ts.fake.submitResult = service.FlowStepResult{State: terminal, Step: &domain.FlowStep{Name: "done", Complete: &complete}}
+
+	resp, _ := doRequest(t, http.MethodPost, ts.srv.URL+"/flow/flow_1/submit", map[string]any{
+		"action": "submit",
+	}, cookieVal)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	got := resp.Header.Get("Set-Cookie")
+	if !strings.Contains(got, "Max-Age=0") {
+		t.Errorf("expected Max-Age=0 on terminal, got %q", got)
+	}
+}
+
+func TestGetFlowStep_ReturnsCurrentStep(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{
+		ID:           "flow_1",
+		ProjectID:    "proj_1",
+		SessionID:    "sess_1",
+		IssuedAt:     ts.now(),
+		FlowProgress: domain.FlowProgress{CurrentStep: "identify"},
+	}
+	cookieVal := ts.sealCookie(t, state)
+	ts.fake.getResult = service.FlowStepResult{State: state, Step: &domain.FlowStep{Name: "identify"}}
+
+	resp, body := doRequest(t, http.MethodGet, ts.srv.URL+"/flow/flow_1", nil, cookieVal)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	var fr gen.FlowResponse
+	if err := json.Unmarshal(body, &fr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if fr.Step.Name != "identify" {
+		t.Errorf("step name = %q, want identify", fr.Step.Name)
+	}
+}
+
+func TestGetFlowStep_TerminalReturns410(t *testing.T) {
+	ts := newTestServer(t, nil)
+	state := &domain.FlowState{ID: "flow_1", IssuedAt: ts.now()}
+	cookieVal := ts.sealCookie(t, state)
+
+	complete := domain.FlowStepCompleteShow
+	ts.fake.getResult = service.FlowStepResult{
+		State: state,
+		Step:  &domain.FlowStep{Name: "done", Complete: &complete},
+	}
+
+	resp, _ := doRequest(t, http.MethodGet, ts.srv.URL+"/flow/flow_1", nil, cookieVal)
+	if resp.StatusCode != http.StatusGone {
+		t.Fatalf("status = %d, want 410", resp.StatusCode)
+	}
+}
+

--- a/internal/api/flow_test.go
+++ b/internal/api/flow_test.go
@@ -100,7 +100,7 @@ func newTestServer(t *testing.T) *testServer {
 	t.Helper()
 	crypter := op.NewAES256GCMCrypto(fixedKey, "")
 	fake := &fakeFlowSvc{}
-	handler := api.NewHandler(crypter, fake, stubAuthAttempt{}, nil, nil, nil, nil)
+	handler := api.NewHandler(crypter, fake, stubAuthAttempt{}, nil, nil, nil, nil, nil)
 	oas, err := gen.NewServer(handler, api.NewSecurityHandler(), gen.WithErrorHandler(api.OgenErrorHandler))
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"time"
 
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/crypto"
@@ -22,7 +21,6 @@ type Handler struct {
 	schemaService         *service.SchemaService
 	flowDefinitionService service.FlowDefinitionService
 	teamService           *service.TeamService
-	now                   func() time.Time
 }
 
 func NewHandler(
@@ -34,11 +32,7 @@ func NewHandler(
 	schemaService *service.SchemaService,
 	flowDefinitionService service.FlowDefinitionService,
 	teamService *service.TeamService,
-	now func() time.Time,
 ) *Handler {
-	if now == nil {
-		now = time.Now
-	}
 	return &Handler{
 		crypter:               crypto,
 		flowService:           flowService,
@@ -48,7 +42,6 @@ func NewHandler(
 		schemaService:         schemaService,
 		flowDefinitionService: flowDefinitionService,
 		teamService:           teamService,
-		now:                   now,
 	}
 }
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"time"
 
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/crypto"
@@ -21,6 +22,7 @@ type Handler struct {
 	schemaService         *service.SchemaService
 	flowDefinitionService service.FlowDefinitionService
 	teamService           *service.TeamService
+	now                   func() time.Time
 }
 
 func NewHandler(
@@ -32,7 +34,11 @@ func NewHandler(
 	schemaService *service.SchemaService,
 	flowDefinitionService service.FlowDefinitionService,
 	teamService *service.TeamService,
+	now func() time.Time,
 ) *Handler {
+	if now == nil {
+		now = time.Now
+	}
 	return &Handler{
 		crypter:               crypto,
 		flowService:           flowService,
@@ -42,6 +48,7 @@ func NewHandler(
 		schemaService:         schemaService,
 		flowDefinitionService: flowDefinitionService,
 		teamService:           teamService,
+		now:                   now,
 	}
 }
 

--- a/internal/api/integration_test/helpers/flow.go
+++ b/internal/api/integration_test/helpers/flow.go
@@ -2,8 +2,10 @@ package helpers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/domain/idgen"
 	"github.com/zitadel/nextgen/internal/service"
 	"github.com/zitadel/nextgen/internal/storage/database/repository"
 )
@@ -14,9 +16,23 @@ func (h *Harness) EnsureFlowService(t *testing.T) service.FlowService {
 		h.FlowService = service.NewFlowService(
 			h.EnsureDBPool(t),
 			h.EnsureFlowDefinitionRepo(t),
+			h.EnsureFlowStateMachine(t),
+			idgen.NewULID(),
 		)
 	}
 	return h.FlowService
+}
+
+func (h *Harness) EnsureFlowStateMachine(t *testing.T) *domain.FlowStateMachineRuntime {
+	t.Helper()
+	if h.FlowStateMachine == nil {
+		fields := domain.NewSchemaFieldResolver(h.EnsureSchemaResolver(t))
+		authAdapter := service.NewFlowAuthAttemptAdapter(h.EnsureAuthAttemptService(t))
+		// create_user handler stays nil — registration flows fail with
+		// ErrIntegrity until the argon2id wiring PR lands.
+		h.FlowStateMachine = domain.NewFlowStateMachine(fields, nil, authAdapter, time.Now)
+	}
+	return h.FlowStateMachine
 }
 
 func (h *Harness) EnsureFlowDefinitionRepo(t *testing.T) domain.FlowDefinitionRepository {

--- a/internal/api/integration_test/helpers/harness.go
+++ b/internal/api/integration_test/helpers/harness.go
@@ -33,6 +33,7 @@ type Harness struct {
 	AuthAttemptService    service.AuthAttemptService
 	ProjectService        service.ProjectService
 	FlowDefinitionService service.FlowDefinitionService
+	FlowStateMachine      *domain.FlowStateMachineRuntime
 	TeamService           *service.TeamService
 
 	SchemaRepo         domain.JSONSchemaRepository

--- a/internal/api/integration_test/helpers/schema.go
+++ b/internal/api/integration_test/helpers/schema.go
@@ -45,7 +45,7 @@ func (h *Harness) EnsureSchemaResolver(t *testing.T) *domain.JSONSchemaResolver 
 		require.NoError(t, err)
 
 		h.SchemaResolver = domain.NewJSONSchemaResolver(
-			h.SchemaRepo,
+			h.EnsureSchemaRepo(t),
 			cache,
 			0,
 			0,

--- a/internal/api/integration_test/helpers/server.go
+++ b/internal/api/integration_test/helpers/server.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	generated "github.com/zitadel/nextgen/api/generated"
@@ -48,7 +47,6 @@ func (h *Harness) EnsureHandler(t *testing.T) *api.Handler {
 			h.EnsureSchemaService(t),
 			h.EnsureFlowDefinitionService(t),
 			h.EnsureTeamService(t),
-			time.Now,
 		)
 	}
 	return h.Handler

--- a/internal/api/integration_test/helpers/server.go
+++ b/internal/api/integration_test/helpers/server.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	generated "github.com/zitadel/nextgen/api/generated"
@@ -47,6 +48,7 @@ func (h *Harness) EnsureHandler(t *testing.T) *api.Handler {
 			h.EnsureSchemaService(t),
 			h.EnsureFlowDefinitionService(t),
 			h.EnsureTeamService(t),
+			time.Now,
 		)
 	}
 	return h.Handler

--- a/internal/api/integration_test/project_test.go
+++ b/internal/api/integration_test/project_test.go
@@ -46,6 +46,18 @@ func (stubFlowService) Resolve(_ context.Context, _ service.ResolveFlowRequest) 
 	return nil, nil
 }
 
+func (stubFlowService) Start(_ context.Context, _ service.StartFlowRequest) (service.FlowStepResult, error) {
+	return service.FlowStepResult{}, nil
+}
+
+func (stubFlowService) Submit(_ context.Context, _ service.SubmitFlowRequest) (service.FlowStepResult, error) {
+	return service.FlowStepResult{}, nil
+}
+
+func (stubFlowService) GetStep(_ context.Context, _ service.GetFlowStepRequest) (service.FlowStepResult, error) {
+	return service.FlowStepResult{}, nil
+}
+
 // stubAuthAttemptService satisfies [service.AuthAttemptService] while doing nothing.
 type stubAuthAttemptService struct{}
 

--- a/internal/domain/flow_field_resolver.go
+++ b/internal/domain/flow_field_resolver.go
@@ -18,8 +18,10 @@ import (
 // api/openapi/endpoints/schemas/user-schema.yaml.
 type FlowFieldResolver interface {
 	// Resolve returns the per-field metadata for fieldNames sourced
-	// from the user schema at userSchemaURL.
-	Resolve(ctx context.Context, client database.QueryExecutor, projectID, userSchemaURL string, fieldNames []string) (FlowResolvedFields, error)
+	// from the user schema at userSchemaURL. stepName is the flow
+	// step the fields are being resolved for; it prefixes each
+	// field's text_key (`<stepName>.field.<name>`).
+	Resolve(ctx context.Context, client database.QueryExecutor, projectID, userSchemaURL, stepName string, fieldNames []string) (FlowResolvedFields, error)
 
 	// Validate checks submitted values against the rules carried by a
 	// previously resolved field set.

--- a/internal/domain/flow_field_resolver.go
+++ b/internal/domain/flow_field_resolver.go
@@ -111,9 +111,9 @@ const (
 type FlowFieldUniqueScope string
 
 const (
-	FlowFieldUniqueScopeNone         FlowFieldUniqueScope = ""
-	FlowFieldUniqueScopeInstance     FlowFieldUniqueScope = "instance"
-	FlowFieldUniqueScopeOrganization FlowFieldUniqueScope = "organization"
+	FlowFieldUniqueScopeNone    FlowFieldUniqueScope = ""
+	FlowFieldUniqueScopeProject FlowFieldUniqueScope = "project"
+	FlowFieldUniqueScopeTeam    FlowFieldUniqueScope = "team"
 )
 
 // FlowFieldValidation carries the validation rules the resolver

--- a/internal/domain/flow_field_resolver.go
+++ b/internal/domain/flow_field_resolver.go
@@ -64,15 +64,15 @@ type FlowField struct {
 	Validation *FlowFieldValidation
 
 	// Unique mirrors the property's `x-unique` annotation: the scope at
-	// which the value must be unique, or [FlowFieldUniqueScopeNone] when
-	// absent. The user-creation path consults it to set the per-attribute
-	// uniqueness scope on storage.
-	Unique FlowFieldUniqueScope
+	// which the value must be unique, or [AttributeUniquenessUnspecified]
+	// when absent. The user-creation path consults it to set the
+	// per-attribute uniqueness scope on storage.
+	Unique AttributeUniqueness
 
 	// Challenge names the auth-attempt challenge the field maps to, or
 	// [FlowFieldChallengeNone] when the field carries neither an
 	// identifier nor a credential proof. Derivation paths: a non-empty
-	// `x-unique` scope on the property surfaces as
+	// `x-unique` annotation on the property surfaces as
 	// [FlowFieldChallengeIdentifier] (any uniquely-keyed property can
 	// identify a user); `x-password: true` combined with schema-level
 	// `x-auth-methods.password.enabled = true` surfaces as
@@ -106,16 +106,6 @@ const (
 	FlowFieldChallengeMagicLink  FlowFieldChallenge = "magic_link"
 	FlowFieldChallengeSSO        FlowFieldChallenge = "sso"
 	FlowFieldChallengeOTP        FlowFieldChallenge = "otp"
-)
-
-// FlowFieldUniqueScope mirrors the `x-unique` enum in the user
-// meta-schema (api/openapi/endpoints/schemas/user-property.yaml).
-type FlowFieldUniqueScope string
-
-const (
-	FlowFieldUniqueScopeNone    FlowFieldUniqueScope = ""
-	FlowFieldUniqueScopeProject FlowFieldUniqueScope = "project"
-	FlowFieldUniqueScopeTeam    FlowFieldUniqueScope = "team"
 )
 
 // FlowFieldValidation carries the validation rules the resolver

--- a/internal/domain/flow_field_resolver_schema.go
+++ b/internal/domain/flow_field_resolver_schema.go
@@ -135,10 +135,10 @@ func deriveChallenge(propSchema *jsonschema.Schema, unique FlowFieldUniqueScope,
 
 func deriveUnique(propSchema *jsonschema.Schema) FlowFieldUniqueScope {
 	switch lookupString(propSchema, "x-unique") {
-	case "organization":
-		return FlowFieldUniqueScopeOrganization
-	case "instance":
-		return FlowFieldUniqueScopeInstance
+	case "project":
+		return FlowFieldUniqueScopeProject
+	case "team":
+		return FlowFieldUniqueScopeTeam
 	}
 	return FlowFieldUniqueScopeNone
 }

--- a/internal/domain/flow_field_resolver_schema.go
+++ b/internal/domain/flow_field_resolver_schema.go
@@ -123,8 +123,8 @@ func deriveFieldType(propSchema *jsonschema.Schema) FlowFieldType {
 // surfaces as Password when the schema-level `x-auth-methods.password`
 // is enabled. Other credential kinds (passkey, magic_link, sso, otp)
 // have no user-property-shaped proof and are never surfaced here.
-func deriveChallenge(propSchema *jsonschema.Schema, unique FlowFieldUniqueScope, passwordEnabled bool) FlowFieldChallenge {
-	if unique != FlowFieldUniqueScopeNone {
+func deriveChallenge(propSchema *jsonschema.Schema, unique AttributeUniqueness, passwordEnabled bool) FlowFieldChallenge {
+	if unique != AttributeUniquenessUnspecified {
 		return FlowFieldChallengeIdentifier
 	}
 	if isPassword(propSchema) && passwordEnabled {
@@ -133,14 +133,14 @@ func deriveChallenge(propSchema *jsonschema.Schema, unique FlowFieldUniqueScope,
 	return FlowFieldChallengeNone
 }
 
-func deriveUnique(propSchema *jsonschema.Schema) FlowFieldUniqueScope {
+func deriveUnique(propSchema *jsonschema.Schema) AttributeUniqueness {
 	switch lookupString(propSchema, "x-unique") {
 	case "project":
-		return FlowFieldUniqueScopeProject
+		return AttributeUniquenessProject
 	case "team":
-		return FlowFieldUniqueScopeTeam
+		return AttributeUniquenessTeam
 	}
-	return FlowFieldUniqueScopeNone
+	return AttributeUniquenessUnspecified
 }
 
 func buildValidation(propSchema *jsonschema.Schema) *FlowFieldValidation {

--- a/internal/domain/flow_field_resolver_schema.go
+++ b/internal/domain/flow_field_resolver_schema.go
@@ -49,7 +49,7 @@ var _ FlowFieldResolver = (*SchemaFieldResolver)(nil)
 func (r *SchemaFieldResolver) Resolve(
 	ctx context.Context,
 	client database.QueryExecutor,
-	projectID, userSchemaURL string,
+	projectID, userSchemaURL, stepName string,
 	fieldNames []string,
 ) (FlowResolvedFields, error) {
 	schema, err := r.schemas.Resolve(ctx, client, projectID, userSchemaURL, nil)
@@ -69,7 +69,7 @@ func (r *SchemaFieldResolver) Resolve(
 		if !ok {
 			return FlowResolvedFields{}, fmt.Errorf("%w: %q", ErrFlowFieldUnknown, name)
 		}
-		field := buildFlowField(name, propSchema, required, passwordEnabled)
+		field := buildFlowField(stepName, name, propSchema, required, passwordEnabled)
 		fields[name] = field
 		if outcomes := ImplicitOutcomesForChallenge(field.Challenge); len(outcomes) > 0 {
 			implicit[name] = append(implicit[name], outcomes...)
@@ -83,10 +83,10 @@ func (r *SchemaFieldResolver) Resolve(
 }
 
 // buildFlowField translates a user-schema property into a [FlowField].
-func buildFlowField(name string, propSchema *jsonschema.Schema, required map[string]struct{}, passwordEnabled bool) FlowField {
+func buildFlowField(stepName, name string, propSchema *jsonschema.Schema, required map[string]struct{}, passwordEnabled bool) FlowField {
 	unique := deriveUnique(propSchema)
 	field := FlowField{
-		TextKey:   "field." + name,
+		TextKey:   stepName + ".field." + name,
 		Type:      deriveFieldType(propSchema),
 		Challenge: deriveChallenge(propSchema, unique, passwordEnabled),
 		Unique:    unique,

--- a/internal/domain/flow_field_resolver_schema_test.go
+++ b/internal/domain/flow_field_resolver_schema_test.go
@@ -71,7 +71,7 @@ func newDefaultResolver(t *testing.T) *domain.SchemaFieldResolver {
 func TestSchemaFieldResolver_Resolve_DefaultFields(t *testing.T) {
 	resolver := newDefaultResolver(t)
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL,
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "identifier",
 		[]string{"email", "username", "password", "given_name", "family_name"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
@@ -82,11 +82,11 @@ func TestSchemaFieldResolver_Resolve_DefaultFields(t *testing.T) {
 		wantType    domain.FlowFieldType
 		wantTextKey string
 	}{
-		{"email", domain.FlowFieldTypeEmail, "field.email"},
-		{"username", domain.FlowFieldTypeText, "field.username"},
-		{"password", domain.FlowFieldTypePassword, "field.password"},
-		{"given_name", domain.FlowFieldTypeText, "field.given_name"},
-		{"family_name", domain.FlowFieldTypeText, "field.family_name"},
+		{"email", domain.FlowFieldTypeEmail, "identifier.field.email"},
+		{"username", domain.FlowFieldTypeText, "identifier.field.username"},
+		{"password", domain.FlowFieldTypePassword, "identifier.field.password"},
+		{"given_name", domain.FlowFieldTypeText, "identifier.field.given_name"},
+		{"family_name", domain.FlowFieldTypeText, "identifier.field.family_name"},
 	}
 	for _, tc := range tests {
 		f, ok := got.Fields[tc.name]
@@ -109,7 +109,7 @@ func TestSchemaFieldResolver_Resolve_DefaultFields(t *testing.T) {
 func TestSchemaFieldResolver_Resolve_IdentifierImpliesUserNotFound(t *testing.T) {
 	resolver := newDefaultResolver(t)
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, []string{"email", "password"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "step", []string{"email", "password"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestSchemaFieldResolver_Resolve_IdentifierImpliesUserNotFound(t *testing.T)
 func TestSchemaFieldResolver_Resolve_ChallengeSurfaces(t *testing.T) {
 	resolver := newDefaultResolver(t)
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, []string{"email", "password", "given_name"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "step", []string{"email", "password", "given_name"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestSchemaFieldResolver_Resolve_PasswordChallengeRequiresAuthMethodEnabled(
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, []string{"password"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, "step", []string{"password"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestSchemaFieldResolver_Resolve_PasswordChallengeRequiresXPassword(t *testi
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, []string{"password"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, "step", []string{"password"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestSchemaFieldResolver_Resolve_RenamedPasswordField(t *testing.T) {
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, []string{"secret"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, "step", []string{"secret"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestSchemaFieldResolver_Resolve_RenamedPasswordField(t *testing.T) {
 func TestSchemaFieldResolver_Resolve_UniqueScopeSurfaces(t *testing.T) {
 	resolver := newDefaultResolver(t)
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, []string{"email", "password"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "step", []string{"email", "password"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestSchemaFieldResolver_Resolve_UniqueScopeProject(t *testing.T) {
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, []string{"handle"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, "step", []string{"handle"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestSchemaFieldResolver_Resolve_UniqueScopeProject(t *testing.T) {
 func TestSchemaFieldResolver_Resolve_UnknownField(t *testing.T) {
 	resolver := newDefaultResolver(t)
 
-	_, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, []string{"not_in_schema"})
+	_, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "step", []string{"not_in_schema"})
 	if !errors.Is(err, domain.ErrFlowFieldUnknown) {
 		t.Fatalf("Resolve err = %v, want ErrFlowFieldUnknown", err)
 	}
@@ -263,7 +263,7 @@ func TestSchemaFieldResolver_Resolve_UnknownField(t *testing.T) {
 func TestSchemaFieldResolver_Resolve_SchemaLoadFailurePropagates(t *testing.T) {
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, nil))
 
-	_, err := resolver.Resolve(t.Context(), nil, testProjectID, "https://example.test/missing.json", []string{"email"})
+	_, err := resolver.Resolve(t.Context(), nil, testProjectID, "https://example.test/missing.json", "step", []string{"email"})
 	if err == nil {
 		t.Fatal("Resolve err = nil, want load failure")
 	}
@@ -283,7 +283,7 @@ func TestSchemaFieldResolver_Resolve_FormatAndTypeVariants(t *testing.T) {
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url,
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, "step",
 		[]string{"website", "birthday", "created", "nickname"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)

--- a/internal/domain/flow_field_resolver_schema_test.go
+++ b/internal/domain/flow_field_resolver_schema_test.go
@@ -52,8 +52,8 @@ func defaultSchemaBytes() []byte {
 		"x-auth-methods": { "password": { "enabled": true } },
 		"required": ["email", "username", "password", "given_name", "family_name"],
 		"properties": {
-			"email":       { "type": "string", "format": "email", "maxLength": 320, "x-unique": "organization" },
-			"username":    { "type": "string", "minLength": 3, "maxLength": 64, "x-unique": "organization" },
+			"email":       { "type": "string", "format": "email", "maxLength": 320, "x-unique": "team" },
+			"username":    { "type": "string", "minLength": 3, "maxLength": 64, "x-unique": "team" },
 			"password":    { "type": "string", "minLength": 8, "x-password": true },
 			"given_name":  { "type": "string", "minLength": 1, "maxLength": 200 },
 			"family_name": { "type": "string", "minLength": 1, "maxLength": 200 }
@@ -223,21 +223,21 @@ func TestSchemaFieldResolver_Resolve_UniqueScopeSurfaces(t *testing.T) {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
 
-	if got.Fields["email"].Unique != domain.FlowFieldUniqueScopeOrganization {
-		t.Errorf("Resolve email Unique = %q, want %q", got.Fields["email"].Unique, domain.FlowFieldUniqueScopeOrganization)
+	if got.Fields["email"].Unique != domain.FlowFieldUniqueScopeTeam {
+		t.Errorf("Resolve email Unique = %q, want %q", got.Fields["email"].Unique, domain.FlowFieldUniqueScopeTeam)
 	}
 	if got.Fields["password"].Unique != domain.FlowFieldUniqueScopeNone {
 		t.Errorf("Resolve password Unique = %q, want %q", got.Fields["password"].Unique, domain.FlowFieldUniqueScopeNone)
 	}
 }
 
-func TestSchemaFieldResolver_Resolve_UniqueScopeInstance(t *testing.T) {
-	const url = "https://example.test/instance-unique.json"
+func TestSchemaFieldResolver_Resolve_UniqueScopeProject(t *testing.T) {
+	const url = "https://example.test/project-unique.json"
 	bytes := []byte(`{
 		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"type": "object",
 		"properties": {
-			"handle": { "type": "string", "x-unique": "instance" }
+			"handle": { "type": "string", "x-unique": "project" }
 		}
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
@@ -246,8 +246,8 @@ func TestSchemaFieldResolver_Resolve_UniqueScopeInstance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
-	if got.Fields["handle"].Unique != domain.FlowFieldUniqueScopeInstance {
-		t.Errorf("Resolve handle Unique = %q, want %q", got.Fields["handle"].Unique, domain.FlowFieldUniqueScopeInstance)
+	if got.Fields["handle"].Unique != domain.FlowFieldUniqueScopeProject {
+		t.Errorf("Resolve handle Unique = %q, want %q", got.Fields["handle"].Unique, domain.FlowFieldUniqueScopeProject)
 	}
 }
 

--- a/internal/domain/flow_field_resolver_schema_test.go
+++ b/internal/domain/flow_field_resolver_schema_test.go
@@ -223,11 +223,11 @@ func TestSchemaFieldResolver_Resolve_UniqueScopeSurfaces(t *testing.T) {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
 
-	if got.Fields["email"].Unique != domain.FlowFieldUniqueScopeTeam {
-		t.Errorf("Resolve email Unique = %q, want %q", got.Fields["email"].Unique, domain.FlowFieldUniqueScopeTeam)
+	if got.Fields["email"].Unique != domain.AttributeUniquenessTeam {
+		t.Errorf("Resolve email Unique = %v, want %v", got.Fields["email"].Unique, domain.AttributeUniquenessTeam)
 	}
-	if got.Fields["password"].Unique != domain.FlowFieldUniqueScopeNone {
-		t.Errorf("Resolve password Unique = %q, want %q", got.Fields["password"].Unique, domain.FlowFieldUniqueScopeNone)
+	if got.Fields["password"].Unique != domain.AttributeUniquenessUnspecified {
+		t.Errorf("Resolve password Unique = %v, want %v", got.Fields["password"].Unique, domain.AttributeUniquenessUnspecified)
 	}
 }
 
@@ -246,8 +246,8 @@ func TestSchemaFieldResolver_Resolve_UniqueScopeProject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
-	if got.Fields["handle"].Unique != domain.FlowFieldUniqueScopeProject {
-		t.Errorf("Resolve handle Unique = %q, want %q", got.Fields["handle"].Unique, domain.FlowFieldUniqueScopeProject)
+	if got.Fields["handle"].Unique != domain.AttributeUniquenessProject {
+		t.Errorf("Resolve handle Unique = %v, want %v", got.Fields["handle"].Unique, domain.AttributeUniquenessProject)
 	}
 }
 

--- a/internal/domain/flow_field_validation_test.go
+++ b/internal/domain/flow_field_validation_test.go
@@ -13,7 +13,7 @@ import (
 func resolveDefaultFields(t *testing.T) domain.FlowResolvedFields {
 	t.Helper()
 	resolver := newDefaultResolver(t)
-	fields, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL,
+	fields, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "step",
 		[]string{"email", "username", "password", "given_name", "family_name"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)

--- a/internal/domain/flow_on_success_create_user.go
+++ b/internal/domain/flow_on_success_create_user.go
@@ -103,16 +103,13 @@ func findPasswordField(resolved map[string]FlowField, submitted map[string]any) 
 	return "", nil, false
 }
 
-// attributeUniquenessFor maps a [FlowFieldUniqueScope] to the
-// [AttributeUniqueness] the user repository understands. Both Project
-// and Team meta-schema scopes currently land on team-level storage
-// uniqueness; storage doesn't yet expose a project-wide scope short of
-// Global. The identifier field defaults to team-level so two users
-// can't share the same login.
-func attributeUniquenessFor(name, identifierName string, scope FlowFieldUniqueScope) AttributeUniqueness {
-	switch scope {
-	case FlowFieldUniqueScopeProject, FlowFieldUniqueScopeTeam:
-		return AttributeUniquenessTeam
+// attributeUniquenessFor picks the [AttributeUniqueness] the user
+// repository writes for a given field. The field's own scope passes
+// through; the identifier field falls back to team-level when the
+// schema didn't pin it, so two users can't share the same login.
+func attributeUniquenessFor(name, identifierName string, scope AttributeUniqueness) AttributeUniqueness {
+	if scope != AttributeUniquenessUnspecified {
+		return scope
 	}
 	if name == identifierName {
 		return AttributeUniquenessTeam

--- a/internal/domain/flow_on_success_create_user.go
+++ b/internal/domain/flow_on_success_create_user.go
@@ -104,14 +104,14 @@ func findPasswordField(resolved map[string]FlowField, submitted map[string]any) 
 }
 
 // attributeUniquenessFor maps a [FlowFieldUniqueScope] to the
-// [AttributeUniqueness] the user repository understands. The
-// identifier field defaults to team-level uniqueness so two users
+// [AttributeUniqueness] the user repository understands. Both Project
+// and Team meta-schema scopes currently land on team-level storage
+// uniqueness; storage doesn't yet expose a project-wide scope short of
+// Global. The identifier field defaults to team-level so two users
 // can't share the same login.
 func attributeUniquenessFor(name, identifierName string, scope FlowFieldUniqueScope) AttributeUniqueness {
 	switch scope {
-	case FlowFieldUniqueScopeInstance:
-		return AttributeUniquenessProject
-	case FlowFieldUniqueScopeOrganization:
+	case FlowFieldUniqueScopeProject, FlowFieldUniqueScopeTeam:
 		return AttributeUniquenessTeam
 	}
 	if name == identifierName {

--- a/internal/domain/flow_state.go
+++ b/internal/domain/flow_state.go
@@ -11,6 +11,10 @@ import "time"
 // live on PivotStack. The remaining fields are session/OIDC context
 // that only makes sense at the top level.
 type FlowState struct {
+	// ID is the flow handle minted at Start. The handler verifies it
+	// matches the path (`/flow/{id}/...`) to reject path/cookie mismatches.
+	ID string
+
 	// ProjectID scopes the flow to a single tenant.
 	ProjectID string
 

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -455,11 +455,18 @@ func (r *FlowStateMachineRuntime) resolveStepFields(ctx context.Context, client 
 }
 
 func (r *FlowStateMachineRuntime) buildStep(step *FlowDefinitionStep, resolved FlowResolvedFields, errorKey *string, complete *FlowStepComplete, redirectURL *string) *FlowStep {
-	actions := make(map[string]FlowAction, len(step.Transitions))
-	for outcome := range step.Transitions {
-		actions[outcome] = FlowAction{
-			TextKey: "action." + outcome,
-			Primary: outcome == FlowActionSubmit,
+	// Surface only user-selectable actions declared on the step.
+	// Implicit outcomes (e.g. user_not_found) live in step.Transitions
+	// but are engine-emitted routing keys, not buttons for the client.
+	actions := make(map[string]FlowAction, len(step.Actions))
+	for name, a := range step.Actions {
+		textKey := a.TextKey
+		if textKey == "" {
+			textKey = "action." + name
+		}
+		actions[name] = FlowAction{
+			TextKey: textKey,
+			Primary: a.Primary,
 		}
 	}
 	return &FlowStep{

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -422,6 +422,15 @@ func (r *FlowStateMachineRuntime) terminate(ctx context.Context, client database
 		rendered.RedirectURL = &uri
 	}
 
+	// Skip handoff when no user was resolved (e.g. user_not_found →
+	// no-account). PrepareHandoff can't catch this today: attempts are
+	// started with empty RequiredChecks, so IsCompleted is vacuously
+	// true and a token would be minted. Remove once the policy engine
+	// populates RequiredChecks.
+	if _, ok := state.CollectedData[FlowCollectedUserIDKey]; !ok {
+		return rendered, FlowHandoffOutput{}, nil
+	}
+
 	if state.AuthAttemptID == "" {
 		return nil, FlowHandoffOutput{}, fmt.Errorf("%w: terminate without auth attempt id", ErrIntegrity)
 	}

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -479,7 +479,7 @@ func (r *FlowStateMachineRuntime) buildStep(step *FlowDefinitionStep, resolved F
 	for name, a := range step.Actions {
 		textKey := a.TextKey
 		if textKey == "" {
-			textKey = "action." + name
+			textKey = step.Name + ".action." + name
 		}
 		actions[name] = FlowAction{
 			TextKey: textKey,

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -19,6 +19,8 @@ import (
 type FlowStateMachine interface {
 	Start(ctx context.Context, client database.QueryExecutor, in FlowStartInput) (FlowStepResult, error)
 	Process(ctx context.Context, client database.QueryExecutor, def *FlowDefinition, state *FlowState, in FlowSubmitInput) (FlowStepResult, error)
+	// Render re-emits the current step without advancing. Backs GET /flow/{id}.
+	Render(ctx context.Context, client database.QueryExecutor, def *FlowDefinition, state *FlowState) (FlowStepResult, error)
 }
 
 // FlowStartInput carries everything the state machine needs to
@@ -28,6 +30,7 @@ type FlowStartInput struct {
 	Purpose       FlowDefinitionPurpose
 	Session       FlowSessionRef
 	AuthRequest   *FlowAuthRequestRef
+	RedirectURI   *string
 	UserSchemaURL string
 }
 
@@ -90,7 +93,6 @@ type FlowSessionRef struct {
 // is fulfilling.
 type FlowAuthRequestRef struct {
 	ID           string
-	RedirectURI  string
 	RequestedACR *string
 }
 
@@ -149,8 +151,11 @@ func (r *FlowStateMachineRuntime) Start(ctx context.Context, client database.Que
 	}
 	if in.AuthRequest != nil {
 		state.AuthRequestID = &in.AuthRequest.ID
-		state.RedirectURI = &in.AuthRequest.RedirectURI
 		state.RequestedACR = in.AuthRequest.RequestedACR
+	}
+	if in.RedirectURI != nil {
+		uri := *in.RedirectURI
+		state.RedirectURI = &uri
 	}
 
 	if r.authAttempts == nil {
@@ -166,6 +171,20 @@ func (r *FlowStateMachineRuntime) Start(ctx context.Context, client database.Que
 	if err != nil {
 		return FlowStepResult{}, err
 	}
+	return FlowStepResult{State: state, Step: step}, nil
+}
+
+// Render re-emits the current step without advancing. Refreshes IssuedAt
+// so the cookie max-age window slides while the user is on the step.
+func (r *FlowStateMachineRuntime) Render(ctx context.Context, client database.QueryExecutor, def *FlowDefinition, state *FlowState) (FlowStepResult, error) {
+	if def == nil || state == nil {
+		return FlowStepResult{}, fmt.Errorf("%w: render without definition or state", ErrIntegrity)
+	}
+	step, err := r.renderStep(ctx, client, def, state, state.UserSchemaURL, nil)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	state.IssuedAt = r.now()
 	return FlowStepResult{State: state, Step: step}, nil
 }
 

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -64,12 +64,20 @@ type FlowStepResult struct {
 // It mirrors the OpenAPI `flow-step` component in domain terms.
 type FlowStep struct {
 	Name         string
+	Texts        FlowStepTexts
 	Error        *string
 	Complete     *FlowStepComplete
 	RedirectURL  *string
 	Fields       map[string]FlowField
 	Actions      map[string]FlowAction
 	SSOProviders []FlowSSOProvider
+}
+
+// FlowStepTexts holds the step-level localization keys (`<step>.title`,
+// `<step>.description`) the template resolves via the `| t` filter.
+type FlowStepTexts struct {
+	TitleKey       string
+	DescriptionKey string
 }
 
 // FlowAction is a single user action surfaced on [FlowStep.Actions].
@@ -447,7 +455,7 @@ func (r *FlowStateMachineRuntime) resolveStepFields(ctx context.Context, client 
 	if len(step.Fields) == 0 {
 		return FlowResolvedFields{}, nil
 	}
-	resolved, err := r.fields.Resolve(ctx, client, projectID, userSchemaURL, step.Fields)
+	resolved, err := r.fields.Resolve(ctx, client, projectID, userSchemaURL, step.Name, step.Fields)
 	if err != nil {
 		return FlowResolvedFields{}, fmt.Errorf("flow state machine: resolve fields on step %q: %w", step.Name, err)
 	}
@@ -471,6 +479,7 @@ func (r *FlowStateMachineRuntime) buildStep(step *FlowDefinitionStep, resolved F
 	}
 	return &FlowStep{
 		Name:         step.Name,
+		Texts:        FlowStepTexts{TitleKey: step.Name + ".title", DescriptionKey: step.Name + ".description"},
 		Error:        errorKey,
 		Complete:     complete,
 		RedirectURL:  redirectURL,

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -140,6 +140,9 @@ func loginDefinition() *domain.FlowDefinition {
 			{
 				Name:   "credentials",
 				Fields: []string{"email", "password"},
+				Actions: map[string]domain.FlowStepAction{
+					domain.FlowActionSubmit: {Primary: true},
+				},
 				Transitions: map[string]domain.FlowStepTransition{
 					domain.FlowActionSubmit:                {Target: "done"},
 					domain.FlowImplicitOutcomeUserNotFound: {Target: "not_found"},
@@ -175,6 +178,9 @@ func signupDefinition() *domain.FlowDefinition {
 				Name:      "credentials",
 				Fields:    []string{"email", "password"},
 				OnSuccess: &createUser,
+				Actions: map[string]domain.FlowStepAction{
+					domain.FlowActionSubmit: {Primary: true},
+				},
 				Transitions: map[string]domain.FlowStepTransition{
 					domain.FlowActionSubmit: {Target: "done"},
 				},

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -324,6 +324,8 @@ func TestFlowStateMachine_Process_LoginUserNotFound(t *testing.T) {
 	require.Equal(t, "not_found", result.Step.Name)
 
 	assert.Empty(t, w.attempts.passwordCalls, "password must not be submitted when identifier is unknown")
+	assert.Empty(t, w.attempts.handoffCalls, "handoff must not run for an informational terminal reached without an identity")
+	assert.Empty(t, result.HandoffToken, "informational terminal must not surface a handoff token")
 }
 
 func TestFlowStateMachine_Process_LoginInvalidPassword(t *testing.T) {

--- a/internal/service/flow.go
+++ b/internal/service/flow.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/domain/idgen"
@@ -24,10 +25,14 @@ type FlowService interface {
 	GetStep(ctx context.Context, req GetFlowStepRequest) (FlowStepResult, error)
 }
 
-// FlowStepResult is what Start/Submit/GetStep return.
+// FlowStepResult is what Start/Submit/GetStep return. HandoffToken and
+// HandoffTokenExpiresAt are populated only on the submit that terminates
+// the flow; zero values on every other call.
 type FlowStepResult struct {
-	State *domain.FlowState
-	Step  *domain.FlowStep
+	State                 *domain.FlowState
+	Step                  *domain.FlowStep
+	HandoffToken          string
+	HandoffTokenExpiresAt time.Time
 }
 
 type StartFlowRequest struct {
@@ -202,7 +207,12 @@ func (s *flowService) Submit(ctx context.Context, req SubmitFlowRequest) (FlowSt
 	if err != nil {
 		return FlowStepResult{}, err
 	}
-	return FlowStepResult{State: result.State, Step: result.Step}, nil
+	return FlowStepResult{
+		State:                 result.State,
+		Step:                  result.Step,
+		HandoffToken:          result.HandoffToken,
+		HandoffTokenExpiresAt: result.HandoffTokenExpiresAt,
+	}, nil
 }
 
 func (s *flowService) GetStep(ctx context.Context, req GetFlowStepRequest) (FlowStepResult, error) {

--- a/internal/service/flow.go
+++ b/internal/service/flow.go
@@ -2,73 +2,89 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/domain/idgen"
 	"github.com/zitadel/nextgen/internal/storage/database"
 )
 
-// FlowService is the flow engine's use-case surface. For now only
-// [FlowService.Resolve] is wired; step emission, submission, and session
-// handling will land as additional methods so the API handler keeps a
-// single dependency.
+// FlowService is the flow engine's use-case surface. The API handler
+// depends only on this interface.
 type FlowService interface {
-	// Resolve returns the [domain.FlowDefinition] to run for an incoming
-	// flow request. Read-only — never touches sessions or cookies.
-	//
-	// Resolution algorithm:
-	//
-	//  1. If [ResolveFlowRequest.Name] is set, look up by
-	//     (ProjectID, Name, SchemaVersion?), pick the highest version,
-	//     and confirm the requested purpose is served. Return
-	//     [domain.ErrFlowDefinitionNotFound] or
-	//     [domain.ErrFlowDefinitionPurposeMismatch] on miss.
-	//  2. Otherwise return the first active definition whose purposes
-	//     include [ResolveFlowRequest.Purpose] (optionally pinned to
-	//     [ResolveFlowRequest.SchemaVersion]). [ResolveFlowRequest.Hint]
-	//     is plumbed through but not yet honored — see TODO on
-	//     resolveByAudience.
+	// Resolve returns the [domain.FlowDefinition] to run. Direct lookup
+	// when Name is set; audience match otherwise.
 	Resolve(ctx context.Context, req ResolveFlowRequest) (*domain.FlowDefinition, error)
+	// Start mints a fresh flow on the resolved definition.
+	Start(ctx context.Context, req StartFlowRequest) (FlowStepResult, error)
+	// Submit advances the state machine. Re-fetches the definition
+	// from FlowState.DefinitionID.
+	Submit(ctx context.Context, req SubmitFlowRequest) (FlowStepResult, error)
+	// GetStep re-emits the current step without advancing.
+	GetStep(ctx context.Context, req GetFlowStepRequest) (FlowStepResult, error)
 }
 
-// ResolveFlowRequest is the input to [FlowService.Resolve].
-type ResolveFlowRequest struct {
-	ProjectID string
-	Purpose   domain.FlowDefinitionPurpose
+// FlowStepResult is what Start/Submit/GetStep return.
+type FlowStepResult struct {
+	State *domain.FlowState
+	Step  *domain.FlowStep
+}
 
-	// Name, when set, switches to direct lookup. It acts as a slug.
-	Name *string
-
-	// SchemaVersion is a semver string. Nil means "latest active".
-	SchemaVersion *string
-
-	// AuthRequestID carries the OIDC/SAML request ID when the flow was
-	// initiated by a downstream protocol handler.
+type StartFlowRequest struct {
+	Definition    *domain.FlowDefinition
+	Purpose       domain.FlowDefinitionPurpose
+	RedirectURI   *string
 	AuthRequestID *string
+	SessionID     *string
+}
 
-	// Hint narrows audience matching when no direct lookup is in play.
-	// Currently ignored — see TODO on resolveByAudience.
+type SubmitFlowRequest struct {
+	State         *domain.FlowState
+	Action        string
+	Fields        map[string]any
+	GateProofs    map[string]string
+	SSOProviderID *string
+}
+
+type GetFlowStepRequest struct {
+	State *domain.FlowState
+}
+
+type ResolveFlowRequest struct {
+	ProjectID     string
+	Purpose       domain.FlowDefinitionPurpose
+	Name          *string // direct-lookup slug
+	SchemaVersion *string // nil = latest active
+	AuthRequestID *string
+	// Hint is plumbed through but not yet honored — see TODO on resolveByAudience.
 	Hint ResolveFlowHint
 }
 
-// ResolveFlowHint carries the audience-narrowing context derived from the
-// request or the auth-request that initiated it. Empty fields are ignored
-// during matching.
 type ResolveFlowHint struct {
 	AppID        *string
 	TeamID       *string
 	UserSchemaID *string
 }
 
-// NewFlowService returns a [FlowService] backed by the given
-// [domain.FlowDefinitionRepository]. The pool is used as the
-// [database.QueryExecutor] for every read.
-func NewFlowService(pool database.Pool, flowDefs domain.FlowDefinitionRepository) FlowService {
-	return &flowService{pool: pool, flowDefs: flowDefs}
+func NewFlowService(
+	pool database.Pool,
+	flowDefs domain.FlowDefinitionRepository,
+	stateMachine domain.FlowStateMachine,
+	ids idgen.Generator,
+) FlowService {
+	return &flowService{
+		pool:         pool,
+		flowDefs:     flowDefs,
+		stateMachine: stateMachine,
+		ids:          ids,
+	}
 }
 
 type flowService struct {
-	pool     database.Pool
-	flowDefs domain.FlowDefinitionRepository
+	pool         database.Pool
+	flowDefs     domain.FlowDefinitionRepository
+	stateMachine domain.FlowStateMachine
+	ids          idgen.Generator
 }
 
 var _ FlowService = (*flowService)(nil)
@@ -80,9 +96,6 @@ func (s *flowService) Resolve(ctx context.Context, req ResolveFlowRequest) (*dom
 	return s.resolveByAudience(ctx, req)
 }
 
-// resolveByName implements the direct-lookup branch: list active definitions
-// matching (ProjectID, Name, SchemaVersion?), pick the latest version, then
-// confirm the requested purpose is served.
 func (s *flowService) resolveByName(ctx context.Context, req ResolveFlowRequest) (*domain.FlowDefinition, error) {
 	opts := []domain.FlowDefinitionListOption{
 		domain.WithFlowDefinitionName(*req.Name),
@@ -107,13 +120,8 @@ func (s *flowService) resolveByName(ctx context.Context, req ResolveFlowRequest)
 	return def, nil
 }
 
-// resolveByAudience picks the first active definition serving the requested
-// purpose (with an optional SchemaVersion pin).
-//
-// TODO: honor [ResolveFlowRequest.Hint]. The MVP returns whichever row the
-// repository yields first; once admin UX produces multiple audience-targeted
-// definitions per purpose, score candidates by AppIDs > TeamIDs >
-// project-wide (both empty) and tie-break by created_at DESC.
+// TODO: honor ResolveFlowRequest.Hint — score by AppIDs > TeamIDs > project-wide,
+// tie-break by created_at DESC.
 func (s *flowService) resolveByAudience(ctx context.Context, req ResolveFlowRequest) (*domain.FlowDefinition, error) {
 	opts := []domain.FlowDefinitionListOption{
 		domain.WithFlowDefinitionStatus(domain.FlowDefinitionStatusActive),
@@ -133,15 +141,92 @@ func (s *flowService) resolveByAudience(ctx context.Context, req ResolveFlowRequ
 	return defs[0], nil
 }
 
+func (s *flowService) Start(ctx context.Context, req StartFlowRequest) (FlowStepResult, error) {
+	if req.Definition == nil {
+		return FlowStepResult{}, fmt.Errorf("flow service: start without definition")
+	}
+
+	sessionID := ""
+	if req.SessionID != nil {
+		sessionID = *req.SessionID
+	} else {
+		id, err := s.ids.New("sess")
+		if err != nil {
+			return FlowStepResult{}, fmt.Errorf("flow service: mint session id: %w", err)
+		}
+		sessionID = id
+	}
+
+	in := domain.FlowStartInput{
+		Definition:    req.Definition,
+		Purpose:       req.Purpose,
+		Session:       domain.FlowSessionRef{ID: sessionID},
+		RedirectURI:   req.RedirectURI,
+		UserSchemaURL: req.Definition.UserSchema,
+	}
+	if req.AuthRequestID != nil {
+		in.AuthRequest = &domain.FlowAuthRequestRef{ID: *req.AuthRequestID}
+	}
+
+	result, err := s.stateMachine.Start(ctx, s.pool, in)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+
+	flowID, err := s.ids.New("flow")
+	if err != nil {
+		return FlowStepResult{}, fmt.Errorf("flow service: mint flow id: %w", err)
+	}
+	result.State.ID = flowID
+
+	return FlowStepResult{State: result.State, Step: result.Step}, nil
+}
+
+func (s *flowService) Submit(ctx context.Context, req SubmitFlowRequest) (FlowStepResult, error) {
+	if req.State == nil {
+		return FlowStepResult{}, fmt.Errorf("flow service: submit without state")
+	}
+	def, err := s.flowDefs.GetFlowDefinition(ctx, s.pool, req.State.ProjectID, req.State.DefinitionID)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	in := domain.FlowSubmitInput{
+		Action:     req.Action,
+		Fields:     req.Fields,
+		GateProofs: req.GateProofs,
+	}
+	if req.SSOProviderID != nil {
+		in.SSOProvider = &domain.FlowSSOProviderRef{ID: *req.SSOProviderID}
+	}
+	result, err := s.stateMachine.Process(ctx, s.pool, def, req.State, in)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	return FlowStepResult{State: result.State, Step: result.Step}, nil
+}
+
+func (s *flowService) GetStep(ctx context.Context, req GetFlowStepRequest) (FlowStepResult, error) {
+	if req.State == nil {
+		return FlowStepResult{}, fmt.Errorf("flow service: get step without state")
+	}
+	def, err := s.flowDefs.GetFlowDefinition(ctx, s.pool, req.State.ProjectID, req.State.DefinitionID)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	result, err := s.stateMachine.Render(ctx, s.pool, def, req.State)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	return FlowStepResult{State: result.State, Step: result.Step}, nil
+}
+
 func flowServesPurpose(def *domain.FlowDefinition, purpose domain.FlowDefinitionPurpose) bool {
 	_, ok := def.Purposes[purpose]
 	return ok
 }
 
-// pickLatestFlowVersion returns the definition with the highest SchemaVersion
-// among defs. Uses lexicographic compare — sufficient while versions stay
-// zero-padded single-digit MAJOR.MINOR.PATCH (MVP scope). Caller must
-// ensure defs is non-empty.
+// pickLatestFlowVersion is a lexicographic compare — sufficient while
+// versions stay zero-padded MAJOR.MINOR.PATCH. Caller ensures defs non-empty.
 func pickLatestFlowVersion(defs []*domain.FlowDefinition) *domain.FlowDefinition {
 	winner := defs[0]
 	for _, def := range defs[1:] {

--- a/internal/service/flow_test.go
+++ b/internal/service/flow_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 	"testing"
+	"time"
 
 	"go.uber.org/mock/gomock"
 
@@ -398,6 +399,38 @@ func TestFlowService_Submit_RefetchesDefinitionAndCallsProcess(t *testing.T) {
 	}
 	if sm.gotSubmitInput.Action != "submit" {
 		t.Errorf("Action = %q, want submit", sm.gotSubmitInput.Action)
+	}
+}
+
+func TestFlowService_Submit_PropagatesHandoffToken(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	repo := stubGetFlowDefinition(t, def)
+	expiresAt := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	sm := &fakeStateMachine{processResult: domain.FlowStepResult{
+		State:                 &domain.FlowState{ID: "flow_1"},
+		Step:                  &domain.FlowStep{Name: "done"},
+		HandoffToken:          "ht_abc",
+		HandoffTokenExpiresAt: expiresAt,
+	}}
+
+	svc := service.NewFlowService(stubPool(), repo, sm, &stubIDGen{})
+
+	res, err := svc.Submit(t.Context(), service.SubmitFlowRequest{
+		State: &domain.FlowState{
+			ID:           "flow_1",
+			ProjectID:    def.ProjectID,
+			FlowProgress: domain.FlowProgress{DefinitionID: def.ID},
+		},
+		Action: "submit",
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if res.HandoffToken != "ht_abc" {
+		t.Errorf("HandoffToken = %q, want ht_abc", res.HandoffToken)
+	}
+	if !res.HandoffTokenExpiresAt.Equal(expiresAt) {
+		t.Errorf("HandoffTokenExpiresAt = %v, want %v", res.HandoffTokenExpiresAt, expiresAt)
 	}
 }
 

--- a/internal/service/flow_test.go
+++ b/internal/service/flow_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -80,7 +81,7 @@ func TestResolve_ResolveByName_ExactVersion(t *testing.T) {
 	other := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{other, want})
 
-	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	got, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID:     "proj",
 		Purpose:       domain.FlowDefinitionPurposeLogin,
 		Name:          ptr("login"),
@@ -115,7 +116,7 @@ func TestResolve_ResolveByName_FiltersWithRequestedOptions(t *testing.T) {
 			return []*domain.FlowDefinition{def}, nil
 		})
 
-	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	_, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID:     "proj",
 		Purpose:       domain.FlowDefinitionPurposeLogin,
 		Name:          ptr("login"),
@@ -132,7 +133,7 @@ func TestResolve_ResolveByName_LatestActiveWhenVersionNil(t *testing.T) {
 	v15 := newDef("login", "1.5.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{v1, v2, v15})
 
-	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	got, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeLogin,
 		Name:      ptr("login"),
@@ -148,7 +149,7 @@ func TestResolve_ResolveByName_LatestActiveWhenVersionNil(t *testing.T) {
 func TestResolve_ResolveByName_NotFound(t *testing.T) {
 	repo := stubListFlowDefinitions(t, nil)
 
-	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	_, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeLogin,
 		Name:      ptr("missing"),
@@ -162,7 +163,7 @@ func TestResolve_ResolveByName_PurposeMismatch(t *testing.T) {
 	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{def})
 
-	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	_, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeRegister,
 		Name:      ptr("login"),
@@ -177,7 +178,7 @@ func TestResolve_ResolveByAudience_ReturnsFirstMatchingPurpose(t *testing.T) {
 	second := newDef("alt", "1.0.0", domain.FlowDefinitionAudience{AppIDs: []string{"app-1"}}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{first, second})
 
-	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	got, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeLogin,
 	})
@@ -193,7 +194,7 @@ func TestResolve_ResolveByAudience_NoMatch(t *testing.T) {
 	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{def})
 
-	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	_, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeRegister,
 	})
@@ -207,7 +208,7 @@ func TestResolve_ResolveByAudience_ExactVersionFiltersOlder(t *testing.T) {
 	v2 := newDef("login", "2.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
 	repo := stubListFlowDefinitions(t, []*domain.FlowDefinition{v1, v2})
 
-	got, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	got, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID:     "proj",
 		Purpose:       domain.FlowDefinitionPurposeLogin,
 		SchemaVersion: ptr("1.0.0"),
@@ -228,11 +229,198 @@ func TestResolve_ResolveByAudience_RepoErrorPropagates(t *testing.T) {
 		ListFlowDefinitions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, sentinel)
 
-	_, err := service.NewFlowService(stubPool(), repo).Resolve(t.Context(), service.ResolveFlowRequest{
+	_, err := service.NewFlowService(stubPool(), repo, nil, nil).Resolve(t.Context(), service.ResolveFlowRequest{
 		ProjectID: "proj",
 		Purpose:   domain.FlowDefinitionPurposeLogin,
 	})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("Resolve err = %v, want boom", err)
+	}
+}
+
+// fakeStateMachine captures inputs and returns pre-loaded results.
+type fakeStateMachine struct {
+	startResult   domain.FlowStepResult
+	startErr      error
+	processResult domain.FlowStepResult
+	processErr    error
+	renderResult  domain.FlowStepResult
+	renderErr     error
+
+	gotStartInput  domain.FlowStartInput
+	gotSubmitInput domain.FlowSubmitInput
+	gotProcessDef  *domain.FlowDefinition
+	gotRenderState *domain.FlowState
+}
+
+func (f *fakeStateMachine) Start(_ context.Context, _ database.QueryExecutor, in domain.FlowStartInput) (domain.FlowStepResult, error) {
+	f.gotStartInput = in
+	return f.startResult, f.startErr
+}
+
+func (f *fakeStateMachine) Process(_ context.Context, _ database.QueryExecutor, def *domain.FlowDefinition, _ *domain.FlowState, in domain.FlowSubmitInput) (domain.FlowStepResult, error) {
+	f.gotProcessDef = def
+	f.gotSubmitInput = in
+	return f.processResult, f.processErr
+}
+
+func (f *fakeStateMachine) Render(_ context.Context, _ database.QueryExecutor, _ *domain.FlowDefinition, state *domain.FlowState) (domain.FlowStepResult, error) {
+	f.gotRenderState = state
+	return f.renderResult, f.renderErr
+}
+
+// stubIDGen returns deterministic prefix_N ids.
+type stubIDGen struct {
+	calls int
+}
+
+func (s *stubIDGen) New(prefix string) (string, error) {
+	s.calls++
+	return prefix + "_" + strconv.Itoa(s.calls), nil
+}
+
+// stubGetFlowDefinition returns def for any GetFlowDefinition call.
+func stubGetFlowDefinition(t *testing.T, def *domain.FlowDefinition) *domainmock.MockFlowDefinitionRepository {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	repo := domainmock.NewMockFlowDefinitionRepository(ctrl)
+	repo.EXPECT().
+		GetFlowDefinition(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(def, nil).
+		AnyTimes()
+	return repo
+}
+
+func TestFlowService_Start_MintsFlowAndSessionIDs(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	def.UserSchema = "https://example.com/user.json"
+
+	state := &domain.FlowState{ProjectID: def.ProjectID}
+	sm := &fakeStateMachine{startResult: domain.FlowStepResult{State: state, Step: &domain.FlowStep{Name: "start"}}}
+	ids := &stubIDGen{}
+
+	svc := service.NewFlowService(stubPool(), nil, sm, ids)
+
+	res, err := svc.Start(t.Context(), service.StartFlowRequest{
+		Definition: def,
+		Purpose:    domain.FlowDefinitionPurposeLogin,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if res.State == nil || res.State.ID == "" {
+		t.Fatal("flow id was not minted")
+	}
+	if sm.gotStartInput.Session.ID == "" {
+		t.Fatal("session id was not minted")
+	}
+	if sm.gotStartInput.UserSchemaURL != def.UserSchema {
+		t.Errorf("UserSchemaURL = %q, want %q", sm.gotStartInput.UserSchemaURL, def.UserSchema)
+	}
+}
+
+func TestFlowService_Start_PassesRedirectURIThrough(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	state := &domain.FlowState{ProjectID: def.ProjectID}
+	sm := &fakeStateMachine{startResult: domain.FlowStepResult{State: state, Step: &domain.FlowStep{}}}
+
+	svc := service.NewFlowService(stubPool(), nil, sm, &stubIDGen{})
+
+	redirect := "https://rp.example.com/cb"
+	if _, err := svc.Start(t.Context(), service.StartFlowRequest{
+		Definition:  def,
+		Purpose:     domain.FlowDefinitionPurposeLogin,
+		RedirectURI: &redirect,
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if sm.gotStartInput.RedirectURI == nil || *sm.gotStartInput.RedirectURI != redirect {
+		t.Errorf("RedirectURI = %v, want %q", sm.gotStartInput.RedirectURI, redirect)
+	}
+}
+
+func TestFlowService_Start_PreservesProvidedSessionID(t *testing.T) {
+	def := newDef("reauth", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeReauth)
+	state := &domain.FlowState{ProjectID: def.ProjectID}
+	sm := &fakeStateMachine{startResult: domain.FlowStepResult{State: state, Step: &domain.FlowStep{}}}
+
+	svc := service.NewFlowService(stubPool(), nil, sm, &stubIDGen{})
+
+	sessionID := "sess_explicit"
+	if _, err := svc.Start(t.Context(), service.StartFlowRequest{
+		Definition: def,
+		Purpose:    domain.FlowDefinitionPurposeReauth,
+		SessionID:  &sessionID,
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if sm.gotStartInput.Session.ID != sessionID {
+		t.Errorf("Session.ID = %q, want %q", sm.gotStartInput.Session.ID, sessionID)
+	}
+}
+
+func TestFlowService_Start_PropagatesStateMachineError(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	sm := &fakeStateMachine{startErr: errors.New("boom")}
+
+	svc := service.NewFlowService(stubPool(), nil, sm, &stubIDGen{})
+
+	_, err := svc.Start(t.Context(), service.StartFlowRequest{
+		Definition: def,
+		Purpose:    domain.FlowDefinitionPurposeLogin,
+	})
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("Start err = %v, want boom", err)
+	}
+}
+
+func TestFlowService_Submit_RefetchesDefinitionAndCallsProcess(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	repo := stubGetFlowDefinition(t, def)
+	processedState := &domain.FlowState{ID: "flow_1"}
+	sm := &fakeStateMachine{processResult: domain.FlowStepResult{State: processedState, Step: &domain.FlowStep{Name: "next"}}}
+
+	svc := service.NewFlowService(stubPool(), repo, sm, &stubIDGen{})
+
+	state := &domain.FlowState{
+		ID:           "flow_1",
+		ProjectID:    def.ProjectID,
+		FlowProgress: domain.FlowProgress{DefinitionID: def.ID},
+	}
+	if _, err := svc.Submit(t.Context(), service.SubmitFlowRequest{
+		State:  state,
+		Action: "submit",
+	}); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if sm.gotProcessDef == nil || sm.gotProcessDef.ID != def.ID {
+		t.Fatalf("Process was not called with refetched definition")
+	}
+	if sm.gotSubmitInput.Action != "submit" {
+		t.Errorf("Action = %q, want submit", sm.gotSubmitInput.Action)
+	}
+}
+
+func TestFlowService_GetStep_CallsRender(t *testing.T) {
+	def := newDef("login", "1.0.0", domain.FlowDefinitionAudience{}, domain.FlowDefinitionPurposeLogin)
+	repo := stubGetFlowDefinition(t, def)
+	state := &domain.FlowState{
+		ID:           "flow_1",
+		ProjectID:    def.ProjectID,
+		FlowProgress: domain.FlowProgress{DefinitionID: def.ID},
+	}
+	sm := &fakeStateMachine{renderResult: domain.FlowStepResult{State: state, Step: &domain.FlowStep{Name: "identify"}}}
+
+	svc := service.NewFlowService(stubPool(), repo, sm, &stubIDGen{})
+
+	res, err := svc.GetStep(t.Context(), service.GetFlowStepRequest{State: state})
+	if err != nil {
+		t.Fatalf("GetStep: %v", err)
+	}
+	if sm.gotRenderState != state {
+		t.Errorf("Render was called with %p, want %p", sm.gotRenderState, state)
+	}
+	if res.Step == nil || res.Step.Name != "identify" {
+		t.Errorf("Step = %+v, want name identify", res.Step)
 	}
 }


### PR DESCRIPTION
## Summary

Wires the flow engine end-to-end through the HTTP handler.

- `POST /flow`, `POST /flow/{id}/submit`, `GET /flow/{id}` (event endpoint deferred)
- `_zflow` encrypted cookie via `cookie.Sealer` — handler owns I/O, state machine stays cookie-free
- `FlowService` use-case layer (resolve / start / submit / get-step) over the auth-attempt–backed state machine
- Default branding liquid template