### PR TITLE
refactor: derive identifier challenge from x-unique

### DIFF
--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -2869,7 +2869,8 @@ type FlowDefinitionStep struct {
 	// Schema property names to collect from the user. Each entry references
 	// a property in the flow's user schema. The engine resolves field type,
 	// validation rules, and implicit outcomes from schema annotations
-	// (e.g. `x-identifier` implies a `user_not_found` transition outcome).
+	// (e.g. a property with `x-unique` set implies a `user_not_found`
+	// transition outcome).
 	Fields []string `json:"fields"`
 	// Actions the user can take. Keyed by action name.
 	// The action name is what the frontend sends back in the submit request.
@@ -2893,7 +2894,7 @@ type FlowDefinitionStep struct {
 	// Maps action/outcome names to their transition descriptor.
 	// Keys match action names from the `actions` dict. Additional keys
 	// come from implicit outcomes based on schema annotations
-	// (e.g. `user_not_found` from `x-identifier` fields) and engine
+	// (e.g. `user_not_found` from `x-unique` fields) and engine
 	// events (e.g. `sso`, `callback`).
 	Transitions OptFlowDefinitionStepTransitions `json:"transitions"`
 }
@@ -3091,7 +3092,7 @@ func (s *FlowDefinitionStepOnSuccess) UnmarshalText(data []byte) error {
 // Maps action/outcome names to their transition descriptor.
 // Keys match action names from the `actions` dict. Additional keys
 // come from implicit outcomes based on schema annotations
-// (e.g. `user_not_found` from `x-identifier` fields) and engine
+// (e.g. `user_not_found` from `x-unique` fields) and engine
 // events (e.g. `sso`, `callback`).
 type FlowDefinitionStepTransitions map[string]FlowDefinitionStepTransitionsItem
 

--- a/api/openapi/components/flows/flow-definition-step.yaml
+++ b/api/openapi/components/flows/flow-definition-step.yaml
@@ -24,7 +24,8 @@ properties:
       Schema property names to collect from the user. Each entry references
       a property in the flow's user schema. The engine resolves field type,
       validation rules, and implicit outcomes from schema annotations
-      (e.g. `x-identifier` implies a `user_not_found` transition outcome).
+      (e.g. a property with `x-unique` set implies a `user_not_found`
+      transition outcome).
     items:
       type: string
     default: []
@@ -96,7 +97,7 @@ properties:
 
       Keys match action names from the `actions` dict. Additional keys
       come from implicit outcomes based on schema annotations
-      (e.g. `user_not_found` from `x-identifier` fields) and engine
+      (e.g. `user_not_found` from `x-unique` fields) and engine
       events (e.g. `sso`, `callback`).
     additionalProperties:
       type: object

--- a/api/openapi/endpoints/schemas/flow-definition.json
+++ b/api/openapi/endpoints/schemas/flow-definition.json
@@ -139,7 +139,7 @@
               "password"
             ]
           ],
-          "description": "Schema property names to collect from the user on this step. Each entry must resolve to a property in the definition's `user_schema`. The engine reads the schema's `x-*` annotations to derive: - field type and validation (rendered into the runtime payload), - implicit transition outcomes \u2014 e.g. `x-identifier: true` makes   `user_not_found` a valid `transitions` key on this step, - credential verification \u2014 e.g. `x-credential: password` causes   submission to invoke an auth_attempt verification before the   transition fires."
+          "description": "Schema property names to collect from the user on this step. Each entry must resolve to a property in the definition's `user_schema`. The engine reads the schema's `x-*` annotations to derive: - field type and validation (rendered into the runtime payload), - implicit transition outcomes - e.g. a property with a non-empty   `x-unique` scope makes `user_not_found` a valid `transitions` key   on this step, - credential verification - e.g. `x-credential: password` causes   submission to invoke an auth_attempt verification before the   transition fires."
         },
         "actions": {
           "type": "object",
@@ -182,7 +182,7 @@
           "additionalProperties": {
             "$ref": "#/$defs/Transition"
           },
-          "description": "Maps action names and engine-emitted outcomes to the next state. Keys are either: - an action name declared in this step's `actions`, or - a reserved outcome the engine produces:   - `user_not_found` \u2014 emitted when a field with     `x-identifier: true` does not match an existing user.   - `callback` \u2014 emitted when an external system returns control     to the flow (SSO callback, device authorization poll, etc.). A transition's `action` field controls whether the target is interpreted as a step in this definition (default) or as the name of another definition to switch or pivot into. "
+          "description": "Maps action names and engine-emitted outcomes to the next state. Keys are either: - an action name declared in this step's `actions`, or - a reserved outcome the engine produces:   - `user_not_found` - emitted when a unique field     (`x-unique`) does not match an existing user.   - `callback` - emitted when an external system returns control     to the flow (SSO callback, device authorization poll, etc.). A transition's `action` field controls whether the target is interpreted as a step in this definition (default) or as the name of another definition to switch or pivot into. "
         }
       }
     },

--- a/internal/domain/flow_field_resolver.go
+++ b/internal/domain/flow_field_resolver.go
@@ -10,7 +10,7 @@ import (
 
 // FlowFieldResolver maps property names referenced by a flow step to
 // fully-resolved [FlowField] payloads, surfaces the implicit transition
-// outcomes the schema implies (an `x-identifier` field implies a
+// outcomes the schema implies (a property with `x-unique` set implies a
 // `user_not_found` outcome), and validates submitted values against the
 // schema-derived rules.
 //
@@ -69,17 +69,17 @@ type FlowField struct {
 
 	// Challenge names the auth-attempt challenge the field maps to, or
 	// [FlowFieldChallengeNone] when the field carries neither an
-	// identifier nor a credential proof. Derivation paths:
-	// `x-identifier: true` on the property surfaces as
-	// [FlowFieldChallengeIdentifier]; `x-password: true` on the
-	// property combined with `x-auth-methods.password.enabled = true`
-	// at the schema root surfaces as [FlowFieldChallengePassword].
-	// Other credential kinds (passkey, magic_link, sso, otp) do not
-	// have user-property-shaped proofs and are produced by the state
-	// machine as challenge steps, not by the resolver. The state
-	// machine consults Challenge on submit to route the value —
-	// identifier fields drive identifier resolution (and the
-	// `user_not_found` implicit outcome), password fields drive the
+	// identifier nor a credential proof. Derivation paths: a non-empty
+	// `x-unique` scope on the property surfaces as
+	// [FlowFieldChallengeIdentifier] (any uniquely-keyed property can
+	// identify a user); `x-password: true` combined with schema-level
+	// `x-auth-methods.password.enabled = true` surfaces as
+	// [FlowFieldChallengePassword]. Other credential kinds (passkey,
+	// magic_link, sso, otp) do not have user-property-shaped proofs and
+	// are produced by the state machine as challenge steps, not by the
+	// resolver. The state machine consults Challenge on submit to route
+	// the value — identifier fields drive identifier resolution (and
+	// the `user_not_found` implicit outcome), password fields drive the
 	// password challenge.
 	Challenge FlowFieldChallenge
 }
@@ -87,13 +87,13 @@ type FlowField struct {
 // FlowFieldChallenge names the auth-attempt challenge a field maps
 // to. Values mirror the keys of `x-auth-methods` in the user
 // meta-schema (api/openapi/endpoints/schemas/user-schema.yaml).
-// `identifier` is sourced from `x-identifier` on the property;
-// `password` is sourced from `x-password` on the property combined
-// with `x-auth-methods.password.enabled` at the schema root. The
-// remaining credential values (passkey, magic_link, sso, otp) have no
-// user-property-shaped proof and are produced by the state machine as
-// challenge steps rather than by the resolver. Empty means the field
-// maps to no challenge.
+// `identifier` is sourced from a non-empty `x-unique` scope on the
+// property; `password` is sourced from `x-password` on the property
+// combined with `x-auth-methods.password.enabled` at the schema root.
+// The remaining credential values (passkey, magic_link, sso, otp) have
+// no user-property-shaped proof and are produced by the state machine
+// as challenge steps rather than by the resolver. Empty means the
+// field maps to no challenge.
 type FlowFieldChallenge string
 
 const (

--- a/internal/domain/flow_field_resolver_schema.go
+++ b/internal/domain/flow_field_resolver_schema.go
@@ -28,9 +28,8 @@ type SchemaResolver interface {
 //     [FlowFieldTypePassword].
 //   - top-level `required` membership → [FlowField.Required]
 //   - `minLength`, `maxLength`, `format` → [FlowFieldValidation]
-//   - `x-identifier` → [FlowFieldChallengeIdentifier] +
-//     [FlowImplicitOutcomeUserNotFound]
-//   - `x-unique` → [FlowField.Unique]
+//   - `x-unique` (non-empty) → [FlowFieldChallengeIdentifier] +
+//     [FlowImplicitOutcomeUserNotFound] + [FlowField.Unique]
 //   - `x-password: true` combined with schema-level
 //     `x-auth-methods.password.enabled = true` →
 //     [FlowFieldChallengePassword]. Other auth methods do not have
@@ -85,11 +84,12 @@ func (r *SchemaFieldResolver) Resolve(
 
 // buildFlowField translates a user-schema property into a [FlowField].
 func buildFlowField(name string, propSchema *jsonschema.Schema, required map[string]struct{}, passwordEnabled bool) FlowField {
+	unique := deriveUnique(propSchema)
 	field := FlowField{
 		TextKey:   "field." + name,
 		Type:      deriveFieldType(propSchema),
-		Challenge: deriveChallenge(propSchema, passwordEnabled),
-		Unique:    deriveUnique(propSchema),
+		Challenge: deriveChallenge(propSchema, unique, passwordEnabled),
+		Unique:    unique,
 	}
 	if _, ok := required[name]; ok {
 		field.Required = true
@@ -117,13 +117,14 @@ func deriveFieldType(propSchema *jsonschema.Schema) FlowFieldType {
 	return FlowFieldTypeText
 }
 
-// deriveChallenge resolves the unified [FlowFieldChallenge].
-// `x-identifier: true` surfaces as Identifier; `x-password: true`
+// deriveChallenge resolves the unified [FlowFieldChallenge]. A
+// non-empty `x-unique` scope marks the field as Identifier (any
+// uniquely-keyed property can identify a user). `x-password: true`
 // surfaces as Password when the schema-level `x-auth-methods.password`
 // is enabled. Other credential kinds (passkey, magic_link, sso, otp)
 // have no user-property-shaped proof and are never surfaced here.
-func deriveChallenge(propSchema *jsonschema.Schema, passwordEnabled bool) FlowFieldChallenge {
-	if isIdentifier(propSchema) {
+func deriveChallenge(propSchema *jsonschema.Schema, unique FlowFieldUniqueScope, passwordEnabled bool) FlowFieldChallenge {
+	if unique != FlowFieldUniqueScopeNone {
 		return FlowFieldChallengeIdentifier
 	}
 	if isPassword(propSchema) && passwordEnabled {
@@ -236,10 +237,6 @@ func lookupInt(schema *jsonschema.Schema, keyword string) int {
 		return int(n)
 	}
 	return 0
-}
-
-func isIdentifier(schema *jsonschema.Schema) bool {
-	return lookupBool(schema, "x-identifier")
 }
 
 func isPassword(schema *jsonschema.Schema) bool {

--- a/internal/domain/flow_field_resolver_schema_test.go
+++ b/internal/domain/flow_field_resolver_schema_test.go
@@ -52,8 +52,8 @@ func defaultSchemaBytes() []byte {
 		"x-auth-methods": { "password": { "enabled": true } },
 		"required": ["email", "username", "password", "given_name", "family_name"],
 		"properties": {
-			"email":       { "type": "string", "format": "email", "maxLength": 320, "x-identifier": true, "x-unique": "organization" },
-			"username":    { "type": "string", "minLength": 3, "maxLength": 64, "x-identifier": true, "x-unique": "organization" },
+			"email":       { "type": "string", "format": "email", "maxLength": 320, "x-unique": "organization" },
+			"username":    { "type": "string", "minLength": 3, "maxLength": 64, "x-unique": "organization" },
 			"password":    { "type": "string", "minLength": 8, "x-password": true },
 			"given_name":  { "type": "string", "minLength": 1, "maxLength": 200 },
 			"family_name": { "type": "string", "minLength": 1, "maxLength": 200 }


### PR DESCRIPTION
The user meta-schema dropped `x-identifier`; `x-unique` is now the only identity marker. The field resolver derives `FlowFieldChallengeIdentifier` from any non-empty `x-unique` scope, so `user_not_found` implicit-outcome routing and auth-attempt identifier dispatch keep working without a second annotation.

- Drop `isIdentifier` (`x-identifier` lookup); `deriveChallenge` keys off the already-derived `FlowFieldUniqueScope`.
- Doc comments + OAS descriptions updated to point at `x-unique`.
- Resolver test schemas stripped of `x-identifier: true` (they already carried `x-unique`).
- `api/generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)