### PR TITLE
fix: don't pass a nil challenge to ChallengeFailed

### DIFF
--- a/internal/service/auth_attempt.go
+++ b/internal/service/auth_attempt.go
@@ -289,8 +289,11 @@ func (s *authAttemptService) VerifyProof(ctx context.Context, input VerifyProofI
 
 	challenge, factor, err := s.verify(ctx, attempt, input.Proof, input.ChallengeID)
 	if err != nil {
-		// Record the failure for rate-limiting — best effort, don't shadow the original error
-		_ = s.attempts.ChallengeFailed(ctx, s.pool, input.ProjectID, input.AttemptID, challenge)
+		// Record the failure for rate-limiting — best effort, don't shadow
+		// the original error. Skip when verify couldn't identify a challenge row.
+		if challenge != nil {
+			_ = s.attempts.ChallengeFailed(ctx, s.pool, input.ProjectID, input.AttemptID, challenge)
+		}
 		return nil, err
 	}
 
@@ -360,7 +363,7 @@ func (s *authAttemptService) verify(ctx context.Context, attempt *domain.AuthAtt
 			}})),
 		)
 		if err != nil {
-			return nil, nil, domain.ErrAuthAttemptProofRejected(err)
+			return userChallenge, nil, domain.ErrAuthAttemptProofRejected(err)
 		}
 		return userChallenge, attempt.SetUserFactor(user), nil
 
@@ -376,10 +379,10 @@ func (s *authAttemptService) verify(ctx context.Context, attempt *domain.AuthAtt
 			database.WithCondition(s.userPasswords.UserIDCondition(userFactor.UserID)),
 		)
 		if err != nil {
-			return nil, nil, domain.ErrAuthAttemptProofRejected(err)
+			return passwordChallenge, nil, domain.ErrAuthAttemptProofRejected(err)
 		}
 		if err := password.Verify(p.Password, s.passwordVerifier); err != nil {
-			return nil, nil, domain.ErrAuthAttemptProofRejected(err)
+			return passwordChallenge, nil, domain.ErrAuthAttemptProofRejected(err)
 		}
 		return passwordChallenge, attempt.SetPasswordFactor(), nil
 

--- a/internal/service/auth_attempt_integration_test.go
+++ b/internal/service/auth_attempt_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+	"github.com/zitadel/nextgen/internal/storage/database"
+	"github.com/zitadel/nextgen/internal/storage/database/repository"
+)
+
+// newAuthAttemptServiceForIntegration wires the service with real repos.
+// The password verifier is nil because these tests exercise only the
+// user-proof path, which never touches it.
+func newAuthAttemptServiceForIntegration(pool database.Pool) service.AuthAttemptService {
+	return service.NewAuthAttemptService(
+		pool,
+		repository.NewAuthAttemptRepository(pool),
+		repository.NewSessionRepository(pool),
+		repository.NewProjectRepository(pool),
+		repository.NewUserRepository(),
+		repository.NewUserPasswordRepository(),
+		repository.NewUserPasskeyRepository(),
+		nil,
+	)
+}
+
+// issueUserChallenge creates a fresh attempt and binds a user challenge,
+// returning the ids needed to drive VerifyProof.
+func issueUserChallenge(t *testing.T, svc service.AuthAttemptService, projectID string) (attemptID, challengeID string) {
+	t.Helper()
+	attempt, err := svc.Create(t.Context(), service.CreateAuthAttemptInput{ProjectID: projectID})
+	require.NoError(t, err)
+
+	issued, err := svc.IssueChallenge(t.Context(), service.IssueChallengeInput{
+		ProjectID: projectID,
+		AttemptID: attempt.ID,
+		Challenge: service.UserChallenge{},
+	})
+	require.NoError(t, err)
+	ch, ok := issued.ChallengeByType(domain.AuthCheckTypeUser)
+	require.True(t, ok)
+	return attempt.ID, ch.GetID()
+}
+
+func TestAuthAttemptService_VerifyProof_integration(t *testing.T) {
+	pool := integrationPoolOrFail(t)
+	svc := newAuthAttemptServiceForIntegration(pool)
+
+	t.Run("user_not_found_records_failure_on_bound_challenge", func(t *testing.T) {
+		projectID := "p-aa-not-found-" + time.Now().Format("150405.000000")
+		ensureProject(t, pool, projectID)
+		attemptID, challengeID := issueUserChallenge(t, svc, projectID)
+
+		_, err := svc.VerifyProof(t.Context(), service.VerifyProofInput{
+			ProjectID:   projectID,
+			AttemptID:   attemptID,
+			ChallengeID: challengeID,
+			Proof:       service.UserProof{AttributeName: "email", LoginName: "ghost@example.com"},
+		})
+		require.ErrorIs(t, err, domain.ErrAuthAttemptProofRejected(nil))
+
+		attempt, err := svc.GetByID(t.Context(), projectID, attemptID)
+		require.NoError(t, err)
+		ch, ok := attempt.ChallengeByType(domain.AuthCheckTypeUser)
+		require.True(t, ok)
+		assert.Equal(t, uint16(1), ch.GetFailureCount())
+		assert.False(t, ch.GetLastFailedAt().IsZero())
+	})
+
+	t.Run("stale_challenge_id_leaves_row_untouched", func(t *testing.T) {
+		projectID := "p-aa-stale-" + time.Now().Format("150405.000000")
+		ensureProject(t, pool, projectID)
+		attemptID, _ := issueUserChallenge(t, svc, projectID)
+
+		_, err := svc.VerifyProof(t.Context(), service.VerifyProofInput{
+			ProjectID:   projectID,
+			AttemptID:   attemptID,
+			ChallengeID: "ch_does_not_exist",
+			Proof:       service.UserProof{AttributeName: "email", LoginName: "alice@example.com"},
+		})
+		require.ErrorIs(t, err, domain.ErrAuthAttemptStaleChallenge())
+
+		attempt, err := svc.GetByID(t.Context(), projectID, attemptID)
+		require.NoError(t, err)
+		ch, ok := attempt.ChallengeByType(domain.AuthCheckTypeUser)
+		require.True(t, ok)
+		assert.Zero(t, ch.GetFailureCount())
+		assert.True(t, ch.GetLastFailedAt().IsZero())
+	})
+}

--- a/internal/service/auth_attempt_test.go
+++ b/internal/service/auth_attempt_test.go
@@ -459,7 +459,7 @@ func TestAuthAttemptService_VerifyProof(t *testing.T) {
 			},
 		},
 		{
-			name:  "stale challenge returns error and records failure",
+			name:  "stale challenge returns error without recording failure",
 			repo:  &fakeAuthAttemptRepo{getByIDAttempt: newUserChallengeAttempt()},
 			users: &fakeUserLookup{user: &domain.User{ID: "user-1"}},
 			input: service.VerifyProofInput{ProjectID: "proj", AttemptID: "att-1", ChallengeID: "different", Proof: service.UserProof{AttributeName: "email", LoginName: "u@example.com"}},
@@ -471,11 +471,9 @@ func TestAuthAttemptService_VerifyProof(t *testing.T) {
 				if !errors.Is(err, domain.ErrAuthAttemptStaleChallenge()) {
 					t.Fatalf("VerifyProof err = %v, want ErrAuthAttemptStaleChallenge", err)
 				}
-				if repo.challengeFailedCalls != 1 {
-					t.Fatalf("ChallengeFailed called %d times, want 1", repo.challengeFailedCalls)
-				}
-				if repo.challengeFailedValue != nil {
-					t.Fatalf("ChallengeFailed challenge = %v, want nil for stale challenge", repo.challengeFailedValue)
+				// Prepare-phase failure: no challenge row to update, skip ChallengeFailed.
+				if repo.challengeFailedCalls != 0 {
+					t.Fatalf("ChallengeFailed called %d times, want 0", repo.challengeFailedCalls)
 				}
 			},
 		},
@@ -495,8 +493,8 @@ func TestAuthAttemptService_VerifyProof(t *testing.T) {
 				if repo.challengeFailedCalls != 1 {
 					t.Fatalf("ChallengeFailed called %d times, want 1", repo.challengeFailedCalls)
 				}
-				if repo.challengeFailedValue != nil {
-					t.Fatalf("ChallengeFailed challenge = %v, want nil for rejected proof", repo.challengeFailedValue)
+				if _, ok := repo.challengeFailedValue.(*domain.AuthChallengeUser); !ok {
+					t.Fatalf("ChallengeFailed challenge = %T, want *domain.AuthChallengeUser", repo.challengeFailedValue)
 				}
 			},
 		},


### PR DESCRIPTION
`AuthAttemptService.VerifyProof` panicked on any rejected proof in production: `verify()` returned a nil challenge on the user-lookup / password-mismatch paths and `VerifyProof` forwarded that nil to `pgAuthAttempt.ChallengeFailed`, which deref'd it. Unit tests used a fake repo that didn't deref, so the bug shipped untriggered.

## Changes

  - `verify()` returns the prepared challenge on proof rejection — `ChallengeFailed` now records on the right row.
  - `VerifyProof` skips `ChallengeFailed` when the challenge is nil — prepare-phase failures (stale id, expired attempt, wrong proof type)
  never bound a row.
  - Unit tests updated to the corrected semantics.

  ## Integration coverage

  Two tests under `-tags=integration` against the embedded Postgres pool (`internal/service/auth_attempt_integration_test.go`):

  - `VerifyProof_UserNotFound_integration` — reproduces the prod panic, asserts the failure counter bumps on the right challenge row.
  - `VerifyProof_StaleChallenge_integration` — asserts a stale id returns the right error without touching any row.