### PR TITLE
fix: change factors from object literal to array

### DIFF
--- a/packages/api-mock/src/server.ts
+++ b/packages/api-mock/src/server.ts
@@ -191,7 +191,7 @@ export function startMockServer(port: number): Server {
       // Spec: 200 returns `session-with-token-response.yaml` —
       // `{session: <SessionResponse>, session_token}`. The mock synthesises a
       // minimal session_response from the handoff claims: `state` is "active"
-      // (we just authenticated), `factors` is an empty record and
+      // (we just authenticated), `factors` is an empty list and
       // `assurance_levels` an empty list (the mock has no factor catalogue),
       // and the TTLs come from the session-cookie window so they stay
       // consistent with the JWT exp.
@@ -213,7 +213,7 @@ export function startMockServer(port: number): Server {
           session_id: `sess_${randomUUID().replace(/-/g, "").slice(0, 12)}`,
           project_id: "proj_mock",
           state: "active",
-          factors: {},
+          factors: [],
           assurance_levels: [],
           created_at: createdAt.toISOString(),
           expires_at: expiresAt.toISOString(),


### PR DESCRIPTION
## What problems are solved

`ci/node-check` and `ci/node-e2e` have been failing on every PR (including `main`) with this error in `@zitadel-nextgen/api-mock:typecheck`:

```
src/server.ts:216:11 - error TS2740: Type '{}' is missing the following properties
from type 'ExchangeHandoff200SessionFactorsItem[]': length, pop, push, concat, and 29 more.

216           factors: {},
```

The cascading `TS6305` errors in the spec files (`index.spec.ts`, `index.browser.spec.ts`, `spec-conformance.spec.ts`) are secondary — they appear because `tsgo --build` aborts on the first error, leaving no `.d.ts` output files for the specs to import.

## How the problems are solved

The generated type `ExchangeHandoff200Session` (in `@zitadel-nextgen/api/dist/generated/model/exchangeHandoff200Session.d.ts`) declares `factors` as `ExchangeHandoff200SessionFactorsItem[]`. At some point the spec or codegen was updated to change `factors` from a map/record to an array, but the mock server's response literal was not updated alongside it.

Two-character fix in `packages/api-mock/src/server.ts`:

```diff
- factors: {},
+ factors: [],
```

The comment above the block was also updated to say "empty list" instead of "empty record".