### PR TITLE
fix: satisfy noUncheckedIndexedAccess in JWT payload decode

### DIFF
--- a/packages/api-mock/src/index.spec.ts
+++ b/packages/api-mock/src/index.spec.ts
@@ -15,6 +15,23 @@ import {
 import type { MockHandle } from "./handlers.js";
 
 const PROJECT_ID = "demo-project";
+
+/**
+ * Decode the payload of a JWT without verifying its signature. Used by the
+ * handoff-token assertions below to inspect the `sub` claim — the standalone
+ * `/sessions/exchange` endpoint already verifies the signature elsewhere.
+ */
+function decodeJwtPayload(token: string): { sub: string } {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error(`expected three JWT parts, got ${parts.length}`);
+  }
+  const [, payload] = parts as [string, string, string];
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+    sub: string;
+  };
+}
+
 const server = setupServer();
 let mock: MockHandle = setupMockHandlers();
 
@@ -235,10 +252,7 @@ describe("setupMockHandlers", () => {
     });
     expect(done.step.name).toBe("done");
     expect(done.handoff_token).toBeTruthy();
-    const payload = JSON.parse(
-      Buffer.from(done.handoff_token!.split(".")[1], "base64url").toString("utf8"),
-    ) as { sub: string };
-    expect(payload.sub).toBe("alice@acme.com");
+    expect(decodeJwtPayload(done.handoff_token ?? "").sub).toBe("alice@acme.com");
   });
 
   test("passkey-login: discoverable credential carries authenticated user into handoff token", async () => {
@@ -260,10 +274,7 @@ describe("setupMockHandlers", () => {
     });
     expect(done.step.name).toBe("done");
     expect(done.handoff_token).toBeTruthy();
-    const payload = JSON.parse(
-      Buffer.from(done.handoff_token!.split(".")[1], "base64url").toString("utf8"),
-    ) as { sub: string };
-    expect(payload.sub).toBe("bob@example.com");
+    expect(decodeJwtPayload(done.handoff_token ?? "").sub).toBe("bob@example.com");
   });
 
   test("passkey-login: unregistered credential stays on passkey-login with error", async () => {


### PR DESCRIPTION
The handoff-token assertions added in #151 use `done.handoff_token!.split(".")[1]`, which is `string | undefined` under `noUncheckedIndexedAccess`. `Buffer.from` rejects `undefined`, so `tsc` fails under `tsconfig.spec.json`. This landed on main while CI was still reporting node-check and node-e2e failures, so main is currently red.

Extract a small `decodeJwtPayload` helper that validates the structure and destructures into a typed tuple, so callers can pass the token directly without a non-null assertion on the segment.