### PR TITLE
feat: step-prefixed localization keys + drop cookie path

### DIFF
--- a/internal/api/branding/default.liquid
+++ b/internal/api/branding/default.liquid
@@ -1,52 +1,103 @@
-{% comment %}
-  Default LiquidJS template for the flow engine MVP. Rendered by the
-  orchestrator into Shadow DOM. Customers can replace it via the
-  Team/App Branding API once that endpoint ships.
-
-  Available context:
-    step.name             - step identifier
-    step.error            - optional error key
-    step.fields           - dictionary of {name -> field}
-    step.actions          - dictionary of {name -> action}
-    step.complete         - "redirect" | "show" | null
-    step.redirect_url     - present when complete == "redirect"
-{% endcomment %}
-
-<section class="zl-flow zl-flow--{{ step.name }}">
-  {% if step.error %}
-    <p class="zl-flow__error" role="alert">{{ step.error | t }}</p>
+<zl-page-shell data-zl-template-root>
+  {% if branding.logo_url %}
+    <img slot="header" class="zl-card-logo" src="{{ branding.logo_url }}" alt="" />
   {% endif %}
+  <zl-card>
+    <h1 slot="header" class="zl-card-title">{{ step.texts.title_key | t: identity.display_name }}</h1>
+    {% if step.texts.description_key %}
+      <p slot="header" class="zl-card-subtitle">{{ step.texts.description_key | t: identity.display_name }}</p>
+    {% endif %}
 
-  {% if step.complete == "show" %}
-    <p class="zl-flow__done">{{ step.name | t }}</p>
-  {% else %}
-    <form class="zl-flow__form">
-      {% for entry in step.fields %}
-        {% assign name = entry[0] %}
-        {% assign field = entry[1] %}
-        <label class="zl-flow__field">
-          <span>{{ field.text_key | t }}</span>
-          <input
-            name="{{ name }}"
-            type="{{ field.type }}"
-            {% if field.required %}required{% endif %}
-            {% if field.value %}value="{{ field.value }}"{% endif %}
-          />
-        </label>
+    {% if errors and errors.size > 0 %}
+      {% for err in errors %}
+        {% if err | formLevelError %}
+          {% assign alert_heading = err.text_key | alertHeading %}
+          {% assign alert_body = err.text_key | alertBody %}
+          <zl-alert severity="error"{% if alert_heading != "" %} heading="{{ alert_heading | t }}"{% endif %}>
+            {% if alert_body != "" %}{{ alert_body | t }}{% elsif err.text_key %}{{ err.text_key | t }}{% else %}{{ err.message }}{% endif %}
+          </zl-alert>
+        {% endif %}
       {% endfor %}
+    {% endif %}
 
-      <div class="zl-flow__actions">
-        {% for entry in step.actions %}
-          {% assign name = entry[0] %}
-          {% assign action = entry[1] %}
-          <button
-            type="submit"
-            name="action"
-            value="{{ name }}"
-            {% if action.primary %}class="zl-flow__action--primary"{% endif %}
-          >{{ action.text_key | t }}</button>
-        {% endfor %}
-      </div>
-    </form>
-  {% endif %}
-</section>
+    {% for entry in fields %}
+      {% assign field_placeholder = entry[1].text_key | fieldPlaceholder %}
+      {% assign field_help = entry[1].text_key | fieldHelp %}
+      {% assign field_err = entry[0] | fieldError: errors %}
+      {% assign autocomplete_val = '' %}
+      {% if entry[0] == 'email' %}
+        {% assign autocomplete_val = 'email' %}
+      {% elsif entry[1].type == 'password' and step.name == 'register' %}
+        {% assign autocomplete_val = 'new-password' %}
+      {% elsif entry[1].type == 'password' %}
+        {% assign autocomplete_val = 'current-password' %}
+      {% endif %}
+      <zl-field
+        name="{{ entry[0] }}"
+        label="{{ entry[1].text_key | t }}"
+        type="{{ entry[1].type }}"
+        value="{{ entry[1].value }}"
+        {% if autocomplete_val != '' %}autocomplete="{{ autocomplete_val }}"{% endif %}
+        {% if entry[1].required %}required{% endif %}
+        {% if field_placeholder != "" %}placeholder="{{ field_placeholder }}"{% endif %}
+        {% if field_err != "" %}invalid error="{{ field_err }}"{% endif %}
+      >
+        {% if field_help != "" %}
+          <span slot="help">{{ field_help }}</span>
+        {% endif %}
+      </zl-field>
+    {% endfor %}
+
+    {% if fields.email and fields.password and step.name == 'identifier' %}
+      <p class="zl-card-forgot">
+        <a href="#" class="zl-card-forgot__link" data-action="recover">{{ 'action.forgot_password' | t }}</a>
+      </p>
+    {% endif %}
+
+    {% for entry in actions %}
+      {% if entry[1].primary %}
+        <zl-button
+          hierarchy="primary"
+          size="medium"
+          type="submit"
+          block
+          action="{{ entry[0] }}"
+          label="{{ entry[1].text_key | t }}"
+          {% if loading %}loading{% endif %}
+        ></zl-button>
+      {% endif %}
+    {% endfor %}
+
+    {% if actions.passkey %}
+      <zl-button
+        hierarchy="secondary"
+        size="medium"
+        block
+        action="passkey"
+        label="{{ actions.passkey.text_key | t }}"
+      ></zl-button>
+    {% endif %}
+
+    {% if actions.register %}
+      <p class="zl-card-nav">
+        {{ 'identifier.action.register.lead' | t }}<a href="#" class="zl-card-nav__link" data-action="register">{{ 'identifier.action.register.link' | t }}</a>
+      </p>
+    {% endif %}
+
+    {% if actions.sign_in %}
+      <p class="zl-card-nav">
+        {{ 'register.action.sign_in.lead' | t }}<a href="#" class="zl-card-nav__link" data-action="sign_in">{{ 'register.action.sign_in.link' | t }}</a>
+      </p>
+    {% endif %}
+
+    {% if challenge and challenge.method == "passkey" %}
+      <zl-passkey
+        ceremony="{{ challenge.options.ceremony | default: 'authenticate' }}"
+        challenge-id="{{ challenge.challenge_id }}"
+        options='{{ challenge.options | json }}'
+      ></zl-passkey>
+    {% endif %}
+
+    {% mandatory_gates %}
+  </zl-card>
+</zl-page-shell>

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	flowCookieName          = "_zflow"
-	flowCookiePath          = "/flow"
 	flowCookieMaxAgeSeconds = 600
 )
 
@@ -195,7 +194,6 @@ func (h *Handler)sealState(state *domain.FlowState) (string, error) {
 func flowSetCookie(value string, clear bool) string {
 	c := &http.Cookie{
 		Name:     flowCookieName,
-		Path:     flowCookiePath,
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
@@ -230,6 +228,7 @@ func toFlowStep(step *domain.FlowStep) api.FlowStep {
 	}
 	out := api.FlowStep{
 		Name:    step.Name,
+		Texts:   api.NewOptStepTexts(toStepTexts(step.Texts)),
 		Fields:  toFlowStepFields(step.Fields),
 		Actions: toFlowStepActions(step.Actions),
 		Gates:   api.FlowStepGates{},
@@ -244,6 +243,17 @@ func toFlowStep(step *domain.FlowStep) api.FlowStep {
 		if u, err := parseURI(*step.RedirectURL); err == nil {
 			out.RedirectURL = api.NewOptURI(u)
 		}
+	}
+	return out
+}
+
+func toStepTexts(t domain.FlowStepTexts) api.StepTexts {
+	out := api.StepTexts{}
+	if t.TitleKey != "" {
+		out.TitleKey = api.NewOptString(t.TitleKey)
+	}
+	if t.DescriptionKey != "" {
+		out.DescriptionKey = api.NewOptNilString(t.DescriptionKey)
 	}
 	return out
 }

--- a/internal/domain/flow_field_resolver.go
+++ b/internal/domain/flow_field_resolver.go
@@ -18,8 +18,10 @@ import (
 // api/openapi/endpoints/schemas/user-schema.yaml.
 type FlowFieldResolver interface {
 	// Resolve returns the per-field metadata for fieldNames sourced
-	// from the user schema at userSchemaURL.
-	Resolve(ctx context.Context, client database.QueryExecutor, projectID, userSchemaURL string, fieldNames []string) (FlowResolvedFields, error)
+	// from the user schema at userSchemaURL. stepName is the flow
+	// step the fields are being resolved for; it prefixes each
+	// field's text_key (`<stepName>.field.<name>`).
+	Resolve(ctx context.Context, client database.QueryExecutor, projectID, userSchemaURL, stepName string, fieldNames []string) (FlowResolvedFields, error)
 
 	// Validate checks submitted values against the rules carried by a
 	// previously resolved field set.

--- a/internal/domain/flow_field_resolver_schema.go
+++ b/internal/domain/flow_field_resolver_schema.go
@@ -49,7 +49,7 @@ var _ FlowFieldResolver = (*SchemaFieldResolver)(nil)
 func (r *SchemaFieldResolver) Resolve(
 	ctx context.Context,
 	client database.QueryExecutor,
-	projectID, userSchemaURL string,
+	projectID, userSchemaURL, stepName string,
 	fieldNames []string,
 ) (FlowResolvedFields, error) {
 	schema, err := r.schemas.Resolve(ctx, client, projectID, userSchemaURL, nil)
@@ -69,7 +69,7 @@ func (r *SchemaFieldResolver) Resolve(
 		if !ok {
 			return FlowResolvedFields{}, fmt.Errorf("%w: %q", ErrFlowFieldUnknown, name)
 		}
-		field := buildFlowField(name, propSchema, required, passwordEnabled)
+		field := buildFlowField(stepName, name, propSchema, required, passwordEnabled)
 		fields[name] = field
 		if outcomes := ImplicitOutcomesForChallenge(field.Challenge); len(outcomes) > 0 {
 			implicit[name] = append(implicit[name], outcomes...)
@@ -83,10 +83,10 @@ func (r *SchemaFieldResolver) Resolve(
 }
 
 // buildFlowField translates a user-schema property into a [FlowField].
-func buildFlowField(name string, propSchema *jsonschema.Schema, required map[string]struct{}, passwordEnabled bool) FlowField {
+func buildFlowField(stepName, name string, propSchema *jsonschema.Schema, required map[string]struct{}, passwordEnabled bool) FlowField {
 	unique := deriveUnique(propSchema)
 	field := FlowField{
-		TextKey:   "field." + name,
+		TextKey:   stepName + ".field." + name,
 		Type:      deriveFieldType(propSchema),
 		Challenge: deriveChallenge(propSchema, unique, passwordEnabled),
 		Unique:    unique,

--- a/internal/domain/flow_field_resolver_schema_test.go
+++ b/internal/domain/flow_field_resolver_schema_test.go
@@ -71,7 +71,7 @@ func newDefaultResolver(t *testing.T) *domain.SchemaFieldResolver {
 func TestSchemaFieldResolver_Resolve_DefaultFields(t *testing.T) {
 	resolver := newDefaultResolver(t)
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL,
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "identifier",
 		[]string{"email", "username", "password", "given_name", "family_name"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
@@ -82,11 +82,11 @@ func TestSchemaFieldResolver_Resolve_DefaultFields(t *testing.T) {
 		wantType    domain.FlowFieldType
 		wantTextKey string
 	}{
-		{"email", domain.FlowFieldTypeEmail, "field.email"},
-		{"username", domain.FlowFieldTypeText, "field.username"},
-		{"password", domain.FlowFieldTypePassword, "field.password"},
-		{"given_name", domain.FlowFieldTypeText, "field.given_name"},
-		{"family_name", domain.FlowFieldTypeText, "field.family_name"},
+		{"email", domain.FlowFieldTypeEmail, "identifier.field.email"},
+		{"username", domain.FlowFieldTypeText, "identifier.field.username"},
+		{"password", domain.FlowFieldTypePassword, "identifier.field.password"},
+		{"given_name", domain.FlowFieldTypeText, "identifier.field.given_name"},
+		{"family_name", domain.FlowFieldTypeText, "identifier.field.family_name"},
 	}
 	for _, tc := range tests {
 		f, ok := got.Fields[tc.name]
@@ -109,7 +109,7 @@ func TestSchemaFieldResolver_Resolve_DefaultFields(t *testing.T) {
 func TestSchemaFieldResolver_Resolve_IdentifierImpliesUserNotFound(t *testing.T) {
 	resolver := newDefaultResolver(t)
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, []string{"email", "password"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "step", []string{"email", "password"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestSchemaFieldResolver_Resolve_IdentifierImpliesUserNotFound(t *testing.T)
 func TestSchemaFieldResolver_Resolve_ChallengeSurfaces(t *testing.T) {
 	resolver := newDefaultResolver(t)
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, []string{"email", "password", "given_name"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "step", []string{"email", "password", "given_name"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestSchemaFieldResolver_Resolve_PasswordChallengeRequiresAuthMethodEnabled(
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, []string{"password"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, "step", []string{"password"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestSchemaFieldResolver_Resolve_PasswordChallengeRequiresXPassword(t *testi
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, []string{"password"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, "step", []string{"password"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestSchemaFieldResolver_Resolve_RenamedPasswordField(t *testing.T) {
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, []string{"secret"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, "step", []string{"secret"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestSchemaFieldResolver_Resolve_RenamedPasswordField(t *testing.T) {
 func TestSchemaFieldResolver_Resolve_UniqueScopeSurfaces(t *testing.T) {
 	resolver := newDefaultResolver(t)
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, []string{"email", "password"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "step", []string{"email", "password"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestSchemaFieldResolver_Resolve_UniqueScopeProject(t *testing.T) {
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, []string{"handle"})
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, "step", []string{"handle"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestSchemaFieldResolver_Resolve_UniqueScopeProject(t *testing.T) {
 func TestSchemaFieldResolver_Resolve_UnknownField(t *testing.T) {
 	resolver := newDefaultResolver(t)
 
-	_, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, []string{"not_in_schema"})
+	_, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "step", []string{"not_in_schema"})
 	if !errors.Is(err, domain.ErrFlowFieldUnknown) {
 		t.Fatalf("Resolve err = %v, want ErrFlowFieldUnknown", err)
 	}
@@ -263,7 +263,7 @@ func TestSchemaFieldResolver_Resolve_UnknownField(t *testing.T) {
 func TestSchemaFieldResolver_Resolve_SchemaLoadFailurePropagates(t *testing.T) {
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, nil))
 
-	_, err := resolver.Resolve(t.Context(), nil, testProjectID, "https://example.test/missing.json", []string{"email"})
+	_, err := resolver.Resolve(t.Context(), nil, testProjectID, "https://example.test/missing.json", "step", []string{"email"})
 	if err == nil {
 		t.Fatal("Resolve err = nil, want load failure")
 	}
@@ -283,7 +283,7 @@ func TestSchemaFieldResolver_Resolve_FormatAndTypeVariants(t *testing.T) {
 	}`)
 	resolver := domain.NewSchemaFieldResolver(newFakeResolver(t, map[string][]byte{url: bytes}))
 
-	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url,
+	got, err := resolver.Resolve(t.Context(), nil, testProjectID, url, "step",
 		[]string{"website", "birthday", "created", "nickname"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)

--- a/internal/domain/flow_field_validation_test.go
+++ b/internal/domain/flow_field_validation_test.go
@@ -13,7 +13,7 @@ import (
 func resolveDefaultFields(t *testing.T) domain.FlowResolvedFields {
 	t.Helper()
 	resolver := newDefaultResolver(t)
-	fields, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL,
+	fields, err := resolver.Resolve(t.Context(), nil, testProjectID, defaultSchemaURL, "step",
 		[]string{"email", "username", "password", "given_name", "family_name"})
 	if err != nil {
 		t.Fatalf("Resolve returned error: %v", err)

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -64,12 +64,20 @@ type FlowStepResult struct {
 // It mirrors the OpenAPI `flow-step` component in domain terms.
 type FlowStep struct {
 	Name         string
+	Texts        FlowStepTexts
 	Error        *string
 	Complete     *FlowStepComplete
 	RedirectURL  *string
 	Fields       map[string]FlowField
 	Actions      map[string]FlowAction
 	SSOProviders []FlowSSOProvider
+}
+
+// FlowStepTexts holds the step-level localization keys (`<step>.title`,
+// `<step>.description`) the template resolves via the `| t` filter.
+type FlowStepTexts struct {
+	TitleKey       string
+	DescriptionKey string
 }
 
 // FlowAction is a single user action surfaced on [FlowStep.Actions].
@@ -447,7 +455,7 @@ func (r *FlowStateMachineRuntime) resolveStepFields(ctx context.Context, client 
 	if len(step.Fields) == 0 {
 		return FlowResolvedFields{}, nil
 	}
-	resolved, err := r.fields.Resolve(ctx, client, projectID, userSchemaURL, step.Fields)
+	resolved, err := r.fields.Resolve(ctx, client, projectID, userSchemaURL, step.Name, step.Fields)
 	if err != nil {
 		return FlowResolvedFields{}, fmt.Errorf("flow state machine: resolve fields on step %q: %w", step.Name, err)
 	}
@@ -471,6 +479,7 @@ func (r *FlowStateMachineRuntime) buildStep(step *FlowDefinitionStep, resolved F
 	}
 	return &FlowStep{
 		Name:         step.Name,
+		Texts:        FlowStepTexts{TitleKey: step.Name + ".title", DescriptionKey: step.Name + ".description"},
 		Error:        errorKey,
 		Complete:     complete,
 		RedirectURL:  redirectURL,


### PR DESCRIPTION
Stacked on #139. Four small tweaks to the flow HTTP surface:

- **`internal/api/branding/default.liquid`** — replace the MVP skeleton with the orchestrator's auth-form template (mirrors `packages/components/src/orchestrator/templates/auth-form.liquid.ts`).
- **`internal/api/flow.go`** — drop `Path=/flow` from the `_zflow` cookie so it's readable on whichever path the client mounts the flow under.
- **`FlowStep.Texts`** — `buildStep` emits `<step>.title` / `<step>.description`, matching the locale convention in `packages/components/src/orchestrator/locales/en.ts`.
- **Resolver `stepName` parameter** — `FlowFieldResolver.Resolve` builds each field's `text_key` as `<step>.field.<name>` directly.

## Test plan

- [x] `go build ./internal/... ./api/...`
- [x] `go test ./internal/api/... ./internal/domain/... ./internal/service/...`
- [ ] Manual: `POST /flow` returns `step.texts.title_key == "<step>.title"`, `fields.<name>.text_key == "<step>.field.<name>"`, and `Set-Cookie: _zflow` omits a `Path` attribute.