### PR TITLE
feat: make projectId configurable via env var

### DIFF
--- a/apps/demo-next/.env.example
+++ b/apps/demo-next/.env.example
@@ -1,0 +1,5 @@
+# URL of the Nextgen auth server
+NEXTGEN_ISSUER_URL=http://localhost:4000
+
+# Project ID passed to <zitadel-login project-id>
+# NEXT_PUBLIC_ZITADEL_PROJECT_ID=demo

--- a/apps/demo-next/README.md
+++ b/apps/demo-next/README.md
@@ -4,14 +4,37 @@ A minimal Next.js application demonstrating [Nextgen Auth](../../packages/sdk-ne
 
 ## Running locally
 
-Use **Nx** from the repo root (`corepack pnpm install` first). Two terminals:
+Use **Nx** from the repo root (`corepack pnpm install` first).
+
+### 1. Configure environment
+
+Copy the example env file and adjust as needed:
+
+```bash
+cp apps/demo-next/.env.example apps/demo-next/.env.local
+```
+
+Or pass them inline when starting the dev server (step 2).
+
+| Variable                          | Default                 | Description                                        |
+| --------------------------------- | ----------------------- | -------------------------------------------------- |
+| `NEXTGEN_ISSUER_URL`              | `http://localhost:4000` | URL of the Nextgen auth server                     |
+| `NEXT_PUBLIC_ZITADEL_PROJECT_ID`  | `demo`                  | Project ID passed to `<zitadel-login project-id>`  |
+
+### 2. Start
+
+Two terminals:
 
 ```bash
 # Terminal 1 — mock auth server on port 4000
 corepack pnpm nx start @zitadel-nextgen/api-mock
 
 # Terminal 2 — Next.js on port 3002
-NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @zitadel-nextgen/demo-next
+corepack pnpm nx dev @zitadel-nextgen/demo-next
+
+# …or with inline env overrides:
+# NEXTGEN_ISSUER_URL=https://my-instance.zitadel.cloud NEXT_PUBLIC_ZITADEL_PROJECT_ID=abc123 \
+#   corepack pnpm nx dev @zitadel-nextgen/demo-next
 ```
 
 Open [http://localhost:3002/login](http://localhost:3002/login). Any email/password combination is accepted by the mock server.
@@ -55,9 +78,3 @@ The demo imports the package from `dist/`, not source.
 **Login widget** (`src/app/login/widget.tsx`) dynamically imports `@zitadel-nextgen/components` with `ssr: false` so custom elements register only in the browser.
 
 **Fonts and branding** — the mock server ships a default `font_url` (Arimo via Google Fonts) on every flow response. `<zitadel-login>` injects it into its shadow root. Root `layout.tsx` sets `body { margin: 0; font-family: sans-serif; }`. **APK Futural** in heading tokens still needs a tenant font URL when you brand beyond the mock baseline.
-
-## Environment variables
-
-| Variable             | Default                   | Description                    |
-| -------------------- | ------------------------- | ------------------------------ |
-| `NEXTGEN_ISSUER_URL` | `http://localhost:4000`   | URL of the Nextgen auth server |

--- a/apps/demo-next/README.md
+++ b/apps/demo-next/README.md
@@ -6,6 +6,12 @@ A minimal Next.js application demonstrating [Nextgen Auth](../../packages/sdk-ne
 
 Use **Nx** from the repo root (`corepack pnpm install` first).
 
+Build the SDK (and its transitive dependencies) once before the first run:
+
+```bash
+corepack pnpm nx build @zitadel-nextgen/sdk-next
+```
+
 ### 1. Configure environment
 
 Copy the example env file and adjust as needed:

--- a/apps/demo-next/next-env.d.ts
+++ b/apps/demo-next/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/demo-next/src/app/login/widget.tsx
+++ b/apps/demo-next/src/app/login/widget.tsx
@@ -9,7 +9,7 @@ const ZitadelLogin = dynamic(
       return (
         <zitadel-login
           api-base="/__nextgen"
-          project-id="demo"
+          project-id={process.env.NEXT_PUBLIC_ZITADEL_PROJECT_ID ?? "demo"}
           post-sign-in-url="/admin"
         />
       );

--- a/apps/demo-nuxt/.env.example
+++ b/apps/demo-nuxt/.env.example
@@ -1,0 +1,5 @@
+# URL of the Nextgen auth server
+NEXTGEN_ISSUER_URL=http://localhost:4000
+
+# Project ID passed to <zitadel-login project-id>
+# NUXT_PUBLIC_ZITADEL_PROJECT_ID=demo

--- a/apps/demo-nuxt/README.md
+++ b/apps/demo-nuxt/README.md
@@ -6,6 +6,12 @@ A minimal Nuxt application demonstrating [Nextgen Auth](../../packages/sdk-nuxt)
 
 Use **Nx** from the repo root (`corepack pnpm install` first).
 
+Build the SDK (and its transitive dependencies) once before the first run:
+
+```bash
+corepack pnpm nx build @zitadel-nextgen/sdk-nuxt
+```
+
 ### 1. Configure environment
 
 Copy the example env file and adjust as needed:

--- a/apps/demo-nuxt/README.md
+++ b/apps/demo-nuxt/README.md
@@ -4,14 +4,37 @@ A minimal Nuxt application demonstrating [Nextgen Auth](../../packages/sdk-nuxt)
 
 ## Running locally
 
-Use **Nx** from the repo root (`corepack pnpm install` first). Two terminals:
+Use **Nx** from the repo root (`corepack pnpm install` first).
+
+### 1. Configure environment
+
+Copy the example env file and adjust as needed:
+
+```bash
+cp apps/demo-nuxt/.env.example apps/demo-nuxt/.env
+```
+
+Or pass them inline when starting the dev server (step 2).
+
+| Variable                          | Default                 | Description                                        |
+| --------------------------------- | ----------------------- | -------------------------------------------------- |
+| `NEXTGEN_ISSUER_URL`              | `http://localhost:4000` | URL of the Nextgen auth server                     |
+| `NUXT_PUBLIC_ZITADEL_PROJECT_ID`  | `demo`                  | Project ID passed to `<zitadel-login project-id>`  |
+
+### 2. Start
+
+Two terminals:
 
 ```bash
 # Terminal 1 — mock auth server on port 4000
 corepack pnpm nx start @zitadel-nextgen/api-mock
 
 # Terminal 2 — Nuxt on port 3001
-NEXTGEN_ISSUER_URL=http://localhost:4000 corepack pnpm nx dev @zitadel-nextgen/demo-nuxt
+corepack pnpm nx dev @zitadel-nextgen/demo-nuxt
+
+# …or with inline env overrides:
+# NEXTGEN_ISSUER_URL=https://my-instance.zitadel.cloud NUXT_PUBLIC_ZITADEL_PROJECT_ID=abc123 \
+#   corepack pnpm nx dev @zitadel-nextgen/demo-nuxt
 ```
 
 Open [http://localhost:3001/login](http://localhost:3001/login). Any email/password combination is accepted by the mock server.
@@ -60,9 +83,3 @@ The demo imports the package from `dist/`, not source.
 | `plugins/auth.server.ts` | Seeds `useState('nextgen-auth')` from verified middleware context |
 
 **Fonts and branding** — same as demo-next: the mock server applies `defaultDevBranding` (Arimo `font_url`), and `<zitadel-login>` injects it into its shadow root. `assets/css/demo-host.css` sets host `body` styles to match Next's `layout.tsx`. Heading tokens may still list **APK Futural** first — that face needs a tenant CDN URL in branding.
-
-## Environment variables
-
-| Variable             | Default                 | Description                    |
-| -------------------- | ----------------------- | ------------------------------ |
-| `NEXTGEN_ISSUER_URL` | `http://localhost:4000` | URL of the Nextgen auth server |

--- a/apps/demo-nuxt/nuxt.config.ts
+++ b/apps/demo-nuxt/nuxt.config.ts
@@ -11,6 +11,9 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {
     nextgenIssuerUrl: process.env.NEXTGEN_ISSUER_URL ?? "http://localhost:4000",
+    public: {
+      zitadelProjectId: process.env.NUXT_PUBLIC_ZITADEL_PROJECT_ID ?? "demo",
+    },
   },
   vite: {
     optimizeDeps: {

--- a/apps/demo-nuxt/pages/login.vue
+++ b/apps/demo-nuxt/pages/login.vue
@@ -11,7 +11,7 @@
     <ClientOnly>
       <zitadel-login
         api-base="/__nextgen"
-        project-id="demo"
+        :project-id="projectId"
         post-sign-in-url="/admin"
       />
     </ClientOnly>
@@ -20,6 +20,8 @@
 
 <script setup lang="ts">
 import type { ClientAuthResult } from "@zitadel-nextgen/sdk-nuxt";
+
+const { public: { zitadelProjectId: projectId } } = useRuntimeConfig();
 
 const auth = useState<ClientAuthResult>("nextgen-auth");
 if (auth.value?.isAuthenticated) {


### PR DESCRIPTION
The `project-id` attribute on `<zitadel-login>` was hardcoded to `"demo"` in both demo apps. This makes it configurable via environment variable so developers can point the demos at a real Zitadel instance without editing source.

**Changes:**
- `demo-next`: reads `NEXT_PUBLIC_ZITADEL_PROJECT_ID` (defaults to `"demo"`)
- `demo-nuxt`: reads `NUXT_PUBLIC_ZITADEL_PROJECT_ID` via `runtimeConfig.public` (defaults to `"demo"`)
- Added `.env.example` to both demos
- Rewrote README "Running locally" sections to clearly separate env configuration (copy `.env.example` or pass inline) from the run commands
