### PR TITLE
refactor: rename AttributeUniqueness Global to Project

### DIFF
--- a/internal/bootstrap/users/import.go
+++ b/internal/bootstrap/users/import.go
@@ -112,7 +112,7 @@ func buildCreateAttributes(attrs map[string]json.RawMessage) ([]*domain.CreateAt
 		}
 		scope := domain.AttributeUniquenessUnspecified
 		if key == attrKeyUsername {
-			scope = domain.AttributeUniquenessGlobal
+			scope = domain.AttributeUniquenessProject
 		}
 		attr, err := domain.NewCreateAttribute(key, value, scope)
 		if err != nil {

--- a/internal/domain/attribute.go
+++ b/internal/domain/attribute.go
@@ -19,7 +19,7 @@ type AttributeUniqueness int
 const (
 	AttributeUniquenessUnspecified AttributeUniqueness = iota
 	AttributeUniquenessTeam
-	AttributeUniquenessGlobal
+	AttributeUniquenessProject
 )
 
 type CreateAttribute struct {

--- a/internal/domain/flow_on_success_create_user.go
+++ b/internal/domain/flow_on_success_create_user.go
@@ -110,7 +110,7 @@ func findPasswordField(resolved map[string]FlowField, submitted map[string]any) 
 func attributeUniquenessFor(name, identifierName string, scope FlowFieldUniqueScope) AttributeUniqueness {
 	switch scope {
 	case FlowFieldUniqueScopeInstance:
-		return AttributeUniquenessGlobal
+		return AttributeUniquenessProject
 	case FlowFieldUniqueScopeOrganization:
 		return AttributeUniquenessTeam
 	}

--- a/internal/storage/database/dialect/postgres/migration/sql/000004_users.sql
+++ b/internal/storage/database/dialect/postgres/migration/sql/000004_users.sql
@@ -77,7 +77,7 @@ CREATE TABLE zitadel_nextgen.user_attributes_part_3 PARTITION OF zitadel_nextgen
 CREATE TABLE zitadel_nextgen.user_unique_attributes (
     project_id TEXT NOT NULL COLLATE "C"
     , user_id TEXT NOT NULL COLLATE "C"
-    , team_id TEXT NOT NULL COLLATE "C" -- empty string if global
+    , team_id TEXT NOT NULL COLLATE "C" -- empty string if project-scoped
     , key TEXT NOT NULL COLLATE "C"
     , value_hash BYTEA NOT NULL -- raw binary SHA-256
     , PRIMARY KEY (project_id, team_id, key, value_hash)
@@ -172,7 +172,7 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE TYPE zitadel_nextgen.uniqueness_scope AS ENUM (
     'unspecified',
     'team',
-    'global'
+    'project'
 );
 
 CREATE TYPE zitadel_nextgen.incoming_user_attribute AS (

--- a/internal/storage/database/dialect/postgres/migration/sql/user_examples/create.sql
+++ b/internal/storage/database/dialect/postgres/migration/sql/user_examples/create.sql
@@ -26,7 +26,7 @@ _registry AS (
     )
     SELECT
         $1, $3,
-        CASE WHEN unique_scope = 'global' THEN ''::text ELSE $4 END,
+        CASE WHEN unique_scope = 'project' THEN ''::text ELSE $4 END,
         key, value_hash
     FROM _input_data
     WHERE unique_scope <> 'unspecified'
@@ -51,8 +51,8 @@ EXECUTE insert_user(
     , 'usr_99999999'
     , 'team_0001'
 , ARRAY[
-        ROW('username'::TEXT,           '"tester_alpha"'::JSONB,        digest('"tester_alpha"'::text, 'md5'),          'global'::TEXT)::zitadel_nextgen.incoming_user_attribute
-        , ROW('email'::TEXT,            '"tester@zitadel.com"'::JSONB,  digest('"tester@zitadel.com"'::text, 'md5'),    'global'::TEXT)::zitadel_nextgen.incoming_user_attribute
+        ROW('username'::TEXT,           '"tester_alpha"'::JSONB,        digest('"tester_alpha"'::text, 'md5'),          'project'::TEXT)::zitadel_nextgen.incoming_user_attribute
+        , ROW('email'::TEXT,            '"tester@zitadel.com"'::JSONB,  digest('"tester@zitadel.com"'::text, 'md5'),    'project'::TEXT)::zitadel_nextgen.incoming_user_attribute
         , ROW('email_verified'::TEXT,   'true'::JSONB,                  null,                                              'unspecified'::TEXT)::zitadel_nextgen.incoming_user_attribute
         , ROW('nickname'::TEXT,         '"TheAlpha"'::JSONB,            digest('"TheAlpha"'::text, 'md5'),              'organization'::TEXT)::zitadel_nextgen.incoming_user_attribute
         , ROW('address.country'::TEXT,  '"Netherlands"'::JSONB,         null,                                              'unspecified'::TEXT)::zitadel_nextgen.incoming_user_attribute

--- a/internal/storage/database/dialect/postgres/migration/sql/user_examples/patch.sql
+++ b/internal/storage/database/dialect/postgres/migration/sql/user_examples/patch.sql
@@ -31,7 +31,7 @@ _ins_registry AS (
     INSERT INTO zitadel_nextgen.user_unique_attributes (
         project_id, user_id, team_id, key, value_hash
     )
-    SELECT $1, $2, CASE WHEN unique_scope = 'global' THEN '' ELSE COALESCE(h.team_id, '')::text END, key, value_hash
+    SELECT $1, $2, CASE WHEN unique_scope = 'project' THEN '' ELSE COALESCE(h.team_id, '')::text END, key, value_hash
     FROM _input_upsert, _header h
     WHERE unique_scope <> 'unspecified'
 ),

--- a/internal/storage/database/dialect/postgres/migration/sql/user_examples/put.sql
+++ b/internal/storage/database/dialect/postgres/migration/sql/user_examples/put.sql
@@ -40,7 +40,7 @@ WITH _header AS (
         h.project_id
         , h.id AS user_id
         , CASE
-            WHEN d.unique_scope = 'global'::zitadel_nextgen.uniqueness_scope THEN ''::text
+            WHEN d.unique_scope = 'project'::zitadel_nextgen.uniqueness_scope THEN ''::text
             ELSE COALESCE(h.team_id, '')::text
           END AS team_id
         , d.key
@@ -49,7 +49,7 @@ WITH _header AS (
     CROSS JOIN _header h
     WHERE d.unique_scope IN (
             'team'::zitadel_nextgen.uniqueness_scope
-            , 'global'::zitadel_nextgen.uniqueness_scope
+            , 'project'::zitadel_nextgen.uniqueness_scope
         )
       AND d.value_hash IS NOT NULL
 )

--- a/internal/storage/database/repository/user.go
+++ b/internal/storage/database/repository/user.go
@@ -143,7 +143,7 @@ _registry AS (
         project_id, user_id, team_id, key, value_hash
     )
     SELECT h.project_id, h.id,
-           CASE WHEN d.unique_scope = 'global'::zitadel_nextgen.uniqueness_scope
+           CASE WHEN d.unique_scope = 'project'::zitadel_nextgen.uniqueness_scope
                 THEN ''
                 ELSE COALESCE(h.team_id, '')::text
            END,

--- a/internal/storage/database/repository/user_helpers.go
+++ b/internal/storage/database/repository/user_helpers.go
@@ -85,8 +85,8 @@ func uniquenessScopeLiteral(scope domain.AttributeUniqueness) string {
 		return "unspecified"
 	case domain.AttributeUniquenessTeam:
 		return "team"
-	case domain.AttributeUniquenessGlobal:
-		return "global"
+	case domain.AttributeUniquenessProject:
+		return "project"
 	default:
 		return "unspecified"
 	}


### PR DESCRIPTION
- Rename `AttributeUniquenessGlobal` → `AttributeUniquenessProject` (We are still unsure if cross-project uniqueness is also needed)
- Rename the matching `'global'` value in the `uniqueness_scope` Postgres enum to `'project'` (safe, no data yet)