### PR TITLE
chore: Set timeouts for all ci steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
 
   node-e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   go-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       # lint openapi
@@ -42,6 +43,7 @@ jobs:
 
   go-integration-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -54,6 +56,7 @@ jobs:
 
   go-integration-test-spanner:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -65,6 +68,7 @@ jobs:
 
   node-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -158,6 +162,7 @@ jobs:
 
   npm-pack-smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: node-check
     steps:
       - uses: actions/checkout@v6
@@ -208,6 +213,7 @@ jobs:
 
   goreleaser-snapshot:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [go-test, go-integration-test, go-integration-test-spanner, node-check]
     steps:
       - name: Checkout


### PR DESCRIPTION
Configure a timeout of 15 minutes for all ci steps to improve workflow reliability.