### PR TITLE
fix: emit per-field validation block on flow step responses

### DIFF
--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -5591,12 +5591,6 @@ func (s *FieldValidation) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.Pattern.Set {
-			e.FieldStart("pattern")
-			s.Pattern.Encode(e)
-		}
-	}
-	{
 		if s.MinLength.Set {
 			e.FieldStart("min_length")
 			s.MinLength.Encode(e)
@@ -5610,11 +5604,10 @@ func (s *FieldValidation) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfFieldValidation = [4]string{
+var jsonFieldsNameOfFieldValidation = [3]string{
 	0: "format",
-	1: "pattern",
-	2: "min_length",
-	3: "max_length",
+	1: "min_length",
+	2: "max_length",
 }
 
 // Decode decodes FieldValidation from json.
@@ -5634,16 +5627,6 @@ func (s *FieldValidation) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"format\"")
-			}
-		case "pattern":
-			if err := func() error {
-				s.Pattern.Reset()
-				if err := s.Pattern.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"pattern\"")
 			}
 		case "min_length":
 			if err := func() error {
@@ -5685,6 +5668,50 @@ func (s *FieldValidation) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *FieldValidation) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes FieldValidationFormat as json.
+func (s FieldValidationFormat) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes FieldValidationFormat from json.
+func (s *FieldValidationFormat) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode FieldValidationFormat to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch FieldValidationFormat(v) {
+	case FieldValidationFormatEmail:
+		*s = FieldValidationFormatEmail
+	case FieldValidationFormatDateTime:
+		*s = FieldValidationFormatDateTime
+	case FieldValidationFormatUUID:
+		*s = FieldValidationFormatUUID
+	case FieldValidationFormatURI:
+		*s = FieldValidationFormatURI
+	default:
+		*s = FieldValidationFormat(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s FieldValidationFormat) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *FieldValidationFormat) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -14266,6 +14293,39 @@ func (s OptFieldValidation) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptFieldValidation) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes FieldValidationFormat as json.
+func (o OptFieldValidationFormat) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Str(string(o.Value))
+}
+
+// Decode decodes FieldValidationFormat from json.
+func (o *OptFieldValidationFormat) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptFieldValidationFormat to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptFieldValidationFormat) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptFieldValidationFormat) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -2312,12 +2312,25 @@ func (s *FactorMethod) UnmarshalText(data []byte) error {
 // Does not contain display text — only a `text_key` resolved client-side.
 // Ref: #
 type Field struct {
+	// The input kind the client should render. Encodes the formats that
+	// have a matching HTML input type (email, url, date). For other
+	// formats (e.g. uuid) the type is `text` and `validation.format`
+	// carries the rule.
 	Type FieldType `json:"type"`
 	// Localization key for the field label.
-	TextKey  string  `json:"text_key"`
+	TextKey string `json:"text_key"`
+	// The field MUST be present and non-empty on submit. Mirrors the
+	// schema's top-level `required` array.
 	Required OptBool `json:"required"`
-	// Pre-filled value (e.g., email carried over from a pivot).
-	Value      jx.Raw             `json:"value"`
+	// Pre-filled value (e.g., an identifier carried over from a pivot).
+	Value jx.Raw `json:"value"`
+	// Schema-derived rules the frontend SHOULD apply at input time. The
+	// server runs the same rules on submit and is the only authority on
+	// whether the step advances — these rules are a UX hint to reduce
+	// round trips, not a contract guarantee.
+	// Omitted entirely when the field has no rules beyond its `type`.
+	// Each key mirrors a JSON Schema keyword on the underlying user
+	// property; absent keys mean no rule.
 	Validation OptFieldValidation `json:"validation"`
 }
 
@@ -2371,6 +2384,10 @@ func (s *Field) SetValidation(val OptFieldValidation) {
 	s.Validation = val
 }
 
+// The input kind the client should render. Encodes the formats that
+// have a matching HTML input type (email, url, date). For other
+// formats (e.g. uuid) the type is `text` and `validation.format`
+// carries the rule.
 type FieldType string
 
 const (
@@ -2454,21 +2471,29 @@ func (s *FieldType) UnmarshalText(data []byte) error {
 	}
 }
 
+// Schema-derived rules the frontend SHOULD apply at input time. The
+// server runs the same rules on submit and is the only authority on
+// whether the step advances — these rules are a UX hint to reduce
+// round trips, not a contract guarantee.
+// Omitted entirely when the field has no rules beyond its `type`.
+// Each key mirrors a JSON Schema keyword on the underlying user
+// property; absent keys mean no rule.
 type FieldValidation struct {
-	Format    OptString `json:"format"`
-	Pattern   OptString `json:"pattern"`
-	MinLength OptInt    `json:"min_length"`
-	MaxLength OptInt    `json:"max_length"`
+	// Semantic format the value must match. Values mirror the user
+	// meta-schema. When `type` already encodes the format (email,
+	// url, date), this key is informative and the input type is
+	// sufficient for client-side validation. When `type` is `text`
+	// (e.g. `format: uuid`), this key is the only signal.
+	Format OptFieldValidationFormat `json:"format"`
+	// Minimum length in characters (inclusive). Mirrors `minLength`.
+	MinLength OptInt `json:"min_length"`
+	// Maximum length in characters (inclusive). Mirrors `maxLength`.
+	MaxLength OptInt `json:"max_length"`
 }
 
 // GetFormat returns the value of Format.
-func (s *FieldValidation) GetFormat() OptString {
+func (s *FieldValidation) GetFormat() OptFieldValidationFormat {
 	return s.Format
-}
-
-// GetPattern returns the value of Pattern.
-func (s *FieldValidation) GetPattern() OptString {
-	return s.Pattern
 }
 
 // GetMinLength returns the value of MinLength.
@@ -2482,13 +2507,8 @@ func (s *FieldValidation) GetMaxLength() OptInt {
 }
 
 // SetFormat sets the value of Format.
-func (s *FieldValidation) SetFormat(val OptString) {
+func (s *FieldValidation) SetFormat(val OptFieldValidationFormat) {
 	s.Format = val
-}
-
-// SetPattern sets the value of Pattern.
-func (s *FieldValidation) SetPattern(val OptString) {
-	s.Pattern = val
 }
 
 // SetMinLength sets the value of MinLength.
@@ -2499,6 +2519,66 @@ func (s *FieldValidation) SetMinLength(val OptInt) {
 // SetMaxLength sets the value of MaxLength.
 func (s *FieldValidation) SetMaxLength(val OptInt) {
 	s.MaxLength = val
+}
+
+// Semantic format the value must match. Values mirror the user
+// meta-schema. When `type` already encodes the format (email,
+// url, date), this key is informative and the input type is
+// sufficient for client-side validation. When `type` is `text`
+// (e.g. `format: uuid`), this key is the only signal.
+type FieldValidationFormat string
+
+const (
+	FieldValidationFormatEmail    FieldValidationFormat = "email"
+	FieldValidationFormatDateTime FieldValidationFormat = "date-time"
+	FieldValidationFormatUUID     FieldValidationFormat = "uuid"
+	FieldValidationFormatURI      FieldValidationFormat = "uri"
+)
+
+// AllValues returns all FieldValidationFormat values.
+func (FieldValidationFormat) AllValues() []FieldValidationFormat {
+	return []FieldValidationFormat{
+		FieldValidationFormatEmail,
+		FieldValidationFormatDateTime,
+		FieldValidationFormatUUID,
+		FieldValidationFormatURI,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s FieldValidationFormat) MarshalText() ([]byte, error) {
+	switch s {
+	case FieldValidationFormatEmail:
+		return []byte(s), nil
+	case FieldValidationFormatDateTime:
+		return []byte(s), nil
+	case FieldValidationFormatUUID:
+		return []byte(s), nil
+	case FieldValidationFormatURI:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *FieldValidationFormat) UnmarshalText(data []byte) error {
+	switch FieldValidationFormat(data) {
+	case FieldValidationFormatEmail:
+		*s = FieldValidationFormatEmail
+		return nil
+	case FieldValidationFormatDateTime:
+		*s = FieldValidationFormatDateTime
+		return nil
+	case FieldValidationFormatUUID:
+		*s = FieldValidationFormatUUID
+		return nil
+	case FieldValidationFormatURI:
+		*s = FieldValidationFormatURI
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
 
 // Scopes which teams or apps this flow definition applies to. Empty or
@@ -7140,6 +7220,52 @@ func (o OptFieldValidation) Get() (v FieldValidation, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptFieldValidation) Or(d FieldValidation) FieldValidation {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptFieldValidationFormat returns new OptFieldValidationFormat with value set to v.
+func NewOptFieldValidationFormat(v FieldValidationFormat) OptFieldValidationFormat {
+	return OptFieldValidationFormat{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptFieldValidationFormat is optional FieldValidationFormat.
+type OptFieldValidationFormat struct {
+	Value FieldValidationFormat
+	Set   bool
+}
+
+// IsSet returns true if OptFieldValidationFormat was set.
+func (o OptFieldValidationFormat) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptFieldValidationFormat) Reset() {
+	var v FieldValidationFormat
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptFieldValidationFormat) SetTo(v FieldValidationFormat) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptFieldValidationFormat) Get() (v FieldValidationFormat, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptFieldValidationFormat) Or(d FieldValidationFormat) FieldValidationFormat {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/api/generated/oas_validators_gen.go
+++ b/api/generated/oas_validators_gen.go
@@ -826,6 +826,24 @@ func (s *Field) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.Validation.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "validation",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -849,6 +867,107 @@ func (s FieldType) Validate() error {
 	case "date":
 		return nil
 	case "hidden":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *FieldValidation) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.Format.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "format",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.MinLength.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "min_length",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.MaxLength.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           0,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "max_length",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s FieldValidationFormat) Validate() error {
+	switch s {
+	case "email":
+		return nil
+	case "date-time":
+		return nil
+	case "uuid":
+		return nil
+	case "uri":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)

--- a/api/openapi/components/flows/field.yaml
+++ b/api/openapi/components/flows/field.yaml
@@ -7,23 +7,49 @@ properties:
   type:
     type: string
     enum: [text, email, password, tel, number, url, date, hidden]
+    description: |
+      The input kind the client should render. Encodes the formats that
+      have a matching HTML input type (email, url, date). For other
+      formats (e.g. uuid) the type is `text` and `validation.format`
+      carries the rule.
   text_key:
     type: string
     description: Localization key for the field label.
-    example: identifier.field.email
+    example: login.field.email
   required:
     type: boolean
     default: false
+    description: |
+      The field MUST be present and non-empty on submit. Mirrors the
+      schema's top-level `required` array.
   value:
-    description: Pre-filled value (e.g., email carried over from a pivot).
+    description: Pre-filled value (e.g., an identifier carried over from a pivot).
   validation:
     type: object
+    description: |
+      Schema-derived rules the frontend SHOULD apply at input time. The
+      server runs the same rules on submit and is the only authority on
+      whether the step advances — these rules are a UX hint to reduce
+      round trips, not a contract guarantee.
+
+      Omitted entirely when the field has no rules beyond its `type`.
+      Each key mirrors a JSON Schema keyword on the underlying user
+      property; absent keys mean no rule.
     properties:
       format:
         type: string
-      pattern:
-        type: string
+        enum: [email, date-time, uuid, uri]
+        description: |
+          Semantic format the value must match. Values mirror the user
+          meta-schema. When `type` already encodes the format (email,
+          url, date), this key is informative and the input type is
+          sufficient for client-side validation. When `type` is `text`
+          (e.g. `format: uuid`), this key is the only signal.
       min_length:
         type: integer
+        minimum: 0
+        description: Minimum length in characters (inclusive). Mirrors `minLength`.
       max_length:
         type: integer
+        minimum: 0
+        description: Maximum length in characters (inclusive). Mirrors `maxLength`.

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -280,7 +280,41 @@ func toFlowField(f domain.FlowField) api.Field {
 	if f.Value != nil {
 		out.Value = jx.Raw(jsonQuoted(*f.Value))
 	}
+	if v := toFlowFieldValidation(f.Validation); v != nil {
+		out.Validation = api.NewOptFieldValidation(*v)
+	}
 	return out
+}
+
+// flowFieldValidationFormats maps the resolver's pass-through format
+// strings (sourced from the user meta-schema's `format` enum) to the
+// generated OpenAPI enum. Strings not in this map are dropped at the
+// mapper rather than violating the regenerated enum.
+var flowFieldValidationFormats = map[string]api.FieldValidationFormat{
+	"email":     api.FieldValidationFormatEmail,
+	"date-time": api.FieldValidationFormatDateTime,
+	"uuid":      api.FieldValidationFormatUUID,
+	"uri":       api.FieldValidationFormatURI,
+}
+
+func toFlowFieldValidation(v *domain.FlowFieldValidation) *api.FieldValidation {
+	if v == nil {
+		return nil
+	}
+	out := api.FieldValidation{}
+	if format, ok := flowFieldValidationFormats[v.Format]; ok {
+		out.Format = api.NewOptFieldValidationFormat(format)
+	}
+	if v.MinLength > 0 {
+		out.MinLength = api.NewOptInt(v.MinLength)
+	}
+	if v.MaxLength > 0 {
+		out.MaxLength = api.NewOptInt(v.MaxLength)
+	}
+	if !out.Format.Set && !out.MinLength.Set && !out.MaxLength.Set {
+		return nil
+	}
+	return &out
 }
 
 func toFlowStepActions(actions map[string]domain.FlowAction) api.FlowStepActions {

--- a/internal/api/flow_internal_test.go
+++ b/internal/api/flow_internal_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apigen "github.com/zitadel/nextgen/api/generated"
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+func TestToFlowField_OmitsValidationWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	got := toFlowField(domain.FlowField{
+		Type:    domain.FlowFieldTypeText,
+		TextKey: "step.field.x",
+	})
+
+	require.False(t, got.Validation.Set)
+}
+
+func TestToFlowField_EmitsFormatLengths(t *testing.T) {
+	t.Parallel()
+
+	got := toFlowField(domain.FlowField{
+		Type:    domain.FlowFieldTypeEmail,
+		TextKey: "step.field.email",
+		Validation: &domain.FlowFieldValidation{
+			Format:    "email",
+			MinLength: 3,
+			MaxLength: 200,
+		},
+	})
+
+	require.True(t, got.Validation.Set)
+	v := got.Validation.Value
+	require.Equal(t, apigen.FieldValidationFormatEmail, v.Format.Value)
+	require.Equal(t, 3, v.MinLength.Value)
+	require.Equal(t, 200, v.MaxLength.Value)
+}
+
+func TestToFlowField_DropsUnknownFormat(t *testing.T) {
+	t.Parallel()
+
+	got := toFlowField(domain.FlowField{
+		Type:    domain.FlowFieldTypeText,
+		TextKey: "step.field.x",
+		Validation: &domain.FlowFieldValidation{
+			Format: "phone",
+		},
+	})
+
+	require.False(t, got.Validation.Set, "validation block omitted when only key would be an unknown format")
+}
+
+func TestToFlowField_UUIDFormatSurfacesAsText(t *testing.T) {
+	t.Parallel()
+
+	got := toFlowField(domain.FlowField{
+		Type:    domain.FlowFieldTypeText,
+		TextKey: "step.field.id",
+		Validation: &domain.FlowFieldValidation{
+			Format: "uuid",
+		},
+	})
+
+	require.Equal(t, apigen.FieldTypeText, got.Type)
+	require.True(t, got.Validation.Set)
+	require.Equal(t, apigen.FieldValidationFormatUUID, got.Validation.Value.Format.Value)
+}


### PR DESCRIPTION
The flow step response shape already declares a per-field `validation` block, and the resolver computes the rules from the user schema, but `toFlowField` was dropping them. Wire it through so the frontend can validate at input time. Server still re-runs on submit and stays authoritative.

Also tightens the contract: drop `pattern` (declared but never produced), constrain `format` to the enum the meta-schema actually allows, add descriptions on each key.

<img width="622" height="278" alt="Screenshot 2026-05-29 at 18 09 56" src="https://github.com/user-attachments/assets/fe3ee39a-291f-4d09-973b-a95c8870d168" />
