### PR TITLE
style: gofmt-clean the tree and add a CI formatting gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Verify gofmt formatting
+        run: |
+          gofmt -l .
+          test -z "$(gofmt -l .)"
       - name: Install embedded-postgres runtime deps
         run: sudo apt-get update -qq && sudo apt-get install -y -qq libicu-dev libssl-dev
       - run: go generate ./...

--- a/internal/api/flow_test.go
+++ b/internal/api/flow_test.go
@@ -338,4 +338,3 @@ func TestGetFlowStep_TerminalReturns410(t *testing.T) {
 		t.Fatalf("status = %d, want 410", resp.StatusCode)
 	}
 }
-

--- a/internal/bootstrap/users/document.go
+++ b/internal/bootstrap/users/document.go
@@ -8,9 +8,9 @@ import (
 
 // Document is the on-disk shape for a single bootstrap user (one file per user).
 type Document struct {
-	Header         Header                      `json:"header"`
-	Attributes     map[string]json.RawMessage  `json:"attributes"`
-	Authenticators map[string]json.RawMessage  `json:"authenticators"`
+	Header         Header                     `json:"header"`
+	Attributes     map[string]json.RawMessage `json:"attributes"`
+	Authenticators map[string]json.RawMessage `json:"authenticators"`
 }
 
 // Header holds users-table metadata.

--- a/internal/domain/flow_field_resolver_schema_test.go
+++ b/internal/domain/flow_field_resolver_schema_test.go
@@ -304,4 +304,3 @@ func TestSchemaFieldResolver_Resolve_FormatAndTypeVariants(t *testing.T) {
 		t.Errorf("Resolve nickname Validation = %+v, want nil (no rules)", got.Fields["nickname"].Validation)
 	}
 }
-

--- a/internal/storage/database/repository/flow_definition.go
+++ b/internal/storage/database/repository/flow_definition.go
@@ -42,14 +42,14 @@ type flowDefinitionAudienceJSON struct {
 }
 
 type flowDefinitionStepJSON struct {
-	Name         string                             `json:"name"`
-	Fields       []string                           `json:"fields,omitempty"`
-	Actions      map[string]flowStepActionJSON      `json:"actions,omitempty"`
-	Gates        map[string]flowStepGateJSON        `json:"gates,omitempty"`
-	SSOProviders []flowSSOProviderJSON              `json:"sso_providers,omitempty"`
-	OnSuccess    *string                            `json:"on_success,omitempty"`
-	Complete     *string                            `json:"complete,omitempty"`
-	Transitions  map[string]flowStepTransitionJSON  `json:"transitions,omitempty"`
+	Name         string                            `json:"name"`
+	Fields       []string                          `json:"fields,omitempty"`
+	Actions      map[string]flowStepActionJSON     `json:"actions,omitempty"`
+	Gates        map[string]flowStepGateJSON       `json:"gates,omitempty"`
+	SSOProviders []flowSSOProviderJSON             `json:"sso_providers,omitempty"`
+	OnSuccess    *string                           `json:"on_success,omitempty"`
+	Complete     *string                           `json:"complete,omitempty"`
+	Transitions  map[string]flowStepTransitionJSON `json:"transitions,omitempty"`
 }
 
 type flowStepActionJSON struct {

--- a/internal/storage/database/repository/helpers_test.go
+++ b/internal/storage/database/repository/helpers_test.go
@@ -104,4 +104,3 @@ func deleteUser(t *testing.T, client database.QueryExecutor, projectID, userID s
 	userRepo := repository.NewUserRepository()
 	require.NoError(t, userRepo.Delete(ctx, client, userRepo.PrimaryKeyCondition(projectID, userID)))
 }
-

--- a/internal/storage/database/repository/json_schema.go
+++ b/internal/storage/database/repository/json_schema.go
@@ -168,9 +168,9 @@ func (r *JSONSchemaRepository) Delete(ctx context.Context, client database.Query
 }
 
 type jsonSchemaRow struct {
-	ProjectID string               `db:"project_id"`
-	URL       string               `db:"url"`
-	CreatedAt time.Time            `db:"created_at"`
+	ProjectID string                `db:"project_id"`
+	URL       string                `db:"url"`
+	CreatedAt time.Time             `db:"created_at"`
 	Payload   JSON[json.RawMessage] `db:"payload"`
 }
 

--- a/internal/storage/database/repository/project.go
+++ b/internal/storage/database/repository/project.go
@@ -15,11 +15,11 @@ const pgTableProjects = "zitadel_nextgen.projects"
 const spannerTableProjects = "projects"
 
 type projectRow struct {
-	ID             string         `db:"id"`
-	CreatedAt      time.Time      `db:"created_at"`
-	UpdatedAt      time.Time      `db:"updated_at"`
-	ProjectSecret  string         `db:"project_secret"`
-	PreviewSecret  string         `db:"preview_secret"`
+	ID             string            `db:"id"`
+	CreatedAt      time.Time         `db:"created_at"`
+	UpdatedAt      time.Time         `db:"updated_at"`
+	ProjectSecret  string            `db:"project_secret"`
+	PreviewSecret  string            `db:"preview_secret"`
 	PreviewOrigins JSONArray[string] `db:"preview_origins"`
 }
 

--- a/internal/storage/database/repository/user.go
+++ b/internal/storage/database/repository/user.go
@@ -18,12 +18,12 @@ const (
 )
 
 var (
-	colUserProjectID    = database.NewColumn(userTable, "project_id")
-	colUserID           = database.NewColumn(userTable, "id")
-	colUserTeamID       = database.NewColumn(userTable, "team_id")
-	colUserSchemaURL    = database.NewColumn(userTable, "schema_url")
-	colUserCreatedAt    = database.NewColumn(userTable, "created_at")
-	colUserUpdatedAt    = database.NewColumn(userTable, "updated_at")
+	colUserProjectID          = database.NewColumn(userTable, "project_id")
+	colUserID                 = database.NewColumn(userTable, "id")
+	colUserTeamID             = database.NewColumn(userTable, "team_id")
+	colUserSchemaURL          = database.NewColumn(userTable, "schema_url")
+	colUserCreatedAt          = database.NewColumn(userTable, "created_at")
+	colUserUpdatedAt          = database.NewColumn(userTable, "updated_at")
 	colUserAttributeProjectID = database.NewColumn(userAttributesTable, "project_id")
 	colUserAttributeUserID    = database.NewColumn(userAttributesTable, "user_id")
 	colUserAttributeKey       = database.NewColumn(userAttributesTable, "key")


### PR DESCRIPTION
## What

Two changes, formatting-only — no logic touched:

1. **gofmt-clean the tree.** Ran `gofmt -w` over the repo, fixing 8 files that were not gofmt-clean (struct/`var` column alignment and a few trailing blank lines):
   - `internal/api/flow_test.go`
   - `internal/bootstrap/users/document.go`
   - `internal/domain/flow_field_resolver_schema_test.go`
   - `internal/storage/database/repository/flow_definition.go`
   - `internal/storage/database/repository/helpers_test.go`
   - `internal/storage/database/repository/json_schema.go`
   - `internal/storage/database/repository/project.go`
   - `internal/storage/database/repository/user.go`

2. **Add a CI formatting gate** so this can't regress. New `Verify gofmt formatting` step in the `go-test` job (`.github/workflows/ci.yml`):
   ```yaml
   - name: Verify gofmt formatting
     run: |
       gofmt -l .
       test -z "$(gofmt -l .)"
   ```
   Placed right after `setup-go` (before the postgres deps + `go generate`) so this pure static check fails fast. It mirrors the existing **Verify generated code is up to date** step's style: surface the offending files via `gofmt -l .`, then assert the set is empty.

## Notes

- `helpers_test.go` was not in the originally-flagged list of 7 files but `gofmt -l .` reports it (trailing blank line), so it's included — the tree is now fully clean.
- `go.mod` declares `go 1.26`; CI's `setup-go` reads `go-version-file: go.mod`, so the gate's `gofmt` matches the toolchain used to format here (local `go1.26.2`). No version-skew risk.

## Verification

- `gofmt -l .` → empty (clean tree)
- `go build ./...` → exit 0
- `go vet ./...` → exit 0
- Gate behavior confirmed locally: passes silently on a clean tree, prints the offending file and exits 1 on a dirty one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)