### PR TITLE
fix: Omit children from IconProps

### DIFF
--- a/packages/ui-react/src/icon.tsx
+++ b/packages/ui-react/src/icon.tsx
@@ -54,7 +54,7 @@ export type IconSize = "16" | "24";
 
 export type IconTone = "default" | "error" | "success" | "disabled";
 
-export interface IconProps extends Omit<SVGAttributes<SVGSVGElement>, "name"> {
+export interface IconProps extends Omit<SVGAttributes<SVGSVGElement>, "children" | "name"> {
   name: IconName;
   size?: IconSize;
   tone?: IconTone;


### PR DESCRIPTION
## Summary
- Remove `children` from `IconProps` in `packages/ui-react/src/icon.tsx`.
- This keeps the React icon wrapper aligned with its actual API and avoids the React type mismatch seen during Vercel typechecking.

## Testing
- Not run (not requested).