### PR TITLE
fix: move per-framework narration data into the patcher

### DIFF
--- a/apps/cli/src/commands/setup/index.ts
+++ b/apps/cli/src/commands/setup/index.ts
@@ -5,7 +5,7 @@ import { consola } from "consola";
 import { BaseCommand, type JsonEnvelope } from "../../lib/oclif";
 import { ZitadelError } from "../../lib/errors";
 import { createOrca, issuerFromPort, type FrameworkFacts, type Orca } from "../../lib/orca";
-import type { PatchContext } from "../../lib/orca/patchers/types";
+import type { PatchContext, PatcherNarration } from "../../lib/orca/patchers/types";
 import { RENDERER_IDS } from "../../lib/orca/patchers/rule/next/renderers/registry";
 import { CreateSchemaBody } from "@zitadel-nextgen/api/generated/endpoints/zitadelNextGen.zod";
 import type { CreateProject201 } from "@zitadel-nextgen/api/generated/model";
@@ -142,10 +142,19 @@ export default class Setup extends BaseCommand {
       server: answers.server,
     };
     consola.start(`Patching project files${dryRun ? " (dry run)" : ""}`);
-    const result = await orca.patcherFor(framework.id).patch(ctx, { cwd, dryRun, force });
+    const patcher = orca.patcherFor(framework.id);
+    const result = await patcher.patch(ctx, { cwd, dryRun, force });
+    const narration = patcher.narration(ctx);
+    const verb = dryRun ? "Would write" : "Wrote";
     for (const file of result.filesWritten) {
-      const sentence = describeWrittenFile(relativeDisplay(cwd, file), dryRun);
-      if (sentence) consola.info(sentence);
+      const rel = relativeDisplay(cwd, file);
+      if (narration.silent.includes(rel)) continue;
+      const sentence = narration.sentences.find((s) => rel === s.path || rel.endsWith(`/${s.path}`));
+      consola.info(
+        sentence
+          ? `${verb} ${sentence.subject} (${stylePath(rel)})`
+          : `${verb} ${stylePath(rel)}`,
+      );
     }
     for (const file of result.filesSkipped) {
       consola.info(`Left ${relativeDisplay(cwd, file)} unchanged (already matches target)`);
@@ -185,6 +194,7 @@ export default class Setup extends BaseCommand {
       const sections = buildSummary({
         projectFacts,
         writtenRel,
+        narration,
         project,
         server: answers.server,
         issuer,
@@ -278,72 +288,12 @@ function shortPath(absolute: string): string {
   return absolute;
 }
 
-/**
- * Picks one written file by suffix so the corresponding INSTALLED row can
- * reference it without hard-coding the path the patcher chose. Returns
- * the first match; falls back to `undefined` when the patcher didn't
- * write that artifact (e.g. `--no-apply` would still write everything,
- * but a user opting out of, say, register pages would not).
- */
-function pickWrittenFile(written: string[], suffix: string): string | undefined {
-  return written.find((file) => file.endsWith(suffix));
-}
-
-/**
- * Translates a patcher-written path into a single sentence the user can
- * read at narration speed. Returns `null` for directories and other
- * scaffolding artefacts that aren't worth narrating individually — the
- * file count in the closing `success(...)` and the summary's INSTALLED
- * section already cover them. The verb tense flips for `--dry-run` so
- * the user sees a preview ("Would write ...") instead of a claim that
- * something happened.
- */
-function describeWrittenFile(relPath: string, dryRun: boolean): string | null {
-  // Mkdir ops surface in `filesWritten` alongside actual file writes.
-  // They're noise at the per-step layer (the files inside them get
-  // narrated on their own lines), so swallow them here.
-  if (
-    relPath === ".zitadel" ||
-    relPath === ".zitadel/flows" ||
-    relPath === ".zitadel/schemas"
-  ) {
-    return null;
-  }
-  const verb = dryRun ? "Would write" : "Wrote";
-  const sentence = SENTENCE_BY_PATH[relPath];
-  if (sentence) {
-    return `${verb} ${sentence.subject} (${stylePath(relPath)})`;
-  }
-  return `${verb} ${stylePath(relPath)}`;
-}
-
-/**
- * Map from the patcher's deterministic output paths to a short noun
- * phrase describing what the file is for. Anything not in the map falls
- * back to the bare path in the narration; add an entry here when a new
- * scaffolded file deserves a clearer label.
- */
-const SENTENCE_BY_PATH: Record<string, { subject: string }> = {
-  ".gitignore": { subject: "the project's .gitignore additions" },
-  ".zitadel/secret": { subject: "the local project secret" },
-  "zitadel.json": { subject: "the Zitadel project configuration" },
-  ".zitadel/schemas/user.json": { subject: "the user schema definition" },
-  ".zitadel/flows/default.json": { subject: "the default authentication flow" },
-  ".env.example": { subject: "the .env example template" },
-  ".env.local": { subject: "the local development environment variables" },
-  ".zitadel/state.json": { subject: "the empty sync state file" },
-  "app/login/page.tsx": { subject: "the login page" },
-  "app/register/page.tsx": { subject: "the registration page" },
-  "app/profile/page.tsx": { subject: "the profile page" },
-  "middleware.ts": { subject: "the Next.js middleware" },
-  "custom-elements.d.ts": { subject: "the web-component type declarations" },
-  "package.json": { subject: "package.json with the SDK dependency" },
-};
-
 /** Builds the section list driving {@link renderSummary} for the setup command. */
 function buildSummary(opts: {
   projectFacts: Awaited<ReturnType<typeof detectProjectFacts>>;
   writtenRel: string[];
+  /** Narration from the patcher — provides the framework-specific INSTALLED rows. */
+  narration: PatcherNarration;
   project: CreateProject201;
   server: string;
   issuer: string;
@@ -351,9 +301,7 @@ function buildSummary(opts: {
   synced: boolean;
   scaffoldedFramework: boolean;
 }): Section[] {
-  const { projectFacts, writtenRel, project, server, issuer, userFields, synced, scaffoldedFramework } = opts;
-  const sdkPackage = "@zitadel-nextgen/sdk-next";
-  const packageJsonHit = pickWrittenFile(writtenRel, "package.json");
+  const { projectFacts, writtenRel, narration, project, server, issuer, userFields, synced, scaffoldedFramework } = opts;
 
   const detected: Row[] = [
     { label: "Framework", value: formatFrameworkLine(projectFacts) },
@@ -363,22 +311,25 @@ function buildSummary(opts: {
   }
 
   const installedRows: Row[] = [];
-  if (packageJsonHit) {
-    installedRows.push({
-      label: "Package",
-      value: sdkPackage,
-      secondary: stylePath(fileNameOf(packageJsonHit)),
-    });
-  }
-  for (const [label, suffix] of [
-    ["Login page", "app/login/page.tsx"],
-    ["Register page", "app/register/page.tsx"],
-    ["Profile page", "app/profile/page.tsx"],
-    ["Middleware", "middleware.ts"],
-    ["Env vars", ".env.local"],
-  ] as const) {
-    const hit = pickWrittenFile(writtenRel, suffix);
-    if (hit) installedRows.push({ label, value: stylePath(hit) });
+  for (const row of narration.installedRows) {
+    const hit = writtenRel.find((file) => file === row.path || file.endsWith(`/${row.path}`));
+    if (!hit) continue;
+    // The "Package" row is the special one: its value is the SDK name
+    // (provided by the patcher), and the secondary text points at the
+    // manifest filename. Every other row's value is the cyan path.
+    if (row.label === "Package") {
+      installedRows.push({
+        label: row.label,
+        value: narration.sdkPackage,
+        secondary: stylePath(fileNameOf(hit)),
+      });
+    } else {
+      installedRows.push({
+        label: row.label,
+        value: stylePath(hit),
+        secondary: row.secondary,
+      });
+    }
   }
 
   const configuredRows: Row[] = [

--- a/apps/cli/src/lib/orca/patchers/rule/base.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/base.ts
@@ -5,7 +5,10 @@ import { scaffold } from "./file-writer";
 import type { FileOp, ScaffoldPlan } from "./file-writer/types";
 import type {
   EjectActions,
+  NarrationRow,
+  NarrationSentence,
   Patcher,
+  PatcherNarration,
   PatchContext,
   PatchExecOptions,
   PatchResult,
@@ -38,6 +41,37 @@ export abstract class AbstractRulePatcher implements Patcher {
   async repair(ctx: PatchContext, opts: PatchExecOptions): Promise<PatchResult> {
     const plan = this.plan(ctx);
     return scaffold({ ops: reclaimableOps(plan), summary: plan.summary }, opts);
+  }
+
+  /**
+   * Cross-framework narration for the `.zitadel/` base files plus the
+   * `package.json` and `.env.local` rows that bookend the INSTALLED
+   * section. Subclasses contribute their framework-specific rows and
+   * sentences via {@link frameworkInstalledRows} and
+   * {@link frameworkSentences}; the result is the merged narration the
+   * setup command consumes.
+   */
+  narration(view: PatchView): PatcherNarration {
+    return {
+      sdkPackage: this.sdkPackageFor(view),
+      installedRows: [
+        // "Package" is always the first row — the SDK the patcher adds
+        // to `package.json`. The label is constant; the value rendered
+        // by the setup command uses `sdkPackage`, with the manifest
+        // file (typically `package.json`) shown as the secondary detail.
+        { label: "Package", path: "package.json", secondary: "package.json" },
+        ...this.frameworkInstalledRows(view),
+        // ".env.local" closes the section. Both the file and the row
+        // are common across every rule-based framework patcher.
+        { label: "Env vars", path: ".env.local" },
+      ],
+      sentences: [...BASE_SENTENCES, ...this.frameworkSentences(view)],
+      // The `mkdir` ops for `.zitadel` and its sub-directories surface
+      // in `filesWritten` alongside actual file writes. They're noise at
+      // the per-step layer (the files inside narrate on their own
+      // lines), so the narrator skips them.
+      silent: [".zitadel", ".zitadel/flows", ".zitadel/schemas"],
+    };
   }
 
   /** Shared base artifacts plus the subclass's marker-bearing route files. */
@@ -139,7 +173,45 @@ export abstract class AbstractRulePatcher implements Patcher {
   protected abstract routeDeps(view: PatchView): ReadonlyArray<string>;
   /** One-line summary of what the integration scaffolded. */
   protected abstract summary(ctx: PatchContext): { title: string; detail: string };
+  /**
+   * The SDK package name shown in the INSTALLED "Package" row. Typically
+   * the same name returned from {@link routeDeps} but exposed separately
+   * because the row carries a label distinct from the dep, and the value
+   * may be a friendlier alias (e.g. `@zitadel-nextgen/sdk-next`).
+   */
+  protected abstract sdkPackageFor(view: PatchView): string;
+  /**
+   * Framework-specific rows appended to the INSTALLED section between
+   * the common "Package" and "Env vars" rows the abstract base provides.
+   * Display order is preserved as-is.
+   */
+  protected abstract frameworkInstalledRows(view: PatchView): ReadonlyArray<NarrationRow>;
+  /**
+   * Subject phrases for the framework-specific files this patcher writes,
+   * used in the `"Wrote {subject} ({path})"` per-file narration. Paths
+   * not listed here narrate as bare paths.
+   */
+  protected abstract frameworkSentences(view: PatchView): ReadonlyArray<NarrationSentence>;
 }
+
+/**
+ * Narration sentences for the cross-framework `.zitadel/` base files plus
+ * `package.json`. Lives on the abstract base because every rule-based
+ * patcher writes exactly these files via {@link AbstractRulePatcher.baseOps};
+ * a framework patcher contributing its own files adds them via
+ * {@link AbstractRulePatcher.frameworkSentences}.
+ */
+const BASE_SENTENCES: ReadonlyArray<NarrationSentence> = [
+  { path: ".gitignore", subject: "the project's .gitignore additions" },
+  { path: ".zitadel/secret", subject: "the local project secret" },
+  { path: "zitadel.json", subject: "the Zitadel project configuration" },
+  { path: ".zitadel/schemas/user.json", subject: "the user schema definition" },
+  { path: ".zitadel/flows/default.json", subject: "the default authentication flow" },
+  { path: ".env.example", subject: "the .env example template" },
+  { path: ".env.local", subject: "the local development environment variables" },
+  { path: ".zitadel/state.json", subject: "the empty sync state file" },
+  { path: "package.json", subject: "package.json with the SDK dependency" },
+];
 
 /** Builds the `zitadel.json` body persisted at the project root. */
 function projectConfig(ctx: PatchContext): Record<string, unknown> {

--- a/apps/cli/src/lib/orca/patchers/rule/next/index.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/next/index.ts
@@ -2,10 +2,23 @@ import { join } from "node:path";
 
 import { MANAGED_MARKER } from "../../../../paths";
 import type { FileOp } from "../file-writer/types";
-import type { PatchContext, PatchView } from "../../types";
+import type {
+  NarrationRow,
+  NarrationSentence,
+  PatchContext,
+  PatchView,
+} from "../../types";
 import { AbstractRulePatcher } from "../base";
 import { getRenderer } from "./renderers/registry";
 import type { RendererSpec } from "./renderers/types";
+
+/**
+ * Fixed name shown in the INSTALLED "Package" row. The Next patcher
+ * always adds the same SDK regardless of renderer; deviation from this
+ * (e.g. a future Lit-only renderer with a different SDK) would override
+ * {@link NextPatcher.sdkPackageFor}.
+ */
+const NEXT_SDK_PACKAGE = "@zitadel-nextgen/sdk-next";
 
 /**
  * Next.js `middleware.ts` at the project root. Wires `nextgenMiddleware` so the
@@ -59,6 +72,58 @@ export class NextPatcher extends AbstractRulePatcher {
       title: "Next.js integration",
       detail: `Scaffolded login/register/profile routes with renderer "${ctx.rendererId}".`,
     };
+  }
+
+  protected sdkPackageFor(_view: PatchView): string {
+    return NEXT_SDK_PACKAGE;
+  }
+
+  /**
+   * INSTALLED rows in display order: login, register, profile (when the
+   * renderer ships one), then middleware. Each row's `path` is taken
+   * straight from {@link nextCodeFilePaths} so the row only shows when
+   * the file was actually written — opt-out renderers (no profile page)
+   * silently drop their row.
+   */
+  protected frameworkInstalledRows(view: PatchView): ReadonlyArray<NarrationRow> {
+    const appDir = view.framework.appDir;
+    const renderer = getRenderer(view.rendererId);
+    const rows: NarrationRow[] = [
+      { label: "Login page", path: join(appDir, "login/page.tsx") },
+      { label: "Register page", path: join(appDir, "register/page.tsx") },
+    ];
+    if (renderer.templates.profilePage) {
+      rows.push({ label: "Profile page", path: join(appDir, "profile/page.tsx") });
+    }
+    rows.push({ label: "Middleware", path: join(appDir, "../middleware.ts") });
+    return rows;
+  }
+
+  /**
+   * Per-file narration subjects for the Next-specific managed files.
+   * Mirrors the path list from {@link nextCodeFilePaths} so the two
+   * cannot drift; paths returned by the abstract base (`.zitadel/*`,
+   * `package.json`, `.env.local`) are narrated by `BASE_SENTENCES` and
+   * deliberately omitted here.
+   */
+  protected frameworkSentences(view: PatchView): ReadonlyArray<NarrationSentence> {
+    const appDir = view.framework.appDir;
+    const renderer = getRenderer(view.rendererId);
+    const sentences: NarrationSentence[] = [
+      { path: join(appDir, "login/page.tsx"), subject: "the login page" },
+      { path: join(appDir, "register/page.tsx"), subject: "the registration page" },
+    ];
+    if (renderer.templates.profilePage) {
+      sentences.push({ path: join(appDir, "profile/page.tsx"), subject: "the profile page" });
+    }
+    sentences.push({ path: join(appDir, "../middleware.ts"), subject: "the Next.js middleware" });
+    if (renderer.templates.customElementsDts) {
+      sentences.push({
+        path: join(appDir, "../custom-elements.d.ts"),
+        subject: "the web-component type declarations",
+      });
+    }
+    return sentences;
   }
 }
 

--- a/apps/cli/src/lib/orca/patchers/types.ts
+++ b/apps/cli/src/lib/orca/patchers/types.ts
@@ -1,7 +1,6 @@
-import type { CreateSchemaBody } from "@zitadel-nextgen/api/generated/model";
+import type { CreateProject201, CreateSchemaBody } from "@zitadel-nextgen/api/generated/model";
 
 import type { FrameworkFacts } from "../detectors/types";
-import type { CreateProjectResponse } from "../../api/client";
 
 /**
  * The minimal, project-independent view a patcher needs to enumerate the files
@@ -21,7 +20,7 @@ export type PatchView = Readonly<{
  */
 export type PatchContext = PatchView &
   Readonly<{
-    project: CreateProjectResponse;
+    project: CreateProject201;
     issuer: string;
     userFields: ReadonlyArray<string>;
     userSchema: CreateSchemaBody;
@@ -72,13 +71,58 @@ export type EjectActions = Readonly<{
 }>;
 
 /**
+ * One file the setup command surfaces in the INSTALLED section of the
+ * end-of-run summary box. `path` is the project-root-relative path the
+ * row points at; the row is only rendered if `path` appears in the
+ * patcher's `filesWritten` (so opt-out templates that didn't write a
+ * given file silently drop their row). `secondary` renders after a dim
+ * `→` arrow — currently used by the "Package" row to point at
+ * `package.json`.
+ */
+export type NarrationRow = Readonly<{
+  label: string;
+  path: string;
+  secondary?: string;
+}>;
+
+/**
+ * Pairs a written path with a short noun phrase used as the subject in
+ * `"Wrote {subject} ({path})"` during the patching-phase narration.
+ * Paths not listed here narrate as bare paths instead of full sentences.
+ */
+export type NarrationSentence = Readonly<{
+  path: string;
+  subject: string;
+}>;
+
+/**
+ * Per-patcher data that drives the setup command's user-facing output:
+ * the per-file `consola.info` lines during patching and the INSTALLED
+ * section of the closing ready box. Framework-specific paths, labels,
+ * and the SDK package live here so the setup command stays
+ * framework-agnostic — adding Nuxt/Remix/… is implemented entirely
+ * inside its patcher.
+ */
+export type PatcherNarration = Readonly<{
+  /** The npm package the patcher adds to the project's `package.json`. */
+  sdkPackage: string;
+  /** INSTALLED rows in display order; setup filters to those whose `path` was actually written. */
+  installedRows: ReadonlyArray<NarrationRow>;
+  /** Sentence overrides for the per-file narration; unknown paths fall back to bare path. */
+  sentences: ReadonlyArray<NarrationSentence>;
+  /** Paths the narrator skips entirely (typically `mkdir` ops whose contents narrate separately). */
+  silent: ReadonlyArray<string>;
+}>;
+
+/**
  * Integrates Zitadel into an existing project of a specific framework. The
  * interface is execution-strategy-agnostic: a rule-based patcher applies file
  * operations, while a future LLM-based patcher would drive an agent — callers
- * only see {@link patch}/{@link repair}/{@link artifacts} and never a file-op
- * plan. `patch` performs the full integration; `repair` re-applies the managed
- * artifacts (`doctor --fix`); `artifacts` describes them for marker-aware
- * ejection.
+ * only see {@link patch}/{@link repair}/{@link artifacts}/{@link narration}
+ * and never a file-op plan. `patch` performs the full integration; `repair`
+ * re-applies the managed artifacts (`doctor --fix`); `artifacts` describes
+ * them for marker-aware ejection; `narration` provides the human-readable
+ * labels and sentences the setup command shows the user as it runs.
  */
 export interface Patcher {
   /** Whether this patcher integrates the given framework id. */
@@ -89,4 +133,6 @@ export interface Patcher {
   repair(ctx: PatchContext, opts: PatchExecOptions): Promise<PatchResult>;
   /** Describe the files/dirs this integration owns, for marker-aware ejection. */
   artifacts(view: PatchView): EjectActions;
+  /** Labels, paths, and sentences the setup command surfaces to the user during a run. */
+  narration(view: PatchView): PatcherNarration;
 }


### PR DESCRIPTION
## Summary

- The setup command had Next-specific paths and sentences hardcoded in three places (\`SENTENCE_BY_PATH\`, the \`[label, suffix]\` INSTALLED loop, the \`@zitadel-nextgen/sdk-next\` literal). Adding a second framework would silently render an empty INSTALLED section and bare-path narration.
- Move the per-framework narration data into the patcher. New \`PatcherNarration\` type + \`Patcher.narration(view)\` method. \`AbstractRulePatcher\` provides the shared rows / sentences (the cross-framework \`.zitadel/*\`, \`package.json\`, \`.env.local\` files); \`NextPatcher\` adds the SDK name, the login / register / profile / middleware rows, and matching sentences. Setup just consumes \`patcher.narration(ctx)\`.
- Drive-by: fix a stale \`import type { CreateProjectResponse } from "../../api/client"\` left over from the removal of the platform-client wrapper in #194 — the path no longer exists and the type was silently \`any\`. Replaced with the orval \`CreateProject201\` already used elsewhere.

## Testing

- 326 CLI tests pass; \`tsc --noEmit\` clean.
- End-to-end smoke against a real local Zitadel: output is byte-identical to before for the Next framework.