### PR TITLE
fix: duplicate passkey button

### DIFF
--- a/internal/api/branding/default.liquid
+++ b/internal/api/branding/default.liquid
@@ -68,16 +68,6 @@
       {% endif %}
     {% endfor %}
 
-    {% if actions.passkey %}
-      <zl-button
-        hierarchy="secondary"
-        size="medium"
-        block
-        action="passkey"
-        label="{{ actions.passkey.text_key | t }}"
-      ></zl-button>
-    {% endif %}
-
     {% if actions.register %}
       <p class="zl-card-nav">
         {{ 'identifier.action.register.lead' | t }}<a href="#" class="zl-card-nav__link" data-action="register">{{ 'identifier.action.register.link' | t }}</a>


### PR DESCRIPTION
remove dedicated passkey zl-button as passkey is already rendered as one of the actions