### PR TITLE
ci: harden postgres integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           mkdir -p test-output/go
           set -o pipefail
-          go test -json -v -p 1 -tags postgres_integration -timeout=10m ./... | tee test-output/go/postgres-integration.json
+          go test -json -v -tags postgres_integration -timeout=10m ./... | tee test-output/go/postgres-integration.json
       - name: Upload Postgres test log on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,19 @@ jobs:
       # Postgres integration tests run against a Docker testcontainer (mirroring
       # the spanner job); ubuntu-latest ships Docker, so no embedded-postgres
       # runtime deps or Maven binary cache are needed here.
-      - run: go test -v -tags postgres_integration -timeout=10m ./...
+      - name: Postgres integration tests
+        run: |
+          mkdir -p test-output/go
+          set -o pipefail
+          go test -json -v -p 1 -tags postgres_integration -timeout=10m ./... | tee test-output/go/postgres-integration.json
+      - name: Upload Postgres test log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: postgres-integration-test-log
+          path: test-output/go/postgres-integration.json
+          if-no-files-found: ignore
+          retention-days: 7
 
   go-integration-test-spanner:
     runs-on: ubuntu-latest

--- a/internal/storage/database/dialect/postgres/embedded/container.go
+++ b/internal/storage/database/dialect/postgres/embedded/container.go
@@ -23,12 +23,38 @@ import (
 // reintroduce the transient pull failures this testcontainer migration removes.
 const containerImage = "public.ecr.aws/docker/library/postgres:18.3"
 
+const containerStartAttempts = 3
+
 // StartContainer starts a Postgres testcontainer and returns a connector plus a
 // stop function, mirroring the Spanner emulator bring-up in dialect/spanner/embedded.
 // It is used by the postgres integration tests; the server's zero-config default
 // connector still uses the embedded binary in start.go. This file is build-tagged
 // so testcontainers-go never enters the production server binary.
 func StartContainer(ctx context.Context) (database.Connector, func(), error) {
+	var err error
+	for attempt := 1; attempt <= containerStartAttempts; attempt++ {
+		var connector database.Connector
+		var stop func()
+		connector, stop, err = startContainerOnce(ctx)
+		if err == nil {
+			return connector, stop, nil
+		}
+		if attempt == containerStartAttempts {
+			break
+		}
+
+		delay := time.Duration(attempt) * 2 * time.Second
+		slog.Info("postgres testcontainer start failed, retrying", "attempt", attempt, "max_attempts", containerStartAttempts, "delay", delay, "err", err)
+		select {
+		case <-ctx.Done():
+			return nil, nil, fmt.Errorf("postgres container start interrupted: %w", ctx.Err())
+		case <-time.After(delay):
+		}
+	}
+	return nil, nil, fmt.Errorf("postgres container failed after %d attempts: %w", containerStartAttempts, err)
+}
+
+func startContainerOnce(ctx context.Context) (database.Connector, func(), error) {
 	req := testcontainers.ContainerRequest{
 		Image:        containerImage,
 		ExposedPorts: []string{"5432/tcp"},
@@ -52,6 +78,9 @@ func StartContainer(ctx context.Context) (database.Connector, func(), error) {
 		Started:          true,
 	})
 	if err != nil {
+		if container != nil {
+			_ = container.Terminate(context.Background())
+		}
 		return nil, nil, fmt.Errorf("unable to start postgres container: %w", err)
 	}
 

--- a/internal/storage/database/repository/repository_test.go
+++ b/internal/storage/database/repository/repository_test.go
@@ -39,12 +39,19 @@ func runTests(m *testing.M) int {
 
 	if err != nil {
 		log.Printf("error setting up test database: %v", err)
+		if stop != nil {
+			stop()
+		}
 		return 1
 	}
 	defer func() {
 		r := recover()
-		pool.Close(ctx)
-		stop()
+		if pool != nil {
+			pool.Close(ctx)
+		}
+		if stop != nil {
+			stop()
+		}
 		if r != nil {
 			panic(r)
 		}
@@ -85,7 +92,10 @@ func newEmbeddedDB(ctx context.Context) (pool database.PoolTest, stop func(), er
 
 	err = pool.MigrateTest(ctx)
 	if err != nil {
-		return nil, stop, fmt.Errorf("unable to migrate database: %w", err)
+		return nil, func() {
+			pool.Close(ctx)
+			stop()
+		}, fmt.Errorf("unable to migrate database: %w", err)
 	}
 	return pool, stop, err
 }

--- a/internal/storage/database/repository/repository_test.go
+++ b/internal/storage/database/repository/repository_test.go
@@ -37,7 +37,6 @@ func runTests(m *testing.M) int {
 		pool, stop, err = newEmbeddedDB(ctx)
 	}
 
-	defer stop()
 	if err != nil {
 		log.Printf("error setting up test database: %v", err)
 		return 1


### PR DESCRIPTION
## Summary
- Keep the Postgres integration job on default Go package parallelism while streaming `go test -json` output into a CI artifact on failure.
- Add a bounded retry around Postgres testcontainer startup so transient Docker/runner startup failures get a fresh container attempt without retrying real test assertions.
- Clean up the repository integration test harness teardown path so setup failures run any returned cleanup and successful setup closes/terminates exactly once.

## Testing
- `go test -json -v -count=1 -tags postgres_integration -timeout=10m ./...`
- 5x local uncached stress loop without `-p 1`: `go test -json -v -count=1 -tags postgres_integration -timeout=10m ./...`
- `go test -tags postgres_integration -timeout=10m -count=20 -run 'TestUserRepository_(CreateGetListDelete|CreateWithoutTeam|AttributesCondition)$' ./internal/storage/database/repository`
- `go test -v -tags spanner_integration -timeout=10m ./...`