### PR TITLE
fix: stop scaffolding and uploading the user schema and flow

### DIFF
--- a/.changeset/cli-server-owned-schema-flow.md
+++ b/.changeset/cli-server-owned-schema-flow.md
@@ -1,0 +1,10 @@
+---
+"@zitadel-nextgen/cli": minor
+"@zitadel-nextgen/sdk-next": patch
+---
+
+`zitadel setup` no longer scaffolds or uploads the user schema and flow definition — the Zitadel server now provisions these defaults when a project is created. Setup no longer writes `.zitadel/schemas/user.json` or `.zitadel/flows/default.json`, runs no sync step at the end, and the `--no-apply` flag (which only gated that sync) has been removed. The sync engine and the hidden `apply`/`plan` commands remain in place for a future pull-based workflow.
+
+**Behavior change for non-interactive callers.** `zitadel setup --no-apply` is no longer a valid flag and will error; remove it from scripts and agents.
+
+Scaffolded Next.js login/register/profile pages now configure the SDK via `configureZitadel(...)` and pass the resulting project handle to the `<zitadel-login>` / `<zitadel-logout>` web components through the `project` prop, instead of the removed `api-base` / `project-id` attributes. To support an app that declares only `@zitadel-nextgen/sdk-next` as a direct dependency, `@zitadel-nextgen/sdk-next/client` now re-exports `configureZitadel` and `getApi`.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -25,7 +25,7 @@ npx @zitadel-nextgen/cli@latest setup --framework next --server http://localhost
 npm run dev
 ```
 
-`setup` creates a project on the Zitadel server, scaffolds `app/login`, `app/register`, `app/profile`, and `middleware.ts`, writes `.env.local` and `.zitadel/`, then applies the config to the server. Open `http://localhost:3000/login` to see the login page.
+`setup` creates a project on the Zitadel server, scaffolds `app/login`, `app/register`, `app/profile`, and `middleware.ts`, and writes `.env.local` and `.zitadel/`. The project's default user schema and login flow are provisioned server-side at creation time, so the CLI does not scaffold or upload them. Open `http://localhost:3000/login` to see the login page.
 
 ## Other commands
 
@@ -206,7 +206,7 @@ Create a Zitadel project and scaffold local auth.
 ```
 USAGE
   $ zitadel setup [--json] [-c <value>] [-s <value>] [-n] [-f] [--dry-run] [--verbose] [--debug]
-    [--framework next] [--renderer react|web-component] [--no-apply]
+    [--framework next] [--renderer react|web-component]
 
 FLAGS
   -c, --cwd=<value>         Project directory to operate on.
@@ -217,7 +217,6 @@ FLAGS
       --dry-run             Preview without mutating files or the platform.
       --framework=<option>  Framework to target.
                             <options: next>
-      --no-apply            Skip the automatic apply at the end of setup.
       --renderer=<option>   Renderer (default: react).
                             <options: react|web-component>
       --verbose             Verbose logging.

--- a/apps/cli/SKILLS.md
+++ b/apps/cli/SKILLS.md
@@ -46,8 +46,9 @@ layer, not the envelope.
 ## Commands
 
 - `setup` — create a Zitadel project and scaffold local auth (routes,
-  middleware, `.zitadel/**`, env templates). Flags: `--framework`,
-  `--auth-method`, `--renderer`, `--no-apply`.
+  middleware, `.zitadel/**`, env templates). The project's default user schema
+  and login flow are provisioned server-side at creation, so setup neither
+  scaffolds nor uploads them. Flags: `--framework`, `--renderer`.
 - `plan` — validate config and preview the sync diff without mutating anything.
 - `apply` — validate and upload repo config to the platform.
 - `doctor` — verify generated files and local state; `--fix` re-applies missing

--- a/apps/cli/src/commands/doctor/checks/index.ts
+++ b/apps/cli/src/commands/doctor/checks/index.ts
@@ -11,7 +11,6 @@ import { SecretPermissionsCheck } from "./secret-permissions";
 import { GitignoreCheck } from "./gitignore";
 import { EnvExampleCheck } from "./env-example";
 import { FrameworkCheck } from "./framework";
-import { SchemaCheck } from "./schema";
 import { DependencyCheck } from "./dependency";
 import { ProjectMatchCheck } from "./project-match";
 
@@ -35,7 +34,11 @@ export const SANITY_CHECKS: ReadonlyArray<SanityCheck> = [
   new GitignoreCheck(),
   new EnvExampleCheck(),
   new FrameworkCheck(),
-  new SchemaCheck(),
+  // SchemaCheck is disabled: the user schema is now provisioned server-side
+  // and no longer scaffolded into `.zitadel/schemas/user.json`, so there is
+  // no local file to verify. The check is kept (imported/exported below) for
+  // the future pull-based workflow that will re-introduce local resources.
+  // new SchemaCheck(),
   new DependencyCheck(),
   new ProjectMatchCheck(),
 ];

--- a/apps/cli/src/commands/doctor/patch-context.ts
+++ b/apps/cli/src/commands/doctor/patch-context.ts
@@ -1,29 +1,21 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import type { CreateSchemaBody } from "@zitadel-nextgen/api/generated/model";
-
-import { isObject } from "../../lib/json";
 import { issuerFromPort, type FrameworkFacts, type Orca } from "../../lib/orca";
 import type { PatchContext } from "../../lib/orca/patchers/types";
 import { readDevelopmentIssuer, readRendererId, readZitadelConfig, readZitadelSecret } from "../../lib/project";
 
 /**
- * Reconstructs a {@link PatchContext} from the on-disk project (config, secret,
- * user schema) plus fresh framework detection, so a patcher repair can rebuild
- * its plan. The user-schema property names are read back from disk; only
- * `.zitadel/` resource contents depend on them, and a repair filters those out
- * anyway. Used by the dependency check's `fix`, which reclaims the
- * framework-specific SDK package via `patcher.repair`.
+ * Reconstructs a {@link PatchContext} from the on-disk project (config, secret)
+ * plus fresh framework detection, so a patcher repair can rebuild its plan.
+ * Used by the dependency check's `fix`, which reclaims the framework-specific
+ * SDK package via `patcher.repair`. The user schema and flow definition are
+ * server-owned and no longer scaffolded locally, so nothing here reads them.
  */
 export async function loadPatchContext(cwd: string, orca: Orca): Promise<PatchContext> {
   const config = await readZitadelConfig(cwd);
   const secret = await readZitadelSecret(cwd);
   const framework = await orca.detect(cwd);
-  const raw = JSON.parse(
-    await readFile(join(cwd, ".zitadel/schemas/user.json"), "utf8"),
-  ) as Record<string, unknown>;
-  const properties = isObject(raw.properties) ? raw.properties : {};
   return {
     framework,
     rendererId: readRendererId(config),
@@ -36,8 +28,6 @@ export async function loadPatchContext(cwd: string, orca: Orca): Promise<PatchCo
       previewOrigins: secret.preview_origins,
       createdAt: secret.created_at,
     },
-    userFields: Object.keys(properties),
-    userSchema: raw as CreateSchemaBody,
   };
 }
 

--- a/apps/cli/src/commands/setup/index.ts
+++ b/apps/cli/src/commands/setup/index.ts
@@ -241,8 +241,7 @@ function shortPath(absolute: string): string {
  * Picks one written file by suffix so the corresponding INSTALLED row can
  * reference it without hard-coding the path the patcher chose. Returns
  * the first match; falls back to `undefined` when the patcher didn't
- * write that artifact (e.g. `--no-apply` would still write everything,
- * but a user opting out of, say, register pages would not).
+ * write that artifact (e.g. a renderer without a register page).
  */
 function pickWrittenFile(written: string[], suffix: string): string | undefined {
   return written.find((file) => file.endsWith(suffix));

--- a/apps/cli/src/commands/setup/index.ts
+++ b/apps/cli/src/commands/setup/index.ts
@@ -7,13 +7,10 @@ import { ZitadelError } from "../../lib/errors";
 import { createOrca, issuerFromPort, type FrameworkFacts, type Orca } from "../../lib/orca";
 import type { PatchContext } from "../../lib/orca/patchers/types";
 import { RENDERER_IDS } from "../../lib/orca/patchers/rule/next/renderers/registry";
-import { CreateSchemaBody } from "@zitadel-nextgen/api/generated/endpoints/zitadelNextGen.zod";
 import type { CreateProject201 } from "@zitadel-nextgen/api/generated/model";
 import { createZitadelClient } from "@zitadel-nextgen/api/client";
 
-import { buildUserSchema } from "../../lib/user-schema";
-import { makeSyncers, runSyncLoop } from "../../lib/sync";
-import { hasZitadelConfig, hasZitadelSecret, readZitadelSecret } from "../../lib/project";
+import { hasZitadelConfig, hasZitadelSecret } from "../../lib/project";
 import { PickFrameworkPrompt, SETUP_PROMPTS, type SetupAnswers } from "./prompts";
 import {
   detectProjectFacts,
@@ -26,9 +23,6 @@ import {
   type Row,
   type Section,
 } from "./summary";
-
-/** The user-schema fields scaffolded for every project. */
-const DEFAULT_USER_FIELDS = ["email", "given_name", "family_name"] as const;
 
 /**
  * The frameworks `--framework` accepts, derived from Orca's registry so the
@@ -44,8 +38,9 @@ const FRAMEWORK_OPTIONS = createOrca()
  *
  * Detects (or, for an empty directory, scaffolds then re-detects) the
  * framework, runs the wizard prompts to fill in any answers not pre-supplied
- * by flags, creates the remote project, patches the local files via
- * `Orca`'s framework patcher, and optionally applies the config.
+ * by flags, creates the remote project (whose default user schema and login
+ * flow are provisioned server-side), and patches the local files via
+ * `Orca`'s framework patcher.
  *
  * Every interactive question lives in {@link SETUP_PROMPTS} (the main wizard
  * — each entry is a small class) and {@link PickFrameworkPrompt} (the
@@ -57,13 +52,12 @@ export default class Setup extends BaseCommand {
   static override flags = {
     framework: Flags.string({ description: "Framework to target.", options: FRAMEWORK_OPTIONS }),
     renderer: Flags.string({ description: "Renderer (default: react).", options: [...RENDERER_IDS] }),
-    "no-apply": Flags.boolean({ description: "Skip the automatic apply at the end of setup." }),
   };
 
   async run(): Promise<JsonEnvelope> {
     const { flags } = await this.parse(Setup);
     await this.toMeta(flags);
-    const { cwd, env, nonInteractive, dryRun, force } = this.meta;
+    const { cwd, nonInteractive, dryRun, force } = this.meta;
 
     if (await hasZitadelConfig(cwd)) {
       return this.emit({ status: "skipped", reason: "already-initialized" });
@@ -112,19 +106,10 @@ export default class Setup extends BaseCommand {
     }
 
     const issuer = issuerFromPort(answers.devPort);
-    const userFields = [...DEFAULT_USER_FIELDS];
-    const userSchema = buildUserSchema(userFields);
-    const schemaValidation = CreateSchemaBody.safeParse(userSchema);
-    if (!schemaValidation.success) {
-      throw new ZitadelError("E_VALIDATION", "Generated user schema is invalid", {
-        details: { issues: schemaValidation.error.issues },
-      });
-    }
-    consola.info(`User schema: ${userFields.length} fields (${userFields.join(", ")})`);
 
-    // `POST /projects` is unauthenticated; the returned `projectSecret`
-    // authorises every subsequent call (we build a second, token-bound
-    // client further down for the sync loop).
+    // `POST /projects` is unauthenticated. Creating the project also
+    // provisions its default user schema and login flow server-side, so the
+    // CLI no longer builds, scaffolds, or uploads those resources here.
     consola.start(`Creating project on ${answers.server}${dryRun ? " (dry run)" : ""}`);
     const unauthClient = createZitadelClient({ baseUrl: answers.server });
     const project = dryRun
@@ -137,8 +122,6 @@ export default class Setup extends BaseCommand {
       rendererId: flags.renderer ?? "react",
       project,
       issuer,
-      userFields,
-      userSchema,
       server: answers.server,
     };
     consola.start(`Patching project files${dryRun ? " (dry run)" : ""}`);
@@ -155,27 +138,6 @@ export default class Setup extends BaseCommand {
         (result.filesSkipped.length > 0 ? ` (${result.filesSkipped.length} unchanged)` : ""),
     );
 
-    let apply: { synced: boolean } | undefined;
-    if (!flags["no-apply"] && !dryRun) {
-      consola.start("Syncing schemas and flows to Zitadel");
-      const secret = await readZitadelSecret(cwd);
-      const client = createZitadelClient({
-        baseUrl: answers.server,
-        token: secret.project_secret,
-      });
-      // `runSyncLoop` emits one `consola.info` line per resource action.
-      await runSyncLoop(
-        cwd,
-        makeSyncers({ client, projectId: secret.project_id, env }),
-      );
-      apply = { synced: true };
-      consola.success("Sync complete");
-    } else if (flags["no-apply"]) {
-      consola.info("Skipping apply (--no-apply); run `zitadel apply` later to sync");
-    } else if (dryRun) {
-      consola.info("Skipping apply (--dry-run)");
-    }
-
     const writtenRel = result.filesWritten.map((file) => relativeDisplay(cwd, file));
     // The structured report is human-only. Under `--json` we let the
     // envelope returned from `this.emit(...)` be the sole stdout
@@ -188,8 +150,6 @@ export default class Setup extends BaseCommand {
         project,
         server: answers.server,
         issuer,
-        userFields,
-        synced: Boolean(apply?.synced),
         scaffoldedFramework,
       });
       // Frame the report in a consola box so it reads as a distinct
@@ -221,7 +181,6 @@ export default class Setup extends BaseCommand {
         server: answers.server,
         files_written: result.filesWritten.map((file) => relativeDisplay(cwd, file)),
         files_skipped: result.filesSkipped.map((file) => relativeDisplay(cwd, file)),
-        apply,
         next_actions: [`Start your project: npm install && npm run dev (then open ${issuer}/login)`],
         next_commands: ["npm install", "npm run dev"],
       },
@@ -327,8 +286,6 @@ const SENTENCE_BY_PATH: Record<string, { subject: string }> = {
   ".gitignore": { subject: "the project's .gitignore additions" },
   ".zitadel/secret": { subject: "the local project secret" },
   "zitadel.json": { subject: "the Zitadel project configuration" },
-  ".zitadel/schemas/user.json": { subject: "the user schema definition" },
-  ".zitadel/flows/default.json": { subject: "the default authentication flow" },
   ".env.example": { subject: "the .env example template" },
   ".env.local": { subject: "the local development environment variables" },
   ".zitadel/state.json": { subject: "the empty sync state file" },
@@ -347,11 +304,9 @@ function buildSummary(opts: {
   project: CreateProject201;
   server: string;
   issuer: string;
-  userFields: string[];
-  synced: boolean;
   scaffoldedFramework: boolean;
 }): Section[] {
-  const { projectFacts, writtenRel, project, server, issuer, userFields, synced, scaffoldedFramework } = opts;
+  const { projectFacts, writtenRel, project, server, issuer, scaffoldedFramework } = opts;
   const sdkPackage = "@zitadel-nextgen/sdk-next";
   const packageJsonHit = pickWrittenFile(writtenRel, "package.json");
 
@@ -381,25 +336,15 @@ function buildSummary(opts: {
     if (hit) installedRows.push({ label, value: stylePath(hit) });
   }
 
-  const configuredRows: Row[] = [
-    {
-      label: "User schema",
-      value: `${userFields.length} fields (${userFields.join(", ")})`,
-    },
-    { label: "Auth method", value: "Password" },
-  ];
-
   const projectRows: Row[] = [
     { label: "Project id", value: styleId(project.id) },
     { label: "Server", value: styleUrl(server) },
     { label: "App will run", value: styleUrl(issuer) },
-    { label: "Synced", value: synced ? "yes" : "no" },
   ];
 
   return [
     { title: "Detected", rows: detected },
     { title: "Installed", rows: installedRows },
-    { title: "Configured", rows: configuredRows },
     { title: "Project", rows: projectRows },
   ];
 }

--- a/apps/cli/src/lib/orca/patchers/rule/base.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/base.ts
@@ -1,4 +1,3 @@
-import { buildFlow } from "../../../flows";
 import { stableStringify } from "../../../json";
 import { DEFAULT_SERVER } from "../../../server";
 import { scaffold } from "./file-writer";
@@ -65,9 +64,11 @@ export abstract class AbstractRulePatcher implements Patcher {
 
   /**
    * The framework-agnostic `.zitadel/` base files every rule patcher writes:
-   * the project secret, `zitadel.json`, user schema, flow definition, env
-   * templates, and sync state. Flow content comes from {@link buildFlow}; the
-   * schema is the caller's already-built object. Pure: no filesystem or network.
+   * the project secret, `zitadel.json`, env templates, and an empty sync
+   * state. The `schemas/` and `flows/` directories are created empty — the
+   * server provisions the default user schema and flow definition when the
+   * project is created, so nothing is scaffolded into them here. Pure: no
+   * filesystem or network.
    */
   private baseOps(ctx: PatchContext): ReadonlyArray<FileOp> {
     return [
@@ -88,16 +89,6 @@ export abstract class AbstractRulePatcher implements Patcher {
         })}\n`,
       },
       { kind: "write", path: "zitadel.json", contents: `${stableStringify(projectConfig(ctx))}\n` },
-      {
-        kind: "write",
-        path: ".zitadel/schemas/user.json",
-        contents: `${stableStringify(ctx.userSchema)}\n`,
-      },
-      {
-        kind: "write",
-        path: ".zitadel/flows/default.json",
-        contents: `${stableStringify(buildFlow(ctx.userFields))}\n`,
-      },
       {
         kind: "merge-env",
         path: ".env.example",

--- a/apps/cli/src/lib/orca/patchers/rule/next/renderers/react/index.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/next/renderers/react/index.ts
@@ -6,19 +6,23 @@ import type { RendererSpec } from "../types";
  * `/profile` pages that drive the `<zitadel-login>` and `<zitadel-logout>`
  * Lit web components.
  *
- * Each page is a single client component (`"use client"`) that imports
- * `@zitadel-nextgen/sdk-next/client` via `next/dynamic({ ssr: false })`.
- * That subpath re-exports from `@zitadel-nextgen/components`, so the
- * `customElements.define` side-effect fires; importing components
- * directly would fail on strict-resolution package managers (pnpm,
- * yarn PnP) because the user only declares `sdk-next` as a direct dep.
- * SSR is disabled because Lit's element registration needs a browser.
+ * Each page is a single client component (`"use client"`) that, inside a
+ * `next/dynamic({ ssr: false })` loader, builds the SDK project handle with
+ * `configureZitadel({ projectId, proxyPath: "/__nextgen" })` and passes it to
+ * the widget via `project={...}`. It also imports
+ * `@zitadel-nextgen/sdk-next/client` for its `customElements.define`
+ * side-effect — importing `@zitadel-nextgen/components` directly would fail on
+ * strict-resolution package managers (pnpm, yarn PnP) because the app only
+ * declares `sdk-next` as a direct dep. SSR is disabled because Lit's element
+ * registration needs a browser.
  *
- * `api-base` is hardcoded to `/__nextgen`: the scaffolded Next `middleware.ts`
- * intercepts that path and forwards same-origin requests to `ZITADEL_URL`
- * (server-side only). The backend URL therefore never reaches the browser
- * bundle. `NEXT_PUBLIC_ZITADEL_PROJECT_ID` is still public — the project ID
- * is not sensitive and the web component needs it to start a flow.
+ * The handle is passed as the `project` DOM property, which relies on React
+ * 19's custom-element property binding (the scaffold targets the latest Next /
+ * React). The backend URL never reaches the browser: the client talks to the
+ * same-origin `/__nextgen` proxy path, and the scaffolded `middleware.ts`
+ * forwards it to `ZITADEL_URL` server-side. `NEXT_PUBLIC_ZITADEL_PROJECT_ID` is
+ * public — the project id is not sensitive and the widget needs it to start a
+ * flow.
  */
 export const reactRenderer: RendererSpec = {
   id: "react",

--- a/apps/cli/src/lib/orca/patchers/rule/next/renderers/react/index.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/next/renderers/react/index.ts
@@ -39,12 +39,20 @@ import dynamic from "next/dynamic";
 
 const ${elementName} = dynamic(
   async () => {
-    await import("@zitadel-nextgen/sdk-next/client");
+    const { configureZitadel } = await import("@zitadel-nextgen/sdk-next/client");
+    // Build the SDK project handle and pass it to the component via the
+    // \`project\` prop. The component reads config from this prop directly, so
+    // it works regardless of how the SDK packages are bundled. The backend URL
+    // stays server-side — requests go through the proxy path "/__nextgen",
+    // which the scaffolded middleware forwards to the Zitadel server.
+    const project = configureZitadel({
+      projectId: process.env.NEXT_PUBLIC_ZITADEL_PROJECT_ID ?? "",
+      proxyPath: "/__nextgen",
+    });
     return function ${elementName}Element() {
       return (
         <zitadel-login
-          api-base="/__nextgen"
-          project-id={process.env.NEXT_PUBLIC_ZITADEL_PROJECT_ID}
+          project={project}
           purpose="${mode}"
           post-sign-in-url="/profile"
         />
@@ -73,11 +81,15 @@ import dynamic from "next/dynamic";
 
 const ZitadelLogout = dynamic(
   async () => {
-    await import("@zitadel-nextgen/sdk-next/client");
+    const { configureZitadel } = await import("@zitadel-nextgen/sdk-next/client");
+    const project = configureZitadel({
+      projectId: process.env.NEXT_PUBLIC_ZITADEL_PROJECT_ID ?? "",
+      proxyPath: "/__nextgen",
+    });
     return function ZitadelLogoutElement() {
       return (
         <zitadel-logout
-          api-base="/__nextgen"
+          project={project}
           post-sign-out-url="/login"
         />
       );
@@ -104,20 +116,19 @@ export default function ProfilePage() {
       return {
         contents: `${MANAGED_MARKER}
 import type React from "react";
+import type { ZitadelProject } from "@zitadel-nextgen/sdk-next/client";
 
 declare module "react" {
   namespace JSX {
     interface IntrinsicElements {
       "zitadel-login": React.HTMLAttributes<HTMLElement> & {
-        "api-base"?: string;
+        project?: ZitadelProject;
         "session-exchange-path"?: string;
         "post-sign-in-url"?: string;
         purpose?: string;
-        "project-id"?: string;
-        issuer?: string;
       };
       "zitadel-logout": React.HTMLAttributes<HTMLElement> & {
-        "api-base"?: string;
+        project?: ZitadelProject;
         "post-sign-out-url"?: string;
       };
     }

--- a/apps/cli/src/lib/orca/patchers/types.ts
+++ b/apps/cli/src/lib/orca/patchers/types.ts
@@ -1,5 +1,3 @@
-import type { CreateSchemaBody } from "@zitadel-nextgen/api/generated/model";
-
 import type { FrameworkFacts } from "../detectors/types";
 import type { CreateProjectResponse } from "../../api/client";
 
@@ -16,15 +14,18 @@ export type PatchView = Readonly<{
 
 /**
  * Everything a patcher needs to integrate Zitadel into a project. Extends
- * {@link PatchView} with the resolved project, issuer, and schema/auth choices
- * that fill file contents. Readonly: a patcher never mutates its input.
+ * {@link PatchView} with the resolved project, issuer, and server it points
+ * at, which fill file contents. Readonly: a patcher never mutates its input.
+ *
+ * Note: the user schema and flow definition are NOT here. The server
+ * provisions those defaults when the project is created, so the patcher no
+ * longer scaffolds them locally. The builders (`lib/user-schema`, `lib/flows`)
+ * and sync engine (`lib/sync`) remain for the future pull-based workflow.
  */
 export type PatchContext = PatchView &
   Readonly<{
     project: CreateProjectResponse;
     issuer: string;
-    userFields: ReadonlyArray<string>;
-    userSchema: CreateSchemaBody;
     server: string;
   }>;
 

--- a/apps/cli/tests/integration/flow-schema.test.ts
+++ b/apps/cli/tests/integration/flow-schema.test.ts
@@ -1,116 +1,16 @@
-import { mkdtemp, readFile } from "node:fs/promises";
-import { mkdir, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
-import { resetPlatformStore, setupPlatformHandlers } from "@zitadel-nextgen/api-mock/platform";
-import { setupServer } from "msw/node";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { CreateFlowDefinitionBody } from "@zitadel-nextgen/api/generated/endpoints/zitadelNextGen.zod";
 
 /** The inner flow-definition shape; the envelope is `CreateFlowDefinitionBody`. */
 const flowDefinitionSchema = CreateFlowDefinitionBody.shape.flow_definition;
-import { runCliForTest } from "../helpers/run-cli";
 
-const MOCK_SERVER_URL = "http://mock.zitadel.test";
-const server = setupServer(...setupPlatformHandlers());
-beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
-afterAll(() => server.close());
-afterEach(() => { server.resetHandlers(); resetPlatformStore(); });
-
-function cli(args: string[]) {
-  return runCliForTest([...args, "--server", MOCK_SERVER_URL]);
-}
-
-async function scaffoldProject(): Promise<string> {
-  const cwd = await mkdtemp(join(tmpdir(), "zitadel-flow-schema-"));
-  await mkdir(join(cwd, "app"), { recursive: true });
-  await writeFile(
-    join(cwd, "package.json"),
-    JSON.stringify({ name: "demo", private: true, dependencies: { next: "^15" } }, null, 2),
-  );
-  await writeFile(
-    join(cwd, "app/layout.tsx"),
-    "export default function Layout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }\n",
-  );
-  const result = await cli([
-    "setup",
-    "--cwd",
-    cwd,
-    "--non-interactive",
-    "--json",
-    "--no-apply",
-  ]);
-  if (result.exitCode !== 0) {
-    throw new Error(`setup failed: ${result.stdout}`);
-  }
-  return cwd;
-}
-
+// The default user schema and flow definition are provisioned server-side
+// when a project is created, so `setup` no longer scaffolds them locally.
+// The builders (`lib/flows`, `lib/user-schema`) and their shapes are covered
+// by their own unit tests; this file keeps the spec-contract check that flow
+// `fields` must be a string[] (not a rich per-field object).
 describe("flow definition schema", () => {
-  it("setup emits a FlowDefinition that parses against the zod schema", async () => {
-    const cwd = await scaffoldProject();
-
-    const flowPath = join(cwd, ".zitadel/flows/default.json");
-    const raw = JSON.parse(await readFile(flowPath, "utf8")) as unknown;
-    const parsed = flowDefinitionSchema.safeParse(raw);
-    expect(parsed.success, parsed.success ? "" : JSON.stringify(parsed.error.issues)).toBe(true);
-    if (!parsed.success) return;
-
-    const flow = parsed.data;
-    expect(flow.name).toBe("default");
-    expect(flow.user_schema).toMatch(/^https?:\/\//);
-    expect(Object.keys(flow.purposes)).toEqual(expect.arrayContaining(["login", "register"]));
-    expect(flow.purposes.login).toBe("identifier");
-    expect(flow.purposes.register).toBe("register-profile");
-
-    const identifier = flow.steps.find((s) => s.name === "identifier");
-    expect(identifier).toBeDefined();
-    if (!identifier) return;
-
-    // Spec: step.fields is a `string[]` of property names from the
-    // user schema (not a rich per-field config — that lives on the
-    // user schema itself).
-    expect(Array.isArray(identifier.fields)).toBe(true);
-    expect(identifier.fields).toContain("email");
-
-    const submitAction = identifier.actions.submit;
-    expect(submitAction).toBeDefined();
-    expect(submitAction?.primary).toBe(true);
-  });
-
-  it("emits a credential step that collects the password property", async () => {
-    const cwd = await scaffoldProject();
-    const flowPath = join(cwd, ".zitadel/flows/default.json");
-    const raw = JSON.parse(await readFile(flowPath, "utf8")) as unknown;
-    const parsed = flowDefinitionSchema.safeParse(raw);
-    expect(parsed.success).toBe(true);
-    if (!parsed.success) return;
-    const credential = parsed.data.steps.find((step) => step.name === "credential");
-    expect(credential?.fields).toEqual(["password"]);
-    expect(credential?.actions.submit?.primary).toBe(true);
-    expect(credential?.transitions).toEqual({
-      submit: { target: "complete" },
-    });
-
-    const userSchema = JSON.parse(
-      await readFile(join(cwd, ".zitadel/schemas/user.json"), "utf8"),
-    ) as { "x-auth-methods": Record<string, unknown> };
-    expect(Object.keys(userSchema["x-auth-methods"])).toEqual(["password"]);
-  });
-
-  it("routes user_not_found from the identifier step to register-profile", async () => {
-    const cwd = await scaffoldProject();
-    const flowPath = join(cwd, ".zitadel/flows/default.json");
-    const raw = JSON.parse(await readFile(flowPath, "utf8")) as unknown;
-    const parsed = flowDefinitionSchema.safeParse(raw);
-    expect(parsed.success).toBe(true);
-    if (!parsed.success) return;
-    const identifier = parsed.data.steps.find((step) => step.name === "identifier");
-    expect(identifier?.transitions?.user_not_found).toEqual({ target: "register-profile" });
-  });
-
   it("rejects flow definitions with object-shaped fields (spec says fields is string[])", () => {
     const legacy = {
       name: "legacy",

--- a/apps/cli/tests/integration/patch-eject.test.ts
+++ b/apps/cli/tests/integration/patch-eject.test.ts
@@ -43,7 +43,6 @@ describe("patch then eject round-trip", () => {
       cwd,
       "--non-interactive",
       "--json",
-      "--no-apply",
     ]);
     expect(setup.exitCode).toBe(0);
     expect((parseJson(setup.stdout) as { status: string }).status).toBe("ok");
@@ -51,8 +50,6 @@ describe("patch then eject round-trip", () => {
     // Patch wrote the managed tree + framework routes.
     expect((await stat(join(cwd, ".zitadel/secret"))).mode & 0o777).toBe(0o600);
     expect(await readFile(join(cwd, "zitadel.json"), "utf8")).toContain('"project"');
-    expect(await readFile(join(cwd, ".zitadel/schemas/user.json"), "utf8")).toContain('"x-unique"');
-    expect(await readFile(join(cwd, ".zitadel/flows/default.json"), "utf8")).toContain('"name"');
     expect(await readFile(join(cwd, "app/login/page.tsx"), "utf8")).toContain(MANAGED_MARKER);
     expect(await readFile(join(cwd, "middleware.ts"), "utf8")).toContain(MANAGED_MARKER);
 

--- a/apps/cli/tests/integration/setup-next.test.ts
+++ b/apps/cli/tests/integration/setup-next.test.ts
@@ -35,24 +35,14 @@ describe("Next setup integration", () => {
       "--json",
     ]);
     expect(setup.exitCode).toBe(0);
-    const setupJson = parseJson(setup.stdout) as {
-      status: string;
-      data: { apply?: unknown };
-    };
+    const setupJson = parseJson(setup.stdout) as { status: string };
     expect(setupJson.status).toBe("ok");
-    expect(setupJson.data.apply).toMatchObject({ synced: true });
 
+    // The user schema and flow are provisioned server-side when the project
+    // is created, so setup does not write `.zitadel/schemas` or
+    // `.zitadel/flows`; only the framework files and project config are
+    // scaffolded locally.
     expect(await readFile(join(cwd, "zitadel.json"), "utf8")).toContain('"project"');
-    expect(await readFile(join(cwd, ".zitadel/schemas/user.json"), "utf8")).toContain(
-      '"x-unique": "project"',
-    );
-    const flowRaw = await readFile(join(cwd, ".zitadel/flows/default.json"), "utf8");
-    // Spec: `name` is the slug-pattern stable identifier; `template_name`
-    // was a non-spec field the CLI used to emit. `step.fields` is a
-    // string[] of property names referencing the user schema.
-    expect(flowRaw).toContain('"name": "default"');
-    expect(flowRaw).toContain('"user_schema":');
-    expect(flowRaw).toContain('"email"');
     const loginPage = await readFile(join(cwd, "app/login/page.tsx"), "utf8");
     expect(loginPage).toContain("zitadel-cli: managed-file v1");
     expect(loginPage).toContain('"use client"');

--- a/apps/cli/tests/integration/setup-next.test.ts
+++ b/apps/cli/tests/integration/setup-next.test.ts
@@ -48,13 +48,19 @@ describe("Next setup integration", () => {
     expect(loginPage).toContain('"use client"');
     expect(loginPage).toContain('purpose="login"');
     expect(loginPage).toContain("<zitadel-login");
-    expect(loginPage).toContain('api-base="/__nextgen"');
+    // The SDK handle is built (proxy path + project id from the public env
+    // var) and passed to the component via the `project` prop; the backend URL
+    // stays server-side.
+    expect(loginPage).toContain("configureZitadel");
+    expect(loginPage).toContain('proxyPath: "/__nextgen"');
+    expect(loginPage).toContain("project={project}");
     expect(loginPage).not.toContain("NEXT_PUBLIC_ZITADEL_API_BASE");
     expect(loginPage).toContain('post-sign-in-url="/profile"');
     const profilePage = await readFile(join(cwd, "app/profile/page.tsx"), "utf8");
     expect(profilePage).toContain("zitadel-cli: managed-file v1");
     expect(profilePage).toContain("<zitadel-logout");
-    expect(profilePage).toContain('api-base="/__nextgen"');
+    expect(profilePage).toContain("configureZitadel");
+    expect(profilePage).toContain("project={project}");
     expect(profilePage).toContain('post-sign-out-url="/login"');
     const middleware = await readFile(join(cwd, "middleware.ts"), "utf8");
     expect(middleware).toContain("zitadel-cli: managed-file v1");

--- a/apps/cli/tests/unit/commands/doctor.test.ts
+++ b/apps/cli/tests/unit/commands/doctor.test.ts
@@ -157,19 +157,6 @@ describe("doctor command", () => {
     expect(match?.status).toBe("fail");
   });
 
-  it("fails the schema check when the user schema is not valid JSON Schema", async () => {
-    const cwd = await makeHealthyProject();
-    // `type` must be a string/array of strings; a number makes the schema invalid.
-    await writeFile(join(cwd, ".zitadel/schemas/user.json"), JSON.stringify({ type: 123 }));
-
-    const res = await doctor(cwd);
-
-    expect(res.exitCode).toBe(3);
-    const json = parseJson(res.stdout) as { details: { checks: Check[] } };
-    const schema = json.details.checks.find((check) => check.name === "schema");
-    expect(schema?.status).toBe("fail");
-  });
-
   it("re-locks loose secret permissions via --fix and then passes", async () => {
     const cwd = await makeHealthyProject();
     await chmod(join(cwd, ".zitadel/secret"), 0o644);
@@ -185,13 +172,19 @@ describe("doctor command", () => {
 
   it("reports E_VALIDATION (not a crash) when --fix cannot repair a broken project", async () => {
     const cwd = await makeHealthyProject();
-    // Remove the user schema: schema check fails outright, and dependency's
-    // repair can't rebuild its context — --fix must stay best-effort.
-    await rm(join(cwd, ".zitadel/schemas/user.json"));
+    // project-match has no auto-repair: a secret/config project_id mismatch
+    // stays failed through --fix, so doctor must report E_VALIDATION rather
+    // than crash.
     await writeFile(
-      join(cwd, "package.json"),
-      JSON.stringify({ name: "demo", dependencies: { next: "^15" } }),
+      join(cwd, ".zitadel/secret"),
+      JSON.stringify({
+        project_id: "mismatch",
+        project_secret: "sk_proj_test",
+        preview_secret: "sk_proj_preview",
+        preview_origins: [],
+      }),
     );
+    await chmod(join(cwd, ".zitadel/secret"), 0o600);
 
     const res = await doctor(cwd, ["--fix"]);
 
@@ -199,7 +192,7 @@ describe("doctor command", () => {
     const json = parseJson(res.stdout) as { status: string; code: string; details: { checks: Check[] } };
     expect(json.status).toBe("error");
     expect(json.code).toBe("E_VALIDATION");
-    expect(json.details.checks.find((check) => check.name === "schema")?.status).toBe("fail");
+    expect(json.details.checks.find((check) => check.name === "project-match")?.status).toBe("fail");
   });
 
   it("re-applies a missing Zitadel dependency via --fix and then passes", async () => {

--- a/apps/cli/tests/unit/commands/doctor/checks.test.ts
+++ b/apps/cli/tests/unit/commands/doctor/checks.test.ts
@@ -286,6 +286,5 @@ describe("loadPatchContext", () => {
     expect(ctx.framework.id).toBe("next");
     expect(ctx.project.id).toBe("proj-001");
     expect(ctx.issuer).toBe("http://localhost:3000");
-    expect(ctx.userFields).toEqual(["email"]);
   });
 });

--- a/apps/cli/tests/unit/commands/setup.test.ts
+++ b/apps/cli/tests/unit/commands/setup.test.ts
@@ -71,17 +71,15 @@ describe("setup command", () => {
   it("dry-run returns ok with a stub project and contacts no platform", async () => {
     const cwd = await makeNextProject();
 
-    const res = await setup(cwd, ["--dry-run", "--no-apply", "--framework", "next"]);
+    const res = await setup(cwd, ["--dry-run", "--framework", "next"]);
 
     expect(res.exitCode).toBe(0);
     const json = parseJson(res.stdout) as {
       status: string;
-      data: { project: { project_id: string }; apply?: unknown };
+      data: { project: { project_id: string } };
     };
     expect(json.status).toBe("ok");
     expect(json.data.project.project_id).toBe("dry-run-0000");
-    // dry-run never applies, so no apply summary is attached.
-    expect(json.data.apply).toBeUndefined();
   });
 
   it("errors in a non-interactive empty directory without --framework", async () => {

--- a/apps/cli/tests/unit/lib/orca/patchers/rule/next/index.test.ts
+++ b/apps/cli/tests/unit/lib/orca/patchers/rule/next/index.test.ts
@@ -4,7 +4,6 @@ import type { FileOp, ScaffoldPlan } from "../../../../../../../src/lib/orca/pat
 import { NextPatcher } from "../../../../../../../src/lib/orca/patchers/rule/next";
 import type { PatchContext } from "../../../../../../../src/lib/orca/patchers/types";
 import { MANAGED_MARKER } from "../../../../../../../src/lib/paths";
-import { buildUserSchema } from "../../../../../../../src/lib/user-schema";
 
 function ctxFor(appDir: "app" | "src/app"): PatchContext {
   return {
@@ -18,8 +17,6 @@ function ctxFor(appDir: "app" | "src/app"): PatchContext {
       createdAt: "2026-01-01T00:00:00.000Z",
     },
     issuer: "http://localhost:3000",
-    userFields: ["email", "given_name"],
-    userSchema: buildUserSchema(["email", "given_name"]),
     server: "https://api.zitadel.cloud",
   };
 }
@@ -35,8 +32,6 @@ function writeContents(plan: ScaffoldPlan, path: string): string | undefined {
 describe("NextPatcher.plan", () => {
   it("emits the base .zitadel files and Next routes for the app dir", () => {
     const plan = new NextPatcher().plan(ctxFor("app"));
-    expect(writeContents(plan, ".zitadel/schemas/user.json")).toContain('"x-unique": "project"');
-    expect(writeContents(plan, ".zitadel/flows/default.json")).toContain('"name": "default"');
     expect(writeContents(plan, "zitadel.json")).toContain('"project": "proj-1"');
     expect(writeContents(plan, "app/login/page.tsx")).toContain(MANAGED_MARKER);
     expect(writeContents(plan, "app/register/page.tsx")).toContain(MANAGED_MARKER);
@@ -44,20 +39,15 @@ describe("NextPatcher.plan", () => {
     expect(plan.ops.some((op) => op.kind === "add-dep")).toBe(true);
   });
 
+  it("does not scaffold the user schema or flow (server-provisioned)", () => {
+    const plan = new NextPatcher().plan(ctxFor("app"));
+    expect(writeContents(plan, ".zitadel/schemas/user.json")).toBeUndefined();
+    expect(writeContents(plan, ".zitadel/flows/default.json")).toBeUndefined();
+  });
+
   it("honors the src/app directory", () => {
     const plan = new NextPatcher().plan(ctxFor("src/app"));
     expect(writeContents(plan, "src/app/login/page.tsx")).toContain(MANAGED_MARKER);
-  });
-
-  it("password flow's credential step references the password property", () => {
-    const plan = new NextPatcher().plan(ctxFor("app"));
-    const flowJson = writeContents(plan, ".zitadel/flows/default.json");
-    expect(flowJson).toBeDefined();
-    const flow = JSON.parse(flowJson ?? "{}") as {
-      steps: ReadonlyArray<{ name: string; fields: ReadonlyArray<string> }>;
-    };
-    const credential = flow.steps.find((step) => step.name === "credential");
-    expect(credential?.fields).toEqual(["password"]);
   });
 });
 

--- a/packages/sdk-next/src/client.ts
+++ b/packages/sdk-next/src/client.ts
@@ -10,8 +10,13 @@
  * await import("@zitadel-nextgen/sdk-next/client");
  * ```
  *
- * SDK configuration is handled separately via `configureZitadel()`
- * from `@zitadel-nextgen/api/config` — typically in a shared
- * `zitadel.ts` init file.
+ * SDK configuration is done via `configureZitadel()`, re-exported here so
+ * a consuming app that only declares `@zitadel-nextgen/sdk-next` as a direct
+ * dependency can configure the SDK without reaching into
+ * `@zitadel-nextgen/api/config` (which strict package managers would not
+ * resolve). Call it inside the same `"use client"` boundary before the
+ * components mount.
  */
 export { ZitadelLogin, ZitadelLogout } from '@zitadel-nextgen/components';
+export { configureZitadel, getApi } from '@zitadel-nextgen/api/config';
+export type { ZitadelConfig, ZitadelProject } from '@zitadel-nextgen/api/config';

--- a/packages/sdk-next/src/client.ts
+++ b/packages/sdk-next/src/client.ts
@@ -19,4 +19,7 @@
  */
 export { ZitadelLogin, ZitadelLogout } from '@zitadel-nextgen/components';
 export { configureZitadel, getApi } from '@zitadel-nextgen/api/config';
-export type { ZitadelConfig, ZitadelProject } from '@zitadel-nextgen/api/config';
+export type {
+  ZitadelConfig,
+  ZitadelProject,
+} from '@zitadel-nextgen/api/config';


### PR DESCRIPTION
The server now provisions the default user schema and login flow when a project is created, so `setup` no longer builds, writes, or syncs them. The sync engine, builders, and `apply`/`plan` commands stay in place (just unwired) for the future pull-based workflow.

Based on `fix/patcher-owns-narration` (#202) since this work stacks on those CLI changes; retarget to `main` once that merges.