### PR TITLE
ci: fix npm release workflow pnpm setup

### DIFF
--- a/.changeset/fix-release-pnpm-setup.md
+++ b/.changeset/fix-release-pnpm-setup.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the npm release workflow's pnpm setup.

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 10.33.2
           run_install: false
 
       - name: Set up Node.js


### PR DESCRIPTION
## Summary
- Remove the duplicated pnpm version pin from `release-npm.yml` so `pnpm/action-setup` uses the workspace `packageManager` value from `package.json`
- Add an empty changeset to record the CI-only workflow fix

## Testing
- Not run (not requested)
- Verified the workflow diff is limited to the pnpm setup step and the added empty changeset