### PR TITLE
ci: skip changeset-check on the Version Packages PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,11 @@ jobs:
     # The check lives in scripts/check-changeset-required.mjs so the publishable
     # package list and rules are testable and shared, rather than duplicated in
     # inline shell.
-    if: github.event_name == 'pull_request'
+    #
+    # Skip the Changesets "Version Packages" PR: it legitimately edits public
+    # package manifests/changelogs and *removes* changesets (consuming them),
+    # which would otherwise trip this gate.
+    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Summary
- The Changesets "Version Packages" PR (`changeset-release/main`) **consumes** changesets: it bumps public package `package.json` versions, writes `CHANGELOG.md` entries, and deletes the `.changeset/*.md` files.
- The `changeset-check` gate (added in #209) sees "public package files changed + no changeset added" and fails the release PR (observed on #213).
- Fix: skip the `changeset-check` job when `github.head_ref == 'changeset-release/main'`.

## Why this is safe
`changeset-check` exists to stop *human/feature* PRs from changing public packages without a release note. The release PR is the mechanism that turns those notes into versions, so requiring a changeset on it is contradictory.

## Test plan
- [ ] CI green on this PR (changeset-check still runs here — this PR touches only `.github/workflows/ci.yml`, no public package, so it passes by having no publishable changes).
- [ ] After merge, #213 re-runs and `changeset-check` is skipped, unblocking the alpha release.

Made with [Cursor](https://cursor.com)