### PR TITLE
ci: drop duplicate pnpm version in release-npm setup

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -66,7 +66,6 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 10.33.2
           run_install: false
 
       - name: Set up Node.js


### PR DESCRIPTION
## Summary
- The `release-npm` workflow failed at **Set up pnpm** with `ERR_PNPM_BAD_PM_VERSION` because `pnpm/action-setup@v5` was given the version **twice**: via the action's `version: 10.33.2` input *and* via `package.json`'s `packageManager` field.
- Removed the `version:` input so `packageManager` is the single source of truth — matching how `ci.yml` already configures pnpm.

## Context
This surfaced on the first `release-npm` run after #218 (App-token integration). The App-token step itself worked correctly; only the pnpm setup was broken.

## Test plan
- [x] `ci.yml` already uses `pnpm/action-setup@v5` with only `run_install: false` and passes
- [ ] Next push to `main` runs `release-npm` past the pnpm step

Made with [Cursor](https://cursor.com)