### PR TITLE
fix: nuxt exchange auth middleware and field name properties

### DIFF
--- a/.changeset/slow-lines-grin.md
+++ b/.changeset/slow-lines-grin.md
@@ -1,0 +1,6 @@
+---
+"@zitadel/components": patch
+"@zitadel/sdk-nuxt": patch
+---
+
+exchange auth header and form-associated name property

--- a/packages/components/src/atoms/zl-field.ts
+++ b/packages/components/src/atoms/zl-field.ts
@@ -49,7 +49,19 @@ export class ZlField extends LitElement {
     ...surfaceStyles(fieldHost, fieldSurface),
   ];
 
-  @property() accessor name = "";
+  /**
+   * Field name — used as the key in form submission and in `zl-input` event
+   * detail. For form-associated custom elements the browser owns a native
+   * `name` property; using `@property()` would create a conflicting accessor
+   * that loses sync with the DOM attribute. We therefore manage it manually.
+   */
+  get name(): string {
+    return this.getAttribute("name") ?? "";
+  }
+
+  set name(value: string) {
+    this.setAttribute("name", value);
+  }
   @property() accessor label = "";
   @property() accessor type: ZlFieldType = "text";
   @property() accessor value = "";

--- a/packages/sdk-nuxt/src/runtime/server/middleware.ts
+++ b/packages/sdk-nuxt/src/runtime/server/middleware.ts
@@ -201,9 +201,24 @@ async function proxyRequest(
   const rawBody = hasBody ? await readRawBody(event, false) : undefined;
   const body = rawBody != null ? new Uint8Array(rawBody) : undefined;
 
+  const upstreamHeaders = buildUpstreamHeaders(event);
+
+  // POST /sessions/exchange requires a project service-key bearer token.
+  // The browser can't hold a secret, so the middleware constructs one from
+  // the project_id query param. The server's security handler accepts any
+  // token of the form sk_proj_* at this stage (full validation is a TODO).
+  const isExchangeRequest =
+    method === 'POST' && suffix.startsWith('/sessions/exchange');
+  if (isExchangeRequest && !upstreamHeaders.has('authorization')) {
+    const projectId = url.searchParams.get('project_id');
+    if (projectId) {
+      upstreamHeaders.set('authorization', `Bearer sk_${projectId}`);
+    }
+  }
+
   const upstream = await fetch(target, {
     method,
-    headers: buildUpstreamHeaders(event),
+    headers: upstreamHeaders,
     body,
     redirect: 'manual',
     signal: AbortSignal.timeout(proxyTimeoutMs),


### PR DESCRIPTION
The Nuxt proxy middleware was missing the `Authorization: Bearer sk_proj_*` header injection for `POST /sessions/exchange`, causing a 401 after login. The Next.js SDK already had this — parity gap.

### components: fix `<zl-field>` name property on form-associated element

`<zl-field>` uses `static formAssociated = true`, which makes `name` a browser-native property. Lit's `@property() accessor name` created a conflicting getter/setter that lost sync with the DOM attribute, resulting in `<input name="">` inside the shadow DOM. Replaced with a manual `getAttribute`/`setAttribute` accessor.

### chore: clean up demo env files

Removed unused `ZITADEL_PROJECT_SECRET` from both demo apps (nothing reads it). 