### PR TITLE
build: install Playwright Chromium before local journey

### DIFF
--- a/.changeset/smooth-playwright-journey.md
+++ b/.changeset/smooth-playwright-journey.md
@@ -1,0 +1,4 @@
+---
+---
+
+Make the local consumer journey install Playwright Chromium before the expensive setup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,11 +124,12 @@ corepack pnpm run journey
 ```
 
 This runner requires Docker for Verdaccio. By default it starts the backend from
-source with embedded Postgres, builds and packs local npm packages with pnpm,
-creates a temporary Next.js app outside the repo, runs CLI setup through npm,
-starts the generated app on `localhost`, and runs Playwright with one worker.
-Use `-- --backend image --image <docker-tag>` to run the backend through the
-local compose profile for image parity.
+source with embedded Postgres, ensures the Playwright Chromium browsers are
+installed, builds and packs local npm packages with pnpm, creates a temporary
+Next.js app outside the repo, runs CLI setup through npm, starts the generated
+app on `localhost`, and runs Playwright with one worker. Use
+`-- --backend image --image <docker-tag>` to run the backend through the local
+compose profile for image parity.
 
 In CI the dedicated `node-e2e` job (in `.github/workflows/ci.yml`) gates merges
 on the checked-in demo integrations. The separate `consumer-journey-e2e` job is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,10 +68,10 @@ corepack pnpm run journey
 
 The local runner needs Docker for Verdaccio, but by default it starts the
 backend from source with embedded Postgres, so no local database container is
-required. It builds and packs the local publishable packages with pnpm,
-publishes them to the temporary registry, creates a Next.js app outside the
-repo, runs CLI setup through npm, starts the generated app on localhost, and
-runs Playwright with one worker.
+required. It ensures the Playwright Chromium browsers are installed, builds and
+packs the local publishable packages with pnpm, publishes them to the temporary
+registry, creates a Next.js app outside the repo, runs CLI setup through npm,
+starts the generated app on localhost, and runs Playwright with one worker.
 
 For image parity with CI, provide a local backend image tag:
 

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ Fresh-app consumer journey check:
 corepack pnpm run journey
 ```
 
-This opt-in check builds the local npm packages, publishes them to a temporary
-Verdaccio registry, starts a source backend with embedded Postgres, scaffolds a
-new Next.js app outside the repo, and verifies registration/login journeys
-against the generated app.
+This opt-in check ensures the Playwright Chromium browsers are installed, builds
+the local npm packages, publishes them to a temporary Verdaccio registry, starts
+a source backend with embedded Postgres, scaffolds a new Next.js app outside the
+repo, and verifies registration/login journeys against the generated app.
 
 ## CI
 

--- a/apps/cli-journey-e2e/README.md
+++ b/apps/cli-journey-e2e/README.md
@@ -17,18 +17,19 @@ corepack pnpm run journey
 The default mode uses Docker only for Verdaccio. The backend runs from local
 source with embedded Postgres:
 
-1. Build the six public workspace packages.
-2. Pack package tarballs with `corepack pnpm --dir <package> pack`.
-3. Verify tarballs are installable and do not contain `catalog:` or
+1. Ensure the Playwright Chromium browsers are installed.
+2. Build the six public workspace packages.
+3. Pack package tarballs with `corepack pnpm --dir <package> pack`.
+4. Verify tarballs are installable and do not contain `catalog:` or
    `workspace:` dependency specs.
-4. Start Verdaccio with npmjs proxying enabled.
-5. Publish tarballs to Verdaccio with `alpha` and `latest` tags.
-6. Start `go run .` on a free local port.
-7. Create a pinned `create-next-app` project in a temporary directory.
-8. Run CLI setup through `npx <cli-package>@alpha`.
-9. Run `npm install` in the generated app against the temporary registry.
-10. Start the generated app on `localhost`.
-11. Run the Playwright tests with one worker.
+5. Start Verdaccio with npmjs proxying enabled.
+6. Publish tarballs to Verdaccio with `alpha` and `latest` tags.
+7. Start `go run .` on a free local port.
+8. Create a pinned `create-next-app` project in a temporary directory.
+9. Run CLI setup through `npx <cli-package>@alpha`.
+10. Run `npm install` in the generated app against the temporary registry.
+11. Start the generated app on `localhost`.
+12. Run the Playwright tests with one worker.
 
 ### Options
 

--- a/apps/cli-journey-e2e/scripts/run-local.mjs
+++ b/apps/cli-journey-e2e/scripts/run-local.mjs
@@ -68,6 +68,7 @@ try {
 
   log(`work dir: ${workDir}`);
   await assertDockerAvailable();
+  await ensurePlaywrightBrowsers();
   await buildPackages();
   await packPackages();
   await run("node", [
@@ -349,6 +350,19 @@ async function packageName(relativePath) {
     throw new Error(`${relativePath}/package.json has no name`);
   }
   return manifest.name;
+}
+
+async function ensurePlaywrightBrowsers() {
+  log("ensuring Playwright Chromium browsers are installed");
+  await run("corepack", [
+    "pnpm",
+    "--filter",
+    "@zitadel/cli-journey-e2e",
+    "exec",
+    "playwright",
+    "install",
+    "chromium",
+  ]);
 }
 
 async function assertDockerAvailable() {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -2,7 +2,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { runCapture } from "./dev-process.mjs";
 
@@ -101,8 +101,8 @@ async function checkDocker() {
 }
 
 async function checkPlaywright() {
-  const browserInfo = findPlaywrightBrowserInfo();
-  if (!browserInfo) {
+  const playwrightInfo = findPlaywrightBrowserInfo();
+  if (!playwrightInfo) {
     warn(
       "Playwright package metadata is unavailable",
       "Run: corepack pnpm install --frozen-lockfile",
@@ -110,8 +110,8 @@ async function checkPlaywright() {
     return;
   }
 
-  const cacheRoot = join(homedir(), ".cache", "ms-playwright");
-  const missing = browserInfo
+  const cacheRoot = resolvePlaywrightBrowserPath(playwrightInfo.packageRoot);
+  const missing = playwrightInfo.browsers
     .filter((browser) => !existsSync(join(cacheRoot, browser.directory)))
     .map((browser) => browser.name);
 
@@ -122,7 +122,7 @@ async function checkPlaywright() {
 
   warn(
     `Playwright browsers missing: ${missing.join(", ")}`,
-    "Run: corepack pnpm --filter @zitadel/demo-next-e2e exec playwright install chromium",
+    "Run: corepack pnpm --filter @zitadel/cli-journey-e2e exec playwright install chromium",
   );
 }
 
@@ -166,15 +166,42 @@ function findPlaywrightBrowserInfo() {
     return null;
   }
   const metadata = JSON.parse(readFileSync(browsersPath, "utf8"));
-  return metadata.browsers
-    .filter((browser) => ["chromium", "chromium-headless-shell"].includes(browser.name))
-    .map((browser) => ({
-      name: browser.name,
-      directory:
-        browser.name === "chromium-headless-shell"
-          ? `chromium_headless_shell-${browser.revision}`
-          : `chromium-${browser.revision}`,
-    }));
+  return {
+    packageRoot: join(pnpmDir, playwrightCoreDir, "node_modules", "playwright-core"),
+    browsers: metadata.browsers
+      .filter((browser) => ["chromium", "chromium-headless-shell"].includes(browser.name))
+      .map((browser) => ({
+        name: browser.name,
+        directory:
+          browser.name === "chromium-headless-shell"
+            ? `chromium_headless_shell-${browser.revision}`
+            : `chromium-${browser.revision}`,
+      })),
+  };
+}
+
+function resolvePlaywrightBrowserPath(packageRoot) {
+  const envPath = process.env.PLAYWRIGHT_BROWSERS_PATH;
+  if (envPath === "0") {
+    return join(packageRoot, ".local-browsers");
+  }
+  if (envPath) {
+    return resolve(process.env.INIT_CWD || process.cwd(), envPath);
+  }
+  return join(defaultCacheDirectory(), "ms-playwright");
+}
+
+function defaultCacheDirectory() {
+  switch (process.platform) {
+    case "linux":
+      return process.env.XDG_CACHE_HOME || join(homedir(), ".cache");
+    case "darwin":
+      return join(homedir(), "Library", "Caches");
+    case "win32":
+      return process.env.LOCALAPPDATA || join(homedir(), "AppData", "Local");
+    default:
+      return join(homedir(), ".cache");
+  }
 }
 
 function readText(relativePath) {


### PR DESCRIPTION
## Summary
- Make `doctor` resolve Playwright browser caches using Playwright’s platform rules and point the warning at `@zitadel/cli-journey-e2e`.
- Have the local consumer journey install Chromium up front before package builds and app setup.
- Update the repo docs and agent guidance to reflect the smoother journey flow.
- Add an empty changeset for the repo-tooling/docs change.

## Testing
- `corepack pnpm run doctor`
- `PLAYWRIGHT_BROWSERS_PATH=/tmp/zitadel-empty-pw-cache node scripts/doctor.mjs`
- `PLAYWRIGHT_BROWSERS_PATH=0 node scripts/doctor.mjs`
- `corepack pnpm run journey -- --keep`
- `git diff --check`