### PR TITLE
docs: add preview vision and public-readiness disclaimers

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -61,4 +61,8 @@ The Go server binary is **not** managed by changesets — it is released with `g
 
 ## Licensing reminder
 
-npm packages published from this repo are **MIT-licensed**, not AGPL like the server. Every `package.json` under `apps/cli/` and `packages/*` must set `"license": "MIT"` and ship a `LICENSE` file. See [/LICENSING.md](../LICENSING.md).
+npm packages published from this repo are **MIT-licensed**, not AGPL like the
+server. Public packages under `apps/cli/` and `packages/*` must set
+`"license": "MIT"` and ship a package-level `LICENSE` file before publishing.
+Private demo, design-system, and integration workspaces are covered by the path
+exceptions in [/LICENSING.md](../LICENSING.md) while they remain private.

--- a/.changeset/vision-public-readiness.md
+++ b/.changeset/vision-public-readiness.md
@@ -1,0 +1,5 @@
+---
+---
+
+Document the preview vision and clarify licensing metadata before public
+release.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,9 @@ more than polish.
   `.changeset/<slug>.md` file directly rather than via the interactive prompt.
   See `AGENTS.md` for the package list and file format. npm package manifests
   must keep `"license": "MIT"`.
+- PR titles must pass Semantic PR. Use `<type>(optional-scope): <summary>` and
+  verify allowed types/scopes against `.github/semantic.yml`; for docs-only
+  changes, use a title such as `docs: add preview status disclaimer`.
 - Server and embedded console changes are AGPL-3.0-only by default; public API,
   docs, CLI, and SDK paths are MIT exceptions per `LICENSING.md`.
 - For `consumer-journey-e2e` or `apps/cli-journey-e2e/**` changes, verify that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,11 @@ For customer-local runtime workflows, agents should prefer
 
 ## Release, Licensing, And Secrets
 
+- PR titles must pass the Semantic PR check. Use the conventional format
+  `<type>(optional-scope): <summary>` and treat `.github/semantic.yml` as the
+  source of truth for allowed types and scopes. Scopes are optional; omit the
+  scope instead of inventing one. For documentation-only changes, use the
+  `docs` type, for example `docs: add preview status disclaimer`.
 - User-visible changes to a public npm package need a changeset. The public
   packages are `@zitadel/cli` (`apps/cli/`), `@zitadel/api`,
   `@zitadel/components`, `@zitadel/sdk-core`, `@zitadel/sdk-next`, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,3 +145,16 @@ Place the platform binary at `linux/amd64/nextgen` in the build context when mim
 
 - [`AGENTS.md`](AGENTS.md) — workspace conventions
 - [`docs/adrs/`](docs/adrs/) — architecture decisions
+
+## Pull request titles
+
+Pull request titles are checked by Semantic PR. Use the conventional format
+`<type>(optional-scope): <summary>`.
+
+Allowed types and scopes live in [`.github/semantic.yml`](.github/semantic.yml).
+Scopes are optional; omit the scope instead of inventing one. For
+documentation-only changes, use the `docs` type, for example:
+
+```text
+docs: add preview status disclaimer
+```

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -2,9 +2,9 @@
 
 This repository uses a split licensing model. The Zitadel product, including the
 server and embedded console, is licensed under the GNU Affero General Public
-License v3.0 only (AGPL-3.0-only). Client libraries, integration surfaces, API
-contracts, and documentation that are meant to be consumed by downstream
-applications are licensed under the MIT License.
+License v3.0 only (AGPL-3.0-only). Client libraries, integration examples, API
+contracts, public documentation, and other surfaces meant to be consumed by
+downstream applications are licensed under the MIT License.
 
 We use SPDX license identifiers for standard license naming.
 
@@ -22,6 +22,9 @@ cmd/
 internal/
 apps/console/
 ```
+
+The private root workspace package (`package.json`) follows this default
+because it describes the source tree as a whole, not a published client package.
 
 The Docker images published from this repository, including
 `ghcr.io/zitadel/nextgen`, are AGPL-3.0-only because they contain the server and
@@ -42,13 +45,24 @@ The following files and directories, including their subdirectories, are
 licensed under the MIT License:
 
 ```text
+README.md
+CONTRIBUTING.md
+AGENTS.md
+LICENSING.md
+VISION.md
+api/
+docs/
 apps/cli/
+apps/demo-next/
+apps/demo-nuxt/
+packages/api/
 packages/components/
+packages/design-tokens/
+packages/shared-component-styles/
+packages/ui-react/
 packages/sdk-core/
 packages/sdk-next/
 packages/sdk-*/
-api/
-docs/
 ```
 
 These exceptions cover code and contracts that are intended to be imported,
@@ -59,11 +73,15 @@ For `api/`, OpenAPI `info.license` metadata describes the exposed API
 contract/specification license. It does not describe or override the
 AGPL-3.0-only license of the Zitadel server implementation.
 
-Each MIT-licensed npm package must:
+Each published MIT-licensed npm package must:
 
 - declare `"license": "MIT"` in its `package.json`,
 - include a `LICENSE` file at the package root containing the MIT license text,
 - carry an SPDX header in source files where reasonable.
+
+Private demo, design-system, and integration workspaces that are listed above
+are covered by the path exception while they remain private. Add package-level
+MIT `LICENSE` files before publishing any of them as npm packages.
 
 For non-package MIT paths such as `api/` and `docs/`, SPDX headers, generated
 metadata, or local README notes are sufficient when the format supports them.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Next iteration of the Zitadel identity platform.
 
+> **Preview status:** This repository is a pre-release next-generation Zitadel
+> preview. The public name may change, and APIs, CLI flags, package surfaces,
+> and docs are still in flux. The checked-in CLI currently supports the local
+> Docker-backed flow documented below; create-first, claim-later is the product
+> direction, but `zitadel claim` is not shipped in this repo yet. See
+> [VISION.md](VISION.md).
+
 ## Workflow front doors
 
 ### I am contributing to Zitadel
@@ -77,6 +84,8 @@ Details: [docs/quick-start/index.md](docs/quick-start/index.md). To build from s
 This repository is pre-release. The Go `server` command serves the OpenAPI
 surface and embeds the console and login UIs at `/ui/console/` and `/ui/login/`.
 CI produces installable snapshots for review, not official releases.
+
+For product direction and public-readiness notes, see [VISION.md](VISION.md).
 
 ## Local checks
 

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,52 @@
+# Vision
+
+The next-generation Zitadel preview is an evolution of the identity platform
+people already trust and enjoy, rebuilt to be more flexible, more
+developer-friendly, and native to the way humans and AI agents build software
+together.
+
+Our north star is simple: a human or agent should be able to add real
+authentication to an app in about 90 seconds, without signup ceremony,
+dashboard detours, or hand-copied client IDs. When the project is ready to be
+shared, deployed, or governed, a human claims it, the work stays in place, and
+the system becomes a team-owned identity platform configured like code.
+
+This preview is not the finished product, and its public name may change. The
+direction is clear: ship auth before signup, claim ownership when it matters,
+and grow into production trust without surprising developers, agents, or
+downstream applications.
+
+## Current Reality
+
+This repository is pre-release. The current checked-in CLI supports the local
+Docker-backed setup flow documented in [README.md](README.md); it does not
+currently ship a `zitadel claim` command.
+
+Create-first, claim-later remains the product direction. The previous mock-only
+claim lifecycle was removed until the real server-side claim contract exists;
+[ADR 003](docs/adrs/003-create-first-claim-later.md) records that current
+implementation state. Platform design notes may still describe the intended
+claim flow, but those examples are target design, not shipped CLI behavior.
+
+## Pre-Public Checklist
+
+- **Vision and naming:** Use "next-generation Zitadel preview" and say the
+  public name may change. Avoid treating `nextgen` as a permanent product name
+  outside literal repository, package, Docker, or artifact identifiers.
+- **Claim/link-first honesty:** Keep "ship auth before signup, claim later" as
+  the direction, but label claim flow docs as target design until OpenAPI,
+  server, and CLI support exist.
+- **Agent-native contract:** Preserve the boundary that agents configure and
+  humans claim. Keep `--non-interactive --json` and
+  [apps/cli/SKILLS.md](apps/cli/SKILLS.md) as the canonical agent-facing CLI
+  surface.
+- **Licensing clarity:** Keep [LICENSING.md](LICENSING.md) explicit that the
+  server, embedded console, and Docker images are AGPL-3.0-only, while root
+  public docs, API contracts, CLI, SDKs, demos, and client-facing integration
+  surfaces are MIT-licensed.
+- **Metadata audit:** Keep the private root package metadata aligned with the
+  AGPL default. Keep published MIT packages on `"license": "MIT"` with
+  package-level `LICENSE` files.
+- **Release posture:** Keep copy preview/alpha-safe: no official-release
+  claims, no stable API promises, no claim-command promises, and no stale
+  `@zitadel-nextgen/*` package wording unless referring to historical context.

--- a/docs/design/platform/README.md
+++ b/docs/design/platform/README.md
@@ -6,6 +6,12 @@
 >
 > **What needs feedback:** The Model-A-only MVP, domains as a security + context primitive, the `preview_origins` declaration at project creation, the three deferred capability tiers (SPA, hosted login, white-label mapping).
 > **What's early draft:** OpenAPI stubs for claim and config APIs (endpoints and schemas marked `TODO` where the team still needs to converge). Flow v1 (the named versioned protocol between UI renderers and the flow engine) is referenced throughout but specified in a follow-up pass.
+>
+> **Current implementation note:** This folder describes target platform design.
+> The shipped CLI and server do not currently expose the claim lifecycle or a
+> `zitadel claim` command. ADR 003 records the current implementation state:
+> claim/link-first was removed from the CLI and api-mock until a real
+> server-side claim contract exists.
 
 ## How this relates to the flow engine
 

--- a/docs/design/platform/claim-flow.md
+++ b/docs/design/platform/claim-flow.md
@@ -2,6 +2,11 @@
 
 > **Status:** Draft
 > **See also:** [README](README.md) · [Overview](overview.md) · [Project Secret](secret.md) · [Configuration Surface](configuration-surface.md) · [Claim API](api/claim-api.yaml) · [Glossary](../glossary.md)
+>
+> **Current implementation note:** This is a target design for the future
+> claim lifecycle. The checked-in CLI and server do not currently expose these
+> endpoints or a `zitadel claim` command; see ADR 003 for the shipped-state
+> decision.
 
 Claim is the transaction that attaches ownership and accountability to a project. Before claim, the project exists but has no accountable owner. After claim, it belongs to a **team** with at least one accountable human. The transition is atomic — nothing partial.
 

--- a/docs/design/platform/overview.md
+++ b/docs/design/platform/overview.md
@@ -2,6 +2,11 @@
 
 > **Status:** Draft
 > **See also:** [README](README.md) · [Project Secret](secret.md) · [Configuration Surface](configuration-surface.md) · [Claim Flow](claim-flow.md)
+>
+> **Current implementation note:** This document describes target platform
+> design. The checked-in CLI and server do not currently expose the claim
+> lifecycle or a `zitadel claim` command; see ADR 003 for the shipped-state
+> decision.
 
 Every identity provider on the market today assumes that identity precedes everything. Before a developer can write their first line of auth code, they must have a tenant, and before a tenant can exist, they must sign up. The signup form is the gate, the tenant is the primitive, and the developer is a downstream consequence of the account.
 

--- a/docs/design/platform/secret.md
+++ b/docs/design/platform/secret.md
@@ -2,6 +2,11 @@
 
 > **Status:** Draft
 > **See also:** [README](README.md) · [Overview](overview.md) · [Configuration Surface](configuration-surface.md) · [Claim Flow](claim-flow.md) · [Claim API](api/claim-api.yaml) · [Glossary](../glossary.md) · [Credentials (canonical taxonomy)](../api/credentials.md)
+>
+> **Current implementation note:** This document describes target platform
+> design. The checked-in CLI and server do not currently expose the claim
+> lifecycle or a `zitadel claim` command; see ADR 003 for the shipped-state
+> decision.
 
 The project secret is a server-issued bearer token that authenticates SDK and CLI calls against a project. Before claim, it is the only authentication on the project. After claim, it is rotated to a **claimed credential** bound to the team that claimed the project. The same file on disk (`.zitadel/secret`) also carries an **origin-scoped project secret** (historically called the "preview secret") — a companion token that the setup CLI hands to the customer's deploy platform (Vercel, Netlify, Cloudflare) so preview builds work before the project is claimed.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@zitadel/source",
   "version": "0.0.0",
   "private": true,
-  "license": "MIT",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "doctor": "node scripts/doctor.mjs",
     "cli": "node scripts/run-cli.mjs",


### PR DESCRIPTION
## Summary
- Add a dedicated `VISION.md` with the public preview statement, current-reality note, and pre-public checklist.
- Surface the preview disclaimer in `README.md` so GitHub visitors see the status immediately.
- Clarify licensing scope in `LICENSING.md` and align the root package metadata with the AGPL default.
- Add a changeset and mark the platform claim docs as target design, not shipped CLI behavior.

## Testing
- `git diff --check`
- Targeted wording and metadata scans for claim, preview, and license references
- JSON parse check for `package.json`