### PR TITLE
fix: normalize doctor setup and CLI follow-up behavior

### DIFF
--- a/.changeset/quiet-doctor-scaffold.md
+++ b/.changeset/quiet-doctor-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/cli": patch
+---
+
+Make doctor local-runtime checks advisory for cloud setup, harden fresh Next.js scaffolding, auto-install setup dependencies, normalize public follow-up commands, and avoid assuming Next.js in local-runtime setup guidance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ more specific rules for a subtree.
 Use `AGENTS.md` as the primary and tool-agnostic instruction source.
 
 Always resolve instructions in this order:
+
 1. Root `AGENTS.md` (this file)
 2. The nearest scoped `AGENTS.md` for the files you read or change
 
@@ -59,31 +60,36 @@ Secrets").
 
 ### I am contributing to Zitadel
 
-| I want to... | Run |
-| --- | --- |
-| Check my setup | `corepack pnpm run doctor` |
-| Try the local Zitadel CLI | `corepack pnpm run cli -- --help` |
-| Run the server from source | `corepack pnpm run server -- --help` |
-| Test the fresh-app onboarding path | `corepack pnpm run journey` |
-| Run normal local checks | `corepack pnpm run check` |
-| Mirror CI locally | `corepack pnpm run check -- --full` |
-| Rerun one failed phase | `corepack pnpm run check -- --only node` |
+| I want to...                       | Run                                      |
+| ---------------------------------- | ---------------------------------------- |
+| Check my setup                     | `corepack pnpm run doctor`               |
+| Try the local Zitadel CLI          | `corepack pnpm run cli -- --help`        |
+| Run the server from source         | `corepack pnpm run server -- --help`     |
+| Test the fresh-app onboarding path | `corepack pnpm run journey`              |
+| Run normal local checks            | `corepack pnpm run check`                |
+| Mirror CI locally                  | `corepack pnpm run check -- --full`      |
+| Rerun one failed phase             | `corepack pnpm run check -- --only node` |
 
 ### I am adding Zitadel to my app
 
-| I want to... | Run |
-| --- | --- |
-| Check local runtime prerequisites | `npx @zitadel/cli@alpha doctor` |
-| Start local Zitadel | `npx @zitadel/cli@alpha start` |
-| Add auth to Next.js | `npx @zitadel/cli@alpha setup --framework next --server local` |
-| Check generated app files | `npx @zitadel/cli@alpha doctor` |
-| Stop local Zitadel, keeping data | `npx @zitadel/cli@alpha stop` |
-| Delete local Zitadel data | `npx @zitadel/cli@alpha reset --force` |
+| I want to...                      | Run                                                            |
+| --------------------------------- | -------------------------------------------------------------- |
+| Check local runtime prerequisites | `npx @zitadel/cli@alpha doctor`                                |
+| Start local Zitadel               | `npx @zitadel/cli@alpha start`                                 |
+| Add auth to Next.js               | `npx @zitadel/cli@alpha setup --framework next --server local` |
+| Check generated app files         | `npx @zitadel/cli@alpha doctor`                                |
+| Stop local Zitadel, keeping data  | `npx @zitadel/cli@alpha stop`                                  |
+| Delete local Zitadel data         | `npx @zitadel/cli@alpha reset --force`                         |
 
 `corepack pnpm run server` is a repository contributor command that runs the Go
 server from source. `zitadel start` is a published product CLI command that
 runs the released Docker image for app developers and agents; it must not rely
 on Go, Nx, or this source checkout.
+
+`corepack pnpm run cli -- start` is the contributor exception: the root wrapper
+builds `ghcr.io/zitadel/nextgen:local-dev` through GoReleaser's single-target
+build when neither `--image` nor `ZITADEL_LOCAL_IMAGE` is provided, then invokes
+the local CLI against that image.
 
 ## Local Checks
 
@@ -93,6 +99,11 @@ Use Node.js from `.nvmrc` and the pinned pnpm version from `package.json`.
 corepack pnpm run doctor
 corepack pnpm run check
 ```
+
+The root doctor treats Docker and GoReleaser as required because the contributor
+CLI wrapper needs them for local runtime image auto-builds. Playwright browsers
+remain warning-only because they are needed only for opt-in e2e and journey
+workflows.
 
 Use `corepack pnpm run check -- --full` for slower CI-parity phases and
 `corepack pnpm run check -- --only <phase>` to rerun one named phase.
@@ -219,13 +230,13 @@ For customer-local runtime workflows, agents should prefer
   `major` (breaking). The repo is in `alpha` prerelease mode
   (`.changeset/pre.json`), so versions cut as `X.Y.Z-alpha.N` automatically — no
   extra action needed.
+
 - For changes that release nothing (docs, tests, CI, chores), add an empty
   changeset: `corepack pnpm changeset --empty`.
 - npm packages under `apps/cli/` and `packages/*` must stay MIT-licensed.
 - Server and console application paths are AGPL-3.0-only by default.
 - Keep local secrets, private keys, tokens, and `.zitadel/secret`-style files out
   of source control and browser-safe runtime metadata.
-
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->
@@ -249,7 +260,6 @@ For customer-local runtime workflows, agents should prefer
 - USE for: advanced config options, unfamiliar flags, migration guides, plugin configuration, edge cases
 - DON'T USE for: basic generator syntax (`nx g @nx/react:app`), standard commands, things you already know
 - The `nx-generate` skill handles generator discovery internally - don't call nx_docs just to look up generator syntax
-
 
 <!-- nx configuration end-->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,31 +10,37 @@
 
 ### I am contributing to Zitadel
 
-| I want to... | Run |
-| --- | --- |
-| Check my setup | `corepack pnpm run doctor` |
-| Try the local Zitadel CLI | `corepack pnpm run cli -- --help` |
-| Run the server from source | `corepack pnpm run server -- --help` |
-| Test the fresh-app onboarding path | `corepack pnpm run journey` |
-| Run normal local checks | `corepack pnpm run check` |
-| Mirror CI locally | `corepack pnpm run check -- --full` |
-| Rerun one failed phase | `corepack pnpm run check -- --only node` |
+| I want to...                       | Run                                      |
+| ---------------------------------- | ---------------------------------------- |
+| Check my setup                     | `corepack pnpm run doctor`               |
+| Try the local Zitadel CLI          | `corepack pnpm run cli -- --help`        |
+| Run the server from source         | `corepack pnpm run server -- --help`     |
+| Test the fresh-app onboarding path | `corepack pnpm run journey`              |
+| Run normal local checks            | `corepack pnpm run check`                |
+| Mirror CI locally                  | `corepack pnpm run check -- --full`      |
+| Rerun one failed phase             | `corepack pnpm run check -- --only node` |
 
 ### I am adding Zitadel to my app
 
-| I want to... | Run |
-| --- | --- |
-| Check local runtime prerequisites | `npx @zitadel/cli@alpha doctor` |
-| Start local Zitadel | `npx @zitadel/cli@alpha start` |
-| Add auth to Next.js | `npx @zitadel/cli@alpha setup --framework next --server local` |
-| Stop local Zitadel, keeping data | `npx @zitadel/cli@alpha stop` |
-| Delete local Zitadel data | `npx @zitadel/cli@alpha reset --force` |
+| I want to...                      | Run                                                            |
+| --------------------------------- | -------------------------------------------------------------- |
+| Check local runtime prerequisites | `npx @zitadel/cli@alpha doctor`                                |
+| Start local Zitadel               | `npx @zitadel/cli@alpha start`                                 |
+| Add auth to Next.js               | `npx @zitadel/cli@alpha setup --framework next --server local` |
+| Stop local Zitadel, keeping data  | `npx @zitadel/cli@alpha stop`                                  |
+| Delete local Zitadel data         | `npx @zitadel/cli@alpha reset --force`                         |
 
 Nx manages TypeScript workspace targets. Go commands and long-running local
 orchestration run through repository scripts so server processes are signaled
 and cleaned up directly. Published `zitadel` runtime commands are for customers and
 agents adding Zitadel to an app; they manage a Docker-backed local runtime and
 do not require Go, Nx, or this source checkout.
+
+For contributors, `corepack pnpm run cli -- start` builds and uses a fresh
+local runtime image by default. The wrapper runs the CLI build, then builds
+`ghcr.io/zitadel/nextgen:local-dev` through GoReleaser's single-target build
+before invoking `zitadel start`. Pass `--image <tag>` or set
+`ZITADEL_LOCAL_IMAGE=<tag>` to use an existing image instead.
 
 `corepack pnpm run server` builds and syncs the embedded console/login UI before
 startup, then runs `go run .`; help output skips the UI sync.
@@ -45,6 +51,11 @@ startup, then runs `go run .`; help output skips the UI sync.
 corepack pnpm run doctor
 corepack pnpm run check
 ```
+
+The repository doctor checks Docker and GoReleaser because contributor
+`corepack pnpm run cli -- start` auto-builds the local runtime image from this
+source checkout. Playwright browsers remain advisory for opt-in e2e and journey
+workflows.
 
 `corepack pnpm run check -- --full` runs the slower CI-parity phases. Use
 `--only <phase>` to rerun one phase after a failure.
@@ -127,19 +138,32 @@ goreleaser release --snapshot --clean --skip=publish,sign
 
 The `before` hook runs `scripts/sync-embedded-ui-dist.sh` automatically.
 
-### Local Docker image from snapshot
+### Local runtime image from source
 
-After a snapshot build, binaries are under `dist/`:
+The contributor CLI wrapper builds the image layout expected by the Dockerfile
+without publishing a snapshot:
 
 ```sh
-docker build -t nextgen:local .
-docker run --rm -p 8080:8080 \
-  -v "$PWD/.zitadel/local/nextgen-data:/var/lib/zitadel/nextgen-data" \
-  -e NEXTGEN_SERVER_DATA_DIR=/var/lib/zitadel/nextgen-data \
-  nextgen:local
+corepack pnpm run cli -- start
 ```
 
-Place the platform binary at `linux/amd64/nextgen` in the build context when mimicking Goreleaser layout, or build with `go build -o nextgen .` and adjust the Dockerfile for local iteration.
+When no image override is present, the wrapper runs:
+
+```sh
+goreleaser build --snapshot --clean --single-target --id nextgen \
+  --output <tmp>/linux/<arch>/nextgen
+docker build --platform linux/<arch> -t ghcr.io/zitadel/nextgen:local-dev <tmp>
+```
+
+The wrapper sets GoReleaser's tag environment from the nearest server semver
+tag and ignores Changesets-created package tags such as `@zitadel/cli@...`.
+
+Use an existing image explicitly when you do not want the wrapper to rebuild:
+
+```sh
+corepack pnpm run cli -- start --image custom:tag
+ZITADEL_LOCAL_IMAGE=custom:tag corepack pnpm run cli -- start
+```
 
 ## Agent and architecture docs
 

--- a/README.md
+++ b/README.md
@@ -13,32 +13,38 @@ Next iteration of the Zitadel identity platform.
 
 ### I am contributing to Zitadel
 
-| I want to... | Run |
-| --- | --- |
-| Check my setup | `corepack pnpm run doctor` |
-| Try the local Zitadel CLI | `corepack pnpm run cli -- --help` |
-| Run the server from source | `corepack pnpm run server -- --help` |
-| Test the fresh-app onboarding path | `corepack pnpm run journey` |
-| Run normal local checks | `corepack pnpm run check` |
-| Mirror CI locally | `corepack pnpm run check -- --full` |
-| Rerun one failed phase | `corepack pnpm run check -- --only node` |
+| I want to...                       | Run                                      |
+| ---------------------------------- | ---------------------------------------- |
+| Check my setup                     | `corepack pnpm run doctor`               |
+| Try the local Zitadel CLI          | `corepack pnpm run cli -- --help`        |
+| Run the server from source         | `corepack pnpm run server -- --help`     |
+| Test the fresh-app onboarding path | `corepack pnpm run journey`              |
+| Run normal local checks            | `corepack pnpm run check`                |
+| Mirror CI locally                  | `corepack pnpm run check -- --full`      |
+| Rerun one failed phase             | `corepack pnpm run check -- --only node` |
 
 ### I am adding Zitadel to my app
 
-| I want to... | Run |
-| --- | --- |
-| Check local runtime prerequisites | `npx @zitadel/cli@alpha doctor` |
-| Start local Zitadel | `npx @zitadel/cli@alpha start` |
-| Add auth to a Next.js app | `npx @zitadel/cli@alpha setup --framework next --server local` |
-| Check generated app files | `npx @zitadel/cli@alpha doctor` |
-| Stop local Zitadel, keeping data | `npx @zitadel/cli@alpha stop` |
-| Delete local Zitadel data | `npx @zitadel/cli@alpha reset --force` |
+| I want to...                      | Run                                                            |
+| --------------------------------- | -------------------------------------------------------------- |
+| Check local runtime prerequisites | `npx @zitadel/cli@alpha doctor`                                |
+| Start local Zitadel               | `npx @zitadel/cli@alpha start`                                 |
+| Add auth to a Next.js app         | `npx @zitadel/cli@alpha setup --framework next --server local` |
+| Check generated app files         | `npx @zitadel/cli@alpha doctor`                                |
+| Stop local Zitadel, keeping data  | `npx @zitadel/cli@alpha stop`                                  |
+| Delete local Zitadel data         | `npx @zitadel/cli@alpha reset --force`                         |
 
 Nx manages TypeScript workspace targets. Go commands and long-running local
 orchestration run through repository scripts so server processes are signaled
 and cleaned up directly. The published `zitadel` runtime commands are customer
 workflow commands; they run the released container image through Docker and do
 not require Go, Nx, or a source checkout.
+
+For contributors, `corepack pnpm run cli -- start` builds and uses a fresh
+local runtime image by default. The wrapper runs the CLI build, then builds
+`ghcr.io/zitadel/nextgen:local-dev` through GoReleaser's single-target build
+before invoking `zitadel start`. Pass `--image <tag>` or set
+`ZITADEL_LOCAL_IMAGE=<tag>` to use an existing image instead.
 
 `corepack pnpm run server` builds and syncs the embedded console/login UI before
 startup, then runs `go run .`; help output skips the UI sync.
@@ -51,14 +57,14 @@ cd myapp
 npx @zitadel/cli@alpha doctor
 npx @zitadel/cli@alpha start
 npx @zitadel/cli@alpha setup --framework next --server local
-npm install
 npm run dev
 ```
 
 Open http://localhost:3000/login and register your first local user. The
 managed Zitadel runtime stores its container metadata and data under
 `.zitadel/local/`; `stop` preserves that data and `reset --force`
-deletes it.
+deletes it. `setup` installs dependencies with the detected package manager;
+pass `--skip-install` if you want to install them yourself.
 
 ## Manual Docker quick start
 
@@ -71,11 +77,11 @@ cp env.example .env
 docker compose up -d
 ```
 
-| Surface | URL |
-| ------- | --- |
+| Surface            | URL                               |
+| ------------------ | --------------------------------- |
 | Management console | http://localhost:8080/ui/console/ |
-| Sign-in shell | http://localhost:8080/ui/login/ |
-| Health | http://localhost:8080/healthz |
+| Sign-in shell      | http://localhost:8080/ui/login/   |
+| Health             | http://localhost:8080/healthz     |
 
 Details: [docs/quick-start/index.md](docs/quick-start/index.md). To build from source: [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -96,6 +102,11 @@ Use Node.js from [.nvmrc](.nvmrc) and the pinned pnpm 10 workspace manager from
 corepack pnpm run doctor
 corepack pnpm run check
 ```
+
+The repository doctor checks Docker and GoReleaser because contributor
+`corepack pnpm run cli -- start` auto-builds the local runtime image from this
+source checkout. Playwright browsers remain advisory for opt-in e2e and journey
+workflows.
 
 `corepack pnpm run check -- --full` runs the slower CI-parity phases, including
 integration tests, demo e2e, package smoke checks, GoReleaser, and the fresh-app

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -3,8 +3,8 @@
 Scaffolds Zitadel auth (login, register, profile, middleware) into a Next.js app.
 
 ```sh
-npx @zitadel/cli@latest start
-npx @zitadel/cli@latest setup --framework next --server local
+npx @zitadel/cli@alpha start
+npx @zitadel/cli@alpha setup --framework next --server local
 ```
 
 > **Beta.** This is the **next-generation Zitadel**, a ground-up rewrite of the platform. It is distinct from the established Zitadel at [github.com/zitadel/zitadel](https://github.com/zitadel/zitadel). APIs and CLI flags will change.
@@ -20,10 +20,9 @@ npx @zitadel/cli@latest setup --framework next --server local
 ```sh
 npx create-next-app@latest my-app
 cd my-app
-npx @zitadel/cli@latest doctor
-npx @zitadel/cli@latest start
-npx @zitadel/cli@latest setup --framework next --server local
-npm install
+npx @zitadel/cli@alpha doctor
+npx @zitadel/cli@alpha start
+npx @zitadel/cli@alpha setup --framework next --server local
 npm run dev
 ```
 
@@ -31,10 +30,11 @@ npm run dev
 under `.zitadel/local/`. It uses `ghcr.io/zitadel/nextgen:latest` unless
 overridden with `--image` or `ZITADEL_LOCAL_IMAGE`. `setup --server local`
 creates a project on that local server, scaffolds `app/login`, `app/register`, and
-`middleware.ts`, and writes `.env.local` and `.zitadel/`. The project's default
-user schema and login flow are provisioned server-side at creation time, so the
-CLI does not scaffold or upload them. Open `http://localhost:3000/login` to see
-the login page.
+`middleware.ts`, writes `.env.local` and `.zitadel/`, and installs dependencies
+with the detected package manager. Pass `--skip-install` to install them
+yourself. The project's default user schema and login flow are provisioned
+server-side at creation time, so the CLI does not scaffold or upload them.
+Open `http://localhost:3000/login` to see the login page.
 
 The default project flow supports password registration/login, passkey
 registration/login, and optional passkey setup after password registration.
@@ -54,21 +54,22 @@ passkey can sign in with either credential.
 <summary>Full command reference</summary>
 
 <!-- commands -->
-* [`zitadel autocomplete [SHELL]`](#zitadel-autocomplete-shell)
-* [`zitadel commands`](#zitadel-commands)
-* [`zitadel doctor`](#zitadel-doctor)
-* [`zitadel eject`](#zitadel-eject)
-* [`zitadel help [COMMAND]`](#zitadel-help-command)
-* [`zitadel logs`](#zitadel-logs)
-* [`zitadel reset`](#zitadel-reset)
-* [`zitadel search`](#zitadel-search)
-* [`zitadel setup`](#zitadel-setup)
-* [`zitadel start`](#zitadel-start)
-* [`zitadel status`](#zitadel-status)
-* [`zitadel stop`](#zitadel-stop)
-* [`zitadel uninstall`](#zitadel-uninstall)
-* [`zitadel version`](#zitadel-version)
-* [`zitadel which`](#zitadel-which)
+
+- [`zitadel autocomplete [SHELL]`](#zitadel-autocomplete-shell)
+- [`zitadel commands`](#zitadel-commands)
+- [`zitadel doctor`](#zitadel-doctor)
+- [`zitadel eject`](#zitadel-eject)
+- [`zitadel help [COMMAND]`](#zitadel-help-command)
+- [`zitadel logs`](#zitadel-logs)
+- [`zitadel reset`](#zitadel-reset)
+- [`zitadel search`](#zitadel-search)
+- [`zitadel setup`](#zitadel-setup)
+- [`zitadel start`](#zitadel-start)
+- [`zitadel status`](#zitadel-status)
+- [`zitadel stop`](#zitadel-stop)
+- [`zitadel uninstall`](#zitadel-uninstall)
+- [`zitadel version`](#zitadel-version)
+- [`zitadel which`](#zitadel-which)
 
 ## `zitadel autocomplete [SHELL]`
 
@@ -279,7 +280,7 @@ Create a Zitadel project and scaffold local auth.
 ```
 USAGE
   $ zitadel setup [--json] [-c <value>] [-s <value>] [-n] [-f] [--dry-run] [--verbose] [--debug]
-    [--framework next] [--renderer react|web-component]
+    [--framework next] [--renderer react|web-component] [--skip-install]
 
 FLAGS
   -c, --cwd=<value>         Project directory to operate on.
@@ -292,6 +293,7 @@ FLAGS
                             <options: next>
       --renderer=<option>   Renderer (default: react).
                             <options: react|web-component>
+      --skip-install        Do not install dependencies after setup updates package.json.
       --verbose             Verbose logging.
 
 GLOBAL FLAGS
@@ -459,6 +461,7 @@ EXAMPLES
 ```
 
 _See code: [@oclif/plugin-which](https://github.com/oclif/plugin-which/blob/3.2.55/src/commands/which.ts)_
+
 <!-- commandsstop -->
 
 </details>

--- a/apps/cli/SKILLS.md
+++ b/apps/cli/SKILLS.md
@@ -24,7 +24,7 @@ parse the result rather than scraping human output.
   metadata) or run `zitadel <command> --help` for the full per-command flag list.
 
 ```sh
-npx @zitadel/cli@latest <command> --non-interactive --json
+npx @zitadel/cli@alpha <command> --non-interactive --json
 ```
 
 ## Reading the envelope
@@ -39,7 +39,7 @@ Each invocation prints one JSON object:
   `message`.
 - `next_commands`: the suggested follow-ups. Prefer these over free-text hints.
 - `E_LOCAL_SERVER_NOT_RUNNING`: start the local Docker runtime with
-  `zitadel start`, then retry with `--server local`.
+  `npx @zitadel/cli@alpha start`, then retry with `--server local`.
 
 Exit codes mirror the error class (3 = validation, 4 = network, 5 = conflict,
 1 = auth, 2 = not-implemented). An unknown command is handled by the CLI's help
@@ -53,9 +53,10 @@ layer, not the envelope.
   scaffolds nor uploads them. Flags: `--framework`, `--renderer`.
 - `plan` — validate config and preview the sync diff without mutating anything.
 - `apply` — validate and upload repo config to the platform.
-- `doctor` — verify local Docker runtime prerequisites and, once `zitadel.json`
-  exists, generated app files and local state; `--fix` re-applies missing
-  managed files.
+- `doctor` — verify generated app files and local state once `zitadel.json`
+  exists. Local Docker runtime prerequisites are advisory warnings unless an
+  existing managed runtime is unhealthy; `--fix` re-applies missing managed
+  files.
 - `status` — summarize the local Docker runtime and project state.
 - `eject` (alias `uninstall`) — remove managed files and local Zitadel state;
   requires `--force` when non-interactive.
@@ -70,17 +71,19 @@ layer, not the envelope.
 ## Golden path
 
 ```sh
-npx @zitadel/cli@latest doctor --non-interactive --json
-npx @zitadel/cli@latest start --non-interactive --json
-npx @zitadel/cli@latest setup --framework next --server local --non-interactive --json
-npx @zitadel/cli@latest doctor --non-interactive --json
-npx @zitadel/cli@latest plan --non-interactive --json
-npx @zitadel/cli@latest apply --non-interactive --json
+npx @zitadel/cli@alpha doctor --non-interactive --json
+npx @zitadel/cli@alpha start --non-interactive --json
+npx @zitadel/cli@alpha setup --framework next --server local --non-interactive --json
+npx @zitadel/cli@alpha doctor --non-interactive --json
+npx @zitadel/cli@alpha plan --non-interactive --json
+npx @zitadel/cli@alpha apply --non-interactive --json
 ```
 
 Repo config is authoritative: edit `zitadel.json` or files under `.zitadel/`,
 then re-run `plan` and `apply`. Managed files carry a marker comment; `eject`
 removes only files that still carry it, preserving anything the user replaced.
 For app-local development, `--server local` resolves through
-`.zitadel/local/runtime.json` and requires a healthy `zitadel start`
-runtime.
+`.zitadel/local/runtime.json` and requires a healthy `npx @zitadel/cli@alpha start`
+runtime. `setup` installs dependencies with the detected package manager by
+default; pass `--skip-install` when the agent or host workflow will install
+dependencies separately.

--- a/apps/cli/src/commands/doctor/checks/types.ts
+++ b/apps/cli/src/commands/doctor/checks/types.ts
@@ -1,9 +1,9 @@
 import type { Orca } from "../../../lib/orca";
 
-/** Pass/fail outcome of a single {@link SanityCheck}. */
+/** Pass/fail/advisory outcome of a single {@link SanityCheck}. */
 export type CheckOutcome = {
   name: string;
-  status: "pass" | "fail";
+  status: "pass" | "warn" | "fail";
   message: string;
   path?: string;
 };

--- a/apps/cli/src/commands/doctor/index.ts
+++ b/apps/cli/src/commands/doctor/index.ts
@@ -1,7 +1,6 @@
 import { Flags } from "@oclif/core";
 import consola from "consola";
 
-import { BaseCommand, type JsonEnvelope } from "../../lib/oclif";
 import { ZitadelError } from "../../lib/errors";
 import { dockerAvailable, imageAvailable } from "../../lib/local-server/docker";
 import {
@@ -14,8 +13,10 @@ import {
   localServerUrl,
   readRuntimeMetadata,
 } from "../../lib/local-server/runtime";
+import { BaseCommand, type JsonEnvelope } from "../../lib/oclif";
 import { createOrca } from "../../lib/orca";
 import { hasZitadelConfig } from "../../lib/project";
+import { publicCliCommand } from "../../lib/public-cli";
 import { SANITY_CHECKS, type CheckContext, type CheckOutcome } from "./checks";
 
 const LOCAL_RUNTIME_CHECK_NAMES = new Set(["docker-cli", "image", "state-dir", "port", "runtime"]);
@@ -70,8 +71,14 @@ export default class Doctor extends BaseCommand {
       : [];
     const checks = [...runtimeChecks, ...projectChecks];
     const failed = checks.filter((check) => check.status === "fail");
+    const warnings = checks.filter((check) => check.status === "warn");
     const data = {
-      title: failed.length === 0 ? "Zitadel doctor passed." : "Zitadel doctor found issues.",
+      title:
+        failed.length > 0
+          ? "Zitadel doctor found issues."
+          : warnings.length > 0
+            ? "Zitadel doctor passed with warnings."
+            : "Zitadel doctor passed.",
       ok: failed.length === 0,
       image,
       port,
@@ -82,7 +89,7 @@ export default class Doctor extends BaseCommand {
     };
 
     if (failed.length > 0) {
-      const advice = failureAdvice(failed, image, port);
+      const advice = failureAdvice(failed, image, port, this.meta.cliVersion);
       throw new ZitadelError("E_VALIDATION", "Zitadel doctor found issues", {
         hint: advice.hint,
         nextCommands: advice.nextCommands,
@@ -90,7 +97,11 @@ export default class Doctor extends BaseCommand {
       });
     }
 
-    return this.emit({ status: "ok", data });
+    return this.emit({
+      status: "ok",
+      data,
+      warnings: warnings.map((warning) => `${warning.name}: ${warning.message}`),
+    });
   }
 }
 
@@ -98,29 +109,28 @@ function failureAdvice(
   failed: CheckOutcome[],
   image: string,
   port: number,
+  cliVersion: string,
 ): { hint: string; nextCommands: string[] } {
   const failedNames = new Set(failed.map((check) => check.name));
 
   if (failedNames.has("docker-cli")) {
     return {
-      hint:
-        "Docker is required for `zitadel start`, but the Docker daemon is not reachable. Install or start Docker, then rerun `zitadel doctor`.",
-      nextCommands: ["docker version", "zitadel doctor"],
+      hint: "Docker is required for `zitadel start`, but the Docker daemon is not reachable. Install or start Docker, then rerun `zitadel doctor`.",
+      nextCommands: ["docker version", publicCliCommand("doctor", cliVersion)],
     };
   }
 
   if (failedNames.has("image")) {
     return {
-      hint:
-        "The local Zitadel image is not available. Check Docker registry access, build it locally, or pass --image / ZITADEL_LOCAL_IMAGE.",
-      nextCommands: [`docker pull ${image}`, "zitadel doctor"],
+      hint: "The local Zitadel image is not available. Check Docker registry access, build it locally, or pass --image / ZITADEL_LOCAL_IMAGE.",
+      nextCommands: [`docker pull ${image}`, publicCliCommand("doctor", cliVersion)],
     };
   }
 
   if (failedNames.has("state-dir")) {
     return {
       hint: "The local Zitadel state directory is not writable. Fix directory permissions, then rerun `zitadel doctor`.",
-      nextCommands: ["zitadel doctor"],
+      nextCommands: [publicCliCommand("doctor", cliVersion)],
     };
   }
 
@@ -128,29 +138,31 @@ function failureAdvice(
     const fallbackPort = port === DEFAULT_LOCAL_SERVER_PORT ? port + 1 : DEFAULT_LOCAL_SERVER_PORT;
     return {
       hint: `Port ${String(port)} is already in use. Stop the process using it, or choose another port for local Zitadel.`,
-      nextCommands: [`zitadel doctor --port ${String(fallbackPort)}`],
+      nextCommands: [publicCliCommand(`doctor --port ${String(fallbackPort)}`, cliVersion)],
     };
   }
 
   if (failedNames.has("runtime")) {
     return {
-      hint:
-        "Existing local runtime metadata was found, but the local Zitadel server is not healthy. Start it again or reset stale local data.",
-      nextCommands: ["zitadel start", "zitadel reset --force"],
+      hint: "Existing local runtime metadata was found, but the local Zitadel server is not healthy. Start it again or reset stale local data.",
+      nextCommands: [
+        publicCliCommand("start", cliVersion),
+        publicCliCommand("reset --force", cliVersion),
+      ],
     };
   }
 
   const hasProjectFailure = failed.some((check) => !LOCAL_RUNTIME_CHECK_NAMES.has(check.name));
   if (hasProjectFailure) {
     return {
-      hint: "Run `npx @zitadel/cli@alpha doctor --fix` to re-apply missing managed files.",
-      nextCommands: ["zitadel doctor --fix"],
+      hint: `Run \`${publicCliCommand("doctor --fix", cliVersion)}\` to re-apply missing managed files.`,
+      nextCommands: [publicCliCommand("doctor --fix", cliVersion)],
     };
   }
 
   return {
     hint: "Fix the reported checks, then rerun `zitadel doctor`.",
-    nextCommands: ["zitadel doctor"],
+    nextCommands: [publicCliCommand("doctor", cliVersion)],
   };
 }
 
@@ -160,34 +172,74 @@ async function runLocalRuntimeChecks(
   port: number,
 ): Promise<CheckOutcome[]> {
   const runtime = await readRuntimeMetadata(cwd);
-  return [
-    await check("docker-cli", "Docker is reachable", async () => {
-      const result = await dockerAvailable();
+  const docker = await check(
+    "docker-cli",
+    "Docker is reachable",
+    async () => {
+      let result: Awaited<ReturnType<typeof dockerAvailable>>;
+      try {
+        result = await dockerAvailable();
+      } catch (error) {
+        throw new Error(dockerUnavailableMessage(error), { cause: error });
+      }
       if (result.status !== 0) {
-        throw new Error(result.stderr || "docker version failed");
+        throw new Error(dockerUnavailableMessage(result.stderr || "docker version failed"));
       }
       return `Docker engine ${result.stdout.trim() || "available"}`;
-    }),
-    await check("image", `Image ${image} is available`, async () => {
-      const source = await imageAvailable(image);
-      return source === "local"
-        ? `Image ${image} is available locally`
-        : `Image ${image} is available from the registry`;
-    }),
-    await check("state-dir", "Local state directory is writable", async () => {
-      const paths = localRuntimePaths(cwd);
-      await assertWritableDirectory(paths.dataDir);
-      return `${paths.dataDir} is writable`;
-    }),
-    await check("port", `Port ${String(port)} is available`, async () => {
-      if (runtime && (await checkLocalServerHealth(runtime.server_url))) {
-        return `${runtime.server_url} is already healthy`;
-      }
-      if (!(await isPortAvailable(port))) {
-        throw new Error(`Port ${String(port)} is already in use`);
-      }
-      return `Port ${String(port)} is available`;
-    }),
+    },
+    "warn",
+  );
+
+  const imageCheck =
+    docker.status === "pass"
+      ? await check(
+          "image",
+          `Image ${image} is available`,
+          async () => {
+            try {
+              const source = await imageAvailable(image);
+              return source === "local"
+                ? `Image ${image} is available locally`
+                : `Image ${image} is available from the registry`;
+            } catch (error) {
+              throw new Error(imageUnavailableMessage(image, error), { cause: error });
+            }
+          },
+          "warn",
+        )
+      : ({
+          name: "image",
+          status: "warn",
+          message: "Skipped image check because Docker is not reachable.",
+        } satisfies CheckOutcome);
+
+  return [
+    docker,
+    imageCheck,
+    await check(
+      "state-dir",
+      "Local state directory is writable",
+      async () => {
+        const paths = localRuntimePaths(cwd);
+        await assertWritableDirectory(paths.dataDir);
+        return `${paths.dataDir} is writable`;
+      },
+      "warn",
+    ),
+    await check(
+      "port",
+      `Port ${String(port)} is available`,
+      async () => {
+        if (runtime && (await checkLocalServerHealth(runtime.server_url))) {
+          return `${runtime.server_url} is already healthy`;
+        }
+        if (!(await isPortAvailable(port))) {
+          throw new Error(`Port ${String(port)} is already in use`);
+        }
+        return `Port ${String(port)} is available`;
+      },
+      "warn",
+    ),
     await check("runtime", "Existing local runtime is healthy", async () => {
       if (!runtime) {
         return "No existing runtime metadata";
@@ -204,14 +256,27 @@ async function check(
   name: string,
   fallback: string,
   run: () => Promise<string>,
+  failureStatus: "warn" | "fail" = "fail",
 ): Promise<CheckOutcome> {
   try {
     return { name, status: "pass", message: await run() };
   } catch (error) {
     return {
       name,
-      status: "fail",
+      status: failureStatus,
       message: error instanceof Error ? error.message : fallback,
     };
   }
+}
+
+function dockerUnavailableMessage(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  const suffix = detail.trim() ? ` (${detail.trim()})` : "";
+  return `Docker is not reachable${suffix}; \`zitadel start\` needs Docker, but cloud setup can continue.`;
+}
+
+function imageUnavailableMessage(image: string, error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  const suffix = detail.trim() ? ` (${detail.trim()})` : "";
+  return `Image ${image} is not available to Docker${suffix}; \`zitadel start\` may need a pull or a different image.`;
 }

--- a/apps/cli/src/commands/logs.ts
+++ b/apps/cli/src/commands/logs.ts
@@ -1,9 +1,10 @@
 import { Flags } from "@oclif/core";
 
-import { BaseCommand, type JsonEnvelope } from "../lib/oclif";
 import { ZitadelError } from "../lib/errors";
 import { containerLogs, followContainerLogs } from "../lib/local-server/docker";
 import { DEFAULT_LOCAL_SERVER_URL, readRuntimeMetadata } from "../lib/local-server/runtime";
+import { BaseCommand, type JsonEnvelope } from "../lib/oclif";
+import { publicCliCommand } from "../lib/public-cli";
 
 export default class Logs extends BaseCommand {
   static override description = "Show local Zitadel server logs.";
@@ -23,7 +24,7 @@ export default class Logs extends BaseCommand {
     if (!runtime) {
       throw new ZitadelError("E_VALIDATION", "Local Zitadel runtime has not been started", {
         hint: "Run `zitadel start` first.",
-        nextCommands: ["zitadel start"],
+        nextCommands: [publicCliCommand("start", this.meta.cliVersion)],
       });
     }
 

--- a/apps/cli/src/commands/reset.ts
+++ b/apps/cli/src/commands/reset.ts
@@ -1,6 +1,5 @@
 import { cancel, confirm, isCancel } from "@clack/prompts";
 
-import { BaseCommand, type JsonEnvelope } from "../lib/oclif";
 import { ZitadelError } from "../lib/errors";
 import { stopAndRemoveContainer } from "../lib/local-server/docker";
 import {
@@ -10,6 +9,8 @@ import {
   removeLocalData,
   removeRuntimeMetadata,
 } from "../lib/local-server/runtime";
+import { BaseCommand, type JsonEnvelope } from "../lib/oclif";
+import { publicCliCommand } from "../lib/public-cli";
 
 export default class Reset extends BaseCommand {
   static override description = "Delete the local Zitadel server runtime and data.";
@@ -32,7 +33,7 @@ export default class Reset extends BaseCommand {
             container_name: containerName,
             data_deleted: true,
           },
-          next_commands: ["zitadel reset --force"],
+          next_commands: [publicCliCommand("reset --force", this.meta.cliVersion)],
         },
       });
     }
@@ -41,7 +42,7 @@ export default class Reset extends BaseCommand {
       if (this.meta.nonInteractive) {
         throw new ZitadelError("E_VALIDATION", "Reset requires --force in non-interactive mode", {
           hint: "Pass --force to delete `.zitadel/local/nextgen-data`.",
-          nextCommands: ["zitadel reset --force"],
+          nextCommands: [publicCliCommand("reset --force", this.meta.cliVersion)],
         });
       }
       const answer = await confirm({
@@ -69,7 +70,6 @@ export default class Reset extends BaseCommand {
           container_name: containerName,
           data_deleted: true,
         },
-        next_commands: ["zitadel start"],
       },
     });
   }

--- a/apps/cli/src/commands/setup/index.ts
+++ b/apps/cli/src/commands/setup/index.ts
@@ -1,16 +1,16 @@
-import { Flags } from "@oclif/core";
 import { intro, outro } from "@clack/prompts";
+import { Flags } from "@oclif/core";
+import { createZitadelClient } from "@zitadel/api/client";
+import type { CreateProject201 } from "@zitadel/api/generated/model";
 import { consola } from "consola";
 
-import { BaseCommand, type JsonEnvelope } from "../../lib/oclif";
 import { ZitadelError } from "../../lib/errors";
+import { BaseCommand, type JsonEnvelope } from "../../lib/oclif";
 import { createOrca, issuerFromPort, type FrameworkFacts, type Orca } from "../../lib/orca";
-import type { PatchContext } from "../../lib/orca/patchers/types";
 import { RENDERER_IDS } from "../../lib/orca/patchers/rule/next/renderers/registry";
-import type { CreateProject201 } from "@zitadel/api/generated/model";
-import { createZitadelClient } from "@zitadel/api/client";
-
+import type { PatchContext } from "../../lib/orca/patchers/types";
 import { hasZitadelConfig, hasZitadelSecret } from "../../lib/project";
+import { installDependenciesForSetup } from "./install";
 import { PickFrameworkPrompt, SETUP_PROMPTS, type SetupAnswers } from "./prompts";
 import {
   detectProjectFacts,
@@ -51,7 +51,13 @@ export default class Setup extends BaseCommand {
   static override examples = ["<%= config.bin %> setup --framework next"];
   static override flags = {
     framework: Flags.string({ description: "Framework to target.", options: FRAMEWORK_OPTIONS }),
-    renderer: Flags.string({ description: "Renderer (default: react).", options: [...RENDERER_IDS] }),
+    renderer: Flags.string({
+      description: "Renderer (default: react).",
+      options: [...RENDERER_IDS],
+    }),
+    "skip-install": Flags.boolean({
+      description: "Do not install dependencies after setup updates package.json.",
+    }),
   };
 
   async run(): Promise<JsonEnvelope> {
@@ -75,7 +81,9 @@ export default class Setup extends BaseCommand {
     let scaffoldedFramework = false;
     try {
       framework = await orca.detect(cwd, flags.framework);
-      consola.success(`Detected ${framework.id}${framework.devPort ? ` (dev port ${framework.devPort})` : ""}`);
+      consola.success(
+        `Detected ${framework.id}${framework.devPort ? ` (dev port ${framework.devPort})` : ""}`,
+      );
     } catch (error) {
       if (
         error instanceof ZitadelError &&
@@ -83,7 +91,10 @@ export default class Setup extends BaseCommand {
         (await orca.isEmpty(cwd))
       ) {
         consola.info("Empty directory — scaffolding a fresh project");
-        framework = await orca.scaffold(cwd, await resolveScaffoldFramework(flags.framework, nonInteractive, orca));
+        framework = await orca.scaffold(
+          cwd,
+          await resolveScaffoldFramework(flags.framework, nonInteractive, orca),
+        );
         scaffoldedFramework = true;
         consola.success(`Scaffolded ${framework.id} skeleton`);
       } else {
@@ -139,6 +150,17 @@ export default class Setup extends BaseCommand {
         (result.filesSkipped.length > 0 ? ` (${result.filesSkipped.length} unchanged)` : ""),
     );
 
+    const installOutcome = await installDependenciesForSetup({
+      cwd,
+      depsAdded: result.depsAdded,
+      dryRun,
+      env: this.meta.env,
+      issuer,
+      json: this.jsonEnabled(),
+      scaffoldedFramework,
+      skipInstall: Boolean(flags["skip-install"]),
+    });
+
     const writtenRel = result.filesWritten.map((file) => relativeDisplay(cwd, file));
     // The structured report is human-only. Under `--json` we let the
     // envelope returned from `this.emit(...)` be the sole stdout
@@ -159,11 +181,7 @@ export default class Setup extends BaseCommand {
       // pre-coloured rows (path/url/id helpers) survive intact.
       consola.box({
         title: "Zitadel is ready",
-        message: [
-          renderSummary(sections),
-          "",
-          `Open your app on ${styleUrl(`${issuer}/login`)} and register your first user.`,
-        ].join("\n"),
+        message: [renderSummary(sections), "", installOutcome.nextActions.join("\n")].join("\n"),
         style: { padding: 1, borderStyle: "rounded", borderColor: "green" },
       });
     }
@@ -182,8 +200,9 @@ export default class Setup extends BaseCommand {
         server: answers.server,
         files_written: result.filesWritten.map((file) => relativeDisplay(cwd, file)),
         files_skipped: result.filesSkipped.map((file) => relativeDisplay(cwd, file)),
-        next_actions: [`Start your project: npm install && npm run dev (then open ${issuer}/login)`],
-        next_commands: ["npm install", "npm run dev"],
+        install: installOutcome.install,
+        next_actions: installOutcome.nextActions,
+        next_commands: installOutcome.nextCommands,
       },
     });
   }
@@ -204,7 +223,7 @@ async function resolveScaffoldFramework(
   }
   if (nonInteractive) {
     throw new ZitadelError("E_FRAMEWORK_NOT_DETECTED", "Empty directory — pass --framework", {
-      hint: "Example: --framework next",
+      hint: "Run without --json/--non-interactive to choose from a prompt, or pass --framework for scripted setup.",
     });
   }
   return new PickFrameworkPrompt().ask(orca.availableFrameworks());
@@ -261,11 +280,7 @@ function describeWrittenFile(relPath: string, dryRun: boolean): string | null {
   // Mkdir ops surface in `filesWritten` alongside actual file writes.
   // They're noise at the per-step layer (the files inside them get
   // narrated on their own lines), so swallow them here.
-  if (
-    relPath === ".zitadel" ||
-    relPath === ".zitadel/flows" ||
-    relPath === ".zitadel/schemas"
-  ) {
+  if (relPath === ".zitadel" || relPath === ".zitadel/flows" || relPath === ".zitadel/schemas") {
     return null;
   }
   const verb = dryRun ? "Would write" : "Wrote";
@@ -310,9 +325,7 @@ function buildSummary(opts: {
   const sdkPackage = "@zitadel/sdk-next";
   const packageJsonHit = pickWrittenFile(writtenRel, "package.json");
 
-  const detected: Row[] = [
-    { label: "Framework", value: formatFrameworkLine(projectFacts) },
-  ];
+  const detected: Row[] = [{ label: "Framework", value: formatFrameworkLine(projectFacts) }];
   if (scaffoldedFramework) {
     detected.push({ label: "Scaffold", value: "fresh project (no existing files)" });
   }

--- a/apps/cli/src/commands/setup/install.ts
+++ b/apps/cli/src/commands/setup/install.ts
@@ -1,0 +1,142 @@
+import { consola } from "consola";
+
+import { ZitadelError } from "../../lib/errors";
+import {
+  detectPackageManager,
+  devCommandFor,
+  installCommandFor,
+  runPackageCommand,
+  type PackageCommand,
+  type PackageManager,
+} from "../../lib/package-manager";
+
+type InstallReason = "dry-run" | "skip-install" | "no-dependency-changes";
+
+export type SetupInstall = {
+  status: "completed" | "skipped" | "not-needed";
+  package_manager: PackageManager;
+  command: string;
+  reason?: InstallReason;
+};
+
+export type SetupInstallOutcome = {
+  install: SetupInstall;
+  devCommand: string;
+  nextActions: string[];
+  nextCommands: string[];
+};
+
+export type SetupInstallInput = {
+  cwd: string;
+  depsAdded: ReadonlyArray<string>;
+  dryRun: boolean;
+  env: NodeJS.ProcessEnv;
+  issuer: string;
+  json: boolean;
+  scaffoldedFramework: boolean;
+  skipInstall: boolean;
+  run?: typeof runPackageCommand;
+};
+
+export async function installDependenciesForSetup(
+  input: SetupInstallInput,
+): Promise<SetupInstallOutcome> {
+  const packageManager = await detectPackageManager(input.cwd);
+  const installCommand = installCommandFor(packageManager);
+  const devCommand = devCommandFor(packageManager);
+  const needsInstall = input.scaffoldedFramework || input.depsAdded.length > 0;
+
+  if (!needsInstall) {
+    return outcome({
+      install: {
+        status: "not-needed",
+        package_manager: packageManager,
+        command: installCommand.display,
+        reason: "no-dependency-changes",
+      },
+      devCommand: devCommand.display,
+      issuer: input.issuer,
+      includeInstallCommand: false,
+    });
+  }
+
+  if (input.dryRun || input.skipInstall) {
+    return outcome({
+      install: {
+        status: "skipped",
+        package_manager: packageManager,
+        command: installCommand.display,
+        reason: input.dryRun ? "dry-run" : "skip-install",
+      },
+      devCommand: devCommand.display,
+      issuer: input.issuer,
+      includeInstallCommand: true,
+    });
+  }
+
+  consola.start(`Installing dependencies with ${installCommand.display}`);
+  try {
+    await (input.run ?? runPackageCommand)(installCommand, {
+      cwd: input.cwd,
+      env: input.env,
+      redirectStdoutToStderr: input.json,
+    });
+  } catch (error) {
+    throw installFailed(error, installCommand, devCommand, input.cwd);
+  }
+  consola.success("Installed dependencies");
+
+  return outcome({
+    install: {
+      status: "completed",
+      package_manager: packageManager,
+      command: installCommand.display,
+    },
+    devCommand: devCommand.display,
+    issuer: input.issuer,
+    includeInstallCommand: false,
+  });
+}
+
+function outcome(input: {
+  install: SetupInstall;
+  devCommand: string;
+  issuer: string;
+  includeInstallCommand: boolean;
+}): SetupInstallOutcome {
+  const startAction = `Start your project: ${input.devCommand} (then open ${input.issuer}/login)`;
+  return {
+    install: input.install,
+    devCommand: input.devCommand,
+    nextActions: input.includeInstallCommand
+      ? [`Install dependencies: ${input.install.command}`, startAction]
+      : [startAction],
+    nextCommands: input.includeInstallCommand
+      ? [input.install.command, input.devCommand]
+      : [input.devCommand],
+  };
+}
+
+function installFailed(
+  error: unknown,
+  installCommand: PackageCommand,
+  devCommand: PackageCommand,
+  cwd: string,
+): ZitadelError {
+  return new ZitadelError("E_VALIDATION", `Dependency install failed: ${installCommand.display}`, {
+    hint: `Run ${installCommand.display} in ${cwd}, then start the app with ${devCommand.display}.`,
+    nextCommands: [installCommand.display],
+    details: { command: installCommand.display, cwd, original: errorShape(error) },
+  });
+}
+
+function errorShape(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      code: (error as NodeJS.ErrnoException).code,
+    };
+  }
+  return { message: String(error) };
+}

--- a/apps/cli/src/commands/setup/summary.ts
+++ b/apps/cli/src/commands/setup/summary.ts
@@ -3,6 +3,8 @@ import { basename, join } from "node:path";
 
 import pc from "picocolors";
 
+import { detectPackageManager, type PackageManager } from "../../lib/package-manager";
+
 /**
  * Structured end-of-command summary, modelled on the report layout the
  * setup mock specifies: one line per fact, grouped under uppercase section
@@ -64,19 +66,15 @@ export type ProjectFacts = {
   framework: string;
   frameworkVersion?: string;
   typescript: boolean;
-  packageManager: "npm" | "pnpm" | "yarn" | "bun" | "unknown";
+  packageManager: PackageManager;
 };
 
 /**
  * Reads the project root to identify the framework version, TS presence,
- * and which package manager the user runs. Returns the worst-case
- * (`"unknown"` PM, no version) on any error so summary rendering can
- * always proceed.
+ * and which package manager the user runs. Returns safe defaults (npm
+ * fallback, no version) on any error so summary rendering can always proceed.
  */
-export async function detectProjectFacts(
-  cwd: string,
-  frameworkId: string,
-): Promise<ProjectFacts> {
+export async function detectProjectFacts(cwd: string, frameworkId: string): Promise<ProjectFacts> {
   const facts: ProjectFacts = {
     framework: frameworkId,
     typescript: await fileExists(join(cwd, "tsconfig.json")),
@@ -107,16 +105,8 @@ export function formatFrameworkLine(facts: ProjectFacts): string {
   const pretty = prettyFramework(facts.framework);
   segments.push(facts.frameworkVersion ? `${pretty} ${facts.frameworkVersion}` : pretty);
   if (facts.typescript) segments.push("TypeScript");
-  if (facts.packageManager !== "unknown") segments.push(facts.packageManager);
+  segments.push(facts.packageManager);
   return segments.join(` ${pc.dim("·")} `);
-}
-
-async function detectPackageManager(cwd: string): Promise<ProjectFacts["packageManager"]> {
-  if (await fileExists(join(cwd, "pnpm-lock.yaml"))) return "pnpm";
-  if (await fileExists(join(cwd, "yarn.lock"))) return "yarn";
-  if (await fileExists(join(cwd, "bun.lockb"))) return "bun";
-  if (await fileExists(join(cwd, "package-lock.json"))) return "npm";
-  return "unknown";
 }
 
 async function fileExists(p: string): Promise<boolean> {

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -2,7 +2,6 @@ import { setTimeout as sleep } from "node:timers/promises";
 
 import { Flags } from "@oclif/core";
 
-import { BaseCommand, type JsonEnvelope } from "../lib/oclif";
 import { ZitadelError } from "../lib/errors";
 import {
   currentUser,
@@ -22,6 +21,8 @@ import {
   localServerUrl,
   writeRuntimeMetadata,
 } from "../lib/local-server/runtime";
+import { BaseCommand, type JsonEnvelope } from "../lib/oclif";
+import { publicCliCommand } from "../lib/public-cli";
 
 const START_TIMEOUT_MS = 90_000;
 
@@ -56,7 +57,7 @@ export default class Start extends BaseCommand {
             console: `${serverUrl}/ui/console/`,
             login: `${serverUrl}/ui/login/`,
           },
-          next_commands: ["zitadel start"],
+          next_commands: [publicCliCommand("start", this.meta.cliVersion)],
         },
       });
     }
@@ -75,7 +76,7 @@ export default class Start extends BaseCommand {
         serverUrl,
       });
       await writeRuntimeMetadata(this.meta.cwd, metadata);
-      return this.emit({ status: "ok", data: readyData(metadata, true) });
+      return this.emit({ status: "ok", data: readyData(metadata, true, this.meta.cliVersion) });
     }
 
     if (existing.exists) {
@@ -90,7 +91,7 @@ export default class Start extends BaseCommand {
       dataDir: paths.dataDir,
       identity: await ensureContainerIdentity(this.meta.cwd, currentUser()),
     });
-    await waitForHealth(serverUrl, containerName);
+    await waitForHealth(serverUrl, containerName, this.meta.cliVersion);
 
     const metadata = metadataFromStart({
       cwdDataDir: paths.dataDir,
@@ -102,11 +103,15 @@ export default class Start extends BaseCommand {
       serverUrl,
     });
     await writeRuntimeMetadata(this.meta.cwd, metadata);
-    return this.emit({ status: "ok", data: readyData(metadata, false) });
+    return this.emit({ status: "ok", data: readyData(metadata, false, this.meta.cliVersion) });
   }
 }
 
-function readyData(metadata: ReturnType<typeof metadataFromStart>, alreadyRunning: boolean) {
+function readyData(
+  metadata: ReturnType<typeof metadataFromStart>,
+  alreadyRunning: boolean,
+  cliVersion: string,
+) {
   return {
     title: alreadyRunning
       ? "Local Zitadel server is already running."
@@ -123,16 +128,19 @@ function readyData(metadata: ReturnType<typeof metadataFromStart>, alreadyRunnin
       console: `${metadata.server_url}/ui/console/`,
       login: `${metadata.server_url}/ui/login/`,
     },
-    next_actions: ["Set up your app, then start its dev server."],
-    next_commands: [
-      "npx @zitadel/cli@alpha setup --framework next --server local",
-      "npm install",
-      "npm run dev",
+    next_actions: [
+      "From your app directory, run setup; the CLI will detect the framework or ask when needed.",
+      "Setup installs dependencies when needed; then start your app dev server.",
     ],
+    next_commands: [publicCliCommand("setup --server local", cliVersion)],
   };
 }
 
-async function waitForHealth(serverUrl: string, containerName: string): Promise<void> {
+async function waitForHealth(
+  serverUrl: string,
+  containerName: string,
+  cliVersion: string,
+): Promise<void> {
   const started = Date.now();
   while (Date.now() - started < START_TIMEOUT_MS) {
     if (await checkLocalServerHealth(serverUrl, 1000)) {
@@ -142,7 +150,10 @@ async function waitForHealth(serverUrl: string, containerName: string): Promise<
   }
   throw new ZitadelError("E_NETWORK", "Local Zitadel server did not become healthy", {
     hint: "Inspect the container logs, then reset the local runtime if needed.",
-    nextCommands: ["zitadel logs", "zitadel reset --force"],
+    nextCommands: [
+      publicCliCommand("logs", cliVersion),
+      publicCliCommand("reset --force", cliVersion),
+    ],
     details: { container_name: containerName, server_url: serverUrl },
   });
 }

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,4 +1,3 @@
-import { BaseCommand, type JsonEnvelope } from "../lib/oclif";
 import { inspectContainer } from "../lib/local-server/docker";
 import {
   DEFAULT_LOCAL_SERVER_URL,
@@ -7,6 +6,7 @@ import {
   readRuntimeMetadata,
   runtimeSummary,
 } from "../lib/local-server/runtime";
+import { BaseCommand, type JsonEnvelope } from "../lib/oclif";
 import {
   hasZitadelConfig,
   hasZitadelSecret,
@@ -14,6 +14,7 @@ import {
   readZitadelConfig,
   readZitadelSecret,
 } from "../lib/project";
+import { publicCliCommand } from "../lib/public-cli";
 
 /**
  * `zitadel status` — summarize the local server and project state.
@@ -56,7 +57,8 @@ export default class Status extends BaseCommand {
       : "missing";
 
     const project = await projectStatus(cwd);
-    const nextCommands = nextCommandsFor(serverLifecycle, project.lifecycle);
+    const nextCommands = nextCommandsFor(serverLifecycle, project.lifecycle, this.meta.cliVersion);
+    const nextActions = nextActionsFor(project.lifecycle);
 
     return this.emit({
       status: "ok",
@@ -77,6 +79,7 @@ export default class Status extends BaseCommand {
           },
         },
         project,
+        next_actions: nextActions,
         next_commands: nextCommands,
       },
     });
@@ -124,17 +127,33 @@ async function projectStatus(cwd: string): Promise<ProjectStatus> {
   };
 }
 
-function nextCommandsFor(serverLifecycle: string, projectLifecycle: ProjectStatus["lifecycle"]): string[] {
+function nextActionsFor(projectLifecycle: ProjectStatus["lifecycle"]): string[] {
+  if (projectLifecycle === "not-configured") {
+    return [
+      "From your app directory, run setup; the CLI will detect the framework or ask in an empty directory.",
+    ];
+  }
+  return [];
+}
+
+function nextCommandsFor(
+  serverLifecycle: string,
+  projectLifecycle: ProjectStatus["lifecycle"],
+  cliVersion: string,
+): string[] {
   const commands: string[] = [];
   if (serverLifecycle !== "running") {
-    commands.push("zitadel start");
+    commands.push(publicCliCommand("start", cliVersion));
   }
   if (projectLifecycle === "not-configured") {
-    commands.push("zitadel setup --framework next --server local");
+    commands.push(publicCliCommand("setup --server local", cliVersion));
   } else if (projectLifecycle === "orphaned-config") {
-    commands.push("zitadel setup --force", "zitadel doctor --fix");
+    commands.push(
+      publicCliCommand("setup --force", cliVersion),
+      publicCliCommand("doctor --fix", cliVersion),
+    );
   } else {
-    commands.push("zitadel doctor", "zitadel apply");
+    commands.push(publicCliCommand("doctor", cliVersion), publicCliCommand("apply", cliVersion));
   }
   return commands;
 }

--- a/apps/cli/src/commands/stop.ts
+++ b/apps/cli/src/commands/stop.ts
@@ -1,10 +1,11 @@
-import { BaseCommand, type JsonEnvelope } from "../lib/oclif";
 import { stopAndRemoveContainer } from "../lib/local-server/docker";
 import {
   DEFAULT_LOCAL_SERVER_URL,
   localContainerName,
   readRuntimeMetadata,
 } from "../lib/local-server/runtime";
+import { BaseCommand, type JsonEnvelope } from "../lib/oclif";
+import { publicCliCommand } from "../lib/public-cli";
 
 export default class Stop extends BaseCommand {
   static override description = "Stop the local Zitadel server.";
@@ -28,7 +29,7 @@ export default class Stop extends BaseCommand {
             data_preserved: true,
             data_dir: runtime?.data_dir,
           },
-          next_commands: ["zitadel stop"],
+          next_commands: [publicCliCommand("stop", this.meta.cliVersion)],
         },
       });
     }
@@ -44,7 +45,6 @@ export default class Stop extends BaseCommand {
           data_preserved: true,
           data_dir: runtime?.data_dir,
         },
-        next_commands: ["zitadel start", "zitadel reset --force"],
       },
     });
   }

--- a/apps/cli/src/lib/oclif/base.ts
+++ b/apps/cli/src/lib/oclif/base.ts
@@ -1,10 +1,11 @@
 import { Command, Flags } from "@oclif/core";
 import consola from "consola";
 
-import { resolveServer } from "../server";
 import { toZitadelError, type ZitadelError } from "../errors";
 import { isObject } from "../json";
 import { resolveCwd } from "../paths";
+import { normalizePublicCliCommand, normalizePublicCliCommands } from "../public-cli";
+import { resolveServer } from "../server";
 import type {
   CommandResult,
   ErrorEnvelope,
@@ -104,8 +105,9 @@ export abstract class BaseCommand extends Command {
    * envelope so oclif's `--json` path serialises it.
    */
   protected emit(result: CommandResult): JsonEnvelope {
-    this.log(renderPretty(result, this.meta));
-    return toEnvelope(result, this.meta);
+    const normalized = normalizeCommandResult(result, this.meta);
+    this.log(renderPretty(normalized, this.meta));
+    return toEnvelope(normalized, this.meta);
   }
 
   /**
@@ -120,7 +122,7 @@ export abstract class BaseCommand extends Command {
     if (this.jsonEnabled()) {
       this.logJson(toErrorEnvelope(zitadelError, meta));
     } else {
-      this.logToStderr(renderError(zitadelError));
+      this.logToStderr(renderError(zitadelError, meta));
     }
     return this.exit(zitadelError.exitCode);
   }
@@ -145,6 +147,32 @@ export abstract class BaseCommand extends Command {
       isTTY: Boolean(process.stdout.isTTY && process.stdin.isTTY),
     };
   }
+}
+
+function normalizeCommandResult(result: CommandResult, meta: GlobalOptions): CommandResult {
+  if (result.status === "ok") {
+    return {
+      ...result,
+      data: normalizeDataNextCommands(result.data, meta),
+    };
+  }
+  return {
+    ...result,
+    data: normalizeDataNextCommands(result.data, meta),
+    nextCommands: normalizePublicCliCommands(result.nextCommands, meta.cliVersion),
+  };
+}
+
+function normalizeDataNextCommands(data: unknown, meta: GlobalOptions): unknown {
+  if (!isObject(data) || !Array.isArray(data.next_commands)) {
+    return data;
+  }
+  return {
+    ...data,
+    next_commands: data.next_commands.map((command) =>
+      typeof command === "string" ? normalizePublicCliCommand(command, meta.cliVersion) : command,
+    ),
+  };
 }
 
 /** Wraps a {@link CommandResult} with the invocation metadata into the final envelope. */
@@ -181,7 +209,7 @@ function toErrorEnvelope(error: ZitadelError, meta: GlobalOptions): ErrorEnvelop
     code: error.code,
     message: error.message,
     hint: error.hint,
-    next_commands: error.nextCommands,
+    next_commands: normalizePublicCliCommands(error.nextCommands, meta.cliVersion),
     details: error.details,
   };
 }
@@ -213,14 +241,15 @@ function renderPretty(result: CommandResult, meta: GlobalOptions): string {
  * Renders a {@link ZitadelError} as a human-readable block for stderr: the
  * coded message, an optional hint, and any suggested next commands.
  */
-function renderError(error: ZitadelError): string {
+function renderError(error: ZitadelError, meta: GlobalOptions): string {
   const lines = [`Error ${error.code}: ${error.message}`];
   if (error.hint) {
     lines.push(error.hint);
   }
-  if (error.nextCommands && error.nextCommands.length > 0) {
+  const nextCommands = normalizePublicCliCommands(error.nextCommands, meta.cliVersion);
+  if (nextCommands && nextCommands.length > 0) {
     lines.push("Next:");
-    for (const cmd of error.nextCommands) {
+    for (const cmd of nextCommands) {
       lines.push(`  $ ${cmd}`);
     }
   }
@@ -265,10 +294,22 @@ function formatData(data: unknown, warnings: string[], opts: GlobalOptions): str
     }
   }
 
-  for (const warning of warnings) {
+  for (const warning of warnings.filter((warning) => !warningRenderedInChecks(data, warning))) {
     lines.push(`Warning: ${warning}`);
   }
   return lines.join("\n");
+}
+
+function warningRenderedInChecks(data: unknown, warning: string): boolean {
+  if (!isObject(data) || !Array.isArray(data.checks)) {
+    return false;
+  }
+  return data.checks.some((check) => {
+    if (!isObject(check) || check.status !== "warn") {
+      return false;
+    }
+    return warning === `${String(check.name ?? "check")}: ${String(check.message ?? "")}`;
+  });
 }
 
 function renderKnownSections(lines: string[], data: Record<string, unknown>): void {
@@ -322,7 +363,7 @@ function renderKnownSections(lines: string[], data: Record<string, unknown>): vo
       if (!isObject(check)) {
         continue;
       }
-      const status = check.status === "pass" ? "ok" : "fail";
+      const status = check.status === "pass" ? "ok" : check.status === "warn" ? "warn" : "fail";
       lines.push(`  [${status}] ${String(check.name ?? "check")}: ${String(check.message ?? "")}`);
     }
   }

--- a/apps/cli/src/lib/orca/index.ts
+++ b/apps/cli/src/lib/orca/index.ts
@@ -51,9 +51,13 @@ export class Orca {
         return facts;
       }
     }
-    throw new ZitadelError("E_FRAMEWORK_NOT_DETECTED", "Could not detect a supported framework", {
-      hint: `Run this from a supported project (${this.frameworkIds().join(", ")}) or pass --cwd <path>.`,
-    });
+    throw new ZitadelError(
+      "E_FRAMEWORK_NOT_DETECTED",
+      "Could not detect a supported app framework",
+      {
+        hint: "Run setup from your app project directory, pass --cwd <path-to-app>, or run setup from an empty directory to scaffold a new app.",
+      },
+    );
   }
 
   /**
@@ -112,7 +116,9 @@ export class Orca {
     const scaffolder = this.scaffolders.find((candidate) => candidate.canScaffold(framework));
     if (!scaffolder) {
       throw new ZitadelError("E_VALIDATION", `No scaffolder supports "${framework}"`, {
-        hint: `Available frameworks: ${this.availableFrameworks().map((f) => f.id).join(", ")}.`,
+        hint: `Available frameworks: ${this.availableFrameworks()
+          .map((f) => f.id)
+          .join(", ")}.`,
       });
     }
     return scaffolder;

--- a/apps/cli/src/lib/orca/scaffolders/cli.ts
+++ b/apps/cli/src/lib/orca/scaffolders/cli.ts
@@ -33,9 +33,7 @@ export abstract class AbstractCLIScaffolder implements Scaffolder {
       const notFound = err.code === "ENOENT";
       throw new ZitadelError(
         "E_VALIDATION",
-        notFound
-          ? `Command not found: ${command}`
-          : `Failed to spawn "${command}": ${err.message}`,
+        notFound ? `Command not found: ${command}` : `Failed to spawn "${command}": ${err.message}`,
         {
           hint: notFound ? `Ensure '${command}' is installed and on PATH.` : undefined,
           details: { command, args: [...args], code: err.code },
@@ -44,11 +42,25 @@ export abstract class AbstractCLIScaffolder implements Scaffolder {
     }
     const status = result.status ?? 1;
     if (status !== 0) {
+      const stdout = String(result.stdout ?? "");
+      const stderr = String(result.stderr ?? "");
+      const output = truncateCommandOutput([stderr, stdout].filter(Boolean).join("\n").trim());
       throw new ZitadelError(
         "E_VALIDATION",
         `Command "${command} ${args.join(" ")}" exited with status ${String(status)}`,
-        { details: { stderr: result.stderr ?? "" } },
+        {
+          hint: output ? `Command output:\n${output}` : "Run the command directly for more detail.",
+          details: { command, args: [...args], cwd, stdout, stderr },
+        },
       );
     }
   }
+}
+
+function truncateCommandOutput(output: string): string {
+  const limit = 4000;
+  if (output.length <= limit) {
+    return output;
+  }
+  return `${output.slice(0, limit)}\n... output truncated ...`;
 }

--- a/apps/cli/src/lib/orca/scaffolders/next.ts
+++ b/apps/cli/src/lib/orca/scaffolders/next.ts
@@ -1,19 +1,32 @@
 import { AbstractCLIScaffolder } from "./cli";
 
+const CREATE_NEXT_APP_VERSION = "16.2.4";
+
 /** Scaffolds a new Next.js App Router project with `create-next-app`. */
 export class NextScaffolder extends AbstractCLIScaffolder {
   readonly displayName = "Next.js";
   readonly supportedFrameworks: ReadonlyArray<string> = ["next"];
 
   /**
-   * Runs `npx create-next-app@latest . --ts --app --no-git --yes` in `cwd`,
-   * creating a TypeScript App Router project in place. `--yes` accepts all
-   * defaults so the command runs unattended.
+   * Runs the pinned `create-next-app` version in `cwd`, creating a TypeScript
+   * App Router project in place. `--yes` accepts all defaults so the command
+   * runs unattended, and `--skip-install` leaves dependency installation to the
+   * setup command's explicit next step after Zitadel patches package.json.
    */
   async scaffold(cwd: string, _framework: string): Promise<void> {
     this.runCommand(
       "npx",
-      ["create-next-app@latest", ".", "--ts", "--app", "--no-git", "--yes"],
+      [
+        "--yes",
+        `create-next-app@${CREATE_NEXT_APP_VERSION}`,
+        ".",
+        "--ts",
+        "--app",
+        "--use-npm",
+        "--disable-git",
+        "--yes",
+        "--skip-install",
+      ],
       cwd,
     );
   }

--- a/apps/cli/src/lib/package-manager.ts
+++ b/apps/cli/src/lib/package-manager.ts
@@ -1,0 +1,109 @@
+import { spawn } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+export type PackageCommand = {
+  command: PackageManager;
+  args: string[];
+  display: string;
+};
+
+export async function detectPackageManager(cwd: string): Promise<PackageManager> {
+  const declared = await packageManagerFromManifest(cwd);
+  if (declared) {
+    return declared;
+  }
+  if (await exists(join(cwd, "pnpm-lock.yaml"))) return "pnpm";
+  if (await exists(join(cwd, "yarn.lock"))) return "yarn";
+  if (await exists(join(cwd, "bun.lock"))) return "bun";
+  if (await exists(join(cwd, "bun.lockb"))) return "bun";
+  if (await exists(join(cwd, "package-lock.json"))) return "npm";
+  return "npm";
+}
+
+export function installCommandFor(packageManager: PackageManager): PackageCommand {
+  return command(packageManager, ["install"]);
+}
+
+export function devCommandFor(packageManager: PackageManager): PackageCommand {
+  switch (packageManager) {
+    case "npm":
+      return command("npm", ["run", "dev"]);
+    case "pnpm":
+      return command("pnpm", ["dev"]);
+    case "yarn":
+      return command("yarn", ["dev"]);
+    case "bun":
+      return command("bun", ["run", "dev"]);
+  }
+}
+
+export async function runPackageCommand(
+  packageCommand: PackageCommand,
+  options: {
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+    redirectStdoutToStderr?: boolean;
+  },
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(packageCommand.command, packageCommand.args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      stdio: options.redirectStdoutToStderr ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+
+    if (options.redirectStdoutToStderr) {
+      child.stdout?.on("data", (chunk) => process.stderr.write(chunk));
+      child.stderr?.on("data", (chunk) => process.stderr.write(chunk));
+    }
+
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const detail = signal ? `signal ${signal}` : `exit ${String(code ?? 1)}`;
+      const error = new Error(`${packageCommand.display} failed with ${detail}`);
+      Object.assign(error, { code: code ?? 1, signal });
+      reject(error);
+    });
+  });
+}
+
+function command(packageManager: PackageManager, args: string[]): PackageCommand {
+  return {
+    command: packageManager,
+    args,
+    display: [packageManager, ...args].join(" "),
+  };
+}
+
+async function packageManagerFromManifest(cwd: string): Promise<PackageManager | undefined> {
+  try {
+    const raw = await readFile(join(cwd, "package.json"), "utf8");
+    const parsed = JSON.parse(raw) as { packageManager?: unknown };
+    return typeof parsed.packageManager === "string"
+      ? packageManagerFromString(parsed.packageManager)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function packageManagerFromString(value: string): PackageManager | undefined {
+  const name = value.split("@")[0];
+  return name === "npm" || name === "pnpm" || name === "yarn" || name === "bun" ? name : undefined;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/cli/src/lib/public-cli.ts
+++ b/apps/cli/src/lib/public-cli.ts
@@ -1,0 +1,29 @@
+const CLI_PACKAGE_NAME = "@zitadel/cli";
+
+export function npmDistTagForCliVersion(cliVersion: string): string {
+  const normalized = cliVersion.trim().replace(/^v/, "");
+  const match = normalized.match(/^\d+\.\d+\.\d+-([0-9A-Za-z][0-9A-Za-z-]*)/);
+  return match?.[1] ?? "latest";
+}
+
+export function publicCliCommand(args: string, cliVersion: string): string {
+  const prefix = `npx ${CLI_PACKAGE_NAME}@${npmDistTagForCliVersion(cliVersion)}`;
+  return args.length > 0 ? `${prefix} ${args}` : prefix;
+}
+
+export function normalizePublicCliCommand(command: string, cliVersion: string): string {
+  if (command === "zitadel") {
+    return publicCliCommand("", cliVersion);
+  }
+  if (command.startsWith("zitadel ")) {
+    return publicCliCommand(command.slice("zitadel ".length), cliVersion);
+  }
+  return command;
+}
+
+export function normalizePublicCliCommands(
+  commands: ReadonlyArray<string> | undefined,
+  cliVersion: string,
+): string[] | undefined {
+  return commands?.map((command) => normalizePublicCliCommand(command, cliVersion));
+}

--- a/apps/cli/tests/integration/contract.test.ts
+++ b/apps/cli/tests/integration/contract.test.ts
@@ -58,7 +58,7 @@ describe("envelope contract", () => {
     expect(envelope.status).toBe("error");
     expect(envelope.code).toBe("E_VALIDATION");
     expect(envelope.message).toBeTypeOf("string");
-    expect(envelope.next_commands).toContain("zitadel setup");
+    expect(envelope.next_commands).toContain("npx @zitadel/cli@alpha setup");
   });
 
   it("renders a human-readable summary (and server suffix) without --json", async () => {
@@ -83,7 +83,13 @@ describe("envelope contract", () => {
       }),
     );
 
-    const result = await runCliForTest(["status", "--cwd", cwd, "--server", "https://self.example"]);
+    const result = await runCliForTest([
+      "status",
+      "--cwd",
+      cwd,
+      "--server",
+      "https://self.example",
+    ]);
     expect(result.exitCode).toBe(0);
     // Pretty (non-JSON) rendering: the title, the project section, the source
     // suffix for a non-default server, and the next-steps block.

--- a/apps/cli/tests/integration/patch-eject.test.ts
+++ b/apps/cli/tests/integration/patch-eject.test.ts
@@ -43,6 +43,7 @@ describe("patch then eject round-trip", () => {
       cwd,
       "--non-interactive",
       "--json",
+      "--skip-install",
     ]);
     expect(setup.exitCode).toBe(0);
     expect((parseJson(setup.stdout) as { status: string }).status).toBe("ok");
@@ -54,7 +55,10 @@ describe("patch then eject round-trip", () => {
     expect(await readFile(join(cwd, "middleware.ts"), "utf8")).toContain(MANAGED_MARKER);
 
     // Simulate the user replacing the register page with their own (unmarked) file.
-    await writeFile(join(cwd, "app/register/page.tsx"), "export default function Page() { return null; }\n");
+    await writeFile(
+      join(cwd, "app/register/page.tsx"),
+      "export default function Page() { return null; }\n",
+    );
 
     const eject = await cli(["eject", "--cwd", cwd, "--force", "--json"]);
     expect(eject.exitCode).toBe(0);

--- a/apps/cli/tests/integration/setup-next.test.ts
+++ b/apps/cli/tests/integration/setup-next.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -27,17 +27,35 @@ function cli(args: string[], env: NodeJS.ProcessEnv = {}) {
 describe("Next setup integration", () => {
   it("sets up, verifies, plans, applies, and preserves idempotency", async () => {
     const cwd = await createNextProject();
+    const fakeNpm = await fakePackageManager("npm");
 
-    const setup = await cli([
-      "setup",
-      "--cwd",
-      cwd,
-      "--non-interactive",
-      "--json",
-    ]);
+    const setup = await cli(["setup", "--cwd", cwd, "--non-interactive", "--json"], {
+      PACKAGE_MANAGER_LOG: fakeNpm.logPath,
+      PATH: `${fakeNpm.binDir}:${process.env.PATH ?? ""}`,
+    });
     expect(setup.exitCode).toBe(0);
-    const setupJson = parseJson(setup.stdout) as { status: string };
+    const setupJson = parseJson(setup.stdout) as {
+      status: string;
+      data: {
+        install: { status: string; package_manager: string; command: string };
+        next_commands: string[];
+      };
+    };
     expect(setupJson.status).toBe("ok");
+    expect(setup.stdout).not.toContain("fake npm stdout");
+    expect(setup.stderr).toContain("fake npm stdout");
+    expect(setup.stderr).toContain("fake npm stderr");
+    expect(setupJson.data.install).toMatchObject({
+      status: "completed",
+      package_manager: "npm",
+      command: "npm install",
+    });
+    expect(setupJson.data.next_commands).toEqual(["npm run dev"]);
+    const installLog = JSON.parse((await readFile(fakeNpm.logPath, "utf8")).trim()) as {
+      cwd: string;
+      args: string[];
+    };
+    expect(installLog).toEqual({ cwd: await realpath(cwd), args: ["install"] });
 
     // The user schema and flow are provisioned server-side when the project
     // is created, so setup does not write `.zitadel/schemas` or
@@ -122,20 +140,15 @@ describe("Next setup integration", () => {
 
   it("fails apply clearly for missing env refs", async () => {
     const cwd = await createNextProject();
-    await cli([
-      "setup",
-      "--cwd",
-      cwd,
-      "--non-interactive",
-      "--json",
-    ]);
+    await cli(["setup", "--cwd", cwd, "--non-interactive", "--json", "--skip-install"]);
 
     const flowWithEnvRef = {
       // Spec: `name` is the slug-pattern stable identifier; required fields
       // are [name, user_schema, purposes, steps]. `purposes` is a map
       // from purpose name to entry-point step name.
       name: "default",
-      user_schema: "https://raw.githubusercontent.com/zitadel/nextgen/refs/heads/main/api/openapi/endpoints/schemas/human-user.yaml",
+      user_schema:
+        "https://raw.githubusercontent.com/zitadel/nextgen/refs/heads/main/api/openapi/endpoints/schemas/human-user.yaml",
       purposes: { login: "identifier" },
       steps: [
         {
@@ -152,7 +165,10 @@ describe("Next setup integration", () => {
         },
       ],
     };
-    await writeFile(join(cwd, ".zitadel/flows/default.json"), JSON.stringify(flowWithEnvRef, null, 2));
+    await writeFile(
+      join(cwd, ".zitadel/flows/default.json"),
+      JSON.stringify(flowWithEnvRef, null, 2),
+    );
 
     const apply = await cli(["apply", "--cwd", cwd, "--json"]);
     expect(apply.exitCode).toBe(3);
@@ -160,10 +176,11 @@ describe("Next setup integration", () => {
     expect(applyJson.code).toBe("E_VALIDATION");
     expect(applyJson.message).toContain("Missing environment variables");
 
-    const applyWithEnv = await cli(["apply", "--cwd", cwd, "--json"], { MY_CAPTCHA_SECRET: "hunter2" });
+    const applyWithEnv = await cli(["apply", "--cwd", cwd, "--json"], {
+      MY_CAPTCHA_SECRET: "hunter2",
+    });
     expect(applyWithEnv.exitCode).toBe(0);
   });
-
 });
 
 async function createNextProject(): Promise<string> {
@@ -191,6 +208,27 @@ async function createNextProject(): Promise<string> {
     "export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }\n",
   );
   return cwd;
+}
+
+async function fakePackageManager(name: "npm"): Promise<{ binDir: string; logPath: string }> {
+  const binDir = await mkdtemp(join(tmpdir(), "zitadel-fake-pm-"));
+  const logPath = join(binDir, "package-manager.log");
+  const binPath = join(binDir, name);
+  await writeFile(
+    binPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(
+  process.env.PACKAGE_MANAGER_LOG,
+  JSON.stringify({ cwd: process.cwd(), args: process.argv.slice(2) }) + "\\n",
+);
+process.stdout.write("fake npm stdout\\n");
+process.stderr.write("fake npm stderr\\n");
+process.exit(0);
+`,
+  );
+  await chmod(binPath, 0o755);
+  return { binDir, logPath };
 }
 
 async function fakeDocker(): Promise<{ binDir: string; logPath: string }> {

--- a/apps/cli/tests/unit/commands/doctor.test.ts
+++ b/apps/cli/tests/unit/commands/doctor.test.ts
@@ -5,10 +5,10 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { parseJson, runCliForTest } from "../../helpers/run-cli";
 import { MANAGED_MARKER } from "../../../src/lib/paths";
+import { parseJson, runCliForTest } from "../../helpers/run-cli";
 
-type Check = { name: string; status: "pass" | "fail"; message: string; path?: string };
+type Check = { name: string; status: "pass" | "warn" | "fail"; message: string; path?: string };
 
 const tempDirs: string[] = [];
 
@@ -22,20 +22,23 @@ const VALID_USER_SCHEMA = {
 async function doctor(cwd: string, extra: string[] = []) {
   const fake = await fakeDocker();
   const port = await freePort();
-  return runCliForTest([
-    "doctor",
-    "--cwd",
-    cwd,
-    "--json",
-    "--port",
-    String(port),
-    "--server",
-    "https://api.zitadel.cloud",
-    ...extra,
-  ], {
-    PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
-    DOCKER_LOG: fake.logPath,
-  });
+  return runCliForTest(
+    [
+      "doctor",
+      "--cwd",
+      cwd,
+      "--json",
+      "--port",
+      String(port),
+      "--server",
+      "https://api.zitadel.cloud",
+      ...extra,
+    ],
+    {
+      PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
+      DOCKER_LOG: fake.logPath,
+    },
+  );
 }
 
 /**
@@ -87,12 +90,18 @@ async function makeHealthyProject(): Promise<string> {
     ["ZITADEL_PROJECT_ID=", "ZITADEL_ENVIRONMENT=", "ZITADEL_ISSUER="].join("\n"),
   );
   await writeFile(join(cwd, ".zitadel/schemas/user.json"), JSON.stringify(VALID_USER_SCHEMA));
-  await writeFile(join(cwd, "app/login/page.tsx"), `${MANAGED_MARKER}\nexport default function L() {}\n`);
+  await writeFile(
+    join(cwd, "app/login/page.tsx"),
+    `${MANAGED_MARKER}\nexport default function L() {}\n`,
+  );
   await writeFile(
     join(cwd, "app/register/page.tsx"),
     `${MANAGED_MARKER}\nexport default function R() {}\n`,
   );
-  await writeFile(join(cwd, "middleware.ts"), `${MANAGED_MARKER}\nexport function middleware() {}\n`);
+  await writeFile(
+    join(cwd, "middleware.ts"),
+    `${MANAGED_MARKER}\nexport function middleware() {}\n`,
+  );
   return cwd;
 }
 
@@ -111,7 +120,10 @@ describe("doctor command", () => {
     const res = await doctor(cwd);
 
     expect(res.exitCode).toBe(0);
-    const json = parseJson(res.stdout) as { status: string; data: { ok: boolean; checks: Check[] } };
+    const json = parseJson(res.stdout) as {
+      status: string;
+      data: { ok: boolean; checks: Check[] };
+    };
     expect(json.status).toBe("ok");
     expect(json.data.ok).toBe(true);
     expect(json.data.checks.every((check) => check.status === "pass")).toBe(true);
@@ -136,7 +148,11 @@ describe("doctor command", () => {
     const res = await doctor(cwd);
 
     expect(res.exitCode).toBe(3);
-    const json = parseJson(res.stdout) as { status: string; code: string; details: { checks: Check[] } };
+    const json = parseJson(res.stdout) as {
+      status: string;
+      code: string;
+      details: { checks: Check[] };
+    };
     expect(json.status).toBe("error");
     expect(json.code).toBe("E_VALIDATION");
     const dependency = json.details.checks.find((check) => check.name === "dependency");
@@ -172,7 +188,10 @@ describe("doctor command", () => {
     const res = await doctor(cwd, ["--fix"]);
 
     expect(res.exitCode).toBe(0);
-    const json = parseJson(res.stdout) as { status: string; data: { ok: boolean; checks: Check[] } };
+    const json = parseJson(res.stdout) as {
+      status: string;
+      data: { ok: boolean; checks: Check[] };
+    };
     expect(json.status).toBe("ok");
     const perms = json.data.checks.find((check) => check.name === "secret-permissions");
     expect(perms?.status).toBe("pass");
@@ -197,10 +216,16 @@ describe("doctor command", () => {
     const res = await doctor(cwd, ["--fix"]);
 
     expect(res.exitCode).toBe(3);
-    const json = parseJson(res.stdout) as { status: string; code: string; details: { checks: Check[] } };
+    const json = parseJson(res.stdout) as {
+      status: string;
+      code: string;
+      details: { checks: Check[] };
+    };
     expect(json.status).toBe("error");
     expect(json.code).toBe("E_VALIDATION");
-    expect(json.details.checks.find((check) => check.name === "project-match")?.status).toBe("fail");
+    expect(json.details.checks.find((check) => check.name === "project-match")?.status).toBe(
+      "fail",
+    );
   });
 
   it("re-applies a missing Zitadel dependency via --fix and then passes", async () => {
@@ -214,7 +239,10 @@ describe("doctor command", () => {
     const res = await doctor(cwd, ["--fix"]);
 
     expect(res.exitCode).toBe(0);
-    const json = parseJson(res.stdout) as { status: string; data: { ok: boolean; checks: Check[] } };
+    const json = parseJson(res.stdout) as {
+      status: string;
+      data: { ok: boolean; checks: Check[] };
+    };
     expect(json.status).toBe("ok");
     expect(json.data.ok).toBe(true);
     const dependency = json.data.checks.find((check) => check.name === "dependency");

--- a/apps/cli/tests/unit/commands/local-runtime.test.ts
+++ b/apps/cli/tests/unit/commands/local-runtime.test.ts
@@ -48,15 +48,11 @@ describe("local runtime commands", () => {
 
     const dockerCalls = await readDockerCalls(fake.logPath);
     expect(dockerCalls).toContainEqual(["image", "inspect", "ghcr.io/zitadel/nextgen:latest"]);
-    expect(dockerCalls).toContainEqual([
-      "manifest",
-      "inspect",
-      "ghcr.io/zitadel/nextgen:latest",
-    ]);
+    expect(dockerCalls).toContainEqual(["manifest", "inspect", "ghcr.io/zitadel/nextgen:latest"]);
     expect(dockerCalls.some((args) => args[0] === "pull")).toBe(false);
   });
 
-  it("doctor reports Docker-specific guidance when runtime prerequisites fail", async () => {
+  it("doctor warns when Docker is unreachable before app setup", async () => {
     const cwd = await tempProject("zitadel-doctor-fail-");
     const fake = await fakeDocker({ dockerAvailable: false });
     const port = await freePort();
@@ -66,20 +62,38 @@ describe("local runtime commands", () => {
       DOCKER_LOG: fake.logPath,
     });
 
-    expect(result.exitCode).toBe(3);
+    expect(result.exitCode).toBe(0);
     const envelope = parseJson(result.stdout) as {
       status: string;
-      hint: string;
-      next_commands: string[];
+      warnings: string[];
+      data: { ok: boolean; checks: Array<{ name: string; status: string; message: string }> };
     };
-    expect(envelope.status).toBe("error");
-    expect(envelope.hint).toContain("Docker is required");
-    expect(envelope.hint).not.toContain("doctor --fix");
-    expect(envelope.next_commands).toContain("docker version");
-    expect(envelope.next_commands).toContain("zitadel doctor");
+    expect(envelope.status).toBe("ok");
+    expect(envelope.data.ok).toBe(true);
+    expect(envelope.warnings.join("\n")).toContain("Docker is not reachable");
+    expect(envelope.data.checks.find((check) => check.name === "docker-cli")).toMatchObject({
+      status: "warn",
+    });
   });
 
-  it("doctor reports unavailable images without pulling", async () => {
+  it("does not print duplicate warning lines in human doctor output", async () => {
+    const cwd = await tempProject("zitadel-doctor-human-warn-");
+    const fake = await fakeDocker({ dockerAvailable: false });
+    const port = await freePort();
+
+    const result = await runCliForTest(["doctor", "--cwd", cwd, "--port", String(port)], {
+      PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
+      DOCKER_LOG: fake.logPath,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("[warn] docker-cli:");
+    expect(result.stdout).toContain("[warn] image:");
+    expect(result.stdout).not.toContain("Warning: docker-cli:");
+    expect(result.stdout).not.toContain("Warning: image:");
+  });
+
+  it("doctor warns about unavailable images without pulling", async () => {
     const cwd = await tempProject("zitadel-doctor-image-fail-");
     const fake = await fakeDocker({ imageAvailable: false });
     const port = await freePort();
@@ -92,20 +106,50 @@ describe("local runtime commands", () => {
       },
     );
 
-    expect(result.exitCode).toBe(3);
+    expect(result.exitCode).toBe(0);
     const envelope = parseJson(result.stdout) as {
       status: string;
-      hint: string;
-      next_commands: string[];
+      warnings: string[];
+      data: { ok: boolean; checks: Array<{ name: string; status: string; message: string }> };
     };
-    expect(envelope.status).toBe("error");
-    expect(envelope.hint).toContain("image is not available");
-    expect(envelope.next_commands).toContain("docker pull missing:test");
+    expect(envelope.status).toBe("ok");
+    expect(envelope.data.ok).toBe(true);
+    expect(envelope.warnings.join("\n")).toContain("Image missing:test is not available");
+    expect(envelope.data.checks.find((check) => check.name === "image")).toMatchObject({
+      status: "warn",
+    });
 
     const dockerCalls = await readDockerCalls(fake.logPath);
     expect(dockerCalls).toContainEqual(["image", "inspect", "missing:test"]);
     expect(dockerCalls).toContainEqual(["manifest", "inspect", "missing:test"]);
     expect(dockerCalls.some((args) => args[0] === "pull")).toBe(false);
+  });
+
+  it("doctor still fails when existing local runtime metadata is unhealthy", async () => {
+    const cwd = await tempProject("zitadel-doctor-runtime-fail-");
+    const fake = await fakeDocker();
+    const port = await freePort();
+    await writeRuntimeMetadata(cwd, runtimeFor(cwd, `http://localhost:${String(port)}`));
+
+    const result = await runCliForTest(["doctor", "--cwd", cwd, "--json", "--port", String(port)], {
+      PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
+      DOCKER_LOG: fake.logPath,
+    });
+
+    expect(result.exitCode).toBe(3);
+    const envelope = parseJson(result.stdout) as {
+      status: string;
+      hint: string;
+      next_commands: string[];
+      details: { checks: Array<{ name: string; status: string }> };
+    };
+    expect(envelope.status).toBe("error");
+    expect(envelope.hint).toContain("Existing local runtime metadata");
+    expect(envelope.next_commands).toContain("npx @zitadel/cli@alpha start");
+    expect(envelope.next_commands).toContain("npx @zitadel/cli@alpha reset --force");
+    expect(envelope.details.checks.find((check) => check.name === "runtime")).toMatchObject({
+      status: "fail",
+    });
   });
 
   it("start --json starts the single-container runtime and writes metadata", async () => {
@@ -122,13 +166,15 @@ describe("local runtime commands", () => {
     expect(result.exitCode).toBe(0);
     const envelope = parseJson(result.stdout) as {
       status: string;
-      data: { urls: { api: string }; next_commands: string[] };
+      data: { urls: { api: string }; next_actions: string[]; next_commands: string[] };
     };
     expect(envelope.status).toBe("ok");
     expect(envelope.data.urls.api).toBe(serverUrl);
-    expect(envelope.data.next_commands).toContain(
-      "npx @zitadel/cli@alpha setup --framework next --server local",
-    );
+    expect(envelope.data.next_actions.join("\n")).toContain("From your app directory");
+    expect(envelope.data.next_actions.join("\n")).toContain("Setup installs dependencies");
+    expect(envelope.data.next_commands).toEqual(["npx @zitadel/cli@alpha setup --server local"]);
+    expect(envelope.data.next_commands).not.toContain("npm install");
+    expect(envelope.data.next_commands).not.toContain("npm run dev");
 
     const runtime = await readRuntimeMetadata(cwd);
     expect(runtime?.server_url).toBe(serverUrl);
@@ -163,7 +209,61 @@ describe("local runtime commands", () => {
     expect(dockerCalls.find((args) => args[0] === "run")?.at(-1)).toBe("zitadel-nextgen:test");
   });
 
-  it("reset --force deletes local runtime data", async () => {
+  it("logs without runtime suggests the published start command", async () => {
+    const cwd = await tempProject("zitadel-logs-no-runtime-");
+    const fake = await fakeDocker();
+
+    const result = await runCliForTest(["logs", "--cwd", cwd, "--json"], {
+      PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
+      DOCKER_LOG: fake.logPath,
+    });
+
+    expect(result.exitCode).toBe(3);
+    const envelope = parseJson(result.stdout) as {
+      status: string;
+      next_commands?: string[];
+    };
+    expect(envelope.status).toBe("error");
+    expect(envelope.next_commands).toEqual(["npx @zitadel/cli@alpha start"]);
+  });
+
+  it("stop succeeds without suggesting a restart", async () => {
+    const cwd = await tempProject("zitadel-stop-");
+    const fake = await fakeDocker();
+
+    const result = await runCliForTest(["stop", "--cwd", cwd, "--json"], {
+      PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
+      DOCKER_LOG: fake.logPath,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson(result.stdout) as {
+      status: string;
+      data: { next_commands?: string[] };
+    };
+    expect(envelope.status).toBe("ok");
+    expect(envelope.data.next_commands).toBeUndefined();
+  });
+
+  it("stop --dry-run suggests the published stop command", async () => {
+    const cwd = await tempProject("zitadel-stop-dry-run-");
+    const fake = await fakeDocker();
+
+    const result = await runCliForTest(["stop", "--cwd", cwd, "--json", "--dry-run"], {
+      PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
+      DOCKER_LOG: fake.logPath,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const envelope = parseJson(result.stdout) as {
+      status: string;
+      data: { next_commands?: string[] };
+    };
+    expect(envelope.status).toBe("ok");
+    expect(envelope.data.next_commands).toEqual(["npx @zitadel/cli@alpha stop"]);
+  });
+
+  it("reset --force deletes local runtime data without suggesting a restart", async () => {
     const cwd = await tempProject("zitadel-reset-");
     const fake = await fakeDocker();
     const paths = localRuntimePaths(cwd);
@@ -177,8 +277,32 @@ describe("local runtime commands", () => {
     });
 
     expect(result.exitCode).toBe(0);
+    const envelope = parseJson(result.stdout) as {
+      status: string;
+      data: { next_commands?: string[] };
+    };
+    expect(envelope.status).toBe("ok");
+    expect(envelope.data.next_commands).toBeUndefined();
     await expect(stat(paths.dataDir)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readRuntimeMetadata(cwd)).resolves.toBeUndefined();
+  });
+
+  it("reset without --force suggests the published force command in non-interactive mode", async () => {
+    const cwd = await tempProject("zitadel-reset-needs-force-");
+    const fake = await fakeDocker();
+
+    const result = await runCliForTest(["reset", "--cwd", cwd, "--json"], {
+      PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
+      DOCKER_LOG: fake.logPath,
+    });
+
+    expect(result.exitCode).toBe(3);
+    const envelope = parseJson(result.stdout) as {
+      status: string;
+      next_commands?: string[];
+    };
+    expect(envelope.status).toBe("error");
+    expect(envelope.next_commands).toEqual(["npx @zitadel/cli@alpha reset --force"]);
   });
 });
 

--- a/apps/cli/tests/unit/commands/setup.test.ts
+++ b/apps/cli/tests/unit/commands/setup.test.ts
@@ -76,10 +76,20 @@ describe("setup command", () => {
     expect(res.exitCode).toBe(0);
     const json = parseJson(res.stdout) as {
       status: string;
-      data: { project: { project_id: string } };
+      data: {
+        install: { status: string; reason: string; command: string };
+        next_commands: string[];
+        project: { project_id: string };
+      };
     };
     expect(json.status).toBe("ok");
     expect(json.data.project.project_id).toBe("dry-run-0000");
+    expect(json.data.install).toMatchObject({
+      status: "skipped",
+      reason: "dry-run",
+      command: "npm install",
+    });
+    expect(json.data.next_commands).toEqual(["npm install", "npm run dev"]);
   });
 
   it("errors in a non-interactive empty directory without --framework", async () => {
@@ -89,8 +99,10 @@ describe("setup command", () => {
     const res = await setup(cwd);
 
     expect(res.exitCode).toBe(3);
-    const json = parseJson(res.stdout) as { status: string; code: string };
+    const json = parseJson(res.stdout) as { status: string; code: string; hint: string };
     expect(json.status).toBe("error");
     expect(json.code).toBe("E_FRAMEWORK_NOT_DETECTED");
+    expect(json.hint).toContain("Run without --json/--non-interactive");
+    expect(json.hint).not.toContain("next");
   });
 });

--- a/apps/cli/tests/unit/commands/setup/install.test.ts
+++ b/apps/cli/tests/unit/commands/setup/install.test.ts
@@ -1,0 +1,117 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  installDependenciesForSetup,
+  type SetupInstallInput,
+} from "../../../../src/commands/setup/install";
+
+const dirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function tempProject(packageJson: Record<string, unknown> = {}): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "zitadel-setup-install-"));
+  dirs.push(dir);
+  await writeFile(join(dir, "package.json"), JSON.stringify({ name: "demo", ...packageJson }));
+  return dir;
+}
+
+function input(overrides: Partial<SetupInstallInput> = {}): SetupInstallInput {
+  return {
+    cwd: "",
+    depsAdded: ["@zitadel/sdk-next"],
+    dryRun: false,
+    env: {},
+    issuer: "http://localhost:3000",
+    json: true,
+    scaffoldedFramework: false,
+    skipInstall: false,
+    ...overrides,
+  };
+}
+
+describe("setup dependency installation", () => {
+  it("installs when setup added a dependency", async () => {
+    const cwd = await tempProject();
+    const run = vi.fn(async () => undefined);
+
+    const result = await installDependenciesForSetup(input({ cwd, run }));
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(run.mock.calls[0]?.[0].display).toBe("npm install");
+    expect(run.mock.calls[0]?.[1]).toMatchObject({
+      cwd,
+      redirectStdoutToStderr: true,
+    });
+    expect(result.install).toMatchObject({
+      status: "completed",
+      package_manager: "npm",
+      command: "npm install",
+    });
+    expect(result.nextCommands).toEqual(["npm run dev"]);
+  });
+
+  it("installs after fresh scaffolding even when no Zitadel dependency changed", async () => {
+    const cwd = await tempProject({ packageManager: "pnpm@10.33.2" });
+    const run = vi.fn(async () => undefined);
+
+    const result = await installDependenciesForSetup(
+      input({ cwd, depsAdded: [], scaffoldedFramework: true, run }),
+    );
+
+    expect(run.mock.calls[0]?.[0].display).toBe("pnpm install");
+    expect(result.nextCommands).toEqual(["pnpm dev"]);
+  });
+
+  it("skips and recommends install when --skip-install is set", async () => {
+    const cwd = await tempProject();
+    const run = vi.fn(async () => undefined);
+
+    const result = await installDependenciesForSetup(input({ cwd, run, skipInstall: true }));
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result.install).toMatchObject({ status: "skipped", reason: "skip-install" });
+    expect(result.nextCommands).toEqual(["npm install", "npm run dev"]);
+  });
+
+  it("skips and recommends install during dry-run", async () => {
+    const cwd = await tempProject();
+    const run = vi.fn(async () => undefined);
+
+    const result = await installDependenciesForSetup(input({ cwd, dryRun: true, run }));
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result.install).toMatchObject({ status: "skipped", reason: "dry-run" });
+    expect(result.nextCommands).toEqual(["npm install", "npm run dev"]);
+  });
+
+  it("does not install when no dependency changed", async () => {
+    const cwd = await tempProject();
+    const run = vi.fn(async () => undefined);
+
+    const result = await installDependenciesForSetup(input({ cwd, depsAdded: [], run }));
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result.install).toMatchObject({ status: "not-needed" });
+    expect(result.nextCommands).toEqual(["npm run dev"]);
+  });
+
+  it("surfaces install failures with remediation", async () => {
+    const cwd = await tempProject();
+    const run = vi.fn(async () => {
+      throw Object.assign(new Error("boom"), { code: 1 });
+    });
+
+    await expect(installDependenciesForSetup(input({ cwd, run }))).rejects.toMatchObject({
+      code: "E_VALIDATION",
+      message: "Dependency install failed: npm install",
+      nextCommands: ["npm install"],
+    });
+  });
+});

--- a/apps/cli/tests/unit/commands/status.test.ts
+++ b/apps/cli/tests/unit/commands/status.test.ts
@@ -24,14 +24,7 @@ async function makeProject(): Promise<string> {
 }
 
 function status(cwd: string) {
-  return runCliForTest([
-    "status",
-    "--cwd",
-    cwd,
-    "--json",
-    "--server",
-    "https://api.zitadel.cloud",
-  ]);
+  return runCliForTest(["status", "--cwd", cwd, "--json", "--server", "https://api.zitadel.cloud"]);
 }
 
 afterEach(async () => {
@@ -72,7 +65,7 @@ describe("status command", () => {
     expect(json.data.project.lifecycle).toBe("configured");
     expect(json.data.project.project_id).toBe("proj-001");
     expect(json.data.project.issuer).toBe("http://localhost:3000");
-    expect(json.data.next_commands).toContain("zitadel doctor");
+    expect(json.data.next_commands).toContain("npx @zitadel/cli@alpha doctor");
   });
 
   it("reports orphaned-config when zitadel.json exists but secret is missing", async () => {
@@ -93,7 +86,7 @@ describe("status command", () => {
       };
     };
     expect(json.status).toBe("ok");
-    expect(json.data.next_commands).toContain("zitadel setup --force");
+    expect(json.data.next_commands).toContain("npx @zitadel/cli@alpha setup --force");
     expect(json.data.project.project_id).toBe("orphan");
     expect(json.data.project.lifecycle).toBe("orphaned-config");
   });
@@ -109,14 +102,16 @@ describe("status command", () => {
       data: {
         server: { lifecycle: string };
         project: { lifecycle: string };
+        next_actions: string[];
         next_commands: string[];
       };
     };
     expect(json.status).toBe("ok");
     expect(json.data.server.lifecycle).toBe("missing");
     expect(json.data.project.lifecycle).toBe("not-configured");
-    expect(json.data.next_commands).toContain("zitadel start");
-    expect(json.data.next_commands).toContain("zitadel setup --framework next --server local");
+    expect(json.data.next_actions.join("\n")).toContain("From your app directory");
+    expect(json.data.next_commands).toContain("npx @zitadel/cli@alpha start");
+    expect(json.data.next_commands).toContain("npx @zitadel/cli@alpha setup --server local");
   });
 
   it("falls back to the secret project_id when config.project is absent", async () => {

--- a/apps/cli/tests/unit/lib/orca/index.test.ts
+++ b/apps/cli/tests/unit/lib/orca/index.test.ts
@@ -8,8 +8,8 @@ import { Orca } from "../../../../src/lib/orca";
 import type { Detector } from "../../../../src/lib/orca";
 import { detectors } from "../../../../src/lib/orca/detectors";
 import { patchers } from "../../../../src/lib/orca/patchers";
-import type { Scaffolder } from "../../../../src/lib/orca/scaffolders/types";
 import { scaffolders } from "../../../../src/lib/orca/scaffolders";
+import type { Scaffolder } from "../../../../src/lib/orca/scaffolders/types";
 
 const orca = new Orca(detectors, scaffolders, patchers);
 
@@ -48,7 +48,10 @@ describe("Orca selection", () => {
 describe("Orca detection", () => {
   it("detects a Next project and extracts facts", async () => {
     const cwd = await nextProject();
-    await writeFile(join(cwd, "package.json"), JSON.stringify({ scripts: { dev: "next dev -p 4321" }, dependencies: { next: "^15" } }));
+    await writeFile(
+      join(cwd, "package.json"),
+      JSON.stringify({ scripts: { dev: "next dev -p 4321" }, dependencies: { next: "^15" } }),
+    );
     expect(await orca.detect(cwd)).toEqual({
       id: "next",
       appDir: "app",
@@ -60,6 +63,8 @@ describe("Orca detection", () => {
   it("throws E_FRAMEWORK_NOT_DETECTED when nothing matches", async () => {
     await expect(orca.detect(await tmp())).rejects.toMatchObject({
       code: "E_FRAMEWORK_NOT_DETECTED",
+      message: "Could not detect a supported app framework",
+      hint: "Run setup from your app project directory, pass --cwd <path-to-app>, or run setup from an empty directory to scaffold a new app.",
     });
   });
 

--- a/apps/cli/tests/unit/lib/orca/scaffolders/next.test.ts
+++ b/apps/cli/tests/unit/lib/orca/scaffolders/next.test.ts
@@ -7,8 +7,8 @@ import { NextScaffolder } from "../../../../../src/lib/orca/scaffolders/next";
 vi.mock("node:child_process", () => ({ spawnSync: vi.fn() }));
 const mockSpawn = vi.mocked(spawnSync);
 
-function spawnResult(status: number, stderr = ""): ReturnType<typeof spawnSync> {
-  return { status, stderr, stdout: "", pid: 1, output: [], signal: null } as ReturnType<
+function spawnResult(status: number, stderr = "", stdout = ""): ReturnType<typeof spawnSync> {
+  return { status, stderr, stdout, pid: 1, output: [], signal: null } as ReturnType<
     typeof spawnSync
   >;
 }
@@ -26,14 +26,26 @@ describe("NextScaffolder", () => {
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     const [command, args, opts] = mockSpawn.mock.calls[0] ?? [];
     expect(command).toBe("npx");
-    expect(args).toEqual(["create-next-app@latest", ".", "--ts", "--app", "--no-git", "--yes"]);
+    expect(args).toEqual([
+      "--yes",
+      "create-next-app@16.2.4",
+      ".",
+      "--ts",
+      "--app",
+      "--use-npm",
+      "--disable-git",
+      "--yes",
+      "--skip-install",
+    ]);
     expect(opts).toMatchObject({ cwd: "/tmp/proj" });
   });
 
   it("throws E_VALIDATION when the command exits non-zero", async () => {
-    mockSpawn.mockReturnValue(spawnResult(1, "boom"));
+    mockSpawn.mockReturnValue(spawnResult(1, "boom", "hello"));
     await expect(new NextScaffolder().scaffold("/tmp/proj", "next")).rejects.toMatchObject({
       code: "E_VALIDATION",
+      hint: expect.stringContaining("boom"),
+      details: expect.objectContaining({ stderr: "boom", stdout: "hello" }),
     });
   });
 

--- a/apps/cli/tests/unit/lib/package-manager.test.ts
+++ b/apps/cli/tests/unit/lib/package-manager.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  detectPackageManager,
+  devCommandFor,
+  installCommandFor,
+  type PackageManager,
+} from "../../../src/lib/package-manager";
+
+const dirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function tempProject(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "zitadel-pm-"));
+  dirs.push(dir);
+  await writeFile(join(dir, "package.json"), JSON.stringify({ name: "demo" }));
+  return dir;
+}
+
+describe("package manager detection", () => {
+  it("prefers package.json#packageManager over lockfiles", async () => {
+    const cwd = await tempProject();
+    await writeFile(
+      join(cwd, "package.json"),
+      JSON.stringify({ name: "demo", packageManager: "pnpm@10.33.2" }),
+    );
+    await writeFile(join(cwd, "package-lock.json"), "{}");
+
+    expect(await detectPackageManager(cwd)).toBe("pnpm");
+  });
+
+  it.each([
+    ["pnpm-lock.yaml", "pnpm"],
+    ["yarn.lock", "yarn"],
+    ["bun.lock", "bun"],
+    ["bun.lockb", "bun"],
+    ["package-lock.json", "npm"],
+  ] satisfies Array<[string, PackageManager]>)("detects %s", async (file, expected) => {
+    const cwd = await tempProject();
+    await writeFile(join(cwd, file), "");
+
+    expect(await detectPackageManager(cwd)).toBe(expected);
+  });
+
+  it("falls back to npm", async () => {
+    expect(await detectPackageManager(await tempProject())).toBe("npm");
+  });
+});
+
+describe("package manager commands", () => {
+  it.each([
+    ["npm", "npm install", "npm run dev"],
+    ["pnpm", "pnpm install", "pnpm dev"],
+    ["yarn", "yarn install", "yarn dev"],
+    ["bun", "bun install", "bun run dev"],
+  ] satisfies Array<[PackageManager, string, string]>)(
+    "maps %s commands",
+    (packageManager, install, dev) => {
+      expect(installCommandFor(packageManager).display).toBe(install);
+      expect(devCommandFor(packageManager).display).toBe(dev);
+    },
+  );
+});

--- a/apps/cli/tests/unit/lib/public-cli.test.ts
+++ b/apps/cli/tests/unit/lib/public-cli.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizePublicCliCommand,
+  npmDistTagForCliVersion,
+  publicCliCommand,
+} from "../../../src/lib/public-cli";
+
+describe("public CLI command formatting", () => {
+  it("uses the prerelease segment as the npm dist-tag", () => {
+    expect(npmDistTagForCliVersion("0.1.0-alpha.1")).toBe("alpha");
+    expect(publicCliCommand("start", "0.1.0-alpha.1")).toBe("npx @zitadel/cli@alpha start");
+  });
+
+  it("uses latest for stable versions", () => {
+    expect(npmDistTagForCliVersion("0.1.0")).toBe("latest");
+    expect(publicCliCommand("start", "0.1.0")).toBe("npx @zitadel/cli@latest start");
+  });
+
+  it("preserves command args exactly", () => {
+    expect(publicCliCommand("setup --server local", "0.1.0-alpha.1")).toBe(
+      "npx @zitadel/cli@alpha setup --server local",
+    );
+  });
+
+  it("normalizes bare zitadel follow-ups and leaves other commands alone", () => {
+    expect(normalizePublicCliCommand("zitadel doctor --fix", "0.1.0-alpha.1")).toBe(
+      "npx @zitadel/cli@alpha doctor --fix",
+    );
+    expect(normalizePublicCliCommand("npm install", "0.1.0-alpha.1")).toBe("npm install");
+    expect(normalizePublicCliCommand("docker version", "0.1.0-alpha.1")).toBe("docker version");
+  });
+});

--- a/apps/cli/tests/unit/scripts/build-local-runtime-image.test.ts
+++ b/apps/cli/tests/unit/scripts/build-local-runtime-image.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "vitest";
+
+type RunCall = {
+  command: string;
+  args: string[];
+  options: { cwd: string; env: Record<string, string | undefined> };
+};
+
+type BuildLocalRuntimeImageModule = {
+  LOCAL_RUNTIME_IMAGE: string;
+  buildLocalRuntimeImage: (options: {
+    repoRoot?: string;
+    tmpdir?: string;
+    nodeArch?: string;
+    env?: Record<string, string | undefined>;
+    mkdtemp?: (prefix: string) => Promise<string>;
+    mkdir?: (path: string, options: { recursive: boolean }) => Promise<void>;
+    copyFile?: (source: string, destination: string) => Promise<void>;
+    readFile?: (path: string, encoding: BufferEncoding) => Promise<string>;
+    writeFile?: (path: string, content: string) => Promise<void>;
+    rm?: (path: string, options: { recursive: boolean; force: boolean }) => Promise<void>;
+    run?: (command: string, args: string[], options: RunCall["options"]) => Promise<void>;
+    runCapture?: (
+      command: string,
+      args: string[],
+      options: RunCall["options"],
+    ) => Promise<{ stdout: string }>;
+  }) => Promise<{ image: string; platform: string }>;
+  linuxArchForNodeArch: (arch?: string) => string;
+  resolveGoreleaserTagEnv: (options: {
+    env?: Record<string, string | undefined>;
+    repoRoot?: string;
+    runCapture?: (
+      command: string,
+      args: string[],
+      options: RunCall["options"],
+    ) => Promise<{ stdout: string }>;
+  }) => Promise<Record<string, string>>;
+  localGoreleaserConfig: (config: string, distDir: string) => string;
+};
+
+async function loadModule(): Promise<BuildLocalRuntimeImageModule> {
+  return (await import(
+    new URL("../../../../../scripts/build-local-runtime-image.mjs", import.meta.url).href
+  )) as BuildLocalRuntimeImageModule;
+}
+
+describe("build-local-runtime-image", () => {
+  it("maps supported host architectures to Docker platforms", async () => {
+    const { linuxArchForNodeArch } = await loadModule();
+
+    expect(linuxArchForNodeArch("x64")).toBe("amd64");
+    expect(linuxArchForNodeArch("arm64")).toBe("arm64");
+    expect(() => linuxArchForNodeArch("ppc64")).toThrow(
+      "Unsupported local runtime image architecture: ppc64",
+    );
+  });
+
+  it("constructs GoReleaser and Docker build commands for the host platform", async () => {
+    const { LOCAL_RUNTIME_IMAGE, buildLocalRuntimeImage } = await loadModule();
+    const calls: Array<
+      | { type: "mkdir"; path: string; options: { recursive: boolean } }
+      | { type: "copyFile"; source: string; destination: string }
+      | { type: "readFile"; path: string; encoding: BufferEncoding }
+      | { type: "writeFile"; path: string; content: string }
+      | { type: "rm"; path: string; options: { recursive: boolean; force: boolean } }
+      | ({ type: "run" } & RunCall)
+    > = [];
+    const contextDir = "/tmp/zitadel-local-image-test";
+
+    const result = await buildLocalRuntimeImage({
+      repoRoot: "/repo",
+      tmpdir: "/tmp",
+      nodeArch: "arm64",
+      env: { CUSTOM_ENV: "1" },
+      mkdtemp: async (prefix) => {
+        expect(prefix).toBe("/tmp/zitadel-local-image-");
+        return contextDir;
+      },
+      mkdir: async (path, options) => {
+        calls.push({ type: "mkdir", path, options });
+      },
+      copyFile: async (source, destination) => {
+        calls.push({ type: "copyFile", source, destination });
+      },
+      readFile: async (path, encoding) => {
+        calls.push({ type: "readFile", path, encoding });
+        return "version: 2\nproject_name: nextgen\n";
+      },
+      writeFile: async (path, content) => {
+        calls.push({ type: "writeFile", path, content });
+      },
+      rm: async (path, options) => {
+        calls.push({ type: "rm", path, options });
+      },
+      runCapture: async (command, args, options) => {
+        calls.push({ type: "run", command, args, options });
+        return { stdout: "v0.1.0-alpha.1\n" };
+      },
+      run: async (command, args, options) => {
+        calls.push({ type: "run", command, args, options });
+      },
+    });
+
+    expect(result).toEqual({ image: LOCAL_RUNTIME_IMAGE, platform: "linux/arm64" });
+    expect(calls).toContainEqual({
+      type: "mkdir",
+      path: "/tmp/zitadel-local-image-test/linux/arm64",
+      options: { recursive: true },
+    });
+    expect(calls).toContainEqual({
+      type: "copyFile",
+      source: "/repo/Dockerfile",
+      destination: "/tmp/zitadel-local-image-test/Dockerfile",
+    });
+    expect(calls).toContainEqual({
+      type: "readFile",
+      path: "/repo/.goreleaser.yaml",
+      encoding: "utf8",
+    });
+    expect(calls).toContainEqual({
+      type: "writeFile",
+      path: "/tmp/zitadel-local-image-test/.goreleaser.local.yaml",
+      content:
+        'dist: "/tmp/zitadel-local-image-test/goreleaser-dist"\nversion: 2\nproject_name: nextgen\n',
+    });
+
+    const runCalls = calls.filter((call): call is { type: "run" } & RunCall => {
+      return call.type === "run";
+    });
+    expect(runCalls).toHaveLength(3);
+    expect(runCalls[0]).toMatchObject({
+      command: "git",
+      args: ["describe", "--tags", "--abbrev=0", "--match", "v[0-9]*", "--match", "[0-9]*"],
+      options: {
+        cwd: "/repo",
+        env: {
+          CUSTOM_ENV: "1",
+        },
+      },
+    });
+    expect(runCalls[1]).toMatchObject({
+      command: "goreleaser",
+      args: [
+        "build",
+        "--config",
+        "/tmp/zitadel-local-image-test/.goreleaser.local.yaml",
+        "--snapshot",
+        "--clean",
+        "--single-target",
+        "--id",
+        "nextgen",
+        "--output",
+        "/tmp/zitadel-local-image-test/linux/arm64/nextgen",
+      ],
+      options: {
+        cwd: "/repo",
+        env: {
+          CUSTOM_ENV: "1",
+          GORELEASER_CURRENT_TAG: "v0.1.0-alpha.1",
+          GORELEASER_PREVIOUS_TAG: "v0.1.0-alpha.1",
+          CGO_ENABLED: "0",
+          GOOS: "linux",
+          GOARCH: "arm64",
+        },
+      },
+    });
+    expect(runCalls[2]).toMatchObject({
+      command: "docker",
+      args: [
+        "build",
+        "--platform",
+        "linux/arm64",
+        "-t",
+        "ghcr.io/zitadel/nextgen:local-dev",
+        "/tmp/zitadel-local-image-test",
+      ],
+      options: {
+        cwd: "/repo",
+        env: {
+          CUSTOM_ENV: "1",
+        },
+      },
+    });
+    expect(calls.at(-1)).toEqual({
+      type: "rm",
+      path: "/tmp/zitadel-local-image-test",
+      options: { recursive: true, force: true },
+    });
+  });
+
+  it("cleans the temporary context when a build step fails", async () => {
+    const { buildLocalRuntimeImage } = await loadModule();
+    const calls: Array<{ type: "run"; command: string } | { type: "rm"; path: string }> = [];
+
+    await expect(
+      buildLocalRuntimeImage({
+        repoRoot: "/repo",
+        nodeArch: "x64",
+        mkdtemp: async () => "/tmp/zitadel-local-image-fail",
+        mkdir: async () => undefined,
+        copyFile: async () => undefined,
+        readFile: async () => "version: 2\nproject_name: nextgen\n",
+        writeFile: async () => undefined,
+        rm: async (path) => {
+          calls.push({ type: "rm", path });
+        },
+        runCapture: async () => ({ stdout: "v0.1.0-alpha.1\n" }),
+        run: async (command) => {
+          calls.push({ type: "run", command });
+          if (command === "docker") {
+            throw new Error("docker failed");
+          }
+        },
+      }),
+    ).rejects.toThrow("docker failed");
+
+    expect(calls).toEqual([
+      { type: "run", command: "goreleaser" },
+      { type: "run", command: "docker" },
+      { type: "rm", path: "/tmp/zitadel-local-image-fail" },
+    ]);
+  });
+
+  it("preserves explicit GoReleaser tag overrides", async () => {
+    const { resolveGoreleaserTagEnv } = await loadModule();
+    const result = await resolveGoreleaserTagEnv({
+      repoRoot: "/repo",
+      env: {
+        GORELEASER_CURRENT_TAG: "v9.9.9",
+        GORELEASER_PREVIOUS_TAG: "v9.9.8",
+      },
+      runCapture: async () => {
+        throw new Error("git should not run");
+      },
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it("derives server semver tags while ignoring scoped package tags", async () => {
+    const { resolveGoreleaserTagEnv } = await loadModule();
+    const result = await resolveGoreleaserTagEnv({
+      repoRoot: "/repo",
+      env: {},
+      runCapture: async (command, args, options) => {
+        expect(command).toBe("git");
+        expect(args).toEqual([
+          "describe",
+          "--tags",
+          "--abbrev=0",
+          "--match",
+          "v[0-9]*",
+          "--match",
+          "[0-9]*",
+        ]);
+        expect(options.cwd).toBe("/repo");
+        return { stdout: "v0.1.0-alpha.1\n" };
+      },
+    });
+
+    expect(result).toEqual({
+      GORELEASER_CURRENT_TAG: "v0.1.0-alpha.1",
+      GORELEASER_PREVIOUS_TAG: "v0.1.0-alpha.1",
+    });
+  });
+
+  it("falls back to an initial server tag when no server semver tag exists", async () => {
+    const { resolveGoreleaserTagEnv } = await loadModule();
+    const result = await resolveGoreleaserTagEnv({
+      repoRoot: "/repo",
+      env: {},
+      runCapture: async () => {
+        throw new Error("no matching server tags");
+      },
+    });
+
+    expect(result).toEqual({
+      GORELEASER_CURRENT_TAG: "v0.0.0",
+      GORELEASER_PREVIOUS_TAG: "v0.0.0",
+    });
+  });
+
+  it("overrides GoReleaser dist in the local config copy", async () => {
+    const { localGoreleaserConfig } = await loadModule();
+
+    expect(localGoreleaserConfig("version: 2\n", "/tmp/dist")).toBe(
+      'dist: "/tmp/dist"\nversion: 2\n',
+    );
+    expect(localGoreleaserConfig("version: 2\ndist: old\n", "/tmp/dist")).toBe(
+      'version: 2\ndist: "/tmp/dist"\n',
+    );
+  });
+});

--- a/apps/cli/tests/unit/scripts/dev-process.test.ts
+++ b/apps/cli/tests/unit/scripts/dev-process.test.ts
@@ -1,0 +1,32 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+type DevProcessModule = {
+  isDirectRun: (moduleUrl: string, argv?: string[]) => boolean;
+};
+
+async function loadModule(): Promise<DevProcessModule> {
+  return (await import(
+    new URL("../../../../../scripts/dev-process.mjs", import.meta.url).href
+  )) as DevProcessModule;
+}
+
+describe("dev-process helpers", () => {
+  it("detects direct script execution when argv[1] is relative", async () => {
+    const { isDirectRun } = await loadModule();
+    const relativePath = "scripts/run-cli.mjs";
+    const moduleUrl = pathToFileURL(resolve(relativePath)).href;
+
+    expect(isDirectRun(moduleUrl, [process.execPath, relativePath])).toBe(true);
+  });
+
+  it("returns false for imports or different entrypoints", async () => {
+    const { isDirectRun } = await loadModule();
+    const moduleUrl = pathToFileURL(resolve("scripts/run-cli.mjs")).href;
+
+    expect(isDirectRun(moduleUrl, [process.execPath])).toBe(false);
+    expect(isDirectRun(moduleUrl, [process.execPath, "scripts/doctor.mjs"])).toBe(false);
+  });
+});

--- a/apps/cli/tests/unit/scripts/run-cli.test.ts
+++ b/apps/cli/tests/unit/scripts/run-cli.test.ts
@@ -1,0 +1,172 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+type RunCliModule = {
+  cliCwdFor: (env?: Record<string, string | undefined>, fallback?: string) => string;
+  commandName: (args: string[]) => string | undefined;
+  main: (options: {
+    args?: string[];
+    cwd?: string;
+    env?: Record<string, string | undefined>;
+    buildCli?: () => Promise<void>;
+    buildLocalRuntimeImage?: (options: {
+      env: Record<string, string | undefined>;
+    }) => Promise<unknown>;
+    run?: (
+      command: string,
+      args: string[],
+      options: { cwd: string; env: Record<string, string | undefined> },
+    ) => Promise<void>;
+  }) => Promise<void>;
+  shouldAutoBuildLocalRuntimeImage: (
+    args: string[],
+    env?: Record<string, string | undefined>,
+  ) => boolean;
+};
+
+type BuildLocalRuntimeImageModule = {
+  LOCAL_RUNTIME_IMAGE: string;
+};
+
+let runCli: RunCliModule;
+let runtimeImage: BuildLocalRuntimeImageModule;
+
+const noop = async (): Promise<void> => undefined;
+
+beforeAll(async () => {
+  runCli = (await import(
+    new URL("../../../../../scripts/run-cli.mjs", import.meta.url).href
+  )) as RunCliModule;
+  runtimeImage = (await import(
+    new URL("../../../../../scripts/build-local-runtime-image.mjs", import.meta.url).href
+  )) as BuildLocalRuntimeImageModule;
+});
+
+describe("run-cli wrapper", () => {
+  it("uses INIT_CWD as the CLI cwd when pnpm runs the script from the repo root", () => {
+    expect(runCli.cliCwdFor({ INIT_CWD: "/tmp/myapp" }, "/repo")).toBe("/tmp/myapp");
+    expect(runCli.cliCwdFor({}, "/repo")).toBe("/repo");
+  });
+
+  it("detects forwarded commands after wrapper flags", () => {
+    expect(runCli.commandName(["start"])).toBe("start");
+    expect(runCli.commandName(["--cwd", "/tmp/project", "start"])).toBe("start");
+    expect(runCli.commandName(["--json", "doctor"])).toBe("doctor");
+    expect(runCli.commandName(["--", "status"])).toBe("status");
+  });
+
+  it("auto-builds a local runtime image only for start without image overrides", () => {
+    expect(runCli.shouldAutoBuildLocalRuntimeImage(["start"], {})).toBe(true);
+    expect(runCli.shouldAutoBuildLocalRuntimeImage(["start", "--image", "custom:tag"], {})).toBe(
+      false,
+    );
+    expect(runCli.shouldAutoBuildLocalRuntimeImage(["start", "--image=custom:tag"], {})).toBe(
+      false,
+    );
+    expect(
+      runCli.shouldAutoBuildLocalRuntimeImage(["start"], {
+        ZITADEL_LOCAL_IMAGE: "custom:tag",
+      }),
+    ).toBe(false);
+    expect(runCli.shouldAutoBuildLocalRuntimeImage(["doctor"], {})).toBe(false);
+    expect(runCli.shouldAutoBuildLocalRuntimeImage(["setup"], {})).toBe(false);
+    expect(runCli.shouldAutoBuildLocalRuntimeImage(["status"], {})).toBe(false);
+  });
+
+  it("builds and injects the local image for start without an override", async () => {
+    const calls: string[] = [];
+    const env = { PATH: "/bin" };
+    let runEnv: Record<string, string | undefined> | undefined;
+
+    await runCli.main({
+      args: ["start"],
+      env,
+      buildCli: async () => {
+        calls.push("build-cli");
+      },
+      buildLocalRuntimeImage: async (options) => {
+        calls.push("build-image");
+        expect(options.env).toBe(env);
+      },
+      run: async (command, args, options) => {
+        calls.push("run-cli");
+        expect(command).toBe(process.execPath);
+        expect(args[0]).toMatch(/apps\/cli\/bin\/run\.js$/);
+        expect(args.slice(1)).toEqual(["start"]);
+        expect(options.cwd).toBe(process.cwd());
+        runEnv = options.env;
+      },
+    });
+
+    expect(calls).toEqual(["build-cli", "build-image", "run-cli"]);
+    expect(runEnv).toMatchObject({
+      PATH: "/bin",
+      ZITADEL_LOCAL_IMAGE: runtimeImage.LOCAL_RUNTIME_IMAGE,
+    });
+    expect(env).not.toHaveProperty("ZITADEL_LOCAL_IMAGE");
+  });
+
+  it("skips the builder when start receives --image", async () => {
+    const buildLocalRuntimeImage = vi.fn(noop);
+    const run = vi.fn(noop);
+
+    await runCli.main({
+      args: ["start", "--image", "custom:tag"],
+      env: { PATH: "/bin" },
+      buildCli: vi.fn(noop),
+      buildLocalRuntimeImage,
+      run,
+    });
+
+    expect(buildLocalRuntimeImage).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledOnce();
+    expect(run.mock.calls[0]?.[2].env).not.toHaveProperty("ZITADEL_LOCAL_IMAGE");
+  });
+
+  it("skips the builder when ZITADEL_LOCAL_IMAGE is set", async () => {
+    const buildLocalRuntimeImage = vi.fn(noop);
+    const run = vi.fn(noop);
+
+    await runCli.main({
+      args: ["start"],
+      env: { PATH: "/bin", ZITADEL_LOCAL_IMAGE: "custom:tag" },
+      buildCli: vi.fn(noop),
+      buildLocalRuntimeImage,
+      run,
+    });
+
+    expect(buildLocalRuntimeImage).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledOnce();
+    expect(run.mock.calls[0]?.[2].env.ZITADEL_LOCAL_IMAGE).toBe("custom:tag");
+  });
+
+  it("skips the builder for non-start commands", async () => {
+    const buildLocalRuntimeImage = vi.fn(noop);
+
+    await runCli.main({
+      args: ["doctor"],
+      env: { PATH: "/bin" },
+      buildCli: vi.fn(noop),
+      buildLocalRuntimeImage,
+      run: vi.fn(noop),
+    });
+
+    expect(buildLocalRuntimeImage).not.toHaveBeenCalled();
+  });
+
+  it("runs the CLI from the original invocation directory", async () => {
+    const run = vi.fn(noop);
+
+    await runCli.main({
+      args: ["setup", "--server", "local"],
+      env: { INIT_CWD: "/tmp/myapp", PATH: "/bin" },
+      buildCli: vi.fn(noop),
+      buildLocalRuntimeImage: vi.fn(noop),
+      run,
+    });
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(run.mock.calls[0]?.[1][0]).toMatch(/apps\/cli\/bin\/run\.js$/);
+    expect(run.mock.calls[0]?.[1].slice(1)).toEqual(["setup", "--server", "local"]);
+    expect(run.mock.calls[0]?.[2].cwd).toBe("/tmp/myapp");
+  });
+});

--- a/scripts/build-local-runtime-image.mjs
+++ b/scripts/build-local-runtime-image.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir as systemTmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { run, runCapture } from "./dev-process.mjs";
+
+export const LOCAL_RUNTIME_IMAGE = "ghcr.io/zitadel/nextgen:local-dev";
+
+const defaultRepoRoot = fileURLToPath(new URL("..", import.meta.url));
+const fallbackServerTag = "v0.0.0";
+
+export function linuxArchForNodeArch(arch = process.arch) {
+  if (arch === "x64") {
+    return "amd64";
+  }
+  if (arch === "arm64") {
+    return "arm64";
+  }
+  throw new Error(`Unsupported local runtime image architecture: ${arch}`);
+}
+
+export async function buildLocalRuntimeImage(options = {}) {
+  const repoRoot = options.repoRoot ?? defaultRepoRoot;
+  const image = options.image ?? LOCAL_RUNTIME_IMAGE;
+  const linuxArch = options.linuxArch ?? linuxArchForNodeArch(options.nodeArch ?? process.arch);
+  const platform = `linux/${linuxArch}`;
+  const mkdtempFn = options.mkdtemp ?? mkdtemp;
+  const mkdirFn = options.mkdir ?? mkdir;
+  const copyFileFn = options.copyFile ?? copyFile;
+  const readFileFn = options.readFile ?? readFile;
+  const writeFileFn = options.writeFile ?? writeFile;
+  const rmFn = options.rm ?? rm;
+  const runFn = options.run ?? run;
+  const runCaptureFn = options.runCapture ?? runCapture;
+  const baseEnv = {
+    ...process.env,
+    ...(options.env ?? {}),
+  };
+  const goreleaserTagEnv = await resolveGoreleaserTagEnv({
+    env: baseEnv,
+    repoRoot,
+    runCapture: runCaptureFn,
+  });
+  const env = {
+    ...baseEnv,
+    ...goreleaserTagEnv,
+    CGO_ENABLED: "0",
+    GOOS: "linux",
+    GOARCH: linuxArch,
+  };
+  const contextDir = await mkdtempFn(
+    join(options.tmpdir ?? systemTmpdir(), "zitadel-local-image-"),
+  );
+  const goreleaserConfigPath = join(contextDir, ".goreleaser.local.yaml");
+  const goreleaserDistDir = join(contextDir, "goreleaser-dist");
+  const binaryDir = join(contextDir, "linux", linuxArch);
+  const binaryPath = join(binaryDir, "nextgen");
+
+  try {
+    await mkdirFn(binaryDir, { recursive: true });
+    const goreleaserConfig = await readFileFn(join(repoRoot, ".goreleaser.yaml"), "utf8");
+    await writeFileFn(
+      goreleaserConfigPath,
+      localGoreleaserConfig(goreleaserConfig, goreleaserDistDir),
+    );
+    await runFn(
+      "goreleaser",
+      [
+        "build",
+        "--config",
+        goreleaserConfigPath,
+        "--snapshot",
+        "--clean",
+        "--single-target",
+        "--id",
+        "nextgen",
+        "--output",
+        binaryPath,
+      ],
+      { cwd: repoRoot, env },
+    );
+    await copyFileFn(join(repoRoot, "Dockerfile"), join(contextDir, "Dockerfile"));
+    await runFn("docker", ["build", "--platform", platform, "-t", image, contextDir], {
+      cwd: repoRoot,
+      env: baseEnv,
+    });
+    return { image, platform };
+  } finally {
+    await rmFn(contextDir, { recursive: true, force: true });
+  }
+}
+
+export function localGoreleaserConfig(config, distDir) {
+  const distLine = `dist: ${JSON.stringify(distDir)}`;
+  if (/^dist\s*:/m.test(config)) {
+    return config.replace(/^dist\s*:.*$/m, distLine);
+  }
+  return `${distLine}\n${config}`;
+}
+
+export async function resolveGoreleaserTagEnv(options = {}) {
+  const env = options.env ?? process.env;
+  const repoRoot = options.repoRoot ?? defaultRepoRoot;
+  const runCaptureFn = options.runCapture ?? runCapture;
+  const currentTag =
+    env.GORELEASER_CURRENT_TAG ??
+    (await serverReleaseTag({ repoRoot, runCapture: runCaptureFn, env })) ??
+    fallbackServerTag;
+
+  return {
+    ...(env.GORELEASER_CURRENT_TAG ? {} : { GORELEASER_CURRENT_TAG: currentTag }),
+    ...(env.GORELEASER_PREVIOUS_TAG ? {} : { GORELEASER_PREVIOUS_TAG: currentTag }),
+  };
+}
+
+async function serverReleaseTag({ repoRoot, runCapture: runCaptureFn, env }) {
+  try {
+    const { stdout } = await runCaptureFn(
+      "git",
+      ["describe", "--tags", "--abbrev=0", "--match", "v[0-9]*", "--match", "[0-9]*"],
+      { cwd: repoRoot, env },
+    );
+    return stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+if (isDirectRun(import.meta.url)) {
+  try {
+    const result = await buildLocalRuntimeImage();
+    console.log(result.image);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(exitCodeForError(error));
+  }
+}
+
+function isDirectRun(moduleUrl) {
+  return Boolean(process.argv[1] && moduleUrl === pathToFileURL(process.argv[1]).href);
+}
+
+function exitCodeForError(error) {
+  return typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "number"
+    ? error.code
+    : 1;
+}

--- a/scripts/build-local-runtime-image.mjs
+++ b/scripts/build-local-runtime-image.mjs
@@ -2,9 +2,9 @@
 import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir as systemTmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
-import { run, runCapture } from "./dev-process.mjs";
+import { isDirectRun, run, runCapture } from "./dev-process.mjs";
 
 export const LOCAL_RUNTIME_IMAGE = "ghcr.io/zitadel/nextgen:local-dev";
 
@@ -136,10 +136,6 @@ if (isDirectRun(import.meta.url)) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(exitCodeForError(error));
   }
-}
-
-function isDirectRun(moduleUrl) {
-  return Boolean(process.argv[1] && moduleUrl === pathToFileURL(process.argv[1]).href);
 }
 
 function exitCodeForError(error) {

--- a/scripts/dev-process.mjs
+++ b/scripts/dev-process.mjs
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 export function run(command, args = [], options = {}) {
   return new Promise((resolve, reject) => {
@@ -90,6 +92,10 @@ export function formatCommand(command, args = []) {
 
 export function forwardedArgs(args = process.argv.slice(2)) {
   return args[0] === "--" ? args.slice(1) : args;
+}
+
+export function isDirectRun(moduleUrl, argv = process.argv) {
+  return Boolean(argv[1] && moduleUrl === pathToFileURL(resolve(argv[1])).href);
 }
 
 function shellQuote(value) {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { runCapture } from "./dev-process.mjs";
 
@@ -62,10 +62,7 @@ function checkNodeModules() {
     pass("workspace dependencies are installed");
     return;
   }
-  fail(
-    "workspace dependencies are not installed",
-    "Run: corepack pnpm install --frozen-lockfile",
-  );
+  fail("workspace dependencies are not installed", "Run: corepack pnpm install --frozen-lockfile");
 }
 
 async function checkGo() {
@@ -93,8 +90,8 @@ async function checkDocker() {
     });
     pass(`Docker engine ${stdout.trim()} is running`);
   } catch {
-    warn(
-      "Docker is not available; journey and integration checks need it",
+    fail(
+      "Docker is not available; local runtime image builds need it",
       "Start Docker Desktop or another Docker daemon, then rerun doctor",
     );
   }
@@ -137,8 +134,8 @@ async function checkGoReleaser() {
     const version = versionLine?.split(/\s+/).at(1) ?? "available";
     pass(`GoReleaser ${version}`);
   } catch {
-    warn(
-      "GoReleaser is not available; release checks need it",
+    fail(
+      "GoReleaser is not available; local runtime image builds and release checks need it",
       "Install GoReleaser v2: https://goreleaser.com/install/",
     );
   }

--- a/scripts/run-cli.mjs
+++ b/scripts/run-cli.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 import { buildLocalRuntimeImage, LOCAL_RUNTIME_IMAGE } from "./build-local-runtime-image.mjs";
-import { forwardedArgs, run } from "./dev-process.mjs";
+import { forwardedArgs, isDirectRun, run } from "./dev-process.mjs";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const cliBin = join(repoRoot, "apps/cli/bin/run.js");
@@ -94,10 +94,6 @@ if (isDirectRun(import.meta.url)) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(exitCodeForError(error));
   }
-}
-
-function isDirectRun(moduleUrl) {
-  return Boolean(process.argv[1] && moduleUrl === pathToFileURL(process.argv[1]).href);
 }
 
 function exitCodeForError(error) {

--- a/scripts/run-cli.mjs
+++ b/scripts/run-cli.mjs
@@ -1,21 +1,71 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { buildLocalRuntimeImage, LOCAL_RUNTIME_IMAGE } from "./build-local-runtime-image.mjs";
 import { forwardedArgs, run } from "./dev-process.mjs";
 
-try {
-  await buildCli();
-  await run(process.execPath, ["apps/cli/bin/run.js", ...forwardedArgs()]);
-} catch (error) {
-  console.error(error.message);
-  process.exit(error.code ?? 1);
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const cliBin = join(repoRoot, "apps/cli/bin/run.js");
+
+export async function main(options = {}) {
+  const args = options.args ?? forwardedArgs();
+  const env = options.env ?? process.env;
+  const runFn = options.run ?? run;
+  const buildCliFn = options.buildCli ?? buildCli;
+  const buildLocalRuntimeImageFn = options.buildLocalRuntimeImage ?? buildLocalRuntimeImage;
+  const cliEnv = { ...env };
+  const cliCwd = options.cwd ?? cliCwdFor(env);
+
+  await buildCliFn();
+
+  if (shouldAutoBuildLocalRuntimeImage(args, env)) {
+    await buildLocalRuntimeImageFn({ env });
+    cliEnv.ZITADEL_LOCAL_IMAGE = LOCAL_RUNTIME_IMAGE;
+  }
+
+  await runFn(process.execPath, [cliBin, ...args], { cwd: cliCwd, env: cliEnv });
 }
 
-function buildCli() {
+export function shouldAutoBuildLocalRuntimeImage(args, env = process.env) {
+  return commandName(args) === "start" && !hasImageOverride(args, env);
+}
+
+export function commandName(args) {
+  const valueFlags = new Set(["--cwd", "-c", "--server", "-s"]);
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") {
+      return args[index + 1];
+    }
+    if (valueFlags.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      continue;
+    }
+    return arg;
+  }
+  return undefined;
+}
+
+export function cliCwdFor(env = process.env, fallback = process.cwd()) {
+  return env.INIT_CWD || fallback;
+}
+
+function hasImageOverride(args, env) {
+  if (env.ZITADEL_LOCAL_IMAGE) {
+    return true;
+  }
+  return args.some((arg) => arg === "--image" || arg.startsWith("--image="));
+}
+
+export function buildCli() {
   return new Promise((resolve, reject) => {
     const child = spawn("corepack", ["pnpm", "nx", "build", "@zitadel/cli"], {
-      cwd: fileURLToPath(new URL("..", import.meta.url)),
+      cwd: repoRoot,
       env: process.env,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -35,4 +85,26 @@ function buildCli() {
       reject(error);
     });
   });
+}
+
+if (isDirectRun(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(exitCodeForError(error));
+  }
+}
+
+function isDirectRun(moduleUrl) {
+  return Boolean(process.argv[1] && moduleUrl === pathToFileURL(process.argv[1]).href);
+}
+
+function exitCodeForError(error) {
+  return typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "number"
+    ? error.code
+    : 1;
 }


### PR DESCRIPTION
## Summary
- Normalize product-facing `next_commands` to copy-pasteable `npx @zitadel/cli@alpha ...` follow-ups and stop suggesting a restart after successful `stop` or `reset --force`.
- Make `setup` auto-install dependencies with the detected package manager, with `--skip-install` as the opt-out.
- Keep local-runtime `doctor` checks advisory for cloud setup while preserving actionable failures for unhealthy managed runtime state.
- Align CLI docs, agent guidance, and root workflow messaging with the current prerelease surface.

## Testing
- Unit and integration tests updated for command normalization, setup install behavior, and local runtime guidance.
- CLI test coverage added for the public command formatter, package-manager detection, and cleanup-command behavior.