### PR TITLE
feat: add standalone browser bundle

### DIFF
--- a/.changeset/components-standalone-bundle.md
+++ b/.changeset/components-standalone-bundle.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/components": minor
+---
+
+Add a standalone browser bundle (`dist/standalone.mjs`) so the components work on a plain HTML page via `<script type="module">` with no import map or bundler. Exposed via the `./standalone` export and `unpkg`/`jsdelivr`.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,12 +19,18 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "unpkg": "./dist/standalone.mjs",
+  "jsdelivr": "./dist/standalone.mjs",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
+    },
+    "./standalone": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/standalone.mjs"
     },
     "./atoms": {
       "types": "./dist/atoms/index.d.mts",

--- a/packages/components/tsdown.config.ts
+++ b/packages/components/tsdown.config.ts
@@ -31,41 +31,65 @@ function liquidRaw(): Plugin {
  * registry deps. `@zitadel/api-mock` stays external because it's a
  * test-only helper consumers never import.
  */
-export default defineConfig({
-  plugins: [liquidRaw()],
-  entry: {
-    index: "src/index.ts",
-    "atoms/index": "src/atoms/index.ts",
-    manifests: "src/manifests.ts",
-    "tokens/index": "src/tokens/index.ts",
-    "orchestrator/index": "src/orchestrator/index.ts",
+/** Internal workspace deps are always inlined so the published package is self-contained. */
+const INLINE_INTERNAL = [
+  /^@zitadel\/api(\/|$)/,
+  /^@zitadel\/design-tokens(\/|$)/,
+  /^@zitadel\/shared-component-styles(\/|$)/,
+];
+
+/** Third-party runtime deps the components need in the browser. */
+const THIRD_PARTY = ["lit", /^lit\//, "liquidjs", "dompurify", "lucide", /^lucide\//] as const;
+
+export default defineConfig([
+  /**
+   * Library build — the npm entrypoints. `lit`/`liquidjs`/`dompurify`/`lucide`
+   * stay EXTERNAL so a consuming app's bundler resolves a single shared copy
+   * (no duplicate-Lit). This is what `import "@zitadel/components"` resolves to.
+   */
+  {
+    plugins: [liquidRaw()],
+    entry: {
+      index: "src/index.ts",
+      "atoms/index": "src/atoms/index.ts",
+      manifests: "src/manifests.ts",
+      "tokens/index": "src/tokens/index.ts",
+      "orchestrator/index": "src/orchestrator/index.ts",
+    },
+    outDir: "dist",
+    format: ["esm"],
+    tsconfig: "tsconfig.lib.json",
+    dts: true,
+    sourcemap: true,
+    // `clean: true` would wipe the .d.ts files tsgo emits during the
+    // `typecheck` target, breaking project-reference consumers
+    // (sdk-next, demo-next, demo-nuxt) whose tsgo --build expects those
+    // .d.ts files to exist. tsdown still overwrites its own .mjs/.d.mts
+    // outputs on each rebuild — stale files just accumulate harmlessly
+    // until a full `git clean` or `nx reset`.
+    clean: false,
+    target: "es2022",
+    external: [...THIRD_PARTY, "@zitadel/api-mock"],
+    noExternal: INLINE_INTERNAL,
   },
-  outDir: "dist",
-  format: ["esm"],
-  tsconfig: "tsconfig.lib.json",
-  dts: true,
-  sourcemap: true,
-  // `clean: true` would wipe the .d.ts files tsgo emits during the
-  // `typecheck` target, breaking project-reference consumers
-  // (sdk-next, demo-next, demo-nuxt) whose tsgo --build expects those
-  // .d.ts files to exist. tsdown still overwrites its own .mjs/.d.mts
-  // outputs on each rebuild — stale files just accumulate harmlessly
-  // until a full `git clean` or `nx reset`.
-  clean: false,
-  target: "es2022",
-  external: [
-    "lit",
-    /^lit\//,
-    "liquidjs",
-    "dompurify",
-    "lucide",
-    /^lucide\//,
-    "@zitadel/api-mock",
-  ],
-  /** Inline internal workspace deps so the published package is self-contained. */
-  noExternal: [
-    /^@zitadel\/api(\/|$)/,
-    /^@zitadel\/design-tokens(\/|$)/,
-    /^@zitadel\/shared-component-styles(\/|$)/,
-  ],
-});
+
+  /**
+   * Standalone build — one self-contained file for a plain HTML page. Here the
+   * third-party UI deps ARE inlined, so `<script type="module"
+   * src="…/standalone.mjs">` works with no import map and no bundler. Kept
+   * separate from the library build above so npm/SDK consumers are unaffected.
+   */
+  {
+    plugins: [liquidRaw()],
+    entry: { standalone: "src/index.ts" },
+    outDir: "dist",
+    format: ["esm"],
+    tsconfig: "tsconfig.lib.json",
+    dts: false,
+    sourcemap: false,
+    clean: false,
+    target: "es2022",
+    external: ["@zitadel/api-mock"],
+    noExternal: [...INLINE_INTERNAL, ...THIRD_PARTY],
+  },
+]);


### PR DESCRIPTION
Adds a single self-contained `standalone.mjs` so the components work on a plain HTML page with just:

```html
<script type="module" src=".../standalone.mjs"></script>
```

No import map or bundler needed — `lit`, `liquidjs`, `dompurify`, and `lucide` are bundled in. The normal `@zitadel/components` build is unchanged. Reachable via the `./standalone` export and `unpkg`/`jsdelivr`.