### PR TITLE
feat: configure web components declaratively via HTML attributes

### DIFF
--- a/.changeset/components-declarative-config.md
+++ b/.changeset/components-declarative-config.md
@@ -2,6 +2,6 @@
 "@zitadel/components": minor
 ---
 
-Allow configuring `<zitadel-login>` and `<zitadel-logout>` declaratively from HTML via `project-id`, `proxy-path`, and `url` attributes, so the components work on a plain page without JS or `configureZitadel()`. The existing `project` property and the `configureZitadel()` global still take precedence, in that order.
+Allow configuring `<zitadel-login>` and `<zitadel-logout>` declaratively from HTML via `project-id`, `proxy-path`, and `url` attributes, so the components work on a plain page without JS or `configureZitadel()`. Configuration resolves in this order, highest first: the `project` property, then the `configureZitadel()` global, then the HTML attributes. The existing JS paths still win — the attributes are the no-JS fallback.
 
 Also fix the standalone bundle so it loads in a browser: it was built for Node and emitted an `import "node:module"` that browsers cannot resolve. It is now built for the browser, so `dist/standalone.mjs` is genuinely self-contained.

--- a/.changeset/components-declarative-config.md
+++ b/.changeset/components-declarative-config.md
@@ -1,0 +1,7 @@
+---
+"@zitadel/components": minor
+---
+
+Allow configuring `<zitadel-login>` and `<zitadel-logout>` declaratively from HTML via `project-id`, `proxy-path`, and `url` attributes, so the components work on a plain page without JS or `configureZitadel()`. The existing `project` property and the `configureZitadel()` global still take precedence, in that order.
+
+Also fix the standalone bundle so it loads in a browser: it was built for Node and emitted an `import "node:module"` that browsers cannot resolve. It is now built for the browser, so `dist/standalone.mjs` is genuinely self-contained.

--- a/packages/components/src/orchestrator/resolve-api.ts
+++ b/packages/components/src/orchestrator/resolve-api.ts
@@ -23,9 +23,11 @@ export interface ProjectAttrs {
  * tuple. `getApi()` caches its client in a `WeakMap` keyed by the project's
  * identity, so the same attribute values must yield the *same* frozen object
  * across the several `resolveApi()` calls a single flow makes — otherwise
- * every call misses the cache and re-wraps a fresh client. Distinct configs
- * on one page are effectively one, so this never grows unbounded in practice.
+ * every call misses the cache and re-wraps a fresh client. A real page uses a
+ * handful of distinct configs at most; the FIFO bound below is just a guard so
+ * a pathological page that churns through unique configs can't leak memory.
  */
+const MAX_SYNTHETIC_PROJECTS = 32;
 const syntheticProjects = new Map<string, ZitadelProject>();
 
 /**
@@ -42,6 +44,9 @@ function projectFromAttrs({ projectId, proxyPath, url }: ProjectAttrs): ZitadelP
   let project = syntheticProjects.get(key);
   if (!project) {
     project = Object.freeze({ projectId, proxyPath: resolvedProxyPath, url: resolvedUrl });
+    if (syntheticProjects.size >= MAX_SYNTHETIC_PROJECTS) {
+      syntheticProjects.delete(syntheticProjects.keys().next().value);
+    }
     syntheticProjects.set(key, project);
   }
   return project;

--- a/packages/components/src/orchestrator/resolve-api.ts
+++ b/packages/components/src/orchestrator/resolve-api.ts
@@ -1,9 +1,59 @@
-import { getApi, getZitadelConfig, type ZitadelApi, type ZitadelProject } from "@zitadel/api/config";
+import {
+  getApi,
+  getZitadelConfig,
+  type ZitadelApi,
+  type ZitadelProject,
+} from "@zitadel/api/config";
+
+/** Matches the `configureZitadel()` default so attribute and JS config agree. */
+const DEFAULT_PROXY_PATH = "/__nextgen";
+
+/**
+ * Declarative configuration read from an element's HTML attributes
+ * (`project-id` / `proxy-path` / `url`). Empty strings mean "unset".
+ */
+export interface ProjectAttrs {
+  readonly projectId: string;
+  readonly proxyPath: string;
+  readonly url: string;
+}
+
+/**
+ * Cache of project handles synthesized from attributes, keyed by their value
+ * tuple. `getApi()` caches its client in a `WeakMap` keyed by the project's
+ * identity, so the same attribute values must yield the *same* frozen object
+ * across the several `resolveApi()` calls a single flow makes — otherwise
+ * every call misses the cache and re-wraps a fresh client. Distinct configs
+ * on one page are effectively one, so this never grows unbounded in practice.
+ */
+const syntheticProjects = new Map<string, ZitadelProject>();
+
+/**
+ * Builds a `ZitadelProject` from declarative attributes, or `undefined` when
+ * no `project-id` was given (nothing to configure). Mirrors
+ * `configureZitadel()`'s proxy-path defaulting so the two config paths are
+ * interchangeable.
+ */
+function projectFromAttrs({ projectId, proxyPath, url }: ProjectAttrs): ZitadelProject | undefined {
+  if (!projectId) return undefined;
+  const resolvedProxyPath = proxyPath || DEFAULT_PROXY_PATH;
+  const resolvedUrl = url || undefined;
+  const key = JSON.stringify([projectId, resolvedProxyPath, resolvedUrl ?? ""]);
+  let project = syntheticProjects.get(key);
+  if (!project) {
+    project = Object.freeze({ projectId, proxyPath: resolvedProxyPath, url: resolvedUrl });
+    syntheticProjects.set(key, project);
+  }
+  return project;
+}
 
 /**
  * Resolves the effective SDK project handle and its typed API client for an
- * orchestrator element. Prefers the element's `project` property; falls back
- * to the global handle set by `configureZitadel()`.
+ * orchestrator element. Precedence, highest first:
+ *
+ * 1. the element's `project` property (an SDK handle set from JS / a framework),
+ * 2. the `project-id` / `proxy-path` / `url` attributes set declaratively in HTML,
+ * 3. the global handle from `configureZitadel()`.
  *
  * Both `<zitadel-login>` and `<zitadel-logout>` need the same resolution and
  * the same "no config" failure, so it lives here rather than being copied
@@ -12,16 +62,19 @@ import { getApi, getZitadelConfig, type ZitadelApi, type ZitadelProject } from "
  * as an unhandled rejection.
  *
  * @param project Optional per-element override handle.
+ * @param attrs Declarative config read from the element's attributes.
  * @param element Tag name used in the thrown error (e.g. `<zitadel-login>`).
  */
 export function resolveApi(
   project: ZitadelProject | undefined,
+  attrs: ProjectAttrs,
   element: string,
 ): { project: ZitadelProject; api: ZitadelApi } {
-  const cfg = project ?? getZitadelConfig();
+  const cfg = project ?? projectFromAttrs(attrs) ?? getZitadelConfig();
   if (!cfg) {
     throw new Error(
-      `${element} requires a configured project: call configureZitadel() or set the \`project\` property.`,
+      `${element} requires a configured project: set the \`project-id\` attribute, ` +
+        `set the \`project\` property, or call configureZitadel().`,
     );
   }
   return { project: cfg, api: getApi(cfg) };

--- a/packages/components/src/orchestrator/resolve-api.ts
+++ b/packages/components/src/orchestrator/resolve-api.ts
@@ -52,8 +52,12 @@ function projectFromAttrs({ projectId, proxyPath, url }: ProjectAttrs): ZitadelP
  * orchestrator element. Precedence, highest first:
  *
  * 1. the element's `project` property (an SDK handle set from JS / a framework),
- * 2. the `project-id` / `proxy-path` / `url` attributes set declaratively in HTML,
- * 3. the global handle from `configureZitadel()`.
+ * 2. the global handle from `configureZitadel()`,
+ * 3. the `project-id` / `proxy-path` / `url` attributes set declaratively in HTML.
+ *
+ * Both JS paths (property and global) win over the declarative attributes, so a
+ * deliberate `configureZitadel()` is never silently overridden by fallback or
+ * stale HTML attributes; the attributes are the no-JS fallback.
  *
  * Both `<zitadel-login>` and `<zitadel-logout>` need the same resolution and
  * the same "no config" failure, so it lives here rather than being copied
@@ -70,7 +74,7 @@ export function resolveApi(
   attrs: ProjectAttrs,
   element: string,
 ): { project: ZitadelProject; api: ZitadelApi } {
-  const cfg = project ?? projectFromAttrs(attrs) ?? getZitadelConfig();
+  const cfg = project ?? getZitadelConfig() ?? projectFromAttrs(attrs);
   if (!cfg) {
     throw new Error(
       `${element} requires a configured project: set the \`project-id\` attribute, ` +

--- a/packages/components/src/orchestrator/resolve-api.ts
+++ b/packages/components/src/orchestrator/resolve-api.ts
@@ -45,7 +45,10 @@ function projectFromAttrs({ projectId, proxyPath, url }: ProjectAttrs): ZitadelP
   if (!project) {
     project = Object.freeze({ projectId, proxyPath: resolvedProxyPath, url: resolvedUrl });
     if (syntheticProjects.size >= MAX_SYNTHETIC_PROJECTS) {
-      syntheticProjects.delete(syntheticProjects.keys().next().value);
+      const oldest = syntheticProjects.keys().next().value;
+      if (oldest !== undefined) {
+        syntheticProjects.delete(oldest);
+      }
     }
     syntheticProjects.set(key, project);
   }

--- a/packages/components/src/orchestrator/zitadel-login.spec.ts
+++ b/packages/components/src/orchestrator/zitadel-login.spec.ts
@@ -19,16 +19,7 @@ import {
 } from "@zitadel/api-mock";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import "./zitadel-login.js";
 import type { ZitadelLogin } from "./zitadel-login.js";
@@ -72,7 +63,10 @@ async function waitFor<T>(probe: () => T | null | undefined, timeout = 1500): Pr
 }
 
 /** Walks the api-mock login path: combined sign-in → passkey-upsell → done. */
-async function advanceMockLoginFlow(element: ZitadelLogin, email = "alice@acme.com"): Promise<void> {
+async function advanceMockLoginFlow(
+  element: ZitadelLogin,
+  email = "alice@acme.com",
+): Promise<void> {
   element.shadowRoot?.dispatchEvent(
     new CustomEvent("zl-input", {
       bubbles: true,
@@ -138,6 +132,37 @@ describe("<zitadel-login> against the typed Flow API", () => {
     expect(fields[1]?.getAttribute("name")).toBe("password");
   });
 
+  it("starts a flow from project-id / proxy-path attributes with no global config", async () => {
+    // Clear the global so the attributes are the only thing that can configure
+    // the element — proves declarative HTML config works on its own.
+    _resetConfigForTesting();
+    const element = document.createElement("zitadel-login") as ZitadelLogin;
+    element.setAttribute("project-id", "demo-project");
+    element.setAttribute("proxy-path", API_BASE);
+    host.appendChild(element);
+    await waitFor(() => element.shadowRoot?.querySelector("zl-field"));
+
+    expect(mock.getCaptured()[0]).toEqual({
+      kind: "createFlow",
+      body: { purpose: "login", project_id: "demo-project" },
+    });
+  });
+
+  it("prefers the project property over the project-id attribute", async () => {
+    const element = document.createElement("zitadel-login") as ZitadelLogin;
+    element.project = testProject; // projectId "demo-project"
+    element.setAttribute("project-id", "ignored-attr-project");
+    element.setAttribute("proxy-path", API_BASE);
+    host.appendChild(element);
+    await waitFor(() => element.shadowRoot?.querySelector("zl-field"));
+
+    // The property wins: the attribute's project id never reaches the wire.
+    expect(mock.getCaptured()[0]).toEqual({
+      kind: "createFlow",
+      body: { purpose: "login", project_id: "demo-project" },
+    });
+  });
+
   it("submits with {session_token, action, fields} and applies the next step", async () => {
     const element = await mount(host);
 
@@ -174,10 +199,12 @@ describe("<zitadel-login> against the typed Flow API", () => {
       return title?.textContent?.includes("Sign in faster") ? title : null;
     });
 
-    const submits = mock.getCaptured().filter(
-      (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
-        req.kind === "submitFlowStep",
-    );
+    const submits = mock
+      .getCaptured()
+      .filter(
+        (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
+          req.kind === "submitFlowStep",
+      );
     expect(submits).toHaveLength(1);
     expect(submits[0]?.body).toMatchObject({
       action: "submit",
@@ -195,12 +222,9 @@ describe("<zitadel-login> against the typed Flow API", () => {
 
     await advanceMockLoginFlow(element);
     await waitFor(() => (completeEvents.length > 0 ? completeEvents : null));
-    expect(completeEvents[0]?.detail).toEqual(
-      expect.objectContaining({ behavior: "show" }),
-    );
+    expect(completeEvents[0]?.detail).toEqual(expect.objectContaining({ behavior: "show" }));
     expect(completeEvents[0]?.detail.handoff_token).toBeTruthy();
   });
-
 
   it("exchanges the handoff token and navigates when post-sign-in-url is set", async () => {
     const assign = vi.fn();
@@ -222,10 +246,12 @@ describe("<zitadel-login> against the typed Flow API", () => {
 
       await waitFor(() => (assign.mock.calls.length > 0 ? assign : null));
       expect(assign).toHaveBeenCalledWith("/admin");
-      const exchanges = mock.getCaptured().filter(
-        (req): req is Extract<CapturedRequest, { kind: "exchangeHandoff" }> =>
-          req.kind === "exchangeHandoff",
-      );
+      const exchanges = mock
+        .getCaptured()
+        .filter(
+          (req): req is Extract<CapturedRequest, { kind: "exchangeHandoff" }> =>
+            req.kind === "exchangeHandoff",
+        );
       expect(exchanges).toHaveLength(1);
       expect(exchanges[0]?.body.handoff_token).toBeTruthy();
       expect(exchanges[0]?.projectId).toBe("demo-project");
@@ -238,13 +264,7 @@ describe("<zitadel-login> against the typed Flow API", () => {
   });
 
   it("surfaces network errors via zitadel-flow-error", async () => {
-    server.resetHandlers(
-      http.post(
-        "*/flow",
-        () => HttpResponse.error(),
-        { once: true },
-      ),
-    );
+    server.resetHandlers(http.post("*/flow", () => HttpResponse.error(), { once: true }));
 
     const errorEvents: CustomEvent[] = [];
     const element = document.createElement("zitadel-login") as ZitadelLogin;
@@ -283,10 +303,12 @@ describe("<zitadel-login> against the typed Flow API", () => {
 
     // Wait for the passkey-login step (which contains a challenge)
     await waitFor(() => {
-      const submits = mock.getCaptured().filter(
-        (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
-          req.kind === "submitFlowStep",
-      );
+      const submits = mock
+        .getCaptured()
+        .filter(
+          (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
+            req.kind === "submitFlowStep",
+        );
       return submits.some((s) => s.body.action === "passkey") ? submits : null;
     });
 
@@ -324,10 +346,12 @@ describe("<zitadel-login> against the typed Flow API", () => {
     await waitFor(() => (completeEvents.length > 0 ? completeEvents : null));
 
     // Assert the submit body includes challenge_response
-    const submits = mock.getCaptured().filter(
-      (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
-        req.kind === "submitFlowStep",
-    );
+    const submits = mock
+      .getCaptured()
+      .filter(
+        (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
+          req.kind === "submitFlowStep",
+      );
     // Two submits: passkey action + challenge_response submit
     expect(submits.length).toBeGreaterThanOrEqual(2);
     const proofSubmit = submits.find((s) => s.body.challenge_response);
@@ -354,10 +378,12 @@ describe("<zitadel-login> against the typed Flow API", () => {
 
     // Wait for the passkey-login step
     await waitFor(() => {
-      const submits = mock.getCaptured().filter(
-        (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
-          req.kind === "submitFlowStep",
-      );
+      const submits = mock
+        .getCaptured()
+        .filter(
+          (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
+            req.kind === "submitFlowStep",
+        );
       return submits.some((s) => s.body.action === "passkey") ? submits : null;
     });
 
@@ -387,10 +413,12 @@ describe("<zitadel-login> against the typed Flow API", () => {
     });
 
     // The step should still be passkey-login (no additional submits from the error)
-    const postErrorSubmits = mock.getCaptured().filter(
-      (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
-        req.kind === "submitFlowStep",
-    );
+    const postErrorSubmits = mock
+      .getCaptured()
+      .filter(
+        (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
+          req.kind === "submitFlowStep",
+      );
     // Only the initial "passkey" action submit — no extra submit from the error handler
     expect(postErrorSubmits).toHaveLength(1);
     expect(postErrorSubmits[0]?.body.action).toBe("passkey");
@@ -457,9 +485,9 @@ describe("<zitadel-login> against the typed Flow API", () => {
     // Regression: empty defaults from the re-rendered step used to wipe
     // formValues, which then propagated back to the field via
     // applyValuesToFields. The typed input must survive.
-    const emailField = element.shadowRoot?.querySelector<
-      HTMLElement & { value?: string }
-    >('zl-field[name="email"]');
+    const emailField = element.shadowRoot?.querySelector<HTMLElement & { value?: string }>(
+      'zl-field[name="email"]',
+    );
     expect(emailField?.value).toBe("bad-email");
   });
 
@@ -479,17 +507,21 @@ describe("<zitadel-login> against the typed Flow API", () => {
     );
 
     await waitFor(() => {
-      const submits = mock.getCaptured().filter(
-        (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
-          req.kind === "submitFlowStep",
-      );
+      const submits = mock
+        .getCaptured()
+        .filter(
+          (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
+            req.kind === "submitFlowStep",
+        );
       return submits.length > 0 ? submits : null;
     });
 
-    const submits = mock.getCaptured().filter(
-      (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
-        req.kind === "submitFlowStep",
-    );
+    const submits = mock
+      .getCaptured()
+      .filter(
+        (req): req is Extract<CapturedRequest, { kind: "submitFlowStep" }> =>
+          req.kind === "submitFlowStep",
+      );
     expect(submits[0]?.body.fields).toEqual({ email: "", password: "" });
   });
 });

--- a/packages/components/src/orchestrator/zitadel-login.spec.ts
+++ b/packages/components/src/orchestrator/zitadel-login.spec.ts
@@ -163,6 +163,21 @@ describe("<zitadel-login> against the typed Flow API", () => {
     });
   });
 
+  it("prefers the configureZitadel() global over the project-id attribute", async () => {
+    // beforeEach already configured the global to "demo-project"; a stray/stale
+    // attribute must not override a deliberate app-wide configureZitadel().
+    const element = document.createElement("zitadel-login") as ZitadelLogin;
+    element.setAttribute("project-id", "ignored-attr-project");
+    element.setAttribute("proxy-path", API_BASE);
+    host.appendChild(element);
+    await waitFor(() => element.shadowRoot?.querySelector("zl-field"));
+
+    expect(mock.getCaptured()[0]).toEqual({
+      kind: "createFlow",
+      body: { purpose: "login", project_id: "demo-project" },
+    });
+  });
+
   it("submits with {session_token, action, fields} and applies the next step", async () => {
     const element = await mount(host);
 

--- a/packages/components/src/orchestrator/zitadel-login.ts
+++ b/packages/components/src/orchestrator/zitadel-login.ts
@@ -18,7 +18,7 @@ import {
   startFlow as apiStartFlow,
   submitStep as apiSubmitStep,
 } from "./api-client.js";
-import { resolveApi } from "./resolve-api.js";
+import { resolveApi, type ProjectAttrs } from "./resolve-api.js";
 import type { Branding } from "./branding.js";
 import { applyBaseTokens, applyBrandingTokens } from "./branding-to-tokens.js";
 import { validateBranding } from "./branding-validator.js";
@@ -90,10 +90,31 @@ export class ZitadelLogin extends LitElement {
   @property({ type: String }) accessor purpose: CreateFlowBodyPurpose = "login";
 
   /**
-   * SDK project handle returned by `configureZitadel()`. When set, takes
-   * precedence over the global singleton from `getZitadelConfig()`.
+   * SDK project handle returned by `configureZitadel()`. Set from JS (or a
+   * framework binding). When set, takes precedence over both the
+   * `project-id`/`proxy-path`/`url` attributes and the global singleton from
+   * `getZitadelConfig()`.
    */
   @property({ attribute: false }) accessor project: ZitadelProject | undefined;
+
+  /**
+   * Project ID, set declaratively in HTML. Lets the component be configured on
+   * a plain page without JS or `configureZitadel()`. Ignored when the
+   * `project` property is set. See {@link projectAttrs}.
+   */
+  @property({ type: String, attribute: "project-id" }) accessor projectId = "";
+
+  /**
+   * Proxy path for API requests (e.g. `/__nextgen`), set declaratively in HTML.
+   * Defaults to `/__nextgen` when omitted, matching `configureZitadel()`.
+   */
+  @property({ type: String, attribute: "proxy-path" }) accessor proxyPath = "";
+
+  /**
+   * Full URL of the Zitadel auth backend, set declaratively in HTML. Optional —
+   * not needed in client-only setups.
+   */
+  @property({ type: String }) accessor url = "";
 
   /**
    * URL to navigate to after a successful embedded sign-in. When set, the
@@ -327,6 +348,11 @@ export class ZitadelLogin extends LitElement {
     return `<div slot="footer" part="attribution" class="zl-attribution"><zl-pill tone="neutral" href="https://zitadel.com" part="attribution-pill" aria-label="Secured with Zitadel">${zitadelAttributionPillInnerHtml()}</zl-pill></div>`;
   }
 
+  /** Declarative config read from this element's attributes. */
+  private get projectAttrs(): ProjectAttrs {
+    return { projectId: this.projectId, proxyPath: this.proxyPath, url: this.url };
+  }
+
   private async startFlow(): Promise<void> {
     this.loading = true;
     this.startupError = null;
@@ -334,14 +360,15 @@ export class ZitadelLogin extends LitElement {
       // Resolve inside the try so a missing configuration surfaces through
       // `handleTransportError` (rendered as `startupError`) rather than as an
       // unhandled promise rejection from `firstUpdated`'s microtask.
-      const { project: cfg, api } = resolveApi(this.project, "<zitadel-login>");
+      const { project: cfg, api } = resolveApi(this.project, this.projectAttrs, "<zitadel-login>");
       let wire: CreateFlow201;
       if (this.resumeFlowId) {
         wire = await getCurrentStep(api, this.resumeFlowId);
       } else {
         if (!cfg.projectId) {
           throw new Error(
-            "<zitadel-login> requires a project id (configureZitadel({ projectId }) or a `project` handle) to start a flow.",
+            "<zitadel-login> requires a project id (the `project-id` attribute, " +
+              "`configureZitadel({ projectId })`, or a `project` handle) to start a flow.",
           );
         }
         wire = await apiStartFlow(api, { project_id: cfg.projectId, purpose: this.purpose });
@@ -401,7 +428,11 @@ export class ZitadelLogin extends LitElement {
     if (behavior === "show" && handoffToken && this.postSignInUrl) {
       this.loading = true;
       try {
-        const { project: cfg, api } = resolveApi(this.project, "<zitadel-login>");
+        const { project: cfg, api } = resolveApi(
+          this.project,
+          this.projectAttrs,
+          "<zitadel-login>",
+        );
         await exchangeSession(api, { handoff_token: handoffToken }, { project_id: cfg.projectId });
         window.location.assign(this.postSignInUrl);
       } catch (error) {
@@ -628,7 +659,7 @@ export class ZitadelLogin extends LitElement {
         fields,
         ...(challengeResponse ? { challenge_response: challengeResponse } : {}),
       };
-      const { api } = resolveApi(this.project, "<zitadel-login>");
+      const { api } = resolveApi(this.project, this.projectAttrs, "<zitadel-login>");
       const wire = await apiSubmitStep(api, id, body);
       this.applyResponse(wire);
       emit(this, "zitadel-flow-step", { step: wire.step });

--- a/packages/components/src/orchestrator/zitadel-login.ts
+++ b/packages/components/src/orchestrator/zitadel-login.ts
@@ -99,8 +99,8 @@ export class ZitadelLogin extends LitElement {
 
   /**
    * Project ID, set declaratively in HTML. Lets the component be configured on
-   * a plain page without JS or `configureZitadel()`. Ignored when the
-   * `project` property is set. See {@link projectAttrs}.
+   * a plain page without JS or `configureZitadel()`. Ignored when the `project`
+   * property or a `configureZitadel()` global is set. See {@link projectAttrs}.
    */
   @property({ type: String, attribute: "project-id" }) accessor projectId = "";
 

--- a/packages/components/src/orchestrator/zitadel-logout.spec.ts
+++ b/packages/components/src/orchestrator/zitadel-logout.spec.ts
@@ -188,6 +188,29 @@ describe("<zitadel-logout>", () => {
     expect(window.location.href).toBe("https://app.test/done");
   });
 
+  it("signs out using project-id / proxy-path attributes with no global config", async () => {
+    // Drop the global so only the declarative attributes can configure the
+    // element; restore it afterwards so later tests keep their global config.
+    _resetConfigForTesting();
+    try {
+      setDisplayCookie("Alice", "alice@acme.com");
+      const element = mount(
+        `<zitadel-logout project-id="test" proxy-path="${API_BASE}"></zitadel-logout>`,
+      );
+      await element.updateComplete;
+      shadowQuery<HTMLButtonElement>(element, ".trigger").click();
+      await element.updateComplete;
+      shadowQuery<HTMLButtonElement>(element, ".signout-btn").click();
+      await new Promise((resolve) => setTimeout(resolve, 32));
+
+      expect(requestLog).toHaveLength(1);
+      expect(requestLog[0]?.url).toBe(`${API_BASE}/sessions/me`);
+      expect(requestLog[0]?.credentials).toBe("include");
+    } finally {
+      configureZitadel({ proxyPath: API_BASE, projectId: "test" });
+    }
+  });
+
   it("surfaces a network error in the dropdown without redirecting", async () => {
     setDisplayCookie("Alice", "alice@acme.com");
     server.use(http.delete(`${API_BASE}/sessions/me`, () => HttpResponse.error()));

--- a/packages/components/src/orchestrator/zitadel-logout.ts
+++ b/packages/components/src/orchestrator/zitadel-logout.ts
@@ -199,8 +199,8 @@ export class ZitadelLogout extends LitElement {
 
   /**
    * Project ID, set declaratively in HTML. Lets the component be configured on
-   * a plain page without JS or `configureZitadel()`. Ignored when the
-   * `project` property is set.
+   * a plain page without JS or `configureZitadel()`. Ignored when the `project`
+   * property or a `configureZitadel()` global is set.
    */
   @property({ type: String, attribute: "project-id" }) accessor projectId = "";
 

--- a/packages/components/src/orchestrator/zitadel-logout.ts
+++ b/packages/components/src/orchestrator/zitadel-logout.ts
@@ -3,7 +3,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { type ZitadelProject } from "@zitadel/api/config";
 
 import { applyBaseTokens } from "./branding-to-tokens.js";
-import { resolveApi } from "./resolve-api.js";
+import { resolveApi, type ProjectAttrs } from "./resolve-api.js";
 import { emit } from "../internal/emit.js";
 import { baseHostStyles, focusVisibleStyles, t } from "../styles/index.js";
 
@@ -190,10 +190,31 @@ export class ZitadelLogout extends LitElement {
   ];
 
   /**
-   * SDK project handle returned by `configureZitadel()`. When set, takes
-   * precedence over the global singleton from `getZitadelConfig()`.
+   * SDK project handle returned by `configureZitadel()`. Set from JS (or a
+   * framework binding). When set, takes precedence over both the
+   * `project-id`/`proxy-path`/`url` attributes and the global singleton from
+   * `getZitadelConfig()`.
    */
   @property({ attribute: false }) accessor project: ZitadelProject | undefined;
+
+  /**
+   * Project ID, set declaratively in HTML. Lets the component be configured on
+   * a plain page without JS or `configureZitadel()`. Ignored when the
+   * `project` property is set.
+   */
+  @property({ type: String, attribute: "project-id" }) accessor projectId = "";
+
+  /**
+   * Proxy path for API requests (e.g. `/__nextgen`), set declaratively in HTML.
+   * Defaults to `/__nextgen` when omitted, matching `configureZitadel()`.
+   */
+  @property({ type: String, attribute: "proxy-path" }) accessor proxyPath = "";
+
+  /**
+   * Full URL of the Zitadel auth backend, set declaratively in HTML. Optional —
+   * not needed in client-only setups.
+   */
+  @property({ type: String }) accessor url = "";
 
   /** URL to navigate to after a successful sign-out. */
   @property({ type: String, attribute: "post-sign-out-url" }) accessor postSignOutUrl = "";
@@ -257,9 +278,7 @@ export class ZitadelLogout extends LitElement {
    */
   private readDisplayCookie(): void {
     if (typeof document === "undefined") return;
-    const match = document.cookie.match(
-      new RegExp(`(?:^|;\\s*)${DISPLAY_COOKIE_NAME}=([^;]+)`),
-    );
+    const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${DISPLAY_COOKIE_NAME}=([^;]+)`));
     if (!match || !match[1]) return;
     try {
       const data = JSON.parse(atob(match[1])) as DisplayData;
@@ -322,12 +341,17 @@ export class ZitadelLogout extends LitElement {
    * clears the cookie via `Set-Cookie: Max-Age=0`. On success this element fires
    * `zitadel-signout` and optionally navigates to `postSignOutUrl`.
    */
+  /** Declarative config read from this element's attributes. */
+  private get projectAttrs(): ProjectAttrs {
+    return { projectId: this.projectId, proxyPath: this.proxyPath, url: this.url };
+  }
+
   private async doLogout(): Promise<void> {
     this.loading = true;
     this.errorMessage = "";
 
     try {
-      const { api } = resolveApi(this.project, "<zitadel-logout>");
+      const { api } = resolveApi(this.project, this.projectAttrs, "<zitadel-logout>");
       await api.revokeMySession({ credentials: "include" });
     } catch (error) {
       const message = error instanceof Error ? error.message : "";
@@ -357,7 +381,7 @@ export class ZitadelLogout extends LitElement {
       ...(this.clientId ? { client_id: this.clientId } : {}),
       ...(this.postSignOutUrl ? { post_logout_redirect_uri: this.postSignOutUrl } : {}),
     };
-    const { api } = resolveApi(this.project, "<zitadel-logout>");
+    const { api } = resolveApi(this.project, this.projectAttrs, "<zitadel-logout>");
     return api.getEndSessionUrl(params);
   }
 

--- a/packages/components/tsdown.config.ts
+++ b/packages/components/tsdown.config.ts
@@ -78,12 +78,22 @@ export default defineConfig([
    * third-party UI deps ARE inlined, so `<script type="module"
    * src="…/standalone.mjs">` works with no import map and no bundler. Kept
    * separate from the library build above so npm/SDK consumers are unaffected.
+   *
+   * `platform: "browser"` is required: the default ("node") makes rolldown emit
+   * `import { createRequire } from "node:module"` for its CJS-interop helper,
+   * which a browser cannot resolve — the whole module then fails to load. The
+   * browser platform also picks the `browser`/`import` export conditions of the
+   * inlined deps so no Node-only entry points leak in.
    */
   {
     plugins: [liquidRaw()],
     entry: { standalone: "src/index.ts" },
     outDir: "dist",
     format: ["esm"],
+    platform: "browser",
+    // `platform: "browser"` would otherwise emit `standalone.js`; force `.mjs`
+    // so the `unpkg`/`jsdelivr`/`./standalone` paths in package.json still match.
+    fixedExtension: true,
     tsconfig: "tsconfig.lib.json",
     dts: false,
     sourcemap: false,


### PR DESCRIPTION
Configure `<zitadel-login>` and `<zitadel-logout>` from HTML via `project-id`, `proxy-path`, and `url` attributes, so they work on a plain page with no JS and no `configureZitadel()`. The `project` property and the global config still win, in that order.

Also fixes the standalone bundle from #261, which was built for Node and emitted an `import "node:module"` that browsers reject. It now builds for the browser, so `dist/standalone.mjs` loads as a plain module script.

Verified with 150 unit tests and in a real browser.
