### PR TITLE
fix(test): serialize harness client cache under parallel integration tests

### DIFF
--- a/.changeset/fix-harness-parallel-test-race.md
+++ b/.changeset/fix-harness-parallel-test-race.md
@@ -1,4 +1,0 @@
----
----
-
-Empty changeset — test harness concurrency fix only.

--- a/.changeset/fix-harness-parallel-test-race.md
+++ b/.changeset/fix-harness-parallel-test-race.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset — test harness concurrency fix only.

--- a/internal/api/integration_test/helpers/client.go
+++ b/internal/api/integration_test/helpers/client.go
@@ -12,6 +12,8 @@ import (
 func (h *Harness) EnsureAPIClient(t *testing.T, projectID string) *api.Client {
 	t.Helper()
 	serv := h.EnsureTestServer(t)
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	if h.apiClients == nil {
 		h.apiClients = make(map[string]*api.Client)
 	}
@@ -20,7 +22,7 @@ func (h *Harness) EnsureAPIClient(t *testing.T, projectID string) *api.Client {
 	}
 	client, err := api.NewClient(
 		serv.URL,
-		h.EnsureFakeSecuritySource(t, projectID),
+		h.ensureFakeSecuritySourceLocked(projectID),
 	)
 	require.NoError(t, err)
 	h.apiClients[projectID] = client
@@ -30,10 +32,12 @@ func (h *Harness) EnsureAPIClient(t *testing.T, projectID string) *api.Client {
 func (h *Harness) EnsureAnonymousAPIClient(t *testing.T) *api.Client {
 	t.Helper()
 	serv := h.EnsureTestServer(t)
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	if h.anonymousClient == nil {
 		client, err := api.NewClient(
 			serv.URL,
-			h.EnsureAnonymousSecuritySource(t),
+			h.ensureAnonymousSecuritySourceLocked(),
 		)
 		require.NoError(t, err)
 		h.anonymousClient = client
@@ -43,6 +47,12 @@ func (h *Harness) EnsureAnonymousAPIClient(t *testing.T) *api.Client {
 
 func (h *Harness) EnsureFakeSecuritySource(t *testing.T, projectID string) *FakeSecuritySource {
 	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.ensureFakeSecuritySourceLocked(projectID)
+}
+
+func (h *Harness) ensureFakeSecuritySourceLocked(projectID string) *FakeSecuritySource {
 	if h.fakeSecuritySources == nil {
 		h.fakeSecuritySources = make(map[string]*FakeSecuritySource)
 	}
@@ -57,6 +67,12 @@ func (h *Harness) EnsureFakeSecuritySource(t *testing.T, projectID string) *Fake
 
 func (h *Harness) EnsureAnonymousSecuritySource(t *testing.T) *FakeSecuritySource {
 	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.ensureAnonymousSecuritySourceLocked()
+}
+
+func (h *Harness) ensureAnonymousSecuritySourceLocked() *FakeSecuritySource {
 	if h.anonymousSecuritySource == nil {
 		h.anonymousSecuritySource = &FakeSecuritySource{}
 	}

--- a/internal/api/integration_test/helpers/client.go
+++ b/internal/api/integration_test/helpers/client.go
@@ -11,9 +11,9 @@ import (
 
 func (h *Harness) EnsureAPIClient(t *testing.T, projectID string) *api.Client {
 	t.Helper()
-	serv := h.EnsureTestServer(t)
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	serv := h.EnsureTestServer(t)
 	if h.apiClients == nil {
 		h.apiClients = make(map[string]*api.Client)
 	}
@@ -31,9 +31,9 @@ func (h *Harness) EnsureAPIClient(t *testing.T, projectID string) *api.Client {
 
 func (h *Harness) EnsureAnonymousAPIClient(t *testing.T) *api.Client {
 	t.Helper()
-	serv := h.EnsureTestServer(t)
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	serv := h.EnsureTestServer(t)
 	if h.anonymousClient == nil {
 		client, err := api.NewClient(
 			serv.URL,

--- a/internal/api/integration_test/helpers/harness.go
+++ b/internal/api/integration_test/helpers/harness.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 
 	generated "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/api"
@@ -15,6 +16,8 @@ import (
 )
 
 type Harness struct {
+	mu sync.Mutex
+
 	DBPool          database.Pool
 	HttpClient      *http.Client
 	TestServer      *httptest.Server


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a flaky `fatal error: concurrent map writes` panic in `go-integration-test-postgres` when parallel subtests share one integration test `Harness`.

The harness lazily caches API clients and fake security sources in maps (`apiClients`, `fakeSecuritySources`) without synchronization. Parallel subtests (for example in flow definition tests) can write to those maps concurrently and crash the test binary.

This change adds a mutex on `Harness` and serializes map initialization and writes in `EnsureAPIClient`, `EnsureAnonymousAPIClient`, and the fake security source helpers.

No product behavior change — test harness only.

## Validation

- CI `go-integration-test-postgres` (primary proof)
- `go build ./...`

## Release notes / changeset

No changeset required — no public npm package files changed.

## Notes

Extracted from #287 so the lifecycle storage work stays focused on ADR 024 / Fixes #267.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f52f2c82-7c40-4962-bf78-39a8915c3d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f52f2c82-7c40-4962-bf78-39a8915c3d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

