### PR TITLE
refactor: remove name-indexed views from orchestrator template context

### DIFF
--- a/apps/demo-next/next-env.d.ts
+++ b/apps/demo-next/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/internal/api/branding/default.liquid
+++ b/internal/api/branding/default.liquid
@@ -48,7 +48,9 @@
       </zl-field>
     {% endfor %}
 
-    {% if fields_by_name.email and fields_by_name.password and step.name == 'identifier' %}
+    {% assign has_email = fields | where: "name", "email" | first %}
+    {% assign has_password = fields | where: "name", "password" | first %}
+    {% if has_email and has_password and step.name == 'identifier' %}
       <p class="zl-card-forgot">
         <a href="#" class="zl-card-forgot__link" data-action="recover">{{ 'action.forgot_password' | t }}</a>
       </p>
@@ -81,24 +83,27 @@
       {% endunless %}
     {% endfor %}
 
-    {% if actions_by_name.passkey %}
+    {% assign passkey = actions | where: "name", "passkey" | first %}
+    {% if passkey %}
       <zl-button
         hierarchy="secondary"
         size="medium"
         block
         action="passkey"
-        label="{{ actions_by_name.passkey.text_key | t }}"
+        label="{{ passkey.text_key | t }}"
       ></zl-button>
     {% endif %}
 
 
-    {% if actions_by_name.register %}
+    {% assign register = actions | where: "name", "register" | first %}
+    {% if register %}
       <p class="zl-card-nav">
         {{ 'identifier.action.register.lead' | t }}<a href="#" class="zl-card-nav__link" data-action="register">{{ 'identifier.action.register.link' | t }}</a>
       </p>
     {% endif %}
 
-    {% if actions_by_name.sign_in %}
+    {% assign sign_in = actions | where: "name", "sign_in" | first %}
+    {% if sign_in %}
       <p class="zl-card-nav">
         {{ 'register.action.sign_in.lead' | t }}<a href="#" class="zl-card-nav__link" data-action="sign_in">{{ 'register.action.sign_in.link' | t }}</a>
       </p>

--- a/packages/api-mock/src/fixtures/login.ts
+++ b/packages/api-mock/src/fixtures/login.ts
@@ -117,15 +117,54 @@ export function registerStep(input: StepFixtureInput): CreateFlow201 {
         required: true,
       },
       {
+        name: "given_name",
+        type: "text",
+        text_key: "register.field.givenName",
+        required: true,
+      },
+      {
+        name: "family_name",
+        type: "text",
+        text_key: "register.field.familyName",
+        required: true,
+      },
+      {
+        name: "date_of_birth",
+        type: "date",
+        text_key: "register.field.dateOfBirth",
+      },
+    ],
+    actions: [
+      { name: "submit", text_key: "register.action.password", primary: true },
+      { name: "passkey_register", text_key: "register.action.passkey" },
+      { name: "sign_in", text_key: "register.action.sign_in.link" },
+    ],
+    gates: {},
+  });
+}
+
+/**
+ * Register-password step — second step in the two-step registration flow.
+ * Collects the password after the user has entered their profile fields.
+ */
+export function registerPasswordStep(input: StepFixtureInput): CreateFlow201 {
+  return wrap(input, {
+    name: "register-password",
+    texts: {
+      title_key: "register-password.title",
+      description_key: "register-password.description",
+    },
+    fields: [
+      {
         name: "password",
         type: "password",
-        text_key: "register.field.password",
+        text_key: "register-password.field.password",
         required: true,
         validation: { min_length: 8 },
       },
     ],
     actions: [
-      { name: "submit", text_key: "register.action.submit", primary: true },
+      { name: "submit", text_key: "register-password.action.submit", primary: true },
     ],
     gates: {},
   });

--- a/packages/api-mock/src/flow-machine.ts
+++ b/packages/api-mock/src/flow-machine.ts
@@ -15,7 +15,8 @@
  *                                       --SUBMIT(register)--> register
  *                                       --SUBMIT(passkey)--> passkey-login
  *                                       --SUBMIT(sso_provider_id)--> sso-redirect
- *      \--START(register)--> register --SUBMIT--> done
+ *      \--START(register)--> register --SUBMIT--> register-password --SUBMIT--> done
+ *                                     --SUBMIT(sign_in)--> identifier
  *
  *   password -- legacy split step; not reachable from any START transition;
  *               kept so tests can target it directly via actor injection
@@ -36,6 +37,7 @@ import { createMachine, type Actor, assign, createActor } from "xstate";
 export type FlowStepName =
   | "identifier"
   | "register"
+  | "register-password"
   | "password"
   | "recover"
   | "passkey-upsell"
@@ -149,6 +151,21 @@ export const flowMachine = createMachine({
       },
     },
     register: {
+      on: {
+        SUBMIT: [
+          {
+            guard: ({ event }) => event.action === "sign_in",
+            target: "identifier",
+            actions: [captureFields, rotateToken],
+          },
+          {
+            target: "register-password",
+            actions: [captureFields, rotateToken],
+          },
+        ],
+      },
+    },
+    "register-password": {
       on: {
         SUBMIT: { target: "done", actions: [captureFields, rotateToken] },
       },

--- a/packages/api-mock/src/handlers.ts
+++ b/packages/api-mock/src/handlers.ts
@@ -40,6 +40,7 @@ import {
   passkeyUpsellStep,
   passwordStep,
   recoverStep,
+  registerPasswordStep,
   registerStep,
   ssoRedirectStep,
 } from "./fixtures/login.js";
@@ -118,6 +119,8 @@ export function setupMockHandlers(options: { iss?: string } = {}): MockHandle {
     switch (step) {
       case "register":
         return withBranding(registerStep(input));
+      case "register-password":
+        return withBranding(registerPasswordStep(input));
       case "recover":
         return withBranding(recoverStep(input));
       case "password":

--- a/packages/api-mock/src/index.spec.ts
+++ b/packages/api-mock/src/index.spec.ts
@@ -110,20 +110,34 @@ describe("setupMockHandlers", () => {
     expect(start.session_token).not.toBe(submit.session_token);
   });
 
-  test("routes register through sign-up step straight to done", async () => {
+  test("routes register through two-step sign-up to done", async () => {
     const start = await createFlow({ purpose: "register", project_id: PROJECT_ID });
     expect(start.step.name).toBe("register");
-    const submit = await submitFlowStep(start.id, {
+    expect(start.step.fields?.some((f) => f.name === "email")).toBe(true);
+    expect(start.step.fields?.some((f) => f.name === "given_name")).toBe(true);
+    expect(start.step.fields?.some((f) => f.name === "family_name")).toBe(true);
+    expect(start.step.fields?.some((f) => f.name === "date_of_birth")).toBe(true);
+
+    const passwordStep = await submitFlowStep(start.id, {
       session_token: start.session_token,
       action: "submit",
       fields: {
         email: "alice@acme.com",
-        password: "hunter2",
+        given_name: "Alice",
+        family_name: "Acme",
       },
     });
-    expect(submit.step.name).toBe("done");
-    expect(submit.step.complete).toBe("show");
-    expect(submit.handoff_token).toBeTruthy();
+    expect(passwordStep.step.name).toBe("register-password");
+    expect(passwordStep.step.fields?.some((f) => f.name === "password")).toBe(true);
+
+    const done = await submitFlowStep(passwordStep.id, {
+      session_token: passwordStep.session_token,
+      action: "submit",
+      fields: { password: "hunter2" },
+    });
+    expect(done.step.name).toBe("done");
+    expect(done.step.complete).toBe("show");
+    expect(done.handoff_token).toBeTruthy();
   });
 
   test("redirects to SSO when sso_provider_id is set", async () => {

--- a/packages/components/src/orchestrator/liquid.spec.ts
+++ b/packages/components/src/orchestrator/liquid.spec.ts
@@ -7,16 +7,13 @@ import { mandatoryGatesMarkerComment } from "./mandatory-gates.js";
 
 /**
  * Convert author-friendly `{ name: {...}, ... }` dicts into the wire-shape
- * `[{ name, ... }, ...]` array plus its `*_by_name` view. Keeps each test's
- * context authoring concise while matching the runtime contract the
- * orchestrator builds for the Liquid engine.
+ * `[{ name, ... }, ...]` array. Keeps each test's context authoring concise
+ * while matching the runtime contract.
  */
-function viewBoth<T extends object>(
+function toArray<T extends object>(
   entries: Record<string, T>,
-): { array: ({ name: string } & T)[]; byName: Record<string, { name: string } & T> } {
-  const array = Object.entries(entries).map(([name, body]) => ({ name, ...body }));
-  const byName = Object.fromEntries(array.map((e) => [e.name, e]));
-  return { array, byName };
+): ({ name: string } & T)[] {
+  return Object.entries(entries).map(([name, body]) => ({ name, ...body }));
 }
 
 const locale: Record<string, string> = {
@@ -85,16 +82,14 @@ describe("LiquidJS engine", () => {
 
   it("renders the bundled default template through the auth-form partial", () => {
     const engine = createLiquidEngine({ locale });
-    const f = viewBoth({
+    const f = toArray({
       identifier: { type: "email", text_key: "identifier.title", required: true },
     });
-    const a = viewBoth({ submit: { text_key: "submit.continue", primary: true } });
+    const a = toArray({ submit: { text_key: "submit.continue", primary: true } });
     const context = {
       step: { name: "identifier", type: "identifier", texts: { title_key: "identifier.title" } },
-      fields: f.array,
-      actions: a.array,
-      fields_by_name: f.byName,
-      actions_by_name: a.byName,
+      fields: f,
+      actions: a,
       branding: {},
       loading: false,
       errors: [],
@@ -116,13 +111,11 @@ describe("LiquidJS engine", () => {
 
   it("renders step title from locale via default template", () => {
     const engine = createLiquidEngine({ locale });
-    const a = viewBoth({ submit: { text_key: "submit.continue", primary: true } });
+    const a = toArray({ submit: { text_key: "submit.continue", primary: true } });
     const context = {
       step: { name: "password", texts: { title_key: "password.title" } },
       fields: [],
-      actions: a.array,
-      fields_by_name: {},
-      actions_by_name: a.byName,
+      actions: a,
       branding: {},
       loading: false,
       errors: [],
@@ -137,16 +130,14 @@ describe("LiquidJS engine", () => {
 
   it("renders passkey upsell: card, primary + secondary CTAs", () => {
     const engine = createLiquidEngine({ locale: fullLocale });
-    const a = viewBoth({
+    const a = toArray({
       setup: { text_key: "passkey-upsell.action.setup", primary: true },
       skip: { text_key: "passkey-upsell.action.skip" },
     });
     const context = {
       step: { name: "passkey-upsell", texts: { title_key: "passkey-upsell.title" } },
       fields: [],
-      actions: a.array,
-      fields_by_name: {},
-      actions_by_name: a.byName,
+      actions: a,
       branding: {},
       loading: false,
       errors: [],
@@ -166,16 +157,14 @@ describe("LiquidJS engine", () => {
 
   it("renders passkey upsell setup error: form-level alert, retry allowed", () => {
     const engine = createLiquidEngine({ locale: fullLocale });
-    const a = viewBoth({
+    const a = toArray({
       setup: { text_key: "passkey-upsell.action.setup", primary: true },
       skip: { text_key: "passkey-upsell.action.skip" },
     });
     const context = {
       step: { name: "passkey-upsell", texts: { title_key: "passkey-upsell.title" } },
       fields: [],
-      actions: a.array,
-      fields_by_name: {},
-      actions_by_name: a.byName,
+      actions: a,
       branding: {},
       loading: false,
       errors: [{ text_key: "error.passkey_cancelled" }],
@@ -197,8 +186,6 @@ describe("LiquidJS engine", () => {
       step: { name: "signed-in", texts: { title_key: "complete.title" } },
       fields: [],
       actions: [],
-      fields_by_name: {},
-      actions_by_name: {},
       branding: {},
       loading: false,
       errors: [],
@@ -213,11 +200,11 @@ describe("LiquidJS engine", () => {
 
   it("renders combined sign-in (6593:141983): email+password, forgot link, sign-in CTA", () => {
     const engine = createLiquidEngine({ locale: fullLocale });
-    const f = viewBoth({
+    const f = toArray({
       email: { type: "email", text_key: "identifier.field.email", required: true },
       password: { type: "password", text_key: "identifier.field.password", required: true },
     });
-    const a = viewBoth({
+    const a = toArray({
       submit: { text_key: "submit.signin", primary: true },
       passkey: { text_key: "identifier.action.passkey" },
       register: { text_key: "identifier.action.register.link" },
@@ -225,10 +212,8 @@ describe("LiquidJS engine", () => {
     });
     const context = {
       step: { name: "identifier", texts: { title_key: "identifier.title" } },
-      fields: f.array,
-      actions: a.array,
-      fields_by_name: f.byName,
-      actions_by_name: a.byName,
+      fields: f,
+      actions: a,
       branding: {},
       loading: false,
       errors: [],
@@ -249,20 +234,18 @@ describe("LiquidJS engine", () => {
 
   it("renders sign-in wrong credentials (6602:180268): inline password error, no form alert", () => {
     const engine = createLiquidEngine({ locale: fullLocale });
-    const f = viewBoth({
+    const f = toArray({
       email: { type: "email", text_key: "identifier.field.email", required: true },
       password: { type: "password", text_key: "identifier.field.password", required: true },
     });
-    const a = viewBoth({
+    const a = toArray({
       submit: { text_key: "submit.signin", primary: true },
       recover: { text_key: "action.forgot_password" },
     });
     const context = {
       step: { name: "identifier", texts: { title_key: "identifier.title" } },
-      fields: f.array,
-      actions: a.array,
-      fields_by_name: f.byName,
-      actions_by_name: a.byName,
+      fields: f,
+      actions: a,
       branding: {},
       loading: false,
       errors: [{ text_key: "error.invalid_credentials" }],
@@ -281,20 +264,18 @@ describe("LiquidJS engine", () => {
 
   it("renders sign-in server error (6594:125237): heading + body alert, fields unchanged", () => {
     const engine = createLiquidEngine({ locale: fullLocale });
-    const f = viewBoth({
+    const f = toArray({
       email: { type: "email", text_key: "identifier.field.email", required: true },
       password: { type: "password", text_key: "identifier.field.password", required: true },
     });
-    const a = viewBoth({
+    const a = toArray({
       submit: { text_key: "submit.signin", primary: true },
       recover: { text_key: "action.forgot_password" },
     });
     const context = {
       step: { name: "identifier", texts: { title_key: "identifier.title" } },
-      fields: f.array,
-      actions: a.array,
-      fields_by_name: f.byName,
-      actions_by_name: a.byName,
+      fields: f,
+      actions: a,
       branding: {},
       loading: false,
       errors: [{ text_key: "error.sign_in_server" }],
@@ -313,19 +294,17 @@ describe("LiquidJS engine", () => {
 
   it("renders sign-up field annotations (6593:141741): autocomplete, help, inline email error", () => {
     const engine = createLiquidEngine({ locale: fullLocale });
-    const f = viewBoth({
+    const f = toArray({
       email: { type: "email", text_key: "register.field.email", required: true },
       password: { type: "password", text_key: "register.field.password", required: true },
     });
-    const a = viewBoth({
+    const a = toArray({
       submit: { text_key: "register.action.submit", primary: true },
     });
     const context = {
       step: { name: "register", texts: { title_key: "register.title" } },
-      fields: f.array,
-      actions: a.array,
-      fields_by_name: f.byName,
-      actions_by_name: a.byName,
+      fields: f,
+      actions: a,
       branding: {},
       loading: false,
       errors: [{ text_key: "error.email_exists" }],
@@ -354,8 +333,6 @@ describe("LiquidJS engine", () => {
       step: { name: "done", complete: "show", texts: { title_key: "complete.title" } },
       fields: [],
       actions: [],
-      fields_by_name: {},
-      actions_by_name: {},
       branding: {},
       loading: false,
       errors: [],

--- a/packages/components/src/orchestrator/template-context.ts
+++ b/packages/components/src/orchestrator/template-context.ts
@@ -9,14 +9,11 @@
  *
  * The orchestrator owns these projections that don't exist on the wire:
  *
- * 1. `fields_by_name` / `actions_by_name` — name-indexed views of the
- *    ordered arrays. Templates iterate `fields` / `actions` for order, then
- *    look up by name (`actions_by_name.passkey`) for keyed branches.
- * 2. `errors` — lifted from `step.error: string | null` so templates iterate
+ * 1. `errors` — lifted from `step.error: string | null` so templates iterate
  *    uniformly even though the wire only carries one error string.
- * 3. `messages` — populated by orchestrator decoration hooks (info banners,
+ * 2. `messages` — populated by orchestrator decoration hooks (info banners,
  *    sticky notices); not on the wire.
- * 4. `identity` — resolved client-side for greet-by-name; not on the wire.
+ * 3. `identity` — resolved client-side for greet-by-name; not on the wire.
  */
 import type {
   CreateFlow201Step,
@@ -59,8 +56,6 @@ export type LiquidContext = {
   fields: readonly CreateFlow201StepFieldsItem[];
   actions: readonly CreateFlow201StepActionsItem[];
   gates: CreateFlow201StepGates;
-  fields_by_name: Record<string, CreateFlow201StepFieldsItem>;
-  actions_by_name: Record<string, CreateFlow201StepActionsItem>;
   sso_providers: readonly CreateFlow201StepSsoProvidersItem[];
   challenge: CreateFlow201StepChallenge | null;
   messages: readonly FlowMessage[];

--- a/packages/components/src/orchestrator/templates/default.liquid
+++ b/packages/components/src/orchestrator/templates/default.liquid
@@ -52,9 +52,10 @@
       </zl-field>
     {% endfor %}
 
-    {% if actions_by_name.recover %}
+    {% assign recover = actions | where: "name", "recover" | first %}
+    {% if recover %}
       <p class="zl-card-forgot">
-        <a href="#" class="zl-card-forgot__link" data-action="recover">{{ actions_by_name.recover.text_key | t }}</a>
+        <a href="#" class="zl-card-forgot__link" data-action="recover">{{ recover.text_key | t }}</a>
       </p>
     {% endif %}
 
@@ -87,25 +88,28 @@
       {% endunless %}
     {% endfor %}
 
-    {% if actions_by_name.passkey %}
+    {% assign passkey = actions | where: "name", "passkey" | first %}
+    {% if passkey %}
       <zl-button
         hierarchy="secondary"
         size="medium"
         block
         action="passkey"
         data-testid="zitadel-action-passkey"
-        label="{{ actions_by_name.passkey.text_key | t }}"
+        label="{{ passkey.text_key | t }}"
       ></zl-button>
     {% endif %}
 
 
-    {% if actions_by_name.register %}
+    {% assign register = actions | where: "name", "register" | first %}
+    {% if register %}
       <p class="zl-card-nav">
         {{ 'identifier.action.register.lead' | t }}<a href="#" class="zl-card-nav__link" data-action="register" data-testid="zitadel-action-register-link">{{ 'identifier.action.register.link' | t }}</a>
       </p>
     {% endif %}
 
-    {% if actions_by_name.sign_in %}
+    {% assign sign_in = actions | where: "name", "sign_in" | first %}
+    {% if sign_in %}
       <p class="zl-card-nav">
         {{ 'register.action.sign_in.lead' | t }}<a href="#" class="zl-card-nav__link" data-action="sign_in" data-testid="zitadel-action-sign_in-link">{{ 'register.action.sign_in.link' | t }}</a>
       </p>

--- a/packages/components/src/orchestrator/zitadel-login.ts
+++ b/packages/components/src/orchestrator/zitadel-login.ts
@@ -457,17 +457,6 @@ export class ZitadelLogin extends LitElement {
 
     const fields = step.fields ?? [];
     const actions = step.actions ?? [];
-    // The wire ships fields and actions as ordered arrays so the template can
-    // iterate them in authorial order. Templates also need keyed lookup
-    // (`actions_by_name.passkey`, `fields_by_name.email`) — we build the
-    // name-indexed views once here so they live only in the render context.
-    // The maps use a null prototype so a malicious flow definition naming a
-    // field/action `__proto__` or `constructor` can't shadow Object.prototype
-    // members through the lookup.
-    const fields_by_name: Record<string, (typeof fields)[number]> = Object.create(null);
-    for (const f of fields) fields_by_name[f.name] = f;
-    const actions_by_name: Record<string, (typeof actions)[number]> = Object.create(null);
-    for (const a of actions) actions_by_name[a.name] = a;
     const context: LiquidContext = {
       step: {
         name: step.name,
@@ -477,8 +466,6 @@ export class ZitadelLogin extends LitElement {
       fields,
       actions,
       gates: step.gates ?? {},
-      fields_by_name,
-      actions_by_name,
       sso_providers: step.sso_providers ?? [],
       challenge: step.challenge ?? null,
       messages: [],


### PR DESCRIPTION
### 1. Remove `*_by_name` maps — use Liquid `where` filter instead
Templates now use `{% assign passkey = actions | where: "name", "passkey" | first %}` instead of `actions_by_name.passkey`. This eliminated the orchestrator-built lookup maps from [template-context.ts](file:///Users/maxpeintner/zitadel/nextgen/packages/components/src/orchestrator/template-context.ts), [zitadel-login.ts](file:///Users/maxpeintner/zitadel/nextgen/packages/components/src/orchestrator/zitadel-login.ts), both liquid templates, and [liquid.spec.ts](file:///Users/maxpeintner/zitadel/nextgen/packages/components/src/orchestrator/liquid.spec.ts).

### 2. Align mock registration with the default flow definition
The mock now has a **two-step registration** matching the default flow definition:
- **Register step**: email, given_name, family_name, date_of_birth fields + submit/passkey_register/sign_in actions
- **Register-password step** (new): password field + submit action

Changed files: [login.ts fixtures](file:///Users/maxpeintner/zitadel/nextgen/packages/api-mock/src/fixtures/login.ts), [flow-machine.ts](file:///Users/maxpeintner/zitadel/nextgen/packages/api-mock/src/flow-machine.ts), [handlers.ts](file:///Users/maxpeintner/zitadel/nextgen/packages/api-mock/src/handlers.ts), [index.spec.ts](file:///Users/maxpeintner/zitadel/nextgen/packages/api-mock/src/index.spec.ts).

All component tests (156) and mock tests (26) pass.