### PR TITLE
feat: improve Next.js auth proof flow

### DIFF
--- a/.changeset/lean-agent-auth-proof.md
+++ b/.changeset/lean-agent-auth-proof.md
@@ -1,0 +1,6 @@
+---
+"@zitadel/cli": minor
+"@zitadel/components": patch
+---
+
+Make the generated Next.js auth app easier for agents and developers to prove end-to-end registration, logout, and login in a visible browser.

--- a/apps/cli-journey-e2e/src/user-journey.spec.ts
+++ b/apps/cli-journey-e2e/src/user-journey.spec.ts
@@ -296,16 +296,30 @@ async function clickAction(
   name: RegExp,
   actionNames: readonly string[] = [],
 ): Promise<void> {
-  let locator = page.getByRole("button", { name }).or(page.getByRole("link", { name }));
+  const candidates: Locator[] = [];
   for (const actionName of actionNames) {
-    locator = page
-      .getByTestId(`zitadel-action-${actionName}-button`)
-      .or(page.getByTestId(`zitadel-action-${actionName}`))
-      .or(page.getByTestId(`zitadel-action-${actionName}-link`))
-      .or(actionLocator(page, actionName))
-      .or(locator);
+    candidates.push(
+      page.getByTestId(`zitadel-action-${actionName}-button`),
+      page.getByTestId(`zitadel-action-${actionName}`),
+      page.getByTestId(`zitadel-action-${actionName}-link`),
+      actionLocator(page, actionName),
+    );
   }
-  await locator.first().click();
+  candidates.push(page.getByRole("button", { name }), page.getByRole("link", { name }));
+
+  for (const candidate of candidates) {
+    const target = candidate.first();
+    if (await target.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await target.click();
+      return;
+    }
+  }
+
+  const fallback = candidates[candidates.length - 1];
+  if (!fallback) {
+    throw new Error("No action candidates configured");
+  }
+  await fallback.first().click();
 }
 
 function actionLocator(page: Page, actionName: string) {

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -37,13 +37,15 @@ back to `ghcr.io/zitadel/nextgen:latest`. Override with `--image` or
 `ZITADEL_LOCAL_IMAGE` for advanced debugging.
 `setup --server local` creates a project on that local server, asks which
 framework to scaffold when the directory is fresh, writes the Next.js app into
-the current directory, scaffolds `app/login`, `app/register`, and `proxy.ts`
-for Next 16+ or `middleware.ts` for older Next versions, writes `.env.local`
-and `.zitadel/`, and installs dependencies with the detected package manager.
-Pass `--skip-install` to install them yourself. The project's default user
-schema and login flow are provisioned server-side at creation time, so the CLI
-does not scaffold or upload them. Open `http://localhost:3000/login` to see the
-login page.
+the current directory, scaffolds `app/login`, `app/register`, `app/profile`, and
+`proxy.ts` for Next 16+ or `middleware.ts` for older Next versions. Fresh
+scaffolds also replace the starter `app/page.tsx` with links to sign in, create
+an account, and profile. Setup writes `.env.local` and `.zitadel/`, and installs
+dependencies with the detected package manager. Pass `--skip-install` to install
+them yourself. The project's default user schema and login flow are provisioned
+server-side at creation time, so the CLI does not scaffold or upload them. Open
+the dev server URL printed by your framework, register a user, log out, log back
+in, and end on the signed-in profile page.
 
 For a reproducible tester report, use the exact alpha train from the GitHub
 Release:

--- a/apps/cli/SKILLS.md
+++ b/apps/cli/SKILLS.md
@@ -104,6 +104,14 @@ npx @zitadel/cli@0.1.0-alpha.N start --non-interactive --json
 npx @zitadel/cli@0.1.0-alpha.N setup --framework next --server local --non-interactive --json
 ```
 
+After `setup`, follow `data.next_commands` to start the app. Prove the generated
+auth flow in a visible browser by registering a unique user, logging out, logging
+back in with the same email/password, and ending on the signed-in profile page.
+Do not treat a rendered login or registration form as completion. If browser DOM
+snapshots are sparse, target the component hooks exposed by the generated UI:
+`zitadel-field-email-input`, `zitadel-field-password-input`, and
+`zitadel-action-submit-button`.
+
 Repo config is authoritative: edit `zitadel.json` or files under `.zitadel/`,
 then re-run `plan` and `apply`. Managed files carry a marker comment; `eject`
 removes only files that still carry it, preserving anything the user replaced.

--- a/apps/cli/src/commands/setup/index.ts
+++ b/apps/cli/src/commands/setup/index.ts
@@ -70,7 +70,11 @@ export default class Setup extends BaseCommand {
 
   async run(): Promise<JsonEnvelope> {
     const { flags } = await this.parse(Setup);
-    await this.toMeta(flags);
+    try {
+      await this.toMeta(flags);
+    } catch (error) {
+      throw localSetupHint(error, flags.framework, this.config.version);
+    }
     const { cwd, nonInteractive, dryRun, force } = this.meta;
 
     if (await hasZitadelConfig(cwd)) {
@@ -170,6 +174,7 @@ export default class Setup extends BaseCommand {
           answers.server,
           this.meta.cliVersion,
           issuer,
+          framework.id,
         );
     consola.success(`Created project ${project.id}`);
 
@@ -180,6 +185,7 @@ export default class Setup extends BaseCommand {
       issuer,
       server: answers.server,
       cliVersion: this.meta.cliVersion,
+      scaffoldedFramework,
     };
     consola.start(`Patching project files${dryRun ? " (dry run)" : ""}`);
     const result = await orca.patcherFor(framework.id).patch(ctx, { cwd, dryRun, force });
@@ -290,6 +296,7 @@ async function createProjectWithLocalHint(
   server: string,
   cliVersion: string,
   issuer: string,
+  framework: string,
 ): Promise<CreateProject201> {
   try {
     // Register the app's own origin so the backend's origin check allows the
@@ -300,11 +307,11 @@ async function createProjectWithLocalHint(
     throw new ZitadelError(normalized.code, normalized.message, {
       hint:
         `${normalized.hint ? `${normalized.hint} ` : ""}` +
-        "If you meant to use a local Zitadel server, run npx @zitadel/cli@alpha start " +
-        "and retry setup with --server local.",
+        "If you meant to use a local Zitadel server, start it first " +
+        `and retry setup with --framework ${framework} --server local.`,
       nextCommands: [
         publicCliCommand("start", cliVersion),
-        publicCliCommand("setup --server local", cliVersion),
+        publicCliCommand(`setup --framework ${framework} --server local`, cliVersion),
       ],
       details: {
         server,
@@ -312,6 +319,29 @@ async function createProjectWithLocalHint(
       },
     });
   }
+}
+
+function localSetupHint(error: unknown, framework: string | undefined, cliVersion: string): unknown {
+  const normalized = toZitadelError(error);
+  if (normalized.code !== "E_LOCAL_SERVER_NOT_RUNNING") {
+    return error;
+  }
+
+  const setupCommand = framework
+    ? `setup --framework ${framework} --server local`
+    : "setup --server local";
+
+  return new ZitadelError(normalized.code, normalized.message, {
+    hint:
+      `${normalized.hint ? `${normalized.hint} ` : ""}` +
+      "Start local Zitadel first, then rerun setup. " +
+      "After setup succeeds, follow its next_commands to start the app and verify registration, logout, and login in the browser.",
+    nextCommands: [
+      publicCliCommand("start", cliVersion),
+      publicCliCommand(setupCommand, cliVersion),
+    ],
+    details: normalized.details,
+  });
 }
 
 /** Renders an absolute path relative to `cwd` for human-readable output. */
@@ -378,6 +408,7 @@ const SENTENCE_BY_PATH: Record<string, { subject: string }> = {
   ".env.example": { subject: "the .env example template" },
   ".env.local": { subject: "the local development environment variables" },
   ".zitadel/state.json": { subject: "the empty sync state file" },
+  "app/page.tsx": { subject: "the auth home page" },
   "app/login/page.tsx": { subject: "the login page" },
   "app/register/page.tsx": { subject: "the registration page" },
   "app/profile/page.tsx": { subject: "the profile page" },
@@ -414,6 +445,7 @@ function buildSummary(opts: {
     });
   }
   for (const [label, suffix] of [
+    ["Home page", "app/page.tsx"],
     ["Login page", "app/login/page.tsx"],
     ["Register page", "app/register/page.tsx"],
     ["Profile page", "app/profile/page.tsx"],

--- a/apps/cli/src/commands/setup/install.ts
+++ b/apps/cli/src/commands/setup/install.ts
@@ -104,13 +104,15 @@ function outcome(input: {
   issuer: string;
   includeInstallCommand: boolean;
 }): SetupInstallOutcome {
-  const startAction = `Start your project: ${input.devCommand} (then open ${input.issuer}/login)`;
+  const startAction = `Start your project: ${input.devCommand} (then open ${input.issuer})`;
+  const verifyAction =
+    "Verify auth in the browser: register a user, log out, log in again with the same user, and confirm /profile shows Signed in.";
   return {
     install: input.install,
     devCommand: input.devCommand,
     nextActions: input.includeInstallCommand
-      ? [`Install dependencies: ${input.install.command}`, startAction]
-      : [startAction],
+      ? [`Install dependencies: ${input.install.command}`, startAction, verifyAction]
+      : [startAction, verifyAction],
     nextCommands: input.includeInstallCommand
       ? [input.install.command, input.devCommand]
       : [input.devCommand],

--- a/apps/cli/src/lib/orca/patchers/rule/next/index.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/next/index.ts
@@ -75,7 +75,11 @@ function nextCodeFilePaths(
   renderer: RendererSpec,
 ): ReadonlyArray<string> {
   const appDir = framework.appDir;
-  const paths = [join(appDir, "login/page.tsx"), join(appDir, "register/page.tsx")];
+  const paths = [
+    join(appDir, "page.tsx"),
+    join(appDir, "login/page.tsx"),
+    join(appDir, "register/page.tsx"),
+  ];
   if (renderer.templates.profilePage) {
     paths.push(join(appDir, "profile/page.tsx"));
   }
@@ -97,6 +101,13 @@ function nextCodeOps(ctx: PatchContext, renderer: RendererSpec): FileOp[] {
   const dts = renderer.templates.customElementsDts?.();
   const boundary = requestBoundaryFile(ctx.framework);
   return [
+    ctx.scaffoldedFramework
+      ? {
+          kind: "edit",
+          path: join(appDir, "page.tsx"),
+          edit: () => homePageTemplate(),
+        }
+      : undefined,
     {
       kind: "write",
       path: join(appDir, "login/page.tsx"),
@@ -134,6 +145,34 @@ function nextCodeOps(ctx: PatchContext, renderer: RendererSpec): FileOp[] {
       version: dependencyVersionForCli(ctx.cliVersion, renderer.dependency.version),
     },
   ].filter((op): op is FileOp => op !== undefined);
+}
+
+function homePageTemplate(): string {
+  return `${MANAGED_MARKER}
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <main style={{ minHeight: "100vh", padding: "48px", display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <section style={{ width: "100%", maxWidth: "560px" }}>
+        <p style={{ margin: "0 0 12px", color: "#4b5563", fontSize: "14px" }}>Zitadel auth</p>
+        <h1 style={{ margin: "0 0 24px", fontSize: "32px", lineHeight: 1.15 }}>Sign in, create an account, or open your profile.</h1>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "12px" }}>
+          <Link href="/login" style={{ padding: "10px 16px", borderRadius: "8px", background: "#111827", color: "#ffffff", textDecoration: "none", fontWeight: 600 }}>
+            Sign in
+          </Link>
+          <Link href="/register" style={{ padding: "10px 16px", borderRadius: "8px", border: "1px solid #d1d5db", color: "#111827", textDecoration: "none", fontWeight: 600 }}>
+            Create account
+          </Link>
+          <Link href="/profile" style={{ padding: "10px 16px", borderRadius: "8px", border: "1px solid #d1d5db", color: "#111827", textDecoration: "none", fontWeight: 600 }}>
+            Profile
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}
+`;
 }
 
 function requestBoundaryFile(framework: PatchContext["framework"]): {

--- a/apps/cli/src/lib/orca/patchers/rule/next/renderers/react/index.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/next/renderers/react/index.ts
@@ -40,6 +40,7 @@ export const reactRenderer: RendererSpec = {
 "use client";
 
 import dynamic from "next/dynamic";
+import Link from "next/link";
 
 const ${elementName} = dynamic(
   async () => {
@@ -47,7 +48,7 @@ const ${elementName} = dynamic(
     // Build the SDK project handle and pass it to the component via the
     // \`project\` prop. The component reads config from this prop directly, so
     // it works regardless of how the SDK packages are bundled. The backend URL
-    // stays server-side — requests go through the proxy path "/__nextgen",
+    // stays server-side: requests go through the proxy path "/__nextgen",
     // which the scaffolded request boundary forwards to the Zitadel server.
     const project = configureZitadel({
       projectId: process.env.NEXT_PUBLIC_ZITADEL_PROJECT_ID ?? "",
@@ -68,7 +69,12 @@ const ${elementName} = dynamic(
 
 export default function ${componentName}() {
   return (
-    <main style={{ minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center" }}>
+    <main style={{ minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center", position: "relative", padding: "48px 24px" }}>
+      <nav aria-label="Authentication" style={{ position: "absolute", top: "24px", right: "24px", display: "flex", gap: "12px" }}>
+        <Link href="${mode === "login" ? "/register" : "/login"}" style={{ color: "#111827", fontWeight: 700, textDecoration: "none" }}>
+          ${mode === "login" ? "Create account" : "Sign in"}
+        </Link>
+      </nav>
       <${elementName} />
     </main>
   );
@@ -82,6 +88,13 @@ export default function ${componentName}() {
 "use client";
 
 import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+
+type SessionProof = {
+  session_id?: string;
+  state?: string;
+  user_id?: string;
+};
 
 const ZitadelLogout = dynamic(
   async () => {
@@ -103,13 +116,58 @@ const ZitadelLogout = dynamic(
 );
 
 export default function ProfilePage() {
+  const [session, setSession] = useState<SessionProof | null>(null);
+  const [sessionError, setSessionError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch("/__nextgen/sessions/me", { cache: "no-store" })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("Session check failed: " + String(response.status));
+        }
+        return response.json() as Promise<SessionProof>;
+      })
+      .then((nextSession) => {
+        if (!cancelled) {
+          setSession(nextSession);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setSessionError(error instanceof Error ? error.message : "Session check failed");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
-    <main style={{ padding: "48px", maxWidth: "600px", margin: "0 auto" }}>
+    <main style={{ padding: "48px", maxWidth: "680px", margin: "0 auto" }}>
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "24px" }}>
         <h1 style={{ fontSize: "24px", fontWeight: 700, margin: 0 }}>Signed in</h1>
         <ZitadelLogout />
       </div>
-      <p style={{ color: "#6b7280" }}>You are signed in. Use the button above to log out.</p>
+      <p style={{ color: "#166534", fontWeight: 600 }}>Signed in profile loaded.</p>
+      {session ? (
+        <dl style={{ display: "grid", gap: "12px", marginTop: "24px" }}>
+          <div>
+            <dt style={{ color: "#6b7280", fontSize: "14px" }}>Session state</dt>
+            <dd style={{ margin: 0, fontWeight: 600 }}>{session.state ?? "active"}</dd>
+          </div>
+          <div>
+            <dt style={{ color: "#6b7280", fontSize: "14px" }}>User id</dt>
+            <dd style={{ margin: 0, fontFamily: "monospace" }}>{session.user_id ?? "available"}</dd>
+          </div>
+        </dl>
+      ) : (
+        <p style={{ color: sessionError ? "#b91c1c" : "#6b7280" }}>
+          {sessionError || "Checking session..."}
+        </p>
+      )}
     </main>
   );
 }

--- a/apps/cli/src/lib/orca/patchers/types.ts
+++ b/apps/cli/src/lib/orca/patchers/types.ts
@@ -28,6 +28,7 @@ export type PatchContext = PatchView &
     issuer: string;
     server: string;
     cliVersion: string;
+    scaffoldedFramework?: boolean;
   }>;
 
 /** Where and how a patch is applied. Family-neutral (no file-op coupling). */

--- a/apps/cli/tests/integration/setup-next.test.ts
+++ b/apps/cli/tests/integration/setup-next.test.ts
@@ -38,6 +38,7 @@ describe("Next setup integration", () => {
       status: string;
       data: {
         install: { status: string; package_manager: string; command: string };
+        next_actions: string[];
         next_commands: string[];
       };
     };
@@ -51,6 +52,9 @@ describe("Next setup integration", () => {
       command: "npm install",
     });
     expect(setupJson.data.next_commands).toEqual(["npm run dev"]);
+    expect(setupJson.data.next_actions.join("\n")).toContain("register a user");
+    expect(setupJson.data.next_actions.join("\n")).toContain("log in again");
+    expect(setupJson.data.next_actions.join("\n")).toContain("/profile shows Signed in");
     const installLog = JSON.parse((await readFile(fakeNpm.logPath, "utf8")).trim()) as {
       cwd: string;
       args: string[];
@@ -75,12 +79,20 @@ describe("Next setup integration", () => {
     expect(loginPage).toContain("project={project}");
     expect(loginPage).not.toContain("NEXT_PUBLIC_ZITADEL_API_BASE");
     expect(loginPage).toContain('post-sign-in-url="/profile"');
+    expect(loginPage).toContain('href="/register"');
+    expect(loginPage).not.toContain('href="/profile"');
+    const registerPage = await readFile(join(cwd, "app/register/page.tsx"), "utf8");
+    expect(registerPage).toContain('purpose="register"');
+    expect(registerPage).toContain('href="/login"');
+    expect(registerPage).not.toContain('href="/profile"');
     const profilePage = await readFile(join(cwd, "app/profile/page.tsx"), "utf8");
     expect(profilePage).toContain("zitadel-cli: managed-file v1");
     expect(profilePage).toContain("<zitadel-logout");
     expect(profilePage).toContain("configureZitadel");
     expect(profilePage).toContain("project={project}");
     expect(profilePage).toContain('post-sign-out-url="/login"');
+    expect(profilePage).toContain('fetch("/__nextgen/sessions/me"');
+    expect(profilePage).toContain("Signed in profile loaded");
     const proxy = await readFile(join(cwd, "proxy.ts"), "utf8");
     expect(proxy).toContain("zitadel-cli: managed-file v1");
     expect(proxy).toContain("nextgenMiddleware");

--- a/apps/cli/tests/unit/commands/setup/index.test.ts
+++ b/apps/cli/tests/unit/commands/setup/index.test.ts
@@ -11,7 +11,7 @@ import {
   writeRuntimeMetadata,
   type RuntimeMetadata,
 } from "../../../../src/lib/local-server/runtime";
-import { parseJson, runCliForTest } from "../../../helpers/run-cli";
+import { expectedPublicCliCommand, parseJson, runCliForTest } from "../../../helpers/run-cli";
 
 /**
  * Unit-level guardrails for the `setup` command. The happy path
@@ -102,6 +102,38 @@ describe("setup command pre-flight", () => {
     expect(json.hint).toContain("--framework");
   });
 
+  it("keeps the framework in local-runtime-missing setup guidance", async () => {
+    const cwd = await makeTempDir();
+    await writeRuntimeMetadata(cwd, runtimeFor(cwd, "http://localhost:9"));
+
+    const res = await runCliForTest([
+      "setup",
+      "--cwd",
+      cwd,
+      "--framework",
+      "next",
+      "--server",
+      "local",
+      "--non-interactive",
+      "--json",
+    ]);
+
+    expect(res.exitCode).toBe(4);
+    const json = parseJson(res.stdout) as {
+      status: string;
+      code: string;
+      hint?: string;
+      next_commands?: string[];
+    };
+    expect(json.status).toBe("error");
+    expect(json.code).toBe("E_LOCAL_SERVER_NOT_RUNNING");
+    expect(json.hint).toContain("Start local Zitadel first");
+    expect(json.next_commands).toEqual([
+      expectedPublicCliCommand("start"),
+      expectedPublicCliCommand("setup --framework next --server local"),
+    ]);
+  });
+
   it("throws E_FRAMEWORK_NOT_DETECTED for a non-empty dir whose framework can't be inferred", async () => {
     const cwd = await makeTempDir();
     // A non-empty dir that isn't a known framework — Orca's detector fails
@@ -145,9 +177,11 @@ describe("setup command pre-flight", () => {
     };
     expect(json.status).toBe("error");
     expect(json.code).toBe("E_VALIDATION");
-    expect(json.hint).toContain("npx @zitadel/cli@alpha start");
-    expect(json.hint).toContain("--server local");
-    expect(json.next_commands?.join(" ")).toContain("setup --server local");
+    expect(json.hint).toContain("--framework next --server local");
+    expect(json.next_commands).toEqual([
+      expectedPublicCliCommand("start"),
+      expectedPublicCliCommand("setup --framework next --server local"),
+    ]);
   });
 });
 

--- a/apps/cli/tests/unit/commands/setup/install.test.ts
+++ b/apps/cli/tests/unit/commands/setup/install.test.ts
@@ -54,6 +54,12 @@ describe("setup dependency installation", () => {
       package_manager: "npm",
       command: "npm install",
     });
+    expect(result.nextActions.join("\n")).toContain(
+      "Start your project: npm run dev (then open http://localhost:3000)",
+    );
+    expect(result.nextActions.join("\n")).not.toContain("http://localhost:3000/login");
+    expect(result.nextActions.join("\n")).toContain("register a user");
+    expect(result.nextActions.join("\n")).toContain("log in again");
     expect(result.nextCommands).toEqual(["npm run dev"]);
   });
 

--- a/apps/cli/tests/unit/lib/orca/patchers/rule/next/index.test.ts
+++ b/apps/cli/tests/unit/lib/orca/patchers/rule/next/index.test.ts
@@ -8,7 +8,11 @@ import { NextPatcher } from "../../../../../../../src/lib/orca/patchers/rule/nex
 import type { PatchContext } from "../../../../../../../src/lib/orca/patchers/types";
 import { MANAGED_MARKER } from "../../../../../../../src/lib/paths";
 
-function ctxFor(appDir: "app" | "src/app", versionMajor = 15): PatchContext {
+function ctxFor(
+  appDir: "app" | "src/app",
+  versionMajor = 15,
+  scaffoldedFramework = false,
+): PatchContext {
   return {
     framework: { id: "next", appDir, devPort: 3000, url: "http://localhost:3000", versionMajor },
     rendererId: "react",
@@ -22,6 +26,7 @@ function ctxFor(appDir: "app" | "src/app", versionMajor = 15): PatchContext {
     issuer: "http://localhost:3000",
     server: "https://api.zitadel.cloud",
     cliVersion: "0.1.0-alpha.0",
+    scaffoldedFramework,
   };
 }
 
@@ -33,15 +38,38 @@ function writeContents(plan: ScaffoldPlan, path: string): string | undefined {
   return op?.contents;
 }
 
+function editContents(plan: ScaffoldPlan, path: string, source = ""): string | undefined {
+  const op = plan.ops.find(
+    (candidate): candidate is Extract<FileOp, { kind: "edit" }> =>
+      candidate.kind === "edit" && candidate.path === path,
+  );
+  return op?.edit(source);
+}
+
 describe("NextPatcher.plan", () => {
   it("emits the base .zitadel files and Next routes for the app dir", () => {
     const plan = new NextPatcher().plan(ctxFor("app"));
     expect(writeContents(plan, "zitadel.json")).toContain('"project": "proj-1"');
+    expect(editContents(plan, "app/page.tsx")).toBeUndefined();
     expect(writeContents(plan, "app/login/page.tsx")).toContain(MANAGED_MARKER);
+    expect(writeContents(plan, "app/login/page.tsx")).toContain('href="/register"');
+    expect(writeContents(plan, "app/login/page.tsx")).not.toContain('href="/profile"');
     expect(writeContents(plan, "app/register/page.tsx")).toContain(MANAGED_MARKER);
+    expect(writeContents(plan, "app/register/page.tsx")).toContain('href="/login"');
+    expect(writeContents(plan, "app/register/page.tsx")).not.toContain('href="/profile"');
     expect(writeContents(plan, "middleware.ts")).toContain(MANAGED_MARKER);
     expect(writeContents(plan, "middleware.ts")).toContain("export function middleware(");
     expect(plan.ops.some((op) => op.kind === "add-dep")).toBe(true);
+  });
+
+  it("replaces the starter home page for a freshly scaffolded Next app", () => {
+    const plan = new NextPatcher().plan(ctxFor("app", 15, true));
+    const homePage = editContents(plan, "app/page.tsx", "starter");
+
+    expect(homePage).toContain(MANAGED_MARKER);
+    expect(homePage).toContain('href="/login"');
+    expect(homePage).toContain('href="/register"');
+    expect(homePage).toContain('href="/profile"');
   });
 
   it("emits proxy.ts for Next 16 projects", () => {
@@ -92,6 +120,7 @@ describe("NextPatcher.artifacts", () => {
       rendererId: "react",
     });
     expect(artifacts.markedFiles).toEqual([
+      "app/page.tsx",
       "app/login/page.tsx",
       "app/register/page.tsx",
       "app/profile/page.tsx",

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -21,10 +21,10 @@ npx @zitadel/cli@alpha setup --server local
 npm run dev
 ```
 
-Open:
+Open the dev server URL printed by Next.js, then complete the browser proof:
 
 ```text
-http://localhost:3000/login
+register a user -> log out -> log in with the same user -> profile shows Signed in
 ```
 
 The managed local Zitadel server listens on http://localhost:8080 by default.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -173,6 +173,10 @@ form-associated inputs.
 | Custom template | (planned) | tenant-supplied Liquid layouts |
 | Atoms-only | hand-built form | non-standard flow shells |
 
+Automation can use the stable host and native shadow-root hooks that the default
+template emits, for example `zitadel-field-email`, `zitadel-field-email-input`,
+and `zitadel-action-submit-button`.
+
 A tenant Liquid template can already be supplied through the branding
 payload's `liquid_template` field; a dedicated declarative `template`
 surface on `<zitadel-login>` is not yet exposed. The orchestrator otherwise

--- a/packages/components/src/orchestrator/liquid.spec.ts
+++ b/packages/components/src/orchestrator/liquid.spec.ts
@@ -277,6 +277,7 @@ describe("LiquidJS engine", () => {
       fields: {
         email: { type: "email", text_key: "register.field.email", required: true },
         password: { type: "password", text_key: "register.field.password", required: true },
+        dateOfBirth: { type: "date", text_key: "register.field.dateOfBirth", required: true },
       },
       actions: {
         submit: { text_key: "register.action.submit", primary: true },
@@ -293,6 +294,8 @@ describe("LiquidJS engine", () => {
     expect(result).toContain('autocomplete="email"');
     expect(result).toContain('autocomplete="new-password"');
     expect(result).toContain("At least 8 characters");
+    expect(result).toContain('placeholder="YYYY-MM-DD"');
+    expect(result).toContain("Use YYYY-MM-DD.");
     expect(result).toContain("An account with this email already exists");
     expect(result).not.toContain("forgot-password-href");
     expect(result).not.toContain('<zl-alert severity="error">An account');

--- a/packages/components/src/orchestrator/locales/de.ts
+++ b/packages/components/src/orchestrator/locales/de.ts
@@ -119,6 +119,11 @@ export const de: Locale = {
   "register.field.password": "Passwort",
   "register.field.password.help":
     "Mindestens 8 Zeichen, einschließlich eines Sonderzeichens und einer Zahl.",
+  "register.field.givenName": "Vorname",
+  "register.field.familyName": "Nachname",
+  "register.field.dateOfBirth": "Geburtsdatum",
+  "register.field.dateOfBirth.placeholder": "JJJJ-MM-TT",
+  "register.field.dateOfBirth.help": "Verwende JJJJ-MM-TT.",
   "register.action.password": "Mit Passwort fortfahren",
   "register.action.passkey": "Weiter mit Passkey",
   "register.action.submit": "Registrieren",

--- a/packages/components/src/orchestrator/locales/en.ts
+++ b/packages/components/src/orchestrator/locales/en.ts
@@ -124,6 +124,8 @@ export const en: Record<string, string> = {
   "register.field.givenName": "Given name",
   "register.field.familyName": "Family name",
   "register.field.dateOfBirth": "Date of birth",
+  "register.field.dateOfBirth.placeholder": "YYYY-MM-DD",
+  "register.field.dateOfBirth.help": "Use YYYY-MM-DD.",
   "register.action.password": "Continue with password",
   "register.action.passkey": "Continue with a passkey",
   "register.action.submit": "Sign up",

--- a/packages/components/src/orchestrator/locales/index.spec.ts
+++ b/packages/components/src/orchestrator/locales/index.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { de } from "./de.js";
+import { en } from "./en.js";
+import { it as italian } from "./it.js";
+
+describe("built-in locale dictionaries", () => {
+  it("keeps translated locale keys aligned with English", () => {
+    const englishKeys = Object.keys(en).sort();
+
+    expect(Object.keys(de).sort()).toEqual(englishKeys);
+    expect(Object.keys(italian).sort()).toEqual(englishKeys);
+  });
+});

--- a/packages/components/src/orchestrator/locales/it.ts
+++ b/packages/components/src/orchestrator/locales/it.ts
@@ -117,6 +117,11 @@ export const it: Locale = {
   "register.field.password": "Password",
   "register.field.password.help":
     "Almeno 8 caratteri, incluso un simbolo e un numero.",
+  "register.field.givenName": "Nome",
+  "register.field.familyName": "Cognome",
+  "register.field.dateOfBirth": "Data di nascita",
+  "register.field.dateOfBirth.placeholder": "AAAA-MM-GG",
+  "register.field.dateOfBirth.help": "Usa AAAA-MM-GG.",
   "register.action.password": "Continua con password",
   "register.action.passkey": "Continua con passkey",
   "register.action.submit": "Registrati",


### PR DESCRIPTION
## Summary
- Scaffold a starter home page plus login, register, and profile links for fresh Next.js apps.
- Tighten setup guidance to point at the local server, preserve framework-specific retries, and require a browser proof of register/logout/login.
- Update journey helpers, CLI docs, and component hooks so automation can verify the signed-in profile state reliably.

## Testing
- Unit tests updated for setup guidance, Next patch planning, and renderer output.
- Integration coverage updated for the Next setup flow and scaffolded file contents.
- Playwright journey coverage updated to prefer visible action targets and to verify the auth flow end to end.