### PR TITLE
ci: fix changesets release prepare

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -22,6 +22,11 @@ package paths changed without a `.changeset/*.md` file, validates that
 changesets name only public packages, and verifies that the fixed alpha group
 matches the product package list below.
 
+Branch protection currently requires the GitHub Actions context `full-pr`,
+shown in the pull request UI as `ci / full-pr`. The `changesets / status`
+workflow is fast release feedback unless repository settings are updated to
+require it too.
+
 Publishable paths are defined in
 [`scripts/check-changesets-status.mjs`](../scripts/check-changesets-status.mjs);
 update that script and this doc together.
@@ -29,7 +34,7 @@ update that script and this doc together.
 ## Publishable npm packages
 
 **Publishable npm packages** are the public `@zitadel/*` packages that ship
-to npm. CI checks **repo paths** (must match the script's `publishableRoots`):
+to npm. CI checks **repo paths** (must match the script's `publicPackages`):
 
 - `apps/cli/` — `@zitadel/cli`
 - `apps/server/` — `@zitadel/server`
@@ -137,6 +142,12 @@ The public packages above are in one Changesets fixed group while the repo is
 in alpha, so a version PR moves the CLI, SDKs, API packages, and server npm
 runtime together.
 
+Before manually preparing a release, validate all pending changesets with:
+
+```sh
+moon run release:changesets -- --pending --summary
+```
+
 ## Alpha prerelease mode
 
 The repo is currently in changesets **prerelease mode** with the `alpha` tag (see `.changeset/pre.json`). While in this mode:
@@ -155,7 +166,14 @@ corepack pnpm changeset version   # strips the -alpha suffix
 
 ## Publishing (npm trusted publishing / OIDC)
 
-The manual `release-prepare.yml` workflow runs the [changesets GitHub Action](https://github.com/changesets/action) to open a "Version Packages" PR aggregating pending changesets. After that PR merges and CI is green, `release-publish.yml` runs Moon release tasks, publishes npm packages with `changeset publish`, pushes server containers, and updates the product GitHub Release.
+The manual `release-prepare.yml` workflow validates all pending changesets,
+then runs the [changesets GitHub Action](https://github.com/changesets/action)
+to open a "Version Packages" PR aggregating pending changesets. It uses the
+release GitHub App token rather than the default `GITHUB_TOKEN`, so the version
+PR triggers the required `full-pr` check normally. After that PR merges and CI
+is green, `release-publish.yml` runs Moon release tasks, publishes npm packages
+with `changeset publish`, pushes server containers, and updates the product
+GitHub Release.
 
 Publishing authenticates with **npm trusted publishing (OIDC)** — there is **no `NPM_TOKEN`** secret. Before the first automated publish, a maintainer must, once per public package:
 

--- a/.changeset/design-tokens-and-ui-react.md
+++ b/.changeset/design-tokens-and-ui-react.md
@@ -1,7 +1,5 @@
 ---
 "@zitadel/components": minor
-"@zitadel/design-tokens": minor
-"@zitadel/ui-react": minor
 ---
 
 Introduce the design-token-driven foundation for the auth surface, replacing

--- a/.changeset/ordered-step-arrays.md
+++ b/.changeset/ordered-step-arrays.md
@@ -1,7 +1,6 @@
 ---
-"@zitadel/api-mock": patch
 "@zitadel/components": patch
 "@zitadel/cli": patch
 ---
 
-Step `fields` and `actions` are now ordered `[{ name, ... }]` arrays on the wire (ADR 021). Templates iterate them in authorial order; the orchestrator builds `fields_by_name` / `actions_by_name` views for keyed lookups. `gates` stays a name-keyed object for now.
+Step `fields` and `actions` are now ordered `[{ name, ... }]` arrays on the wire (ADR 021). Templates iterate them in authorial order; the orchestrator builds `fields_by_name` / `actions_by_name` views for keyed lookups. The private `@zitadel/api-mock` workspace follows the same wire shape for tests. `gates` stays a name-keyed object for now.

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -12,9 +12,17 @@ jobs:
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 20
     steps:
+      - name: Generate release app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: moonrepo/setup-toolchain@v0
 
@@ -33,11 +41,15 @@ jobs:
       - name: Validate release version source
         run: env -u CI -u GITHUB_ACTIONS moon run release:version
 
+      - name: Validate pending changesets
+        run: moon run release:changesets -- --pending --summary
+
       - name: Open or update version PR
         uses: changesets/action@v1
         with:
           version: corepack pnpm exec changeset version
           title: "build: version packages"
           commit: "build: version packages"
+          createGithubReleases: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,11 +161,14 @@ Use `moon run workspace:journey` for deterministic CI-style proof of the
 fresh-app path. Use `moon run workspace:cli -- ...` for manual browser or agent
 experiments against the same local package train.
 
-In CI the required PR checks are `changesets / status` and `ci / full-pr`.
-`ci / full-pr` consumes current workflow npm package tarballs instead of public
-Zitadel packages and exercises the default npm-binary local runtime. The Docker
-fallback journey runs in the `ci-docker-runtime` workflow on `main` and by
-manual dispatch. The checked-in demo integrations, raw binary embedded-postgres
+In CI the branch-protection check is the GitHub Actions context `full-pr`,
+shown in the pull request UI as `ci / full-pr`. It consumes current workflow
+npm package tarballs instead of public Zitadel packages and exercises the
+default npm-binary local runtime. The `changesets / status` workflow runs in
+parallel as fast release feedback, but is not a branch-protection requirement
+unless repository settings are updated. The Docker fallback journey runs in the
+`ci-docker-runtime` workflow on `main` and by manual dispatch. The checked-in
+demo integrations, raw binary embedded-postgres
 smoke, and documented quick-start compose smoke remain release-surface
 confidence checks.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@
 | Run the server from source         | `moon run workspace:server -- --help`      |
 | Test the fresh-app onboarding path | `moon run workspace:journey`               |
 | Run normal local checks            | `moon ci :lint :typecheck :build :test`    |
-| Check release notes status         | `moon run release:changesets -- --summary` |
+| Check whether a changeset is required | `moon run release:changesets -- --summary` |
 | Mirror CI locally                  | `moon run workspace:check -- --full`       |
 | Rerun one failed task              | `moon run <project>:<task>`                |
 
@@ -76,7 +76,10 @@ Moon task targets use the `<project>:<task>` form, for example
 `moon run cli:test`.
 
 Use `moon run release:changesets -- --base origin/main --summary` for the fast
-local version of the required `changesets / status` PR check.
+local version of the `changesets / status` PR feedback check. If this check
+fails because publishable package paths changed, add a real changeset with
+`corepack pnpm changeset`, or rarely an empty changeset for non-shipping
+changes.
 
 `moon run workspace:check -- --full` runs the repository's slower local
 CI-parity script, including integration tests, demo e2e, package smoke checks,

--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ server bootstrapping, and release tasks, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## CI
 
-Pull requests run two required checks in parallel. `changesets / status` gives
-fast package release feedback. `ci / full-pr` runs the Moon-driven PR
-confidence path on a 16-core Depot runner:
+Pull requests run parallel CI checks. Branch protection currently requires the
+GitHub Actions context `full-pr`, shown in the pull request UI as
+`ci / full-pr`. `changesets / status` gives fast package release feedback.
+`ci / full-pr` runs the Moon-driven PR confidence path on a 16-core Depot
+runner:
 
 - Go vet and tests.
 - pnpm install and Moon lint/typecheck/build/test tasks.
@@ -149,15 +151,23 @@ corepack pnpm changeset
 ```
 
 The manual `release-prepare.yml` workflow runs Moon release validation,
-executes `changeset version`, and opens or updates the version PR. After that
-PR is reviewed and merged, `release-publish.yml` publishes npm packages with
-Changesets, pushes the product tag and container image, and creates or updates
-the single product GitHub Release.
+preflights pending Changesets, executes `changeset version`, and opens or
+updates the version PR with the release GitHub App so the required `full-pr`
+check runs normally. After that PR is reviewed and merged,
+`release-publish.yml` publishes npm packages with Changesets, pushes the
+product tag and container image, and creates or updates the single product
+GitHub Release.
 
 Check local Changesets status with:
 
 ```sh
 moon run release:changesets -- --base origin/main --summary
+```
+
+Before manually preparing a release, validate all pending changesets with:
+
+```sh
+moon run release:changesets -- --pending --summary
 ```
 
 Follow the [manual release runbook](docs/runbooks/manual-release.md) when

--- a/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
+++ b/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 type CheckChangesetsStatusModule = {
   checkChangesetsStatus: (options: {
     base?: string;
+    pending?: boolean;
     entries: Array<{ status: string; file: string }>;
     config: { fixed: string[][] };
     changesetSources?: Record<string, string>;
@@ -19,6 +20,11 @@ type CheckChangesetsStatusModule = {
         changesets?: string[];
       }>;
     };
+    runChangesetStatus?: (options: {
+      repoRoot: string;
+      base: string;
+      pending: boolean;
+    }) => Promise<CheckChangesetStatus>;
   }) => Promise<{
     ok: boolean;
     errors: Array<{ code: string; message: string }>;
@@ -29,6 +35,20 @@ type CheckChangesetsStatusModule = {
     nextAction: string;
   }>;
   publicPackages: Array<{ name: string; root: string }>;
+};
+
+type CheckChangesetStatus = {
+  changesets?: Array<{
+    id: string;
+    releases: Array<{ name: string; type: string }>;
+  }>;
+  releases?: Array<{
+    name: string;
+    type: string;
+    oldVersion?: string;
+    newVersion?: string;
+    changesets?: string[];
+  }>;
 };
 
 async function loadModule(): Promise<CheckChangesetsStatusModule> {
@@ -104,6 +124,78 @@ Improve local start behavior.
 
     expect(report.ok).toBe(true);
     expect(report.nextAction).toContain("Changesets are present");
+  });
+
+  it("passes pending mode when public changesets are valid", async () => {
+    const { checkChangesetsStatus } = await loadModule();
+    const report = await checkChangesetsStatus({
+      pending: true,
+      entries: [{ status: "A", file: ".changeset/cli-start.md" }],
+      config: validConfig(),
+      changesetSources: {
+        ".changeset/cli-start.md": `---
+"@zitadel/cli": minor
+---
+
+Improve local start behavior.
+`,
+      },
+      changesetStatus: {
+        changesets: [
+          {
+            id: "cli-start",
+            releases: [{ name: "@zitadel/cli", type: "minor" }],
+          },
+        ],
+        releases: [
+          {
+            name: "@zitadel/cli",
+            type: "minor",
+            oldVersion: "0.1.0-alpha.5",
+            newVersion: "0.1.0-alpha.6",
+            changesets: ["cli-start"],
+          },
+        ],
+      },
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.nextAction).toContain("Changesets are present");
+  });
+
+  it("runs Changesets status in pending mode so mixed ignored package errors are visible", async () => {
+    const { checkChangesetsStatus } = await loadModule();
+    const report = await checkChangesetsStatus({
+      pending: true,
+      entries: [{ status: "A", file: ".changeset/mixed.md" }],
+      config: validConfig(),
+      changesetSources: {
+        ".changeset/mixed.md": `---
+"@zitadel/api-mock": patch
+"@zitadel/cli": patch
+---
+
+Keep private mocks aligned with public CLI behavior.
+`,
+      },
+      runChangesetStatus: async () => {
+        throw new Error("Found mixed changeset mixed: ignored @zitadel/api-mock and not ignored @zitadel/cli");
+      },
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "invalid-changeset-package",
+          message: expect.stringContaining("@zitadel/api-mock"),
+        }),
+        expect.objectContaining({
+          code: "changeset-status",
+          message: expect.stringContaining("Found mixed changeset"),
+        }),
+      ]),
+    );
   });
 
   it("rejects changesets that reference unknown or private packages", async () => {

--- a/scripts/check-changesets-status.mjs
+++ b/scripts/check-changesets-status.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { existsSync } from "node:fs";
-import { appendFile, mkdtemp, readFile, rm } from "node:fs/promises";
+import { appendFile, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -32,6 +32,7 @@ const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 export function parseArgs(args) {
   const parsed = {
     base: "origin/main",
+    pending: false,
     summary: false,
     help: false,
   };
@@ -49,6 +50,10 @@ export function parseArgs(args) {
     }
     if (arg === "--summary") {
       parsed.summary = true;
+      continue;
+    }
+    if (arg === "--pending") {
+      parsed.pending = true;
       continue;
     }
     if (arg === "--help" || arg === "-h") {
@@ -175,8 +180,9 @@ export function validateFixedGroup(config) {
 
 export async function checkChangesetsStatus(options) {
   const base = options.base ?? "origin/main";
+  const pending = options.pending ?? false;
   const root = options.repoRoot ?? repoRoot;
-  const entries = options.entries ?? (await gitChangedEntries(root, base));
+  const entries = options.entries ?? (pending ? await pendingChangesetEntries(root) : await gitChangedEntries(root, base));
   const config = options.config ?? (await readChangesetsConfig(root));
   const analysis = analyzeChangedEntries(entries);
   const errors = validateFixedGroup(config).map((message) => ({
@@ -203,11 +209,12 @@ export async function checkChangesetsStatus(options) {
       }
     }
 
-    if (!changesetStatus && !errors.some((error) => error.code === "invalid-changeset-package")) {
+    if (!changesetStatus && (pending || !errors.some((error) => error.code === "invalid-changeset-package"))) {
       try {
         changesetStatus = await (options.runChangesetStatus ?? readChangesetStatus)({
           repoRoot: root,
           base,
+          pending,
         });
       } catch (error) {
         errors.push({
@@ -230,11 +237,12 @@ export async function checkChangesetsStatus(options) {
   return {
     ok: errors.length === 0,
     base,
+    pending,
     analysis,
     errors,
     parsedChangesets,
     changesetStatus,
-    nextAction: nextAction({ analysis, errors, changesetStatus }),
+    nextAction: nextAction({ analysis, errors, changesetStatus, pending }),
   };
 }
 
@@ -270,7 +278,8 @@ export function renderStepSummary(report) {
     "# Changesets status",
     "",
     `Status: ${report.ok ? "passed" : "failed"}`,
-    `Base: \`${report.base}\``,
+    `Mode: ${report.pending ? "pending changesets" : "diff against base"}`,
+    ...(report.pending ? [] : [`Base: \`${report.base}\``]),
     "",
     "## Changed publishable paths",
     "",
@@ -342,6 +351,7 @@ export async function main(args = forwardedArgs(), options = {}) {
   const report = await checkChangesetsStatus({
     repoRoot: options.repoRoot ?? repoRoot,
     base: parsed.base,
+    pending: parsed.pending,
     entries: options.entries,
     config: options.config,
     changesetSources: options.changesetSources,
@@ -385,6 +395,14 @@ async function gitChangedEntries(root, base) {
   return [...entries.values()].sort((left, right) => left.file.localeCompare(right.file));
 }
 
+async function pendingChangesetEntries(root) {
+  const entries = await readdir(join(root, ".changeset"), { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && isChangesetMarkdown(`.changeset/${entry.name}`))
+    .map((entry) => ({ status: "A", file: `.changeset/${entry.name}` }))
+    .sort((left, right) => left.file.localeCompare(right.file));
+}
+
 async function readChangesetsConfig(root) {
   return JSON.parse(await readFile(join(root, ".changeset/config.json"), "utf8"));
 }
@@ -398,15 +416,16 @@ async function readChangesetSources(root, files) {
   return sources;
 }
 
-async function readChangesetStatus({ repoRoot: root, base }) {
+async function readChangesetStatus({ repoRoot: root, base, pending }) {
   const dir = await mkdtemp(join(tmpdir(), "zitadel-changesets-"));
   const output = join(dir, "status.json");
+  const args = ["pnpm", "exec", "changeset", "status"];
+  if (!pending) {
+    args.push("--since", base);
+  }
+  args.push("--output", output);
   try {
-    await runCapture(
-      "corepack",
-      ["pnpm", "exec", "changeset", "status", "--since", base, "--output", output],
-      { cwd: root },
-    );
+    await runCapture("corepack", args, { cwd: root });
     return JSON.parse(await readFile(output, "utf8"));
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
@@ -441,7 +460,7 @@ function groupPublishableEntries(entries) {
   return groups;
 }
 
-function nextAction({ analysis, errors, changesetStatus }) {
+function nextAction({ analysis, errors, changesetStatus, pending }) {
   if (errors.some((error) => error.code === "missing-changeset")) {
     return "Add a real changeset with `corepack pnpm changeset`, or rarely add an empty changeset if no published behavior changes.";
   }
@@ -456,6 +475,9 @@ function nextAction({ analysis, errors, changesetStatus }) {
   }
   if (analysis.versionOnly) {
     return "Version PR output detected. Merge after CI is green, then run the manual publish workflow.";
+  }
+  if (pending && analysis.currentChangesetFiles.length === 0) {
+    return "No pending changesets found.";
   }
   if (analysis.currentChangesetFiles.length > 0 && changesetStatus) {
     return "Changesets are present and Changesets can calculate the planned alpha product bump.";
@@ -472,9 +494,10 @@ function escapeMarkdown(value) {
 }
 
 function printUsage() {
-  console.log(`Usage: node scripts/check-changesets-status.mjs [--base <ref>] [--summary]
+  console.log(`Usage: node scripts/check-changesets-status.mjs [--base <ref>] [--pending] [--summary]
 
 Checks whether the current diff has valid Changesets coverage for public packages.
+Use --pending to validate all current pending .changeset/*.md files before release prepare.
 `);
 }
 


### PR DESCRIPTION
## Summary

- Restore release app token usage in `release-prepare.yml` so the generated Version Packages PR triggers the required `full-pr` check.
- Add a pending Changesets preflight mode and run it before `changesets/action`.
- Remove private/ignored package names from pending changeset frontmatter while keeping the private-package impact in prose.
- Clarify docs around `full-pr` branch protection versus `changesets / status` feedback.

## Validation

- `corepack pnpm exec oxlint scripts/check-changesets-status.mjs apps/cli/tests/unit/scripts/check-changesets-status.test.ts`
- `corepack pnpm --filter @zitadel/cli exec vitest run tests/unit/scripts/check-changesets-status.test.ts`
- `corepack pnpm exec changeset status --output /tmp/nextgen-changeset-status.json`
- `moon run release:changesets -- --pending --summary`
- `moon run release:changesets -- --base origin/main --summary`
- `moon run release:version`
- `git diff --check`

## Release notes / changeset

No new changeset required — no published package behavior changes. This PR changes release workflow/docs and a package-internal unit test, and corrects existing pending changeset frontmatter so private workspaces are described only in prose.

## Notes

npm Trusted Publisher settings still need to trust `release-publish.yml` for each public package if they currently point at `ci.yml`.
