### PR TITLE
ci: automate changesets release flow

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -142,7 +142,8 @@ The public packages above are in one Changesets fixed group while the repo is
 in alpha, so a version PR moves the CLI, SDKs, API packages, and server npm
 runtime together.
 
-Before manually preparing a release, validate all pending changesets with:
+Before forcing release preparation manually, validate all pending changesets
+with:
 
 ```sh
 moon run release:changesets -- --pending --summary
@@ -166,14 +167,16 @@ corepack pnpm changeset version   # strips the -alpha suffix
 
 ## Publishing (npm trusted publishing / OIDC)
 
-The manual `release-prepare.yml` workflow validates all pending changesets,
-then runs the [changesets GitHub Action](https://github.com/changesets/action)
-to open a "Version Packages" PR aggregating pending changesets. It uses the
-release GitHub App token rather than the default `GITHUB_TOKEN`, so the version
-PR triggers the required `full-pr` check normally. After that PR merges and CI
-is green, `release-publish.yml` runs Moon release tasks, publishes npm packages
-with `changeset publish`, pushes server containers, and updates the product
-GitHub Release.
+When pending changesets are merged to `main`, `release-prepare.yml` validates
+them, then runs the [changesets GitHub Action](https://github.com/changesets/action)
+to open or update a "Version Packages" PR aggregating pending changesets. It
+uses the release GitHub App token rather than the default `GITHUB_TOKEN`, so the
+version PR triggers the required `full-pr` check normally. After that PR merges
+and CI is green, `release-publish.yml` automatically runs Moon release tasks,
+publishes npm packages with `changeset publish`, pushes server containers, and
+updates the product GitHub Release. Manual workflow dispatch remains available
+for retrying prepare, dry-running publish, or recovering from external registry
+problems.
 
 Publishing authenticates with **npm trusted publishing (OIDC)** — there is **no `NPM_TOKEN`** secret. Before the first automated publish, a maintainer must, once per public package:
 

--- a/.changeset/automate-release-workflows.md
+++ b/.changeset/automate-release-workflows.md
@@ -1,0 +1,4 @@
+---
+---
+
+Automate release prepare and publish workflow triggering without changing published package behavior.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -36,6 +36,12 @@ jobs:
         run: corepack pnpm install --frozen-lockfile
 
       - name: Check Changesets status
-        run: moon run release:changesets -- --base "$BASE_REF" --summary
+        run: |
+          args=(--base "$BASE_REF" --summary)
+          if [[ "$VERSION_PR" == "true" ]]; then
+            args+=(--version-pr)
+          fi
+          moon run release:changesets -- "${args[@]}"
         env:
           BASE_REF: ${{ github.event.pull_request.base.sha || 'origin/main' }}
+          VERSION_PR: ${{ startsWith(github.head_ref || github.ref_name, 'changeset-release/') }}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,11 +1,18 @@
 name: release-prepare
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: release-prepare
+  cancel-in-progress: false
 
 jobs:
   prepare:
@@ -24,27 +31,38 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Detect pending changesets
+        id: release-prepare
+        run: node scripts/release-automation.mjs prepare --summary
+
       - uses: moonrepo/setup-toolchain@v0
+        if: ${{ steps.release-prepare.outputs.should_run == 'true' }}
 
       - uses: pnpm/action-setup@v5
+        if: ${{ steps.release-prepare.outputs.should_run == 'true' }}
         with:
           run_install: false
 
       - uses: actions/setup-node@v6
+        if: ${{ steps.release-prepare.outputs.should_run == 'true' }}
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
+        if: ${{ steps.release-prepare.outputs.should_run == 'true' }}
         run: corepack pnpm install --frozen-lockfile
 
       - name: Validate release version source
+        if: ${{ steps.release-prepare.outputs.should_run == 'true' }}
         run: env -u CI -u GITHUB_ACTIONS moon run release:version
 
       - name: Validate pending changesets
+        if: ${{ steps.release-prepare.outputs.should_run == 'true' }}
         run: moon run release:changesets -- --pending --summary
 
       - name: Open or update version PR
+        if: ${{ steps.release-prepare.outputs.should_run == 'true' }}
         uses: changesets/action@v1
         with:
           version: corepack pnpm exec changeset version

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,6 +1,9 @@
 name: release-publish
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       dry_run:
@@ -14,14 +17,38 @@ permissions:
   packages: write
   id-token: write
 
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
 jobs:
+  detect:
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 10
+    outputs:
+      should_run: ${{ steps.release-publish.outputs.should_run }}
+      reason: ${{ steps.release-publish.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'push' && github.sha || 'main' }}
+          fetch-depth: 0
+
+      - name: Detect release publish
+        id: release-publish
+        run: node scripts/release-automation.mjs publish --base "$BASE_SHA" --summary
+        env:
+          BASE_SHA: ${{ github.event.before || 'HEAD^' }}
+
   publish:
+    needs: detect
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect.outputs.should_run == 'true' }}
     runs-on: depot-ubuntu-24.04-16
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.event_name == 'push' && github.sha || 'main' }}
           fetch-depth: 0
 
       - uses: moonrepo/setup-toolchain@v0
@@ -45,8 +72,15 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
+      - name: Validate manual publish target
+        if: ${{ github.event_name == 'workflow_dispatch' && ! inputs.dry_run && needs.detect.outputs.should_run != 'true' }}
+        run: |
+          echo "Manual publish can only run from a Changesets version package commit."
+          echo "Detector reason: ${{ needs.detect.outputs.reason }}"
+          exit 1
+
       - name: Login to GHCR
-        if: ${{ ! inputs.dry_run }}
+        if: ${{ github.event_name == 'push' || (! inputs.dry_run && needs.detect.outputs.should_run == 'true') }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -57,14 +91,14 @@ jobs:
         run: corepack pnpm install --frozen-lockfile
 
       - name: Publish dry run
-        if: ${{ inputs.dry_run }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: env -u CI -u GITHUB_ACTIONS moon run release:publish -- --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "false"
 
       - name: Publish release
-        if: ${{ ! inputs.dry_run }}
+        if: ${{ github.event_name == 'push' || (! inputs.dry_run && needs.detect.outputs.should_run == 'true') }}
         run: env -u CI -u GITHUB_ACTIONS moon run release:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ release metadata.
 # Local snapshot without publishing
 moon run release:snapshot
 
-# Dry-run the manual publish graph
+# Dry-run the publish graph
 moon run release:publish -- --dry-run
 ```
 
@@ -150,13 +150,13 @@ user-visible change to those packages:
 corepack pnpm changeset
 ```
 
-The manual `release-prepare.yml` workflow runs Moon release validation,
-preflights pending Changesets, executes `changeset version`, and opens or
-updates the version PR with the release GitHub App so the required `full-pr`
-check runs normally. After that PR is reviewed and merged,
-`release-publish.yml` publishes npm packages with Changesets, pushes the
-product tag and container image, and creates or updates the single product
-GitHub Release.
+When pending changesets land on `main`, `release-prepare.yml` runs Moon release
+validation, preflights pending Changesets, executes `changeset version`, and
+opens or updates the version PR with the release GitHub App so the required
+`full-pr` check runs normally. After that PR is reviewed and merged,
+`release-publish.yml` automatically publishes npm packages with Changesets,
+pushes the product tag and container image, and creates or updates the single
+product GitHub Release.
 
 Check local Changesets status with:
 
@@ -164,14 +164,15 @@ Check local Changesets status with:
 moon run release:changesets -- --base origin/main --summary
 ```
 
-Before manually preparing a release, validate all pending changesets with:
+Before forcing release preparation manually, validate all pending changesets
+with:
 
 ```sh
 moon run release:changesets -- --pending --summary
 ```
 
-Follow the [manual release runbook](docs/runbooks/manual-release.md) when
-cutting a release.
+Follow the [release runbook](docs/runbooks/manual-release.md) when cutting or
+recovering a release.
 
 Release process checks can be run locally with:
 

--- a/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
+++ b/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
@@ -403,6 +403,20 @@ describe("release-automation", () => {
     expect(result.shouldRun).toBe(false);
   });
 
+  it("skips publish for version package commits with only empty changeset output", async () => {
+    const { detectReleaseAutomation } = await loadReleaseAutomationModule();
+    const result = await detectReleaseAutomation({
+      mode: "publish",
+      message: "build: version packages (alpha)\n",
+      pendingChangesets: [],
+      entries: [{ status: "D", file: ".changeset/release-tests.md" }],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.shouldRun).toBe(false);
+    expect(result.reason).toContain("no publishable package version output");
+  });
+
   it("fails publish when a version package commit changes non-version files", async () => {
     const { detectReleaseAutomation } = await loadReleaseAutomationModule();
     const result = await detectReleaseAutomation({

--- a/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
+++ b/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
@@ -4,6 +4,7 @@ type CheckChangesetsStatusModule = {
   checkChangesetsStatus: (options: {
     base?: string;
     pending?: boolean;
+    versionPr?: boolean;
     entries: Array<{ status: string; file: string }>;
     config: { fixed: string[][] };
     changesetSources?: Record<string, string>;
@@ -37,6 +38,22 @@ type CheckChangesetsStatusModule = {
   publicPackages: Array<{ name: string; root: string }>;
 };
 
+type ReleaseAutomationModule = {
+  detectReleaseAutomation: (options: {
+    mode: "prepare" | "publish";
+    base?: string;
+    entries?: Array<{ status: string; file: string }>;
+    message?: string;
+    pendingChangesets?: string[];
+  }) => Promise<{
+    ok: boolean;
+    shouldRun: boolean;
+    reason: string;
+    errors: string[];
+  }>;
+  isVersionPackageCommit: (message: string) => boolean;
+};
+
 type CheckChangesetStatus = {
   changesets?: Array<{
     id: string;
@@ -55,6 +72,12 @@ async function loadModule(): Promise<CheckChangesetsStatusModule> {
   return (await import(
     new URL("../../../../../scripts/check-changesets-status.mjs", import.meta.url).href
   )) as CheckChangesetsStatusModule;
+}
+
+async function loadReleaseAutomationModule(): Promise<ReleaseAutomationModule> {
+  return (await import(
+    new URL("../../../../../scripts/release-automation.mjs", import.meta.url).href
+  )) as ReleaseAutomationModule;
 }
 
 describe("check-changesets-status", () => {
@@ -124,6 +147,27 @@ Improve local start behavior.
 
     expect(report.ok).toBe(true);
     expect(report.nextAction).toContain("Changesets are present");
+  });
+
+  it("passes when an empty changeset covers non-shipping publishable path changes", async () => {
+    const { checkChangesetsStatus } = await loadModule();
+    const report = await checkChangesetsStatus({
+      entries: [
+        { status: "M", file: "apps/cli/tests/unit/scripts/check-changesets-status.test.ts" },
+        { status: "A", file: ".changeset/release-tests.md" },
+      ],
+      config: validConfig(),
+      changesetSources: {
+        ".changeset/release-tests.md": `---
+---
+
+Exercise release workflow scripts without changing published package behavior.
+`,
+      },
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.nextAction).toContain("Empty changeset");
   });
 
   it("passes pending mode when public changesets are valid", async () => {
@@ -259,6 +303,123 @@ This package is private.
     expect(report.ok).toBe(true);
     expect(report.analysis.versionOnly).toBe(true);
     expect(report.nextAction).toContain("Version PR output detected");
+  });
+
+  it("passes generated version PR output without deleted changeset files in version PR mode", async () => {
+    const { checkChangesetsStatus } = await loadModule();
+    const report = await checkChangesetsStatus({
+      versionPr: true,
+      entries: [
+        { status: "M", file: ".changeset/pre.json" },
+        { status: "M", file: "apps/cli/package.json" },
+        { status: "M", file: "apps/cli/CHANGELOG.md" },
+        { status: "M", file: "packages/sdk-core/package.json" },
+        { status: "M", file: "packages/sdk-core/CHANGELOG.md" },
+      ],
+      config: validConfig(),
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.analysis.versionOnly).toBe(true);
+    expect(report.nextAction).toContain("Version PR output detected");
+  });
+
+  it("does not treat package and changelog edits as version output outside version PR mode", async () => {
+    const { checkChangesetsStatus } = await loadModule();
+    const report = await checkChangesetsStatus({
+      entries: [
+        { status: "M", file: "apps/cli/package.json" },
+        { status: "M", file: "apps/cli/CHANGELOG.md" },
+      ],
+      config: validConfig(),
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.analysis.versionOnly).toBe(false);
+    expect(report.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "missing-changeset",
+        }),
+      ]),
+    );
+  });
+});
+
+describe("release-automation", () => {
+  it("runs prepare when pending changesets exist", async () => {
+    const { detectReleaseAutomation } = await loadReleaseAutomationModule();
+    const result = await detectReleaseAutomation({
+      mode: "prepare",
+      pendingChangesets: [".changeset/cli-start.md"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.shouldRun).toBe(true);
+    expect(result.reason).toContain("pending changeset");
+  });
+
+  it("skips prepare when no pending changesets exist", async () => {
+    const { detectReleaseAutomation } = await loadReleaseAutomationModule();
+    const result = await detectReleaseAutomation({
+      mode: "prepare",
+      pendingChangesets: [],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.shouldRun).toBe(false);
+  });
+
+  it("runs publish for a valid Changesets version package commit", async () => {
+    const { detectReleaseAutomation } = await loadReleaseAutomationModule();
+    const result = await detectReleaseAutomation({
+      mode: "publish",
+      message: "build: version packages (alpha)\n",
+      pendingChangesets: [],
+      entries: [
+        { status: "M", file: ".changeset/pre.json" },
+        { status: "M", file: "apps/cli/package.json" },
+        { status: "M", file: "apps/cli/CHANGELOG.md" },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.shouldRun).toBe(true);
+  });
+
+  it("skips publish for ordinary main commits", async () => {
+    const { detectReleaseAutomation } = await loadReleaseAutomationModule();
+    const result = await detectReleaseAutomation({
+      mode: "publish",
+      message: "feat: update cli start\n",
+      pendingChangesets: [],
+      entries: [
+        { status: "M", file: "apps/cli/src/commands/start.ts" },
+        { status: "A", file: ".changeset/cli-start.md" },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.shouldRun).toBe(false);
+  });
+
+  it("fails publish when a version package commit changes non-version files", async () => {
+    const { detectReleaseAutomation } = await loadReleaseAutomationModule();
+    const result = await detectReleaseAutomation({
+      mode: "publish",
+      message: "build: version packages (alpha)\n",
+      pendingChangesets: [],
+      entries: [
+        { status: "M", file: "apps/cli/package.json" },
+        { status: "M", file: "docs/release.md" },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.shouldRun).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining("outside Changesets version output")]),
+    );
   });
 });
 

--- a/docs/adrs/002-multi-package-release-strategy.md
+++ b/docs/adrs/002-multi-package-release-strategy.md
@@ -24,6 +24,12 @@ Release orchestration is split by responsibility:
 Nx and GoReleaser are retired dependencies. They are not part of the target CI
 or release path.
 
+Release execution is automatic after review. When pending changesets land on
+`main`, the prepare workflow opens or updates the Changesets version PR. Merging
+that reviewed version PR is the release approval; the publish workflow then runs
+from the version commit on `main` and performs the npm, container, product tag,
+and GitHub Release steps with idempotent guards.
+
 ## Context
 
 This monorepo contains different release surfaces:

--- a/docs/runbooks/manual-release.md
+++ b/docs/runbooks/manual-release.md
@@ -1,28 +1,35 @@
-# Manual Release Runbook
+# Release Runbook
 
 This repo uses Moon for CI/build orchestration, server artifacts, and the
 product GitHub Release. Changesets owns package versioning, changelogs, npm
 publishing, and public package tags.
 
-## Prepare a version PR
+## Normal release
 
 1. Make sure every user-visible public package or product change has a
    `.changeset/*.md`.
-2. Run the manual `release-prepare` workflow.
-3. Review the generated version PR. It should update package versions,
+2. Merge those changes to `main`.
+3. `release-prepare` runs automatically, validates pending changesets, and
+   opens or updates the generated version PR.
+4. Review the generated version PR. It should update package versions,
    changelogs, and the `@zitadel/server` npm runtime version. The version PR
    should not create the product GitHub Release; `release-publish` does that
    from the reviewed fixed package version.
-4. Merge the version PR only after split CI is green.
+5. Merge the version PR only after CI is green.
+6. `release-publish` runs automatically from that merge commit on `main`,
+   publishes npm packages, pushes containers, creates the product tag, and
+   creates or updates the GitHub Release.
 
-## Publish
+## Manual controls
 
-1. Run `release-publish` from `main` with `dry_run=true`.
-2. Confirm the dry run builds server archives, checksums, npm tarballs, and
-   Docker metadata.
-3. Run `release-publish` again with `dry_run=false`.
-4. Verify npm packages, `ghcr.io/zitadel/nextgen:<version>`, the product
-   `v<version>` tag, and the GitHub Release.
+- Run `release-prepare` manually when automation needs to be retried. It
+  no-ops when there are no pending `.changeset/*.md` files.
+- Run `release-publish` manually with `dry_run=true` to build and verify server
+  archives, checksums, npm tarballs, and Docker metadata without publishing.
+- Run `release-publish` manually with `dry_run=false` only to retry a publish
+  from the current `main` version commit.
+- Verify npm packages, `ghcr.io/zitadel/nextgen:<version>`, the product
+  `v<version>` tag, and the GitHub Release after publish.
 
 ## Recover
 

--- a/scripts/check-changesets-status.mjs
+++ b/scripts/check-changesets-status.mjs
@@ -116,6 +116,7 @@ export function analyzeChangedEntries(entries, options = {}) {
     deletedChangesetFiles,
     publishableEntries,
     changedPackages,
+    versionOutputOnly,
     versionOnly,
   };
 }

--- a/scripts/check-changesets-status.mjs
+++ b/scripts/check-changesets-status.mjs
@@ -34,6 +34,7 @@ export function parseArgs(args) {
     base: "origin/main",
     pending: false,
     summary: false,
+    versionPr: false,
     help: false,
   };
 
@@ -54,6 +55,10 @@ export function parseArgs(args) {
     }
     if (arg === "--pending") {
       parsed.pending = true;
+      continue;
+    }
+    if (arg === "--version-pr") {
+      parsed.versionPr = true;
       continue;
     }
     if (arg === "--help" || arg === "-h") {
@@ -84,7 +89,7 @@ export function parseNameStatus(output) {
     });
 }
 
-export function analyzeChangedEntries(entries) {
+export function analyzeChangedEntries(entries, options = {}) {
   const changedFiles = entries.map((entry) => entry.file);
   const currentChangesetFiles = entries
     .filter((entry) => entry.status !== "D" && isChangesetMarkdown(entry.file))
@@ -96,11 +101,14 @@ export function analyzeChangedEntries(entries) {
     .map((entry) => ({ ...entry, pkg: packageForFile(entry.file) }))
     .filter((entry) => entry.pkg);
   const changedPackages = groupPublishableEntries(publishableEntries);
-  const versionOnly =
+  const versionOutputOnly =
     entries.length > 0 &&
     currentChangesetFiles.length === 0 &&
-    deletedChangesetFiles.length > 0 &&
     entries.every((entry) => isVersionOutputFile(entry.file));
+  const versionOnly =
+    versionOutputOnly &&
+    publishableEntries.length > 0 &&
+    (deletedChangesetFiles.length > 0 || options.versionPr === true);
 
   return {
     changedFiles,
@@ -181,10 +189,11 @@ export function validateFixedGroup(config) {
 export async function checkChangesetsStatus(options) {
   const base = options.base ?? "origin/main";
   const pending = options.pending ?? false;
+  const versionPr = options.versionPr ?? false;
   const root = options.repoRoot ?? repoRoot;
   const entries = options.entries ?? (pending ? await pendingChangesetEntries(root) : await gitChangedEntries(root, base));
   const config = options.config ?? (await readChangesetsConfig(root));
-  const analysis = analyzeChangedEntries(entries);
+  const analysis = analyzeChangedEntries(entries, { versionPr });
   const errors = validateFixedGroup(config).map((message) => ({
     code: "fixed-group",
     message,
@@ -209,7 +218,12 @@ export async function checkChangesetsStatus(options) {
       }
     }
 
-    if (!changesetStatus && (pending || !errors.some((error) => error.code === "invalid-changeset-package"))) {
+    const hasPackageChangeset = parsedChangesets.some((changeset) => changeset.packages.length > 0);
+    if (
+      hasPackageChangeset &&
+      !changesetStatus &&
+      (pending || !errors.some((error) => error.code === "invalid-changeset-package"))
+    ) {
       try {
         changesetStatus = await (options.runChangesetStatus ?? readChangesetStatus)({
           repoRoot: root,
@@ -238,11 +252,12 @@ export async function checkChangesetsStatus(options) {
     ok: errors.length === 0,
     base,
     pending,
+    versionPr,
     analysis,
     errors,
     parsedChangesets,
     changesetStatus,
-    nextAction: nextAction({ analysis, errors, changesetStatus, pending }),
+    nextAction: nextAction({ analysis, errors, changesetStatus, pending, parsedChangesets }),
   };
 }
 
@@ -279,6 +294,7 @@ export function renderStepSummary(report) {
     "",
     `Status: ${report.ok ? "passed" : "failed"}`,
     `Mode: ${report.pending ? "pending changesets" : "diff against base"}`,
+    `Version PR: ${report.versionPr ? "yes" : "no"}`,
     ...(report.pending ? [] : [`Base: \`${report.base}\``]),
     "",
     "## Changed publishable paths",
@@ -352,6 +368,7 @@ export async function main(args = forwardedArgs(), options = {}) {
     repoRoot: options.repoRoot ?? repoRoot,
     base: parsed.base,
     pending: parsed.pending,
+    versionPr: parsed.versionPr,
     entries: options.entries,
     config: options.config,
     changesetSources: options.changesetSources,
@@ -460,7 +477,7 @@ function groupPublishableEntries(entries) {
   return groups;
 }
 
-function nextAction({ analysis, errors, changesetStatus, pending }) {
+function nextAction({ analysis, errors, changesetStatus, pending, parsedChangesets }) {
   if (errors.some((error) => error.code === "missing-changeset")) {
     return "Add a real changeset with `corepack pnpm changeset`, or rarely add an empty changeset if no published behavior changes.";
   }
@@ -474,7 +491,13 @@ function nextAction({ analysis, errors, changesetStatus, pending }) {
     return "Fix the Changesets status errors above, then rerun this check.";
   }
   if (analysis.versionOnly) {
-    return "Version PR output detected. Merge after CI is green, then run the manual publish workflow.";
+    return "Version PR output detected. Merge after CI is green; release-publish will run automatically from main.";
+  }
+  if (
+    analysis.currentChangesetFiles.length > 0 &&
+    parsedChangesets.every((changeset) => changeset.packages.length === 0)
+  ) {
+    return "Empty changeset is present for non-shipping publishable path changes.";
   }
   if (pending && analysis.currentChangesetFiles.length === 0) {
     return "No pending changesets found.";
@@ -494,10 +517,11 @@ function escapeMarkdown(value) {
 }
 
 function printUsage() {
-  console.log(`Usage: node scripts/check-changesets-status.mjs [--base <ref>] [--pending] [--summary]
+  console.log(`Usage: node scripts/check-changesets-status.mjs [--base <ref>] [--pending] [--version-pr] [--summary]
 
 Checks whether the current diff has valid Changesets coverage for public packages.
 Use --pending to validate all current pending .changeset/*.md files before release prepare.
+Use --version-pr only for generated Changesets Version Packages PRs.
 `);
 }
 

--- a/scripts/release-automation.mjs
+++ b/scripts/release-automation.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+import { appendFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { analyzeChangedEntries, parseNameStatus } from "./check-changesets-status.mjs";
+import { forwardedArgs, isDirectRun, runCapture } from "./dev-process.mjs";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+
+export function parseArgs(args) {
+  const parsed = {
+    mode: args[0] ?? "",
+    base: "HEAD^",
+    message: "",
+    summary: false,
+    help: false,
+  };
+
+  for (let index = 1; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--base") {
+      const value = args[index + 1];
+      if (!value) {
+        throw new Error("--base requires a value");
+      }
+      parsed.base = value;
+      index += 1;
+      continue;
+    }
+    if (arg === "--message") {
+      parsed.message = args[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--summary") {
+      parsed.summary = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  return parsed;
+}
+
+export async function detectReleaseAutomation(options) {
+  const mode = options.mode;
+  const root = options.repoRoot ?? repoRoot;
+  const pendingChangesets = options.pendingChangesets ?? (await readPendingChangesets(root));
+
+  if (mode === "prepare") {
+    return {
+      ok: true,
+      mode,
+      shouldRun: pendingChangesets.length > 0,
+      reason:
+        pendingChangesets.length > 0
+          ? `found ${pendingChangesets.length} pending changeset file(s)`
+          : "no pending changeset files",
+      pendingChangesets,
+      changedFiles: [],
+      errors: [],
+    };
+  }
+
+  if (mode !== "publish") {
+    throw new Error(`unknown release automation mode: ${mode || "(empty)"}`);
+  }
+
+  const base = normalizeBase(options.base ?? "HEAD^");
+  const entries = options.entries ?? (await gitChangedEntries(root, base));
+  const analysis = analyzeChangedEntries(entries, { versionPr: true });
+  const message = options.message ?? (await readHeadCommitMessage(root));
+  const versionCommit = isVersionPackageCommit(message);
+  const errors = [];
+
+  if (versionCommit && pendingChangesets.length > 0) {
+    errors.push(`version package commit still has pending changesets: ${pendingChangesets.join(", ")}`);
+  }
+  if (versionCommit && !analysis.versionOnly) {
+    errors.push("version package commit changed files outside Changesets version output");
+  }
+
+  const shouldRun = versionCommit && pendingChangesets.length === 0 && analysis.versionOnly;
+  return {
+    ok: errors.length === 0,
+    mode,
+    shouldRun,
+    reason: publishReason({ versionCommit, pendingChangesets, analysis, errors }),
+    base,
+    message,
+    pendingChangesets,
+    changedFiles: analysis.changedFiles,
+    errors,
+  };
+}
+
+export function isVersionPackageCommit(message) {
+  return message
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .some((line) => /^build: version packages(?:\s|\(|$)/.test(line));
+}
+
+export function renderStepSummary(result) {
+  const lines = [
+    "# Release automation",
+    "",
+    `Mode: ${result.mode}`,
+    `Should run: ${result.shouldRun ? "yes" : "no"}`,
+    `Reason: ${result.reason}`,
+    "",
+  ];
+
+  if (result.pendingChangesets.length > 0) {
+    lines.push("## Pending changesets", "");
+    for (const file of result.pendingChangesets) {
+      lines.push(`- \`${file}\``);
+    }
+    lines.push("");
+  }
+
+  if (result.changedFiles.length > 0) {
+    lines.push("## Changed files", "");
+    for (const file of result.changedFiles.slice(0, 30)) {
+      lines.push(`- \`${file}\``);
+    }
+    if (result.changedFiles.length > 30) {
+      lines.push(`- and ${result.changedFiles.length - 30} more`);
+    }
+    lines.push("");
+  }
+
+  if (result.errors.length > 0) {
+    lines.push("## Errors", "");
+    for (const error of result.errors) {
+      lines.push(`- ${error}`);
+    }
+    lines.push("");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export async function main(args = forwardedArgs(), options = {}) {
+  const parsed = parseArgs(args);
+  if (parsed.help) {
+    printUsage();
+    return 0;
+  }
+
+  const result = await detectReleaseAutomation({
+    repoRoot: options.repoRoot ?? repoRoot,
+    mode: parsed.mode,
+    base: parsed.base,
+    message: parsed.message || undefined,
+    entries: options.entries,
+    pendingChangesets: options.pendingChangesets,
+  });
+
+  await writeOutputs(result, options.outputPath ?? process.env.GITHUB_OUTPUT);
+  const summary = renderStepSummary(result);
+  if (parsed.summary) {
+    await writeSummary(summary, options.summaryPath ?? process.env.GITHUB_STEP_SUMMARY);
+  }
+
+  if (!result.ok) {
+    console.error(`release ${result.mode} automation: failed - ${result.reason}`);
+    for (const error of result.errors) {
+      console.error(`- ${error}`);
+    }
+    return 1;
+  }
+
+  console.log(`release ${result.mode} automation: ${result.shouldRun ? "run" : "skip"} - ${result.reason}`);
+  return 0;
+}
+
+async function readPendingChangesets(root) {
+  const entries = await readdir(join(root, ".changeset"), { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "README.md")
+    .map((entry) => `.changeset/${entry.name}`)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+async function gitChangedEntries(root, base) {
+  const range = `${normalizeBase(base)}..HEAD`;
+  const output = await runCapture("git", ["diff", "--name-status", range], { cwd: root });
+  return parseNameStatus(output.stdout);
+}
+
+async function readHeadCommitMessage(root) {
+  const output = await runCapture("git", ["log", "-1", "--pretty=%B"], { cwd: root });
+  return output.stdout;
+}
+
+async function writeOutputs(result, outputPath) {
+  if (!outputPath) {
+    return;
+  }
+  const lines = [
+    `should_run=${result.shouldRun ? "true" : "false"}`,
+    `reason=${sanitizeOutput(result.reason)}`,
+  ];
+  if (result.base) {
+    lines.push(`base=${sanitizeOutput(result.base)}`);
+  }
+  await appendFile(outputPath, `${lines.join("\n")}\n`);
+}
+
+async function writeSummary(summary, summaryPath) {
+  if (summaryPath) {
+    await appendFile(summaryPath, summary);
+    return;
+  }
+  console.log(summary);
+}
+
+function publishReason({ versionCommit, pendingChangesets, analysis, errors }) {
+  if (errors.length > 0) {
+    return "release commit preflight failed";
+  }
+  if (!versionCommit) {
+    return "latest commit is not a Changesets version package commit";
+  }
+  if (pendingChangesets.length > 0) {
+    return "pending changesets remain";
+  }
+  if (!analysis.versionOnly) {
+    return "diff is not generated version output";
+  }
+  return "Changesets version package commit detected";
+}
+
+function normalizeBase(base) {
+  if (!base || /^0+$/.test(base)) {
+    return "HEAD^";
+  }
+  return base;
+}
+
+function sanitizeOutput(value) {
+  return String(value).replace(/\r?\n/g, " ");
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/release-automation.mjs <prepare|publish> [--base <ref>] [--message <text>] [--summary]
+
+Detects whether automatic release prepare or publish should run for the current checkout.
+`);
+}
+
+if (isDirectRun(import.meta.url)) {
+  main().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    },
+  );
+}

--- a/scripts/release-automation.mjs
+++ b/scripts/release-automation.mjs
@@ -81,7 +81,7 @@ export async function detectReleaseAutomation(options) {
   if (versionCommit && pendingChangesets.length > 0) {
     errors.push(`version package commit still has pending changesets: ${pendingChangesets.join(", ")}`);
   }
-  if (versionCommit && !analysis.versionOnly) {
+  if (versionCommit && !analysis.versionOutputOnly) {
     errors.push("version package commit changed files outside Changesets version output");
   }
 
@@ -232,7 +232,7 @@ function publishReason({ versionCommit, pendingChangesets, analysis, errors }) {
     return "pending changesets remain";
   }
   if (!analysis.versionOnly) {
-    return "diff is not generated version output";
+    return "version package commit has no publishable package version output";
   }
   return "Changesets version package commit detected";
 }


### PR DESCRIPTION
## Summary

- make `release-prepare` run automatically on pushes to `main`, with a cheap no-op when no pending `.changeset/*.md` files exist
- make `release-publish` run automatically after a merged Changesets Version Packages commit, while keeping manual dry-run/retry dispatches
- fix `changesets / status` so generated `changeset-release/*` version PRs pass without pending markdown changeset files, and so empty changesets satisfy non-shipping publishable-path changes
- update the release docs/runbook to say the Version Packages PR merge is the release approval

## Validation

- `corepack pnpm exec oxlint scripts/check-changesets-status.mjs scripts/release-automation.mjs apps/cli/tests/unit/scripts/check-changesets-status.test.ts`
- `corepack pnpm --filter @zitadel/cli exec vitest run tests/unit/scripts/check-changesets-status.test.ts`
- `moon run release:changesets -- --base origin/main --summary`
- `moon run release:changesets -- --pending --summary`
- `node scripts/release-automation.mjs prepare --summary`
- `node scripts/release-automation.mjs publish --base origin/main --summary`
- `git diff --check`

`actionlint` is not installed locally, so workflow syntax was not checked with actionlint.

## Release notes / changeset

Empty changeset: `.changeset/automate-release-workflows.md`.

This PR touches `apps/cli/tests/...` to cover release workflow scripts, but does not change published package behavior or require a package bump.

## Notes

- npm Trusted Publisher settings should continue to point at `.github/workflows/release-publish.yml`; that filename remains the publishing workflow.
- Manual `release-publish` with `dry_run=false` now refuses to run unless the current `main` commit is detected as a Changesets Version Packages commit.
