### PR TITLE
ci: fix prerelease release automation

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -154,6 +154,8 @@ moon run release:changesets -- --pending --summary
 The repo is currently in changesets **prerelease mode** with the `alpha` tag (see `.changeset/pre.json`). While in this mode:
 
 - `changeset version` cuts versions like `0.1.0-alpha.0`, `0.1.0-alpha.1`, …
+- Pending `.changeset/*.md` files remain in the tree after versioning; consumed
+  changesets are recorded in `.changeset/pre.json`.
 - Public product packages are versioned together through the fixed group.
 - `changeset publish` publishes public npm packages under the **`alpha`** npm dist-tag while prerelease mode is active.
 - A package that has never had a stable release is published to `latest` on its first publish (changesets behaviour), then to `alpha` thereafter until it has a stable release.

--- a/.changeset/prerelease-release-automation.md
+++ b/.changeset/prerelease-release-automation.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix prerelease release automation without changing published package behavior.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -11,6 +11,11 @@ on:
         required: true
         default: true
         type: boolean
+      retry_current_version:
+        description: "Allow a real manual retry for the current already-versioned main commit."
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -73,14 +78,15 @@ jobs:
       - uses: docker/setup-buildx-action@v4
 
       - name: Validate manual publish target
-        if: ${{ github.event_name == 'workflow_dispatch' && ! inputs.dry_run && needs.detect.outputs.should_run != 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && ! inputs.dry_run && ! inputs.retry_current_version && needs.detect.outputs.should_run != 'true' }}
         run: |
           echo "Manual publish can only run from a Changesets version package commit."
+          echo "For failed-publish recovery of the already-versioned current main commit, set retry_current_version=true."
           echo "Detector reason: ${{ needs.detect.outputs.reason }}"
           exit 1
 
       - name: Login to GHCR
-        if: ${{ github.event_name == 'push' || (! inputs.dry_run && needs.detect.outputs.should_run == 'true') }}
+        if: ${{ github.event_name == 'push' || (! inputs.dry_run && (inputs.retry_current_version || needs.detect.outputs.should_run == 'true')) }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -98,7 +104,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: "false"
 
       - name: Publish release
-        if: ${{ github.event_name == 'push' || (! inputs.dry_run && needs.detect.outputs.should_run == 'true') }}
+        if: ${{ github.event_name == 'push' || (! inputs.dry_run && (inputs.retry_current_version || needs.detect.outputs.should_run == 'true')) }}
         run: env -u CI -u GITHUB_ACTIONS moon run release:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
+++ b/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
@@ -1,3 +1,7 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 type CheckChangesetsStatusModule = {
@@ -45,6 +49,7 @@ type ReleaseAutomationModule = {
     entries?: Array<{ status: string; file: string }>;
     message?: string;
     pendingChangesets?: string[];
+    prereleaseChangesetIds?: string[];
   }) => Promise<{
     ok: boolean;
     shouldRun: boolean;
@@ -52,6 +57,10 @@ type ReleaseAutomationModule = {
     errors: string[];
   }>;
   isVersionPackageCommit: (message: string) => boolean;
+};
+
+type ReleaseModule = {
+  assertNoUnrecordedPendingChangesets: (repoRoot: string) => Promise<void>;
 };
 
 type CheckChangesetStatus = {
@@ -78,6 +87,12 @@ async function loadReleaseAutomationModule(): Promise<ReleaseAutomationModule> {
   return (await import(
     new URL("../../../../../scripts/release-automation.mjs", import.meta.url).href
   )) as ReleaseAutomationModule;
+}
+
+async function loadReleaseModule(): Promise<ReleaseModule> {
+  return (await import(
+    new URL("../../../../../scripts/release.mjs", import.meta.url).href
+  )) as ReleaseModule;
 }
 
 describe("check-changesets-status", () => {
@@ -370,12 +385,43 @@ describe("release-automation", () => {
     expect(result.shouldRun).toBe(false);
   });
 
+  it("skips prepare when prerelease mode already recorded the pending changesets", async () => {
+    const { detectReleaseAutomation } = await loadReleaseAutomationModule();
+    const result = await detectReleaseAutomation({
+      mode: "prepare",
+      pendingChangesets: [".changeset/cli-start.md"],
+      prereleaseChangesetIds: ["cli-start"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.shouldRun).toBe(false);
+    expect(result.reason).toContain("already recorded");
+  });
+
   it("runs publish for a valid Changesets version package commit", async () => {
     const { detectReleaseAutomation } = await loadReleaseAutomationModule();
     const result = await detectReleaseAutomation({
       mode: "publish",
       message: "build: version packages (alpha)\n",
       pendingChangesets: [],
+      entries: [
+        { status: "M", file: ".changeset/pre.json" },
+        { status: "M", file: "apps/cli/package.json" },
+        { status: "M", file: "apps/cli/CHANGELOG.md" },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.shouldRun).toBe(true);
+  });
+
+  it("runs publish for a prerelease version commit with recorded pending changesets", async () => {
+    const { detectReleaseAutomation } = await loadReleaseAutomationModule();
+    const result = await detectReleaseAutomation({
+      mode: "publish",
+      message: "build: version packages (alpha)\n",
+      pendingChangesets: [".changeset/cli-start.md"],
+      prereleaseChangesetIds: ["cli-start"],
       entries: [
         { status: "M", file: ".changeset/pre.json" },
         { status: "M", file: "apps/cli/package.json" },
@@ -434,6 +480,49 @@ describe("release-automation", () => {
     expect(result.errors).toEqual(
       expect.arrayContaining([expect.stringContaining("outside Changesets version output")]),
     );
+  });
+
+  it("fails publish when a version package commit leaves unrecorded pending changesets", async () => {
+    const { detectReleaseAutomation } = await loadReleaseAutomationModule();
+    const result = await detectReleaseAutomation({
+      mode: "publish",
+      message: "build: version packages (alpha)\n",
+      pendingChangesets: [".changeset/cli-start.md", ".changeset/sdk-start.md"],
+      prereleaseChangesetIds: ["cli-start"],
+      entries: [
+        { status: "M", file: ".changeset/pre.json" },
+        { status: "M", file: "apps/cli/package.json" },
+        { status: "M", file: "apps/cli/CHANGELOG.md" },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.shouldRun).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining(".changeset/sdk-start.md")]),
+    );
+  });
+});
+
+describe("release publish guard", () => {
+  it("allows prerelease-recorded pending changesets and rejects unrecorded ones", async () => {
+    const { assertNoUnrecordedPendingChangesets } = await loadReleaseModule();
+    const repoRoot = await mkdtemp(join(tmpdir(), "zitadel-release-guard-"));
+    try {
+      await mkdir(join(repoRoot, ".changeset"));
+      await writeFile(join(repoRoot, ".changeset", "cli-start.md"), "---\n---\n");
+      await writeFile(
+        join(repoRoot, ".changeset", "pre.json"),
+        JSON.stringify({ mode: "pre", changesets: ["cli-start"] }),
+      );
+
+      await expect(assertNoUnrecordedPendingChangesets(repoRoot)).resolves.toBeUndefined();
+
+      await writeFile(join(repoRoot, ".changeset", "sdk-start.md"), "---\n---\n");
+      await expect(assertNoUnrecordedPendingChangesets(repoRoot)).rejects.toThrow("sdk-start");
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/docs/runbooks/manual-release.md
+++ b/docs/runbooks/manual-release.md
@@ -27,7 +27,9 @@ publishing, and public package tags.
 - Run `release-publish` manually with `dry_run=true` to build and verify server
   archives, checksums, npm tarballs, and Docker metadata without publishing.
 - Run `release-publish` manually with `dry_run=false` only to retry a publish
-  from the current `main` version commit.
+  from a detected version commit. If the version commit already merged and a
+  later release-infrastructure fix is needed, set `retry_current_version=true`
+  as well to publish the already-versioned current `main`.
 - Verify npm packages, `ghcr.io/zitadel/nextgen:<version>`, the product
   `v<version>` tag, and the GitHub Release after publish.
 

--- a/scripts/release-automation.mjs
+++ b/scripts/release-automation.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { appendFile, readdir } from "node:fs/promises";
+import { appendFile, readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -51,17 +51,23 @@ export async function detectReleaseAutomation(options) {
   const mode = options.mode;
   const root = options.repoRoot ?? repoRoot;
   const pendingChangesets = options.pendingChangesets ?? (await readPendingChangesets(root));
+  const prereleaseChangesetIds = normalizeChangesetIdSet(
+    options.prereleaseChangesetIds ?? (await readPrereleaseChangesetIds(root)),
+  );
+  const unrecordedPendingChangesets = findUnrecordedPendingChangesets(
+    pendingChangesets,
+    prereleaseChangesetIds,
+  );
 
   if (mode === "prepare") {
+    const shouldRun = unrecordedPendingChangesets.length > 0;
     return {
       ok: true,
       mode,
-      shouldRun: pendingChangesets.length > 0,
-      reason:
-        pendingChangesets.length > 0
-          ? `found ${pendingChangesets.length} pending changeset file(s)`
-          : "no pending changeset files",
+      shouldRun,
+      reason: prepareReason({ pendingChangesets, unrecordedPendingChangesets }),
       pendingChangesets,
+      unrecordedPendingChangesets,
       changedFiles: [],
       errors: [],
     };
@@ -78,22 +84,25 @@ export async function detectReleaseAutomation(options) {
   const versionCommit = isVersionPackageCommit(message);
   const errors = [];
 
-  if (versionCommit && pendingChangesets.length > 0) {
-    errors.push(`version package commit still has pending changesets: ${pendingChangesets.join(", ")}`);
+  if (versionCommit && unrecordedPendingChangesets.length > 0) {
+    errors.push(
+      `version package commit still has pending changesets not recorded in .changeset/pre.json: ${unrecordedPendingChangesets.join(", ")}`,
+    );
   }
   if (versionCommit && !analysis.versionOutputOnly) {
     errors.push("version package commit changed files outside Changesets version output");
   }
 
-  const shouldRun = versionCommit && pendingChangesets.length === 0 && analysis.versionOnly;
+  const shouldRun = versionCommit && unrecordedPendingChangesets.length === 0 && analysis.versionOnly;
   return {
     ok: errors.length === 0,
     mode,
     shouldRun,
-    reason: publishReason({ versionCommit, pendingChangesets, analysis, errors }),
+    reason: publishReason({ versionCommit, unrecordedPendingChangesets, analysis, errors }),
     base,
     message,
     pendingChangesets,
+    unrecordedPendingChangesets,
     changedFiles: analysis.changedFiles,
     errors,
   };
@@ -122,6 +131,16 @@ export function renderStepSummary(result) {
       lines.push(`- \`${file}\``);
     }
     lines.push("");
+  }
+
+  if (result.unrecordedPendingChangesets?.length > 0) {
+    lines.push("## Pending changesets not recorded in prerelease state", "");
+    for (const file of result.unrecordedPendingChangesets) {
+      lines.push(`- \`${file}\``);
+    }
+    lines.push("");
+  } else if (result.pendingChangesets.length > 0) {
+    lines.push("All pending changesets are recorded in `.changeset/pre.json`.", "");
   }
 
   if (result.changedFiles.length > 0) {
@@ -180,12 +199,33 @@ export async function main(args = forwardedArgs(), options = {}) {
   return 0;
 }
 
-async function readPendingChangesets(root) {
+export async function readPendingChangesets(root) {
   const entries = await readdir(join(root, ".changeset"), { withFileTypes: true });
   return entries
     .filter((entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "README.md")
     .map((entry) => `.changeset/${entry.name}`)
     .sort((left, right) => left.localeCompare(right));
+}
+
+export async function readPrereleaseChangesetIds(root) {
+  try {
+    const source = await readFile(join(root, ".changeset/pre.json"), "utf8");
+    const parsed = JSON.parse(source);
+    if (parsed?.mode !== "pre" || !Array.isArray(parsed.changesets)) {
+      return new Set();
+    }
+    return new Set(parsed.changesets.map((id) => String(id)));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return new Set();
+    }
+    throw error;
+  }
+}
+
+export function findUnrecordedPendingChangesets(pendingChangesets, prereleaseChangesetIds) {
+  const ids = normalizeChangesetIdSet(prereleaseChangesetIds);
+  return pendingChangesets.filter((file) => !ids.has(changesetIdFromFile(file)));
 }
 
 async function gitChangedEntries(root, base) {
@@ -221,20 +261,41 @@ async function writeSummary(summary, summaryPath) {
   console.log(summary);
 }
 
-function publishReason({ versionCommit, pendingChangesets, analysis, errors }) {
+function prepareReason({ pendingChangesets, unrecordedPendingChangesets }) {
+  if (pendingChangesets.length === 0) {
+    return "no pending changeset files";
+  }
+  if (unrecordedPendingChangesets.length === 0) {
+    return "pending changesets are already recorded in .changeset/pre.json";
+  }
+  return `found ${unrecordedPendingChangesets.length} pending changeset file(s) needing version prepare`;
+}
+
+function publishReason({ versionCommit, unrecordedPendingChangesets, analysis, errors }) {
   if (errors.length > 0) {
     return "release commit preflight failed";
   }
   if (!versionCommit) {
     return "latest commit is not a Changesets version package commit";
   }
-  if (pendingChangesets.length > 0) {
-    return "pending changesets remain";
+  if (unrecordedPendingChangesets.length > 0) {
+    return "pending changesets are not recorded in .changeset/pre.json";
   }
   if (!analysis.versionOnly) {
     return "version package commit has no publishable package version output";
   }
   return "Changesets version package commit detected";
+}
+
+function normalizeChangesetIdSet(ids) {
+  if (ids instanceof Set) {
+    return ids;
+  }
+  return new Set((ids ?? []).map((id) => String(id)));
+}
+
+function changesetIdFromFile(file) {
+  return file.split("/").at(-1)?.replace(/\.md$/, "") ?? file;
 }
 
 function normalizeBase(base) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
-import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { forwardedArgs, isDirectRun, run, runCapture } from "./dev-process.mjs";
+import {
+  findUnrecordedPendingChangesets,
+  readPendingChangesets,
+  readPrereleaseChangesetIds,
+} from "./release-automation.mjs";
 import {
   CONTAINER_PLATFORMS,
   buildContainerImage,
@@ -93,7 +97,7 @@ async function commandPack() {
 async function commandPublish(options) {
   const release = await readServerRelease(repoRoot);
   const outDir = releaseDir(repoRoot, release.version);
-  await assertNoPendingChangesets();
+  await assertNoUnrecordedPendingChangesets();
   await assertMainBranch(options);
 
   if (options.dryRun) {
@@ -174,13 +178,14 @@ function parseOptions(args) {
   return parsed;
 }
 
-async function assertNoPendingChangesets() {
-  const entries = await readdir(join(repoRoot, ".changeset"), { withFileTypes: true });
-  const pending = entries
-    .filter((entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "README.md")
-    .map((entry) => entry.name);
-  if (pending.length > 0) {
-    throw new Error(`release publish requires a versioned branch with no pending changesets: ${pending.join(", ")}`);
+export async function assertNoUnrecordedPendingChangesets(root = repoRoot) {
+  const pending = await readPendingChangesets(root);
+  const prereleaseChangesetIds = await readPrereleaseChangesetIds(root);
+  const unrecorded = findUnrecordedPendingChangesets(pending, prereleaseChangesetIds);
+  if (unrecorded.length > 0) {
+    throw new Error(
+      `release publish requires all pending changesets to be recorded in .changeset/pre.json: ${unrecorded.join(", ")}`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- teach release prepare/publish detection that Changesets prerelease mode keeps consumed `.changeset/*.md` files in the tree and records them in `.changeset/pre.json`
- allow `release:publish` to proceed when pending changesets are recorded in prerelease state, while still failing on unrecorded pending changesets
- add a guarded `retry_current_version` manual publish input for recovering the already-versioned current `main` after this detector bug

## Validation

- `node scripts/release-automation.mjs prepare --summary`
- `node scripts/release-automation.mjs publish --base HEAD^ --summary`
- `corepack pnpm exec oxlint scripts/release-automation.mjs scripts/release.mjs apps/cli/tests/unit/scripts/check-changesets-status.test.ts`
- `corepack pnpm --filter @zitadel/cli exec vitest run tests/unit/scripts/check-changesets-status.test.ts`
- `moon run release:changesets -- --base origin/main --summary`
- `git diff --check`

## Release notes / changeset

Added an empty changeset: `.changeset/prerelease-release-automation.md`. This touches release automation/tests only and does not change published package behavior.

## Notes

Root cause: the failed `release-publish` run on `60cbf41` assumed a Changesets version commit must delete all pending changeset markdown. That is false while prerelease mode is active; Changesets keeps the markdown files and records consumed changeset IDs in `.changeset/pre.json`.

After this PR merges, retry the missed release with `release-publish` using `dry_run=false` and `retry_current_version=true` so the current already-versioned `main` can publish.