### PR TITLE
build: create fresh alpha changeset

### DIFF
--- a/.changeset/recover-alpha-seven.md
+++ b/.changeset/recover-alpha-seven.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+Cut a fresh alpha package train after the release automation fixes.


### PR DESCRIPTION
## Summary
- Add a real patch changeset for `@zitadel/server` so Changesets creates a fresh alpha version PR.
- Rely on the fixed alpha package group to bump the CLI, server packages, API, components, and SDKs together.

## Validation
- `corepack pnpm exec changeset status --since origin/main`
- `git diff --cached --check`

## Release notes / changeset
- Real changeset added: `.changeset/recover-alpha-seven.md` for `@zitadel/server` patch. This intentionally creates a new alpha package train after release automation fixes.

## Notes
- Merging this PR should not publish directly. It should make the `release-publish` workflow open or update the generated `build: version packages` PR on `main`.