### PR TITLE
ci: build embedded UI through Moon

### DIFF
--- a/.changeset/recover-alpha-eight.md
+++ b/.changeset/recover-alpha-eight.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+Cut a fresh alpha package train with the embedded UI release build fix.

--- a/scripts/sync-embedded-ui-dist.sh
+++ b/scripts/sync-embedded-ui-dist.sh
@@ -4,15 +4,20 @@ set -eu
 
 root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
 
+build_project() {
+  project="$1"
+  (cd "$root" && moon run "$project:build")
+}
+
 build_console() {
   if [ -f "$root/apps/console/package.json" ]; then
-    (cd "$root" && COREPACK_DEFAULT_TO_LATEST=0 corepack pnpm --filter @zitadel/console run build)
+    build_project console
   fi
 }
 
 build_login() {
   if [ -f "$root/apps/login-ui/package.json" ]; then
-    (cd "$root" && COREPACK_DEFAULT_TO_LATEST=0 corepack pnpm --filter @zitadel/login-ui run build)
+    build_project login-ui
   fi
 }
 


### PR DESCRIPTION
## Summary
- Build embedded console and login UI through Moon project tasks instead of direct pnpm package builds.
- Preserve the existing sync behavior while letting Moon build workspace dependencies such as `components:build` before `login-ui:build`.
- Add a real patch changeset so merging this PR creates a fresh Changesets version PR after the failed alpha.7 publish attempt.

## Validation
- Removed generated `dist` folders for console, login-ui, and dependent packages, then ran `sh scripts/sync-embedded-ui-dist.sh all` successfully.
- `corepack pnpm exec changeset status --since origin/main`
- `git diff --check`

## Release notes / changeset
- Real changeset added: `.changeset/recover-alpha-eight.md` for `@zitadel/server` patch. The fixed alpha group bumps the CLI, server packages, API, components, and SDKs together.

## Notes
- This addresses the failed `release-publish` run for `0.1.0-alpha.7`, where `apps/login-ui` could not resolve `@zitadel/components` during `scripts/sync-embedded-ui-dist.sh all`.
- Merging this PR should create a new generated `build: version packages` PR; publishing should happen only after that generated version PR merges.