### PR TITLE
ci: preserve npm trusted publishing environment

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -148,7 +148,9 @@ jobs:
           if [ -n "$RECOVER_VERSION" ]; then
             args+=(--recover-version "$RECOVER_VERSION")
           fi
-          env -u CI -u GITHUB_ACTIONS moon run "${args[@]}"
+          # Keep the GitHub Actions environment intact: npm trusted publishing
+          # uses it to exchange the workflow OIDC token during real publishes.
+          moon run "${args[@]}"
         env:
           BASE_SHA: ${{ github.event.before || 'HEAD^' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -162,7 +164,9 @@ jobs:
           if [ -n "$RECOVER_VERSION" ]; then
             args+=(-- --recover-version "$RECOVER_VERSION")
           fi
-          env -u CI -u GITHUB_ACTIONS moon run "${args[@]}"
+          # Keep the GitHub Actions environment intact: npm trusted publishing
+          # uses it to exchange the workflow OIDC token during real publishes.
+          moon run "${args[@]}"
         env:
           BASE_SHA: ${{ github.event.before || 'HEAD^' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/release/moon.yml
+++ b/tools/release/moon.yml
@@ -39,4 +39,4 @@ tasks:
     command: "node scripts/release.mjs publish"
     options:
       runFromWorkspaceRoot: true
-      runInCI: false
+      runInCI: true


### PR DESCRIPTION
## Summary
- Keep the GitHub Actions environment intact when `release-publish` runs `moon run release:publish`.
- Mark the Moon `release:publish` task as CI-runnable so the workflow no longer needs to spoof a non-CI shell.
- Preserve npm trusted publishing OIDC variables for the `changeset publish` step.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/release-publish.yml tools/release/moon.yml`
- `CI=true GITHUB_ACTIONS=true moon run release:publish -- --help`
- `if rg -n "env -u CI|env -u GITHUB_ACTIONS" .github/workflows/release-publish.yml tools/release/moon.yml scripts -S; then exit 1; fi`
- `git diff --check origin/main..HEAD`

## Release notes / changeset
No changeset required — this is release workflow plumbing only and does not change public npm package behavior.

## Notes
Root cause from failed run 27640869689: the workflow invoked `env -u CI -u GITHUB_ACTIONS moon run release:publish`, which hid the GitHub Actions OIDC environment before `changeset publish`. npm then rejected the trusted-publishing attempt with package-level 404/permission errors before Docker publishing could run.