### PR TITLE
fix: make docs deploy on Vercel

### DIFF
--- a/apps/docs/moon.yml
+++ b/apps/docs/moon.yml
@@ -11,6 +11,8 @@ tasks:
       - "scripts/bundle-openapi.mjs"
     outputs:
       - ".generated/openapi.yaml"
+      - ".generated/openapi.json"
+      - ".generated/openapi.mjs"
 
   generate:
     command: "corepack pnpm run generate"
@@ -21,22 +23,26 @@ tasks:
       - "scripts/bundle-openapi.mjs"
     outputs:
       - ".generated/openapi.yaml"
+      - ".generated/openapi.json"
+      - ".generated/openapi.mjs"
       - ".source/**/*"
 
   typecheck:
-    command: "corepack pnpm run typecheck"
+    command: "corepack pnpm exec tsc --noEmit -p tsconfig.json"
     deps:
       - "generate"
 
   build:
-    command: "corepack pnpm run build"
+    command: "corepack pnpm exec waku build"
     deps:
       - "generate"
     outputs:
       - "dist/**/*"
 
   dev:
-    command: "corepack pnpm run dev"
+    command: "corepack pnpm exec waku dev --port 3003"
+    deps:
+      - "generate"
     options:
       persistent: true
       runInCI: false

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,7 +10,7 @@
     "generate": "pnpm run generate:openapi && pnpm run generate:source",
     "dev": "pnpm run generate && waku dev --port 3003",
     "build": "pnpm run generate && waku build",
-    "preview": "waku start --port 3003",
+    "preview": "node scripts/preview.mjs",
     "typecheck": "pnpm run generate && tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/docs/press.config.tsx
+++ b/apps/docs/press.config.tsx
@@ -1,6 +1,5 @@
 // @ts-nocheck
 // TS 6 currently crashes while checking the Fumapress config chain.
-import path from "node:path";
 import { mcpPlugin } from "@fumapress/ai";
 import { createOpenAPI } from "fumadocs-openapi/server";
 import { fumadocsMdx } from "fumapress/adapters/mdx";
@@ -10,11 +9,14 @@ import { flexsearchPlugin } from "fumapress/plugins/flexsearch";
 import { llmsPlugin } from "fumapress/plugins/llms.txt";
 import { openapiPlugin } from "fumapress/plugins/openapi";
 
+import openapiDocument from "./.generated/openapi.mjs";
 import { docs } from "./.source/server";
 import { pageToFlexsearchIndex, pageToLLMText, pageToMcpIndex } from "./src/lib/llm-text";
 
 const openapi = createOpenAPI({
-  input: [path.resolve("./.generated/openapi.yaml")],
+  input: {
+    "zitadel-nextgen": openapiDocument,
+  },
 });
 
 export default defineConfig({

--- a/apps/docs/scripts/bundle-openapi.mjs
+++ b/apps/docs/scripts/bundle-openapi.mjs
@@ -1,4 +1,4 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
@@ -6,9 +6,12 @@ import { spawn } from "node:child_process";
 const docsRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = resolve(docsRoot, "../..");
 const input = resolve(repoRoot, "api/openapi/openapi-spec.yaml");
-const output = resolve(docsRoot, ".generated/openapi.yaml");
+const outputDir = resolve(docsRoot, ".generated");
+const yamlOutput = resolve(outputDir, "openapi.yaml");
+const jsonOutput = resolve(outputDir, "openapi.json");
+const moduleOutput = resolve(outputDir, "openapi.mjs");
 
-await mkdir(dirname(output), { recursive: true });
+await mkdir(dirname(yamlOutput), { recursive: true });
 
 await run("npx", [
   "--yes",
@@ -16,8 +19,20 @@ await run("npx", [
   "bundle",
   input,
   "--output",
-  output,
+  yamlOutput,
 ]);
+
+await run("npx", [
+  "--yes",
+  "@redocly/cli@2.31.5",
+  "bundle",
+  input,
+  "--output",
+  jsonOutput,
+]);
+
+const bundledJson = await readFile(jsonOutput, "utf8");
+await writeFile(moduleOutput, `export default ${bundledJson.trim()};\n`);
 
 function run(command, args) {
   return new Promise((resolveRun, reject) => {

--- a/apps/docs/scripts/preview.mjs
+++ b/apps/docs/scripts/preview.mjs
@@ -1,0 +1,26 @@
+import { spawn } from "node:child_process";
+
+const env = { ...process.env };
+delete env.VERCEL;
+
+await run("pnpm", ["run", "build"], { env });
+await run("pnpm", ["exec", "waku", "start", "--port", env.PORT || "3003"], { env });
+
+function run(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      ...options,
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`${command} ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+}

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "pnpm run build"
+}


### PR DESCRIPTION
## Summary
- Fix the docs OpenAPI source wiring so the Vercel function no longer depends on a build-machine absolute path to `.generated/openapi.yaml`.
- Generate an importable bundled OpenAPI module alongside the YAML/JSON artifacts and feed that object into Fumadocs OpenAPI.
- Add an app-level `apps/docs/vercel.json` and make `pnpm run preview` rebuild without `VERCEL` before running `waku start`, so local preview still works after Vercel-shaped builds.
- Polish the docs Moon task graph: declare all generated OpenAPI artifacts, then let Moon run `tsc`, `waku build`, and `waku dev` directly after `docs:generate` instead of re-running package scripts that generate a second time.

## Validation
- `moon project docs --json` confirmed generated outputs include `.generated/openapi.yaml`, `.generated/openapi.json`, and `.generated/openapi.mjs`.
- `moon run docs:typecheck`
- `moon run docs:build`
- `VERCEL=1 corepack pnpm --dir apps/docs run build`
- `git diff --check`
- `corepack pnpm --dir apps/docs run preview`
- Smoke checks against local preview:
  - `curl http://localhost:3003/docs` -> 200
  - `curl http://localhost:3003/reference/api` -> 200
  - `curl http://localhost:3003/reference/api/system/getHealth` -> 200
  - `curl http://localhost:3003/llms.txt` -> 200
- `moon run docs:dev`, then `curl http://localhost:3003/docs` -> 200

## Release notes / changeset
No changeset required — no public npm package files changed.

## Notes
The Vercel project root is `apps/docs`, so `vercel.json` is scoped there. It intentionally keeps `buildCommand` as `pnpm run build` rather than `moon run docs:build`: Vercel should use the package-local deploy entrypoint, while Moon owns the contributor/CI task graph. `outputDirectory` is also omitted because Waku emits the Build Output API structure under `.vercel/output`.