### PR TITLE
fix: build local server binary for CLI start

### DIFF
--- a/.changeset/workspace-cli-start-wrapper.md
+++ b/.changeset/workspace-cli-start-wrapper.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update contributor-only workspace CLI wrapper tests without changing published npm package behavior.

--- a/apps/cli/tests/unit/scripts/run-cli.test.ts
+++ b/apps/cli/tests/unit/scripts/run-cli.test.ts
@@ -7,7 +7,7 @@ type RunCliModule = {
     args?: string[];
     cwd?: string;
     env?: Record<string, string | undefined>;
-    buildCli?: () => Promise<void>;
+    buildCli?: (options: { env: Record<string, string | undefined> }) => Promise<void>;
     buildLocalServerBinary?: (options: {
       env: Record<string, string | undefined>;
     }) => Promise<string>;
@@ -143,8 +143,9 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["start"],
       env,
-      buildCli: async () => {
+      buildCli: async (options) => {
         calls.push("build-cli");
+        expect(options.env).toBe(env);
       },
       buildLocalServerBinary: async (options) => {
         calls.push("build-server");
@@ -183,8 +184,9 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["start", "--runtime", "docker"],
       env,
-      buildCli: async () => {
+      buildCli: async (options) => {
         calls.push("build-cli");
+        expect(options.env).toBe(env);
       },
       buildLocalServerBinary: async () => {
         calls.push("build-server");

--- a/apps/cli/tests/unit/scripts/run-cli.test.ts
+++ b/apps/cli/tests/unit/scripts/run-cli.test.ts
@@ -8,6 +8,9 @@ type RunCliModule = {
     cwd?: string;
     env?: Record<string, string | undefined>;
     buildCli?: () => Promise<void>;
+    buildLocalServerBinary?: (options: {
+      env: Record<string, string | undefined>;
+    }) => Promise<string>;
     buildLocalRuntimeImage?: (options: {
       env: Record<string, string | undefined>;
     }) => Promise<unknown>;
@@ -33,10 +36,8 @@ type RunCliModule = {
     args: string[],
     env?: Record<string, string | undefined>,
   ) => boolean;
-  shouldPrepareLocalPackages: (
-    args: string[],
-    env?: Record<string, string | undefined>,
-  ) => boolean;
+  shouldPrepareLocalPackages: (args: string[], env?: Record<string, string | undefined>) => boolean;
+  shouldUseLocalServerBinary: (args: string[], env?: Record<string, string | undefined>) => boolean;
 };
 
 type BuildLocalRuntimeImageModule = {
@@ -75,15 +76,11 @@ describe("run-cli wrapper", () => {
     expect(runCli.shouldAutoBuildLocalRuntimeImage(["start", "--runtime", "binary"], {})).toBe(
       false,
     );
-    expect(runCli.shouldAutoBuildLocalRuntimeImage(["start", "--runtime=binary"], {})).toBe(
-      false,
-    );
+    expect(runCli.shouldAutoBuildLocalRuntimeImage(["start", "--runtime=binary"], {})).toBe(false);
     expect(runCli.shouldAutoBuildLocalRuntimeImage(["start", "--runtime", "docker"], {})).toBe(
       true,
     );
-    expect(runCli.shouldAutoBuildLocalRuntimeImage(["start", "--runtime=docker"], {})).toBe(
-      true,
-    );
+    expect(runCli.shouldAutoBuildLocalRuntimeImage(["start", "--runtime=docker"], {})).toBe(true);
     expect(runCli.shouldAutoBuildLocalRuntimeImage(["start", "--help"], {})).toBe(false);
     expect(runCli.shouldAutoBuildLocalRuntimeImage(["start", "-h"], {})).toBe(false);
     expect(runCli.shouldAutoBuildLocalRuntimeImage(["--version"], {})).toBe(false);
@@ -124,7 +121,21 @@ describe("run-cli wrapper", () => {
     ).toBe(false);
   });
 
-  it("does not build a local image for the default binary start runtime", async () => {
+  it("uses a local server binary only for executable binary start commands", () => {
+    expect(runCli.shouldUseLocalServerBinary(["start"], {})).toBe(true);
+    expect(runCli.shouldUseLocalServerBinary(["start", "--runtime", "binary"], {})).toBe(true);
+    expect(runCli.shouldUseLocalServerBinary(["start", "--runtime", "docker"], {})).toBe(false);
+    expect(runCli.shouldUseLocalServerBinary(["start", "--image", "custom:tag"], {})).toBe(false);
+    expect(runCli.shouldUseLocalServerBinary(["start", "--dry-run"], {})).toBe(false);
+    expect(runCli.shouldUseLocalServerBinary(["start", "--help"], {})).toBe(false);
+    expect(
+      runCli.shouldUseLocalServerBinary(["start"], {
+        ZITADEL_SERVER_BINARY: "/tmp/custom-nextgen",
+      }),
+    ).toBe(false);
+  });
+
+  it("builds and injects a local server binary for the default binary start runtime", async () => {
     const calls: string[] = [];
     const env = { PATH: "/bin" };
     let runEnv: Record<string, string | undefined> | undefined;
@@ -134,6 +145,11 @@ describe("run-cli wrapper", () => {
       env,
       buildCli: async () => {
         calls.push("build-cli");
+      },
+      buildLocalServerBinary: async (options) => {
+        calls.push("build-server");
+        expect(options.env).toBe(env);
+        return "/repo/dist/server/nextgen";
       },
       buildLocalRuntimeImage: async (options) => {
         calls.push("build-image");
@@ -149,11 +165,13 @@ describe("run-cli wrapper", () => {
       },
     });
 
-    expect(calls).toEqual(["build-cli", "run-cli"]);
+    expect(calls).toEqual(["build-cli", "build-server", "run-cli"]);
     expect(runEnv).toMatchObject({
       PATH: "/bin",
+      ZITADEL_SERVER_BINARY: "/repo/dist/server/nextgen",
     });
     expect(runEnv).not.toHaveProperty("ZITADEL_LOCAL_IMAGE");
+    expect(env).not.toHaveProperty("ZITADEL_SERVER_BINARY");
     expect(env).not.toHaveProperty("ZITADEL_LOCAL_IMAGE");
   });
 
@@ -167,6 +185,10 @@ describe("run-cli wrapper", () => {
       env,
       buildCli: async () => {
         calls.push("build-cli");
+      },
+      buildLocalServerBinary: async () => {
+        calls.push("build-server");
+        return "/repo/dist/server/nextgen";
       },
       buildLocalRuntimeImage: async (options) => {
         calls.push("build-image");
@@ -192,16 +214,19 @@ describe("run-cli wrapper", () => {
 
   it("skips the builder when start receives --image", async () => {
     const buildLocalRuntimeImage = vi.fn(noop);
+    const buildLocalServerBinary = vi.fn(async () => "/repo/dist/server/nextgen");
     const run = vi.fn(noop);
 
     await runCli.main({
       args: ["start", "--image", "custom:tag"],
       env: { PATH: "/bin" },
       buildCli: vi.fn(noop),
+      buildLocalServerBinary,
       buildLocalRuntimeImage,
       run,
     });
 
+    expect(buildLocalServerBinary).not.toHaveBeenCalled();
     expect(buildLocalRuntimeImage).not.toHaveBeenCalled();
     expect(run).toHaveBeenCalledOnce();
     expect(run.mock.calls[0]?.[2].env).not.toHaveProperty("ZITADEL_LOCAL_IMAGE");
@@ -209,32 +234,71 @@ describe("run-cli wrapper", () => {
 
   it("skips the builder when ZITADEL_LOCAL_IMAGE is set", async () => {
     const buildLocalRuntimeImage = vi.fn(noop);
+    const buildLocalServerBinary = vi.fn(async () => "/repo/dist/server/nextgen");
     const run = vi.fn(noop);
 
     await runCli.main({
       args: ["start"],
       env: { PATH: "/bin", ZITADEL_LOCAL_IMAGE: "custom:tag" },
       buildCli: vi.fn(noop),
+      buildLocalServerBinary,
       buildLocalRuntimeImage,
       run,
     });
 
+    expect(buildLocalServerBinary).not.toHaveBeenCalled();
     expect(buildLocalRuntimeImage).not.toHaveBeenCalled();
     expect(run).toHaveBeenCalledOnce();
     expect(run.mock.calls[0]?.[2].env.ZITADEL_LOCAL_IMAGE).toBe("custom:tag");
   });
 
+  it("preserves an explicit local server binary override for binary start", async () => {
+    const buildLocalServerBinary = vi.fn(async () => "/repo/dist/server/nextgen");
+    const run = vi.fn(noop);
+
+    await runCli.main({
+      args: ["start", "--runtime", "binary"],
+      env: { PATH: "/bin", ZITADEL_SERVER_BINARY: "/tmp/custom-nextgen" },
+      buildCli: vi.fn(noop),
+      buildLocalServerBinary,
+      buildLocalRuntimeImage: vi.fn(noop),
+      run,
+    });
+
+    expect(buildLocalServerBinary).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledOnce();
+    expect(run.mock.calls[0]?.[2].env.ZITADEL_SERVER_BINARY).toBe("/tmp/custom-nextgen");
+  });
+
+  it("skips the local server binary build for dry-run start", async () => {
+    const buildLocalServerBinary = vi.fn(async () => "/repo/dist/server/nextgen");
+
+    await runCli.main({
+      args: ["start", "--dry-run"],
+      env: { PATH: "/bin" },
+      buildCli: vi.fn(noop),
+      buildLocalServerBinary,
+      buildLocalRuntimeImage: vi.fn(noop),
+      run: vi.fn(noop),
+    });
+
+    expect(buildLocalServerBinary).not.toHaveBeenCalled();
+  });
+
   it("skips the builder for non-start commands", async () => {
     const buildLocalRuntimeImage = vi.fn(noop);
+    const buildLocalServerBinary = vi.fn(async () => "/repo/dist/server/nextgen");
 
     await runCli.main({
       args: ["doctor"],
       env: { PATH: "/bin" },
       buildCli: vi.fn(noop),
+      buildLocalServerBinary,
       buildLocalRuntimeImage,
       run: vi.fn(noop),
     });
 
+    expect(buildLocalServerBinary).not.toHaveBeenCalled();
     expect(buildLocalRuntimeImage).not.toHaveBeenCalled();
   });
 

--- a/scripts/run-cli.mjs
+++ b/scripts/run-cli.mjs
@@ -32,7 +32,7 @@ export async function main(options = {}) {
   const cliCwd = options.cwd ?? cliCwdFor(env);
   let registryProcess;
 
-  await buildCliFn();
+  await buildCliFn({ env });
 
   if (shouldUseLocalServerBinary(args, env)) {
     cliEnv.ZITADEL_SERVER_BINARY = await buildLocalServerBinaryFn({ env });
@@ -202,8 +202,8 @@ function wrapperRun({ jsonMode, runCaptureFn, runFn, stderr }) {
   };
 }
 
-export function buildCli() {
-  return runMoonToStderr(["run", "cli:build"], "moon run cli:build");
+export function buildCli({ env = process.env } = {}) {
+  return runMoonToStderr(["run", "cli:build"], "moon run cli:build", env);
 }
 
 export async function buildLocalServerBinary({ env = process.env } = {}) {

--- a/scripts/run-cli.mjs
+++ b/scripts/run-cli.mjs
@@ -14,6 +14,7 @@ import { forwardedArgs, isDirectRun, run, runCapture } from "./dev-process.mjs";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const cliBin = join(repoRoot, "apps/cli/bin/run.js");
+const localServerBinary = join(repoRoot, "dist/server/nextgen");
 const localRegistryWorkDir = join(repoRoot, "tmp", "cli-local-registry");
 
 export async function main(options = {}) {
@@ -22,6 +23,7 @@ export async function main(options = {}) {
   const runFn = options.run ?? run;
   const runCaptureFn = options.runCapture ?? runCapture;
   const buildCliFn = options.buildCli ?? buildCli;
+  const buildLocalServerBinaryFn = options.buildLocalServerBinary ?? buildLocalServerBinary;
   const buildLocalRuntimeImageFn = options.buildLocalRuntimeImage ?? buildLocalRuntimeImage;
   const prepareLocalRegistryFn = options.prepareLocalRegistry ?? prepareLocalRegistry;
   const stopLocalRegistryFn = options.stopLocalRegistry ?? stopLocalRegistry;
@@ -31,6 +33,10 @@ export async function main(options = {}) {
   let registryProcess;
 
   await buildCliFn();
+
+  if (shouldUseLocalServerBinary(args, env)) {
+    cliEnv.ZITADEL_SERVER_BINARY = await buildLocalServerBinaryFn({ env });
+  }
 
   if (shouldPrepareLocalPackages(args, env)) {
     const registryWorkDir = options.localRegistryWorkDir ?? localRegistryWorkDir;
@@ -71,18 +77,32 @@ export async function main(options = {}) {
 }
 
 export function shouldAutoBuildLocalRuntimeImage(args, env = process.env) {
-  return commandName(args) === "start" &&
+  return (
+    commandName(args) === "start" &&
     runtimeFlagValue(args, env) === "docker" &&
     !hasRuntimeImageSource(args, env) &&
-    !isHelpOrVersion(args);
+    !isHelpOrVersion(args)
+  );
+}
+
+export function shouldUseLocalServerBinary(args, env = process.env) {
+  return (
+    commandName(args) === "start" &&
+    runtimeFlagValue(args, env) === "binary" &&
+    !hasFlag(args, "--dry-run") &&
+    !env.ZITADEL_SERVER_BINARY &&
+    !isHelpOrVersion(args)
+  );
 }
 
 export function shouldPrepareLocalPackages(args, env = process.env) {
-  return commandName(args) === "setup" &&
+  return (
+    commandName(args) === "setup" &&
     !isHelpOrVersion(args) &&
     !hasFlag(args, "--dry-run") &&
     !hasFlag(args, "--skip-install") &&
-    !usesPublicPackages(env);
+    !usesPublicPackages(env)
+  );
 }
 
 export function commandName(args) {
@@ -141,9 +161,11 @@ function runtimeFlagValue(args, env = process.env) {
 
 function isHelpOrVersion(args) {
   const command = commandName(args);
-  return command === "help" ||
+  return (
+    command === "help" ||
     command === "version" ||
-    args.some((arg) => arg === "--help" || arg === "-h" || arg === "--version");
+    args.some((arg) => arg === "--help" || arg === "-h" || arg === "--version")
+  );
 }
 
 function usesPublicPackages(env) {
@@ -181,10 +203,24 @@ function wrapperRun({ jsonMode, runCaptureFn, runFn, stderr }) {
 }
 
 export function buildCli() {
+  return runMoonToStderr(["run", "cli:build"], "moon run cli:build");
+}
+
+export async function buildLocalServerBinary({ env = process.env } = {}) {
+  await runMoonToStderr(
+    ["run", "console:build", "login-ui:build"],
+    "moon run console:build login-ui:build",
+    env,
+  );
+  await runMoonToStderr(["run", "server:build"], "moon run server:build", env);
+  return localServerBinary;
+}
+
+function runMoonToStderr(args, label, env = process.env) {
   return new Promise((resolve, reject) => {
-    const child = spawn("moon", ["run", "cli:build"], {
+    const child = spawn("moon", args, {
       cwd: repoRoot,
-      env: process.env,
+      env,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -197,7 +233,7 @@ export function buildCli() {
         return;
       }
       const detail = signal ? `signal ${signal}` : `exit ${code}`;
-      const error = new Error(`moon run cli:build failed with ${detail}`);
+      const error = new Error(`${label} failed with ${detail}`);
       error.code = code;
       error.signal = signal;
       reject(error);


### PR DESCRIPTION
## Summary
- Build `cli:build` with the wrapper-provided `env` so test and caller overrides apply consistently.
- Build and inject a fresh local server binary for binary `workspace:cli -- start`, while preserving Docker and explicit binary override paths.
- Expand wrapper unit coverage for binary selection, env forwarding, dry-run/help skips, and Docker overrides.

## Validation
- `corepack pnpm exec oxfmt --check scripts/run-cli.mjs apps/cli/tests/unit/scripts/run-cli.test.ts .changeset/workspace-cli-start-wrapper.md`
- `corepack pnpm exec oxlint scripts/run-cli.mjs apps/cli/tests/unit/scripts/run-cli.test.ts`
- `corepack pnpm --filter @zitadel/cli exec vitest run tests/unit/scripts/run-cli.test.ts`
- `node --input-type=module -e "import { buildLocalServerBinary } from './scripts/run-cli.mjs'; console.log(await buildLocalServerBinary());"`
- Temp-dir smoke: `node scripts/run-cli.mjs start --cwd <tmp> --json --port <free-port>` followed by `node scripts/run-cli.mjs stop --cwd <tmp> --json`
- `git add --intent-to-add .changeset/workspace-cli-start-wrapper.md && corepack pnpm exec changeset status --since origin/main` (then unstaged with `git reset -- .changeset/workspace-cli-start-wrapper.md`)
- `gh pr checks 358 --json name,state,bucket,link,description`

## Release notes / changeset
- Empty changeset: `.changeset/workspace-cli-start-wrapper.md` — publishable-path changes are package-internal tests only, and the runtime wrapper change is contributor-only rather than published npm package behavior.

## Notes
- PR title updated to `fix: build local server binary for CLI start`; `Semantic PR` is now passing.
- Existing local runtime processes under `/Users/ffo/git/myapp` were observed during smoke cleanup and intentionally left untouched.