### PR TITLE
docs: clarify changeset guidance for shipped server changes

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,8 +1,13 @@
 # Changesets
 
 This directory holds [changesets](https://github.com/changesets/changesets) for
-the npm-published packages in this monorepo. For "do I need a changeset on this
-PR?", see [Publishable npm packages](#publishable-npm-packages) and the
+the public release surfaces in this monorepo. Changesets are the per-PR release
+intent that feeds the generated changelogs and the single GitHub Release notes
+draft for `v<version>`. They also drive npm package versions and publishing.
+For "do I need a changeset on this PR?", see
+[Release notes and shared version tags](#release-notes-and-shared-version-tags),
+[Publishable npm packages](#publishable-npm-packages),
+[Go server runtime changes](#go-server-runtime-changes), and the
 [Decision table](#decision-table).
 
 ## PR workflow and visibility
@@ -16,10 +21,25 @@ Branch protection currently requires the GitHub Actions context `full-pr`,
 shown in the pull request UI as `ci / full-pr`. Changesets PR comments are
 visibility only; they are not a blocking release-policy gate.
 
+## Release notes and shared version tags
+
+Nextgen publishes one product release at a time during alpha. The GitHub Release
+for `v<version>` is the place users check what changed across the CLI, SDKs,
+API packages, Go server runtime, containers, archives, and server npm packages.
+The container image and server artifacts use the same version tag as the fixed
+Changesets release group.
+
+That means release intent is about the product release, not only about whether a
+specific npm package path changed. If shipped server behavior changes, users
+need to see that in the release notes for the same version that tags the
+container and server artifacts.
+
 ## Publishable npm packages
 
-**Publishable npm packages** are the public `@zitadel/*` packages that ship
-to npm:
+**Publishable npm packages** are the public `@zitadel/*` packages that ship to
+npm. This list mirrors the fixed release group in
+[`.changeset/config.json`](config.json); if the prose and config ever drift, the
+config is the source of truth.
 
 - `apps/cli/` — `@zitadel/cli`
 - `apps/server/` — `@zitadel/server`
@@ -36,22 +56,79 @@ to npm:
 - `packages/sdk-react/` — `@zitadel/sdk-react`
 - `packages/sdk-vue/` — `@zitadel/sdk-vue`
 - `packages/sdk-angular/` — `@zitadel/sdk-angular`
+- `packages/sdk-solid/` — `@zitadel/sdk-solid`
+- `packages/sdk-svelte/` — `@zitadel/sdk-svelte`
+- `packages/sdk-qwik/` — `@zitadel/sdk-qwik`
 
 `AGENTS.md` files under those roots do not require a changeset on their own.
 
-Everything else — `internal/`, `docs/`, `.github/`, `apps/console/`,
-`packages/api-mock/`, demos, and other private workspaces — does **not** require
-any changeset file. Other workspaces such as
-`@zitadel/api-mock`, `@zitadel/design-tokens`, `@zitadel/shared-component-styles`,
-`@zitadel/ui-react`, and `@zitadel/lint` are marked `"private": true` and are
-never published.
+Non-publishable files such as root `docs/`, `.github/`, demos, and private
+workspaces do not require a changeset on their own. Other workspaces such as
+`@zitadel/api-mock`, `@zitadel/design-tokens`,
+`@zitadel/shared-component-styles`, `@zitadel/ui-react`, and `@zitadel/lint`
+are marked `"private": true` and are never published.
+
+Do not use touched paths as the only release-intent test. The Go server is
+implemented mostly outside `apps/server*`, but server changes still belong in
+the single GitHub Release notes and on the same versioned release train as the
+container, archives, `@zitadel/server`, and platform server packages.
+
+## Go server runtime changes
+
+Add a real changeset for `@zitadel/server` when a PR changes shipped server
+behavior, even if the files live under implementation paths such as
+`internal/`, `cmd/`, `api/openapi/`, storage migrations, or embedded static UI
+inputs. The primary reason is release-note visibility for the unified GitHub
+Release and shared container/server version tags; npm publication is one of the
+distribution mechanisms attached to that same release.
+
+Examples that usually need a real `@zitadel/server` changeset:
+
+- HTTP API behavior, OpenAPI contract, auth/session semantics, lifecycle
+  semantics, data migrations, defaults, configuration, runtime startup, or
+  security behavior changes that users can experience.
+- Bug fixes in Go handlers, services, repositories, migrations, or runtime
+  packaging that change what the published server does.
+- New customer-usable server capability, route, configuration option, or local
+  runtime behavior.
+
+Examples that usually do not need a changeset:
+
+- Go-only test changes, repository-only refactors with no shipped behavior
+  change, comments, contributor docs, generated mocks, or CI/build wiring that
+  does not change a public package or product runtime.
+
+For Go runtime changes, list `@zitadel/server` in the changeset so the generated
+changelog and draft GitHub Release include the server note. If the same PR also
+changes another public package surface, such as `@zitadel/api` or an SDK
+contract, list that package too. The fixed Changesets group moves the server
+platform packages and the rest of the alpha release train to the same version;
+Moon uses that server version for containers, archives, and the draft GitHub
+Release shell.
 
 ## User-visible changes
 
-**User-visible** means npm consumers would notice: exported APIs/types, CLI
-command surface or JSON contract, published component behavior, or install/setup
-docs shipped in the package. Internal refactors, tests-only edits, and
-contributor-only files are not user-visible unless they change what publishes.
+**User-visible** means someone consuming the shipped product would notice:
+exported APIs/types, CLI command surface or JSON contract, published component
+behavior, server runtime/API behavior, data/lifecycle semantics, or install/setup
+docs shipped in a public package. Internal refactors, tests-only edits, and
+contributor-only files are not user-visible unless they change what ships.
+
+Use the release-note reader's perspective when picking the changeset wording.
+Do not call internal prework a feature unless customers can use a new capability
+in the release being cut. Prefer:
+
+- `patch` / `fix` wording for customer-visible correctness, compatibility, or
+  behavior fixes.
+- `minor` / feature wording only for new customer-usable capabilities.
+- No changeset for a pure refactor with no shipped behavior.
+
+Semantic PR titles and Changesets both describe release intent, but they answer
+different review questions. If structural work has no shipped behavior change,
+`refactor(...)` and no changeset usually fit. If the change fixes
+customer-visible behavior, prefer `fix(...)` and add a `patch` changeset. If it
+exposes a new customer-usable capability, prefer `feat(...)` and add a `minor`
+changeset.
 
 ## Decision table
 
@@ -59,8 +136,9 @@ Follow in order before opening a PR:
 
 | If the PR… | Add `.changeset/*.md`? | **Release notes / changeset** section |
 | --- | --- | --- |
-| Does **not** modify any publishable path above | **No** | `No changeset required — no public npm package files changed.` |
-| Modifies publishable paths **and** has user-visible npm impact | **Yes** — real changeset | Name the file and summarize the consumer-facing note |
+| Does **not** modify any publishable path and does **not** change shipped server/runtime behavior | **No** | `No changeset required — no public package or shipped server behavior changed.` |
+| Changes shipped Go server/runtime/API behavior from any path | **Yes** — real changeset for `@zitadel/server` | Name the file and summarize the server/runtime release note users should read |
+| Modifies publishable paths **and** has user-visible public package impact | **Yes** — real changeset | Name the file and summarize the consumer-facing note |
 | Modifies publishable paths only for non-shipping reasons (e.g. package-internal test) | **Rare:** empty changeset | Explain why the path changed but nothing ships |
 
 ## How to add a changeset
@@ -89,25 +167,29 @@ One-line, user-facing summary of the change.
 List only public package names (`@zitadel/cli`, `@zitadel/server`,
 `@zitadel/server-*`, `@zitadel/api`, `@zitadel/components`,
 `@zitadel/sdk-core`, `@zitadel/sdk-next`, `@zitadel/sdk-nuxt`,
-`@zitadel/sdk-react`, `@zitadel/sdk-vue`, `@zitadel/sdk-angular`). Pick `patch`
-(fixes), `minor` (features), or `major` (breaking). The repo is in `alpha`
-prerelease mode (`.changeset/pre.json`) and public packages are in one fixed
-group, so versions cut as one `X.Y.Z-alpha.N` train automatically — see
+`@zitadel/sdk-react`, `@zitadel/sdk-vue`, `@zitadel/sdk-angular`,
+`@zitadel/sdk-solid`, `@zitadel/sdk-svelte`, `@zitadel/sdk-qwik`). For shipped
+Go server behavior, list `@zitadel/server`. Pick `patch` (fixes), `minor`
+(features), or `major` (breaking). The repo is in `alpha` prerelease mode
+(`.changeset/pre.json`) and public packages are in one fixed group, so versions
+cut as one `X.Y.Z-alpha.N` train automatically — see
 [Alpha prerelease mode](#alpha-prerelease-mode).
 
 ## Empty changeset
 
 **Empty changeset** (rare) — only when publishable paths changed but nothing
-should ship: `corepack pnpm changeset --empty`. Do **not** use this for Go
-implementation-only paths (`internal/`, `cmd/`, `api/openapi/`), root `docs/`,
-CI-only, or other PRs that never touch the publishable paths above.
+should ship: `corepack pnpm changeset --empty`. Do not use an empty changeset
+as a substitute for release intent. For Go implementation paths, choose between:
+no changeset when no shipped behavior changes, or a real `@zitadel/server`
+changeset when shipped server behavior changes.
 
 ## Anti-patterns
 
-- Do **not** add an empty changeset on PRs that only touch non-publishable
-  paths (for example `internal/`, `docs/`, `.github/`, storage migrations).
-- Do **not** skip a changeset when changing published CLI, server runtime, SDK,
-  or components behavior under the publishable paths above.
+- Do **not** add an empty changeset on PRs that only touch non-publishable paths
+  and have no shipped server behavior change.
+- Do **not** skip a real changeset when changing published CLI, server runtime,
+  SDK, API, or component behavior, even when the server change is implemented
+  under `internal/`, `cmd/`, `api/openapi/`, or a migration path.
 
 ## Verify locally
 
@@ -118,11 +200,14 @@ corepack pnpm exec changeset status --since origin/main
 ```
 
 Use the output to confirm that Changesets sees the intended package bumps, then
-state the correct PR outcome from the decision table above.
+state the correct PR outcome from the decision table above. This command cannot
+infer server runtime impact from Go implementation paths by itself; review that
+intent manually and add an `@zitadel/server` changeset when the server change
+belongs in the unified release notes.
 
 The public packages above are in one Changesets fixed group while the repo is
-in alpha, so a version PR moves the CLI, SDKs, API packages, and server npm
-runtime together.
+in alpha, so a version PR moves the CLI, SDKs, API packages, Go server runtime,
+and server npm artifacts together.
 
 ## Alpha prerelease mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,7 @@ For customer-local runtime workflows, agents should prefer
   handoff. Use sections for `Summary`, `Validation`,
   `Release notes / changeset`, and `Notes`. List the exact validation commands
   run; if validation was not run, say so explicitly. In **Release notes /
-  changeset**, state one of the three outcomes from the
+  changeset**, state one of the outcomes from the
   [decision table](.changeset/README.md#decision-table) — do not add a
   `.changeset/*.md` file unless that table says you should.
 
@@ -250,16 +250,34 @@ For customer-local runtime workflows, agents should prefer
 
 When a PR touches [publishable npm packages](.changeset/README.md#publishable-npm-packages)
 (the public `@zitadel/*` packages under `apps/cli/`, `apps/server*`, and
-selected `packages/*` paths), follow the
+selected `packages/*` paths) or changes
+[shipped Go server runtime behavior](.changeset/README.md#go-server-runtime-changes),
+follow the
 [decision table](.changeset/README.md#decision-table) and workflow in
 [`.changeset/README.md`](.changeset/README.md). Verify locally with
 `corepack pnpm exec changeset status --since origin/main` when you need to
 inspect planned package bumps.
 
+Do not use file paths alone to decide release intent. Go changes under
+`internal/`, `cmd/`, `api/openapi/`, migrations, or embedded server assets can
+require a real `@zitadel/server` changeset when they change shipped server/API
+behavior. The primary reason is the single GitHub Release notes and shared
+container/server version tags; the npm server package is a distribution
+mechanism on that same release train. Pure tests, comments, generated mocks, and
+internal refactors with no shipped behavior change do not need one.
+
+Semantic PR title type should describe the change from a release-note reader's
+perspective: use `feat` for a new customer-usable capability, `fix` for
+customer-visible correctness or compatibility, and `refactor` for structural
+work with no intended behavior change. If a structural Go change changes shipped
+server behavior, prefer a behavior-bearing title type such as `fix(...)` or
+`feat(...)` and add the matching `@zitadel/server` changeset.
+
 The public packages are `@zitadel/cli`, `@zitadel/server`, the
 `@zitadel/server-*` platform packages, `@zitadel/api`, `@zitadel/components`,
 `@zitadel/sdk-core`, `@zitadel/sdk-next`, `@zitadel/sdk-nuxt`,
-`@zitadel/sdk-react`, `@zitadel/sdk-vue`, and `@zitadel/sdk-angular`. These
+`@zitadel/sdk-react`, `@zitadel/sdk-vue`, `@zitadel/sdk-angular`,
+`@zitadel/sdk-solid`, `@zitadel/sdk-svelte`, and `@zitadel/sdk-qwik`. These
 packages are in one Changesets fixed group for alpha product releases. Moon
 still creates or updates the draft GitHub Release shell for `v<version>` from
 the fixed package version; maintainers publish product notes manually.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,16 @@ preview the package bumps Changesets will plan from your PR. Pull requests also
 get an informational Changesets comment; maintainers use that and
 `.changeset/README.md` to review release intent.
 
+Changesets are not only a path-based npm-package check. They feed the generated
+changelogs and the single GitHub Release notes draft for `v<version>`. The Go
+server release shares that version through containers, archives,
+`@zitadel/server`, and platform server packages. If a change under `internal/`,
+`cmd/`, `api/openapi/`, a migration, or embedded server assets changes shipped
+server/API/runtime behavior, add a real changeset for `@zitadel/server` so users
+can see the server change in the release notes. If the Go change is tests-only,
+comments-only, generated mocks, or a refactor with no shipped behavior change,
+no changeset is needed.
+
 `moon run workspace:check -- --full` runs the repository's slower local
 CI-parity script, including integration tests, demo e2e, package smoke checks,
 release snapshots, and the fresh-app journey. Use `moon run <project>:<task>` to
@@ -254,6 +264,13 @@ documentation-only changes, use the `docs` type, for example:
 docs: add preview status disclaimer
 ```
 
+Choose the title type from the release-note reader's perspective. Use `feat`
+for a new customer-usable capability, `fix` for customer-visible correctness or
+compatibility, and `refactor` for structural work with no intended behavior
+change. If structural Go work changes shipped server behavior, prefer a
+behavior-bearing title type such as `fix(...)` or `feat(...)` and add the
+matching `@zitadel/server` changeset.
+
 ## Pull request descriptions
 
 Include a concise PR description before handing work off for review. Use these
@@ -262,6 +279,6 @@ sections:
 - `Summary` — what changed and why.
 - `Validation` — exact commands run. If validation was not run, say so
   explicitly.
-- `Release notes / changeset` — changeset status for user-visible package
-  changes.
+- `Release notes / changeset` — changeset status for user-visible package or
+  shipped server/runtime changes.
 - `Notes` — reviewer context, follow-ups, risks, or `None`.

--- a/README.md
+++ b/README.md
@@ -130,11 +130,12 @@ days and are not release artifacts.
 ## Build & release
 
 This monorepo uses Moon for task execution, non-npm artifact builds, and the
-draft GitHub Release shell for `v<version>`. Changesets owns package versions,
-changelogs, npm publishing, and public package tags. Product release prose is
-written manually by maintainers when a GitHub Release is published.
+draft GitHub Release shell for `v<version>`. Changesets owns per-PR release
+intent, generated changelogs, package versions, npm publishing, and public
+package tags. Product release prose is written manually by maintainers when a
+GitHub Release is published.
 The current alpha release model uses one fixed Changesets version across the
-CLI, server npm runtime, API packages, components, and SDKs. The full rationale
+CLI, Go server runtime, API packages, components, and SDKs. The full rationale
 lives in
 [docs/adrs/002-multi-package-release-strategy.md](docs/adrs/002-multi-package-release-strategy.md)
 and [docs/adrs/023-lockstep-alpha-release-train.md](docs/adrs/023-lockstep-alpha-release-train.md).
@@ -159,15 +160,28 @@ immutable container version tags from the fixed `@zitadel/server` version and
 creates or updates the matching draft GitHub Release with generated artifact and
 package facts; stable releases may also move `ghcr.io/zitadel/nextgen:latest`.
 
-### npm packages (`changesets`)
+### Release notes and packages (`changesets`)
 
-`apps/cli`, `apps/server*`, and the public packages under `packages/` publish
-to npm via [changesets](https://github.com/changesets/changesets). On any
-user-visible change to those packages:
+[Changesets](https://github.com/changesets/changesets) records per-PR release
+intent for the single GitHub Release notes draft for `v<version>`. It also owns
+npm versions and publishing for `apps/cli`, `apps/server*`, and the public
+packages under `packages/`. The Go server shares that release version through
+containers, archives, `@zitadel/server`, and platform server packages. On any
+user-visible change to those packages, or any shipped Go server/API/runtime
+change from `internal/`, `cmd/`, `api/openapi/`, migrations, or embedded server
+assets:
 
 ```sh
 corepack pnpm changeset
 ```
+
+For Go runtime changes, add the changeset to `@zitadel/server` so the generated
+changelog and GitHub Release notes include the server change. If the same PR
+changes another public package surface such as `@zitadel/api` or an SDK
+contract, list that package too. The fixed alpha release group and Moon release
+tasks move the related server artifacts together. Pure tests, comments,
+generated mocks, contributor docs, and internal refactors with no shipped
+behavior change do not need a changeset.
 
 When pending changesets land on `main`, `release-publish.yml` runs the
 Changesets action and opens or updates the version PR with the release GitHub

--- a/docs/adrs/002-multi-package-release-strategy.md
+++ b/docs/adrs/002-multi-package-release-strategy.md
@@ -1,7 +1,7 @@
 # ADR 002: Multi-package Release Strategy
 
 > **Status:** Accepted
-> **Date:** 2026-04-25 (revised 2026-06-16)
+> **Date:** 2026-04-25 (revised 2026-06-19)
 > **Context:** nextgen monorepo release pipelines
 
 ## Decision
@@ -11,10 +11,11 @@ Release orchestration is split by responsibility:
 1. **Moon owns the monorepo task graph and artifact builds.** CI, local checks,
    Go cross-builds, npm package packing, Docker Buildx image creation, and
    release verification run through `moon` targets.
-2. **Changesets owns versions, changelogs, npm publishing, and public package
-   tags.** The public product packages release as one fixed group while the
-   repo is in alpha: CLI, server npm runtime, server platform binaries, API,
-   components, and SDK packages share one version.
+2. **Changesets owns per-PR release intent, generated changelogs, versions, npm
+   publishing, and public package tags.** The public product surfaces release
+   as one fixed group while the repo is in alpha: CLI, Go server runtime,
+   server platform binaries, API, components, and SDK packages share one
+   version.
 3. **Moon publishes non-npm product artifacts.**
    The server release target reads `@zitadel/server`, stages the Go binaries
    into the platform npm packages, builds the Go archives, and pushes
@@ -49,6 +50,14 @@ state across multiple release systems.
 
 The new model keeps the explicit per-PR release notes from Changesets, but
 makes Moon the single task graph for both Go and TypeScript work.
+
+Because the product publishes one GitHub Release for a shared `v<version>`,
+server-runtime release intent is recorded in Changesets too. That lets users
+read one release note for the CLI, SDKs, API packages, Go server runtime,
+containers, archives, and server npm packages that share the same version tag. A
+PR that changes shipped Go server behavior needs an `@zitadel/server` changeset
+even when the source files are implementation paths such as `internal/`, `cmd/`,
+`api/openapi/`, or storage migrations.
 
 ## Consequences
 

--- a/docs/runbooks/manual-release.md
+++ b/docs/runbooks/manual-release.md
@@ -8,7 +8,11 @@ prose is written manually by maintainers.
 ## Normal release
 
 1. Make sure every user-visible public package or product change has a
-   `.changeset/*.md`.
+   `.changeset/*.md` so it appears in the generated changelogs and the draft
+   GitHub Release notes for `v<version>`. This includes shipped Go
+   server/API/runtime behavior changes implemented under `internal/`, `cmd/`,
+   `api/openapi/`, migrations, or embedded server assets; record those as
+   `@zitadel/server` changesets.
 2. Merge those changes to `main`.
 3. `release-publish` runs the Changesets action and opens or updates the
    generated version PR.
@@ -92,8 +96,11 @@ gh release view v0.1.0-alpha.8 --repo zitadel/nextgen
 Product release prose is manual. Use the draft GitHub Release's generated facts
 block, the generated Changesets changelogs,
 `dist/release/<version>/artifact-summary.md`, and the merged product PRs as
-inputs. Publish the draft GitHub Release only when the product needs an
-announcement.
+inputs. Server-runtime notes should come from `@zitadel/server` changesets even
+when the original PR only touched Go implementation paths, because users read
+the single GitHub Release to understand what changed for the matching container
+and server artifact tags. Publish the draft GitHub Release only when the product
+needs an announcement.
 
 ## Local checks
 


### PR DESCRIPTION
## Summary
- Clarify that Changesets describe per-PR release intent for the shared alpha release train, not just path-based npm publishing.
- Document when shipped Go server/runtime/API changes need a real `@zitadel/server` changeset, even when implemented under `internal/`, `cmd/`, or `api/openapi/`.
- Align AGENTS, CONTRIBUTING, README, ADRs, and release runbooks on the same release-note and version-tag model.

## Testing
- Not run (not requested)