### PR TITLE
test: reject identifier rebind after a direct user-factor set

### DIFF
--- a/internal/domain/auth_attempt_test.go
+++ b/internal/domain/auth_attempt_test.go
@@ -523,6 +523,48 @@ func TestAuthAttempt_SetFactors(t *testing.T) {
 	})
 }
 
+// A user factor that was installed without going through a credential
+// verification cycle — RegisterCreatedUser is the production example,
+// promoting a synthetic challenge to a factor inside the same transaction
+// that inserts the user row — must not be silently replaced by a subsequent
+// SubmitIdentifier for a different value. Today the entity's only
+// structural protection is the "non-user factor present?" check at
+// auth_attempt.go:321-325, which misses this case because the direct-set
+// path installs only a user factor. Result: the just-created user binding
+// is overwritten and the row it inserted is orphaned.
+//
+// Not reachable from any current flow definition (no flow places an
+// identifier step after create_user / passkey_register), but the entity
+// must structurally prevent the subject-switch — relying on flow-definition
+// discipline is fragile, and the same shape will resurface as soon as a
+// step layout puts an identifier collection downstream of a creation path.
+func TestAuthAttempt_PrepareUserVerification_RejectsRebindAfterDirectUserFactorSet(t *testing.T) {
+	ttl := time.Minute
+	attempt := &domain.AuthAttempt{
+		CreatedAt:  time.Now(),
+		TimeToLive: &ttl,
+	}
+
+	// Direct user-factor install, mirroring RegisterCreatedUser (see
+	// service/auth_attempt.go's RegisterCreatedUser, which calls
+	// SetChallenge + ChallengeSucceeded with a synthetic challenge and
+	// promotes a *domain.AuthFactorUser without any credential proof).
+	attempt.SetUserFactor(&domain.User{ID: "user_A_created_here"})
+
+	// Simulate the SubmitIdentifier path for a different user: issue a
+	// user challenge, prepare verification. If the entity allows the
+	// prep, SetUserFactor will overwrite without protest.
+	attempt.Checks = append(attempt.Checks, domain.SetAuthChallengeUser("ch-1", time.Now(), time.Time{}, 0))
+	if _, err := attempt.PrepareUserVerification("ch-1"); err == nil {
+		attempt.SetUserFactor(&domain.User{ID: "user_B_existing"})
+	}
+
+	got, ok := domain.CheckAs[*domain.AuthFactorUser](attempt, domain.AuthCheckTypeUser)
+	require.True(t, ok)
+	assert.Equal(t, "user_A_created_here", got.UserID,
+		"the user factor installed by the direct path must survive a subsequent SubmitIdentifier; orphaning the just-created user is a subject-switch hazard")
+}
+
 func TestAuthAttempt_PrepareHandoff(t *testing.T) {
 	ttl := time.Minute
 


### PR DESCRIPTION
## Summary

Failing test (`internal/domain/auth_attempt_test.go`) for a subject-switch hazard in the `AuthAttempt` entity: when a user factor is installed without going through a credential verification cycle, a subsequent \`SubmitIdentifier\` for a different value silently overwrites the binding.

The production path that reaches this shape is `RegisterCreatedUser` (`internal/service/auth_attempt.go:361`), which promotes a synthetic user challenge to a factor inside the same transaction that inserts the user row. The just-inserted user is then orphaned if a downstream \`SubmitIdentifier\` runs.

## Why the existing lock doesn't catch it

The entity's only structural protection today is at `internal/domain/auth_attempt.go:321-325` (inside \`PrepareUserVerification\`):

```go
for _, check := range a.Checks {
    if _, ok := check.(AuthFactor); ok && check.Type() != AuthCheckTypeUser {
        return nil, ErrAuthAttemptInvalidRequest()...
    }
}
```

That fires for `id(A) → password(A) → id(B)` (password factor is non-user) and `id(A) → passkey verify (discoverable) → id(B)` (passkey factor is non-user). It does **not** fire for `RegisterCreatedUser → id(B)` because only a user factor is ever installed.

## Reachability today

Not reachable from any current flow definition — no flow places an identifier step downstream of \`create_user\` / \`passkey_register\`. So this is a **latent hazard, not an active bug**.

The reason to close it anyway: relying on flow-definition discipline to avoid subject switches is fragile. The same shape will resurface the moment a step layout puts an identifier collection downstream of a creation path.

## Fix shape (not in this PR)

Most likely a `Committed bool` (or origin enum) on `AuthFactorUser`. Set true by paths that have side effects or carry a credential (RegisterCreatedUser, passkey discoverable verify); set false by `SubmitIdentifier`. Extend the \`PrepareUserVerification\` lock to also reject when the existing user factor is committed.

Exact landing is a design call — this PR just pins the contract.

## Relationship to PR #363

#363 fixes the **end-to-end manifestation** of the rebinding bug at the flow-engine layer (passkey login fails for the second user without a refresh). This PR addresses an **adjacent latent hazard** at the auth-attempt layer that survives #363's fix. They can land independently.

## Test plan

- [x] `go test ./internal/domain -run TestAuthAttempt_PrepareUserVerification_RejectsRebindAfterDirectUserFactorSet` fails: \`user_A_created_here\` got replaced by \`user_B_existing\`.
- [x] All other `./internal/domain` tests still pass.
- [ ] After the entity fix lands, this test passes without modification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)