### PR TITLE
docs: back-navigation ADR changes

### DIFF
--- a/api/openapi/components/flows/step-action.yaml
+++ b/api/openapi/components/flows/step-action.yaml
@@ -11,7 +11,7 @@ properties:
     example: submit
   kind:
     type: string
-    enum: [submit, passkey, passkey_register, navigate]
+    enum: [submit, passkey, passkey_register, navigate, back]
     example: submit
     description: |
       Classifies how the engine handles this action:
@@ -21,7 +21,9 @@ properties:
       - `passkey_register`: issue a WebAuthn registration challenge; the matching
         transition fires once the returned attestation verifies.
       - `navigate`: route through the transition without running the input
-        pipeline. Used for back-navigation and similar pure-routing actions.
+        pipeline. Used for pure-routing actions like skip or switch-method.
+      - `back`: pop the previous step from the runtime history and return it.
+        The engine injects this kind; flow definitions do not declare it.
   primary:
     type: boolean
     default: false

--- a/api/openapi/components/flows/step-action.yaml
+++ b/api/openapi/components/flows/step-action.yaml
@@ -11,7 +11,7 @@ properties:
     example: submit
   kind:
     type: string
-    enum: [submit, passkey, passkey_register, navigate, back]
+    enum: [submit, passkey, passkey_register, navigate]
     example: submit
     description: |
       Classifies how the engine handles this action:
@@ -21,9 +21,7 @@ properties:
       - `passkey_register`: issue a WebAuthn registration challenge; the matching
         transition fires once the returned attestation verifies.
       - `navigate`: route through the transition without running the input
-        pipeline. Used for pure-routing actions like skip or switch-method.
-      - `back`: pop the previous step from the runtime history and return it.
-        The engine injects this kind; flow definitions do not declare it.
+        pipeline. Used for back-navigation and similar pure-routing actions.
   primary:
     type: boolean
     default: false

--- a/docs/adrs/022-flow-back-navigation.md
+++ b/docs/adrs/022-flow-back-navigation.md
@@ -20,17 +20,19 @@ losing widget state.
 
 ### The `back` action
 
-`back` is a plain action — same shape as `submit` or `register`:
+`back` is an action with `kind: "back"`. The name is conventionally
+`"back"` but only the `kind` is load-bearing — clients identify the
+back action by kind, never by name:
 
 ```json
 {
   "step": {
     "name": "passkey-upsell",
-    "actions": {
-      "setup": { "text_key": "passkey-upsell.action.setup", "primary": true },
-      "skip":  { "text_key": "passkey-upsell.action.skip" },
-      "back":  { "text_key": "action.back" }
-    }
+    "actions": [
+      { "name": "setup", "kind": "passkey_register", "text_key": "passkey-upsell.action.setup", "primary": true },
+      { "name": "skip",  "kind": "navigate",         "text_key": "passkey-upsell.action.skip" },
+      { "name": "back",  "kind": "back",             "text_key": "action.back" }
+    ]
   }
 }
 ```
@@ -48,8 +50,8 @@ session token rotates as usual. No special API endpoint, no per-step
 
 ### When the engine injects `back`
 
-The engine adds `back` to a step's `actions` dict iff **both** of the
-following hold:
+The engine adds a `kind: "back"` action to the step's `actions` iff
+**both** of the following hold:
 
 1. The runtime `history` array has at least one prior step.
 2. The current step is not terminal.
@@ -60,8 +62,9 @@ ones (e.g., the action just created the user or rotated a credential).
 The engine classifies reversibility from the semantics of the action it
 executed — flow definitions carry no reversibility metadata.
 
-The frontend never needs to hardcode which steps support back — the presence
-or absence of the `back` action in the response is the single source of truth.
+The frontend never needs to hardcode which steps support back — the
+presence or absence of a `kind: "back"` action in the response is the
+single source of truth.
 
 ### Browser History API integration
 
@@ -72,19 +75,20 @@ the native back gesture work without page reloads.
 #### Lifecycle
 
 1. **On each submit response** (after `applyResponse`):
-   - New step has `back` and the step name changed →
+   - New step has a `kind: "back"` action and the step name changed →
      `history.pushState(null, '', '#s' + this.stepSeq++)`.
    - Otherwise → no history call.
 
 2. **On `popstate` event** (browser back button):
-   - If the current step's `actions` contains `back` →
-     submit `{ action: "back" }` to the API, apply the response
-   - If no `back` action → call `history.forward()` to restore the
-     consumed entry without growing the stack, and surface a brief
-     visual indicator that going back is not available. This avoids
-     trapping the user in an ever-growing back loop — the history
-     stack stays fixed and the host page remains reachable once the
-     flow's entries are exhausted
+   - If the current step has a `kind: "back"` action →
+     submit `{ action: <that action's name> }` to the API, apply the
+     response.
+   - Else → call `history.forward()` to restore the consumed entry
+     without growing the stack, and surface a brief visual indicator
+     that going back is not available. This avoids trapping the user
+     in an ever-growing back loop — the history stack stays fixed and
+     the host page remains reachable once the flow's entries are
+     exhausted.
 
 3. **On `disconnectedCallback`** (widget removed):
    - Remove the `popstate` listener — clean up
@@ -108,7 +112,7 @@ identical to clicking an in-UI back button.
 
 | Scenario | Behavior |
 |---|---|
-| User presses back on the initial step | No `back` action → browser navigates the host page (leaves the flow) — correct behavior |
+| User presses back on the initial step | No `kind: "back"` action → browser navigates the host page (leaves the flow) — correct behavior |
 | User presses forward after going back | `popstate` fires with a forward state — orchestrator calls `history.back()` to undo the traversal and keep the URL aligned with the displayed step. The flow state is server-authoritative; the browser cannot skip ahead. |
 | Multiple rapid back presses | Each `popstate` triggers a sequential `submit("back")` — the session token rotation prevents race conditions |
 | Embedded in a SPA with its own router | The host router and the flow's fragment entries coexist — fragments are scoped and don't conflict with path-based routing |
@@ -116,17 +120,18 @@ identical to clicking an in-UI back button.
 ### Template rendering
 
 The `default.liquid` template already iterates all non-primary actions and
-renders them. A `back` action renders automatically as a secondary button or
-link — no template changes required.
+renders them. A `kind: "back"` action renders automatically as a secondary
+button or link — no template changes required.
 
-For visual consistency, the `back` action can be rendered as a left-arrow
-link above the card (matching common auth UI patterns) by checking the
-action key name in the template:
+For visual consistency, the back action can be rendered as a left-arrow
+link above the card (matching common auth UI patterns) by selecting it
+by kind in the template:
 
 ```liquid
-{% if actions.back %}
-  <a class="zl-card-nav__link" data-action="back">
-    {{ actions.back.text_key | t }}
+{% assign back = actions | where: "kind", "back" | first %}
+{% if back %}
+  <a class="zl-card-nav__link" data-action="{{ back.name }}">
+    {{ back.text_key | t }}
   </a>
 {% endif %}
 ```
@@ -186,7 +191,8 @@ increases flow abandonment.
 
 ## Consequences
 
-- **`step-action.yaml`** — unchanged. `back` is a plain action.
+- **`step-action.yaml`** — `kind` enum gains `back`. Clients identify the
+  back action by `kind: "back"`, never by name.
 - **`flow-submit-request.yaml`** — unchanged. `back` is already documented
   as a valid action value.
 - **Flow definitions** — unchanged. No per-step `back` transitions and no

--- a/docs/adrs/022-flow-back-navigation.md
+++ b/docs/adrs/022-flow-back-navigation.md
@@ -72,18 +72,9 @@ the native back gesture work without page reloads.
 #### Lifecycle
 
 1. **On each submit response** (after `applyResponse`):
-   - If `newStep.name === previousStep.name` → no history call. Same-name
-     responses are validation errors or re-renders; the engine treated
-     them as non-advancing, so the browser stack must not move either.
-   - Else if the new step's `actions` contains `back` →
-     `history.pushState(null, '', '#s' + this.stepSeq++)`. The fragment
-     (`#s1`, `#s2`, …) has no semantic meaning; it is never read back.
-   - Else → `history.replaceState(...)`. No new entry; back from here
-     leaves the flow (intercepted by step 2 below).
-
-   The presence of `back` in the response is the single signal — the
-   engine's injection rules (above) decide it; the client just reads it.
-   The two layers stay in lockstep by construction.
+   - New step has `back` and the step name changed →
+     `history.pushState(null, '', '#s' + this.stepSeq++)`.
+   - Otherwise → no history call.
 
 2. **On `popstate` event** (browser back button):
    - If the current step's `actions` contains `back` →

--- a/docs/adrs/022-flow-back-navigation.md
+++ b/docs/adrs/022-flow-back-navigation.md
@@ -1,4 +1,4 @@
-# ADR 016: Flow Back-Navigation
+# ADR 022: Flow Back-Navigation
 
 > **Status:** Proposed
 > **Date:** 2026-05-21
@@ -7,10 +7,11 @@
 ## Decision
 
 Back-navigation in the flow engine uses the **existing action contract**.
-The server declares a `back` action on steps where returning to the previous
-step is allowed. The orchestrator submits `{ action: "back" }` like any other
-action. The server follows the `back` transition in the flow definition and
-returns the target step.
+The engine **injects** a `back` action on steps where returning to the
+previous step is allowed — flow authors do not declare back transitions
+per step. The orchestrator submits `{ action: "back" }` like any other
+action. The engine pops the previous step from the runtime history and
+returns it.
 
 The `<zitadel-login>` orchestrator additionally integrates with the browser's
 **History API** so that the native back gesture (swipe, button, keyboard
@@ -40,36 +41,24 @@ When submitted:
 POST /flow/{id}/submit { session_token, action: "back" }
 ```
 
-The server resolves this like any other action: it looks up the `back`
-transition in the flow definition, follows it to the target step, and returns
-the new step response. The session token rotates as usual. No special API
-endpoint, no history stack popping — `back` is a regular edge in the
-definition's step graph:
+The engine pops the previous step from the runtime `history` array stored
+in the encrypted flow cookie and returns it as the new step response. The
+session token rotates as usual. No special API endpoint, no per-step
+`back` transition in the flow definition.
 
-```json
-{
-  "name": "passkey-upsell",
-  "transitions": {
-    "setup": { "target": "done" },
-    "skip":  { "target": "done" },
-    "back":  { "target": "identifier" }
-  }
-}
-```
+### When the engine injects `back`
 
-### Server-side contract
+The engine adds `back` to a step's `actions` dict iff **both** of the
+following hold:
 
-The server controls **whether** back is allowed. It includes `back` in the
-step's `actions` dict only when the flow definition declares a `back`
-transition for the current step.
+1. The runtime `history` array has at least one prior step.
+2. The current step is not terminal.
 
-Steps where `back` is **not** offered:
-
-| Step | Reason |
-|---|---|
-| Initial step (e.g. `identifier`) | No `back` transition defined — nowhere to go back to |
-| Post-mutation steps | User was already created / credential was reset — irreversible |
-| Terminal steps (`complete`) | Flow is done |
+Reversibility is folded into rule 1: the engine pushes onto `history`
+only on reversible transitions, and **clears** `history` on irreversible
+ones (e.g., the action just created the user or rotated a credential).
+The engine classifies reversibility from the semantics of the action it
+executed — flow definitions carry no reversibility metadata.
 
 The frontend never needs to hardcode which steps support back — the presence
 or absence of the `back` action in the response is the single source of truth.
@@ -82,13 +71,19 @@ the native back gesture work without page reloads.
 
 #### Lifecycle
 
-1. **On each step transition** (after `applyResponse`):
-   - If the new step's `actions` contains `back` →
-     `history.pushState(null, '', '#s' + this.stepSeq++)` — creates a
-     history entry with an opaque, incrementing fragment (`#s1`, `#s2`, …).
-     The fragment has no semantic meaning; it is never read back.
-   - If the new step has no `back` action → `history.replaceState(...)` (no
-     new entry — browser back navigates the host page, which is correct)
+1. **On each submit response** (after `applyResponse`):
+   - If `newStep.name === previousStep.name` → no history call. Same-name
+     responses are validation errors or re-renders; the engine treated
+     them as non-advancing, so the browser stack must not move either.
+   - Else if the new step's `actions` contains `back` →
+     `history.pushState(null, '', '#s' + this.stepSeq++)`. The fragment
+     (`#s1`, `#s2`, …) has no semantic meaning; it is never read back.
+   - Else → `history.replaceState(...)`. No new entry; back from here
+     leaves the flow (intercepted by step 2 below).
+
+   The presence of `back` in the response is the single signal — the
+   engine's injection rules (above) decide it; the client just reads it.
+   The two layers stay in lockstep by construction.
 
 2. **On `popstate` event** (browser back button):
    - If the current step's `actions` contains `back` →
@@ -147,17 +142,11 @@ action key name in the template:
 
 ### Mock server changes
 
-The xstate flow machine adds `back` transitions to steps that follow the
-initial step:
-
-```
-passkey-upsell → back → identifier
-register       → back → identifier
-password       → back → identifier
-```
-
-Step fixtures include `back: { text_key: "action.back" }` in their `actions`
-dict where appropriate.
+No per-step `back` transitions in the xstate machine — the mock engine
+derives back from its runtime history, same as production. The mock
+classifies the same action semantics as irreversible (e.g., the action
+that creates the user) so `back` is automatically omitted on the
+following step.
 
 ## Context
 
@@ -209,14 +198,15 @@ increases flow abandonment.
 - **`step-action.yaml`** — unchanged. `back` is a plain action.
 - **`flow-submit-request.yaml`** — unchanged. `back` is already documented
   as a valid action value.
-- **Flow definitions** — gain `back` transitions on steps where backtracking
-  is allowed. The `history` array in `flow-engine-storage.md` is unrelated
-  internal bookkeeping — `back` is resolved via the transition graph.
+- **Flow definitions** — unchanged. No per-step `back` transitions and no
+  reversibility metadata; the engine derives back from the runtime
+  `history` array (see `flow-engine-storage.md`) and from the semantics
+  of the actions it executes.
 - **`zitadel-login.ts`** — gains `pushState` calls on step transitions and a
   `popstate` listener.
 - **Locale files** — gain `action.back` translation key.
-- **Mock server** — `flow-machine.ts` gains `back` transitions;
-  `fixtures/login.ts` gains `back` actions on applicable steps.
+- **Mock server** — no `back` edges added to `flow-machine.ts`; the mock
+  engine applies the same back-injection rules as production.
 
 [storage]: ../design/flowengine/flow-engine-storage.md
 [submit]: ../../api/openapi/components/flows/flow-submit-request.yaml


### PR DESCRIPTION
## Summary

Restructures ADR 022 (Flow Back-Navigation). Docs-only — no code or schema changes; the listed contract additions land in a follow-up implementation PR.

- **Engine injects `back`** from runtime state. Flow definitions no longer declare per-step `back` transitions or reversibility metadata.
- **Two-rule injection contract**: (1) `history` non-empty, (2) not terminal. Reversibility is folded into rule 1 — the engine pushes onto `history` only on reversible transitions and clears it on irreversible ones. Action semantics (which only the engine knows) classify reversibility.
- **Identify by `kind`, not name**: the ADR specifies a new `kind: "back"` value on `step-action.yaml` so clients match on kind rather than the literal action name. The schema change itself is **not** in this PR — it will land with the engine implementation.
- **Browser History API lifecycle**: `pushState` iff a `kind: "back"` action is present and the step name changed; otherwise no-op. Single signal keeps the browser and engine in lockstep.
- **Heading fix**: `# ADR 016` → `# ADR 022`.

## Test plan

Docs-only — no code paths or schemas touched.

- [ ] Engine contract reads cleanly (no reversibility leaks to flow authors).
- [ ] Browser lifecycle and engine rules align on `kind: "back"` presence.
- [ ] "Mock server" and "Consequences" sections agree with the new model.
- [ ] Heading matches filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)