### PR TITLE
fix: set required kind on default flow actions

### DIFF
--- a/.changeset/fix-default-flow-action-kind.md
+++ b/.changeset/fix-default-flow-action-kind.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/cli": patch
+---
+
+Set the now-required `kind` on the default flow's step actions: submit actions use `submit`, the register/login routing actions use `navigate`. Without it, the generated flow fails validation against the updated flow-definition schema.

--- a/apps/cli/src/lib/flows/build.ts
+++ b/apps/cli/src/lib/flows/build.ts
@@ -52,8 +52,8 @@ export function buildFlow(
         name: "identifier",
         fields: ["email"],
         actions: [
-          { name: "submit", primary: true },
-          { name: "register" },
+          { name: "submit", kind: "submit", primary: true },
+          { name: "register", kind: "navigate" },
         ],
         gates: {},
         transitions: {
@@ -67,7 +67,7 @@ export function buildFlow(
       {
         name: "credential",
         fields: ["password"],
-        actions: [{ name: "submit", primary: true }],
+        actions: [{ name: "submit", kind: "submit", primary: true }],
         gates: {},
         transitions: { submit: { target: "complete" } },
       },
@@ -79,8 +79,8 @@ export function buildFlow(
         // the user row and the password row in one transaction.
         fields: [...fields, "password"],
         actions: [
-          { name: "submit", primary: true },
-          { name: "login" },
+          { name: "submit", kind: "submit", primary: true },
+          { name: "login", kind: "navigate" },
         ],
         gates: {},
         on_success: "create_user",


### PR DESCRIPTION
Adds the required `kind` to each action in the CLI's default flow builder (`apps/cli/src/lib/flows/build.ts`). #353 made `kind` mandatory on step actions but didn't update the builder, so the generated flow failed schema validation and broke `cli:test` on any branch merging current main. Submit actions get `kind: submit`; the register/login actions that only route to another step get `kind: navigate` (they skip the input pipeline, matching the engine). Verified by regenerating the zod and running the full CLI suite (606 tests). Includes a changeset (`@zitadel/cli` patch).
