### PR TITLE
chore: make the repo publishable to the public

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -36,6 +36,9 @@ to npm:
 - `packages/sdk-react/` — `@zitadel/sdk-react`
 - `packages/sdk-vue/` — `@zitadel/sdk-vue`
 - `packages/sdk-angular/` — `@zitadel/sdk-angular`
+- `packages/sdk-solid/` — `@zitadel/sdk-solid`
+- `packages/sdk-svelte/` — `@zitadel/sdk-svelte`
+- `packages/sdk-qwik/` — `@zitadel/sdk-qwik`
 
 `AGENTS.md` files under those roots do not require a changeset on their own.
 
@@ -89,10 +92,11 @@ One-line, user-facing summary of the change.
 List only public package names (`@zitadel/cli`, `@zitadel/server`,
 `@zitadel/server-*`, `@zitadel/api`, `@zitadel/components`,
 `@zitadel/sdk-core`, `@zitadel/sdk-next`, `@zitadel/sdk-nuxt`,
-`@zitadel/sdk-react`, `@zitadel/sdk-vue`, `@zitadel/sdk-angular`). Pick `patch`
-(fixes), `minor` (features), or `major` (breaking). The repo is in `alpha`
-prerelease mode (`.changeset/pre.json`) and public packages are in one fixed
-group, so versions cut as one `X.Y.Z-alpha.N` train automatically — see
+`@zitadel/sdk-react`, `@zitadel/sdk-vue`, `@zitadel/sdk-angular`,
+`@zitadel/sdk-solid`, `@zitadel/sdk-svelte`, `@zitadel/sdk-qwik`). Pick
+`patch` (fixes), `minor` (features), or `major` (breaking). The repo is in
+`alpha` prerelease mode (`.changeset/pre.json`) and public packages are in one
+fixed group, so versions cut as one `X.Y.Z-alpha.N` train automatically — see
 [Alpha prerelease mode](#alpha-prerelease-mode).
 
 ## Empty changeset
@@ -170,11 +174,10 @@ Publishing authenticates with **npm trusted publishing (OIDC)** — there is **n
    - Workflow filename: `release-publish.yml` (exact, case-sensitive)
 3. Optionally, under **Publishing access**, require 2FA and disallow tokens so only this workflow can publish.
 
-While this repository is private, the workflow keeps npm provenance disabled
-with `NPM_CONFIG_PROVENANCE=false`. Trusted publishing still authenticates with
-short-lived OIDC credentials, but npm only accepts public provenance
-attestations from public source repositories. Re-enable provenance when
-`zitadel/nextgen` is public.
+The workflow sets `NPM_CONFIG_PROVENANCE` from the repository visibility:
+`false` while this repository is private and `true` once it is public. Trusted
+publishing still authenticates with short-lived OIDC credentials, but npm only
+accepts public provenance attestations from public source repositories.
 
 Changesets publishes the npm packages, including `@zitadel/server`. Moon
 release tasks read the `@zitadel/server` version, cross-build the Go server,

--- a/.changeset/public-preview-readiness.md
+++ b/.changeset/public-preview-readiness.md
@@ -1,0 +1,4 @@
+---
+---
+
+Repository public-preview readiness only. No published package behavior changes.

--- a/.github/instructions/consumer-journey.instructions.md
+++ b/.github/instructions/consumer-journey.instructions.md
@@ -11,7 +11,7 @@ gate, not as a demo-app e2e suite.
   tarballs. Do not replace this with public npm packages for Zitadel packages.
 - The journey must exercise the customer local runtime flow through `npx`:
   `doctor`, `start`, then
-  `setup --framework <next|nuxt|react|vue|angular> --server local` with
+  `setup --framework <next|nuxt|react|vue|angular|solid|svelte|qwik> --server local` with
   `--non-interactive --json`.
 - Produce package artifacts with `corepack pnpm --dir <package> pack` and keep
   tarball verification for required package presence plus unresolved

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -14,7 +14,8 @@ Vitest.
   contract updates when user-facing.
 - The public npm packages (`apps/cli`, `packages/api`, `packages/components`,
   `packages/sdk-core`, `packages/sdk-next`, `packages/sdk-nuxt`,
-  `packages/sdk-react`, `packages/sdk-vue`, `packages/sdk-angular`) must keep
+  `packages/sdk-react`, `packages/sdk-vue`, `packages/sdk-angular`,
+  `packages/sdk-solid`, `packages/sdk-svelte`, `packages/sdk-qwik`) must keep
   `"license": "MIT"`.
 - Follow the [decision table in `.changeset/README.md`](../../.changeset/README.md#decision-table)
   for publishable package paths; add a real changeset for user-visible changes,

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -154,7 +154,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.before || 'HEAD^' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "false"
+          NPM_CONFIG_PROVENANCE: ${{ github.event.repository.private == false }}
           RECOVER_VERSION: ${{ inputs.recover_version }}
 
       - name: Publish release
@@ -170,5 +170,5 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.before || 'HEAD^' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "false"
+          NPM_CONFIG_PROVENANCE: ${{ github.event.repository.private == false }}
           RECOVER_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.recover_version || '' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,8 @@ Secrets").
   registration/login flows.
 - `packages/components/` contains shared Lit components.
 - `packages/sdk-core/`, `packages/sdk-next/`, `packages/sdk-nuxt/`,
-  `packages/sdk-react/`, `packages/sdk-vue/`, and `packages/sdk-angular/`
+  `packages/sdk-react/`, `packages/sdk-vue/`, `packages/sdk-angular/`,
+  `packages/sdk-solid/`, `packages/sdk-svelte/`, and `packages/sdk-qwik/`
   contain public TypeScript SDKs.
 - `packages/api-mock/` contains the in-process MSW handlers and standalone
   mock auth server used by demos and e2e tests.
@@ -259,7 +260,8 @@ inspect planned package bumps.
 The public packages are `@zitadel/cli`, `@zitadel/server`, the
 `@zitadel/server-*` platform packages, `@zitadel/api`, `@zitadel/components`,
 `@zitadel/sdk-core`, `@zitadel/sdk-next`, `@zitadel/sdk-nuxt`,
-`@zitadel/sdk-react`, `@zitadel/sdk-vue`, and `@zitadel/sdk-angular`. These
+`@zitadel/sdk-react`, `@zitadel/sdk-vue`, `@zitadel/sdk-angular`,
+`@zitadel/sdk-solid`, `@zitadel/sdk-svelte`, and `@zitadel/sdk-qwik`. These
 packages are in one Changesets fixed group for alpha product releases. Moon
 still creates or updates the draft GitHub Release shell for `v<version>` from
 the fixed package version; maintainers publish product notes manually.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+legal@zitadel.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -10,9 +10,9 @@ We use SPDX license identifiers for standard license naming.
 
 ## AGPL-3.0-only default
 
-Unless a path-specific MIT override below applies, the contents of this
-repository are licensed under AGPL-3.0-only. The full license text is in
-[LICENSE](LICENSE).
+Unless a path-specific MIT override or third-party community-document note below
+applies, the contents of this repository are licensed under AGPL-3.0-only. The
+full license text is in [LICENSE](LICENSE).
 
 This default includes, without limitation:
 
@@ -47,7 +47,6 @@ licensed under the MIT License:
 ```text
 README.md
 CONTRIBUTING.md
-CODE_OF_CONDUCT.md
 AGENTS.md
 LICENSING.md
 SUPPORT.md
@@ -88,6 +87,13 @@ MIT `LICENSE` files before publishing any of them as npm packages.
 
 For non-package MIT paths such as `api/` and `docs/`, SPDX headers, generated
 metadata, or local README notes are sufficient when the format supports them.
+
+## Third-party community documents
+
+`CODE_OF_CONDUCT.md` is adapted from the Contributor Covenant version 2.0 and is
+included as a community governance document, not as product source code or a
+downstream integration surface. It is intentionally not listed under the MIT
+exceptions above; its attribution and upstream terms are stated in that file.
 
 ## External contributions
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -47,8 +47,10 @@ licensed under the MIT License:
 ```text
 README.md
 CONTRIBUTING.md
+CODE_OF_CONDUCT.md
 AGENTS.md
 LICENSING.md
+SUPPORT.md
 VISION.md
 api/
 docs/

--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 Next iteration of the Zitadel identity platform.
 
 > **Preview status:** This repository is a pre-release next-generation Zitadel
-> preview. The public name may change, and APIs, CLI flags, package surfaces,
-> and docs are still in flux. The checked-in CLI currently supports the local
-> npm-binary flow documented below; create-first, claim-later is the product
-> direction, but `zitadel claim` is not shipped in this repo yet. See
-> [VISION.md](VISION.md).
+> preview for testing and feedback. It is not production software: APIs,
+> storage, CLI flags, package surfaces, and docs may change without a migration
+> guarantee. The checked-in CLI currently supports the local npm-binary flow
+> documented below; create-first, claim-later is the product direction, but
+> `zitadel claim` is not shipped in this repo yet. See [VISION.md](VISION.md).
+>
+> This preview does not yet participate in Zitadel's production security
+> advisory process. For security-sensitive production evaluation, use the main
+> Zitadel project and policies instead.
 
 ## Workflow front doors
 
@@ -15,6 +19,7 @@ Next iteration of the Zitadel identity platform.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contributor setup, Moon commands,
 local checks, source builds, release workflows, and troubleshooting.
+For preview feedback routing, see [SUPPORT.md](SUPPORT.md).
 
 Preview the documentation site with:
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,11 @@
+# Support
+
+This repository is a pre-release next-generation Zitadel preview for testing
+and feedback. It is not production software and does not provide a production
+support channel or production security-advisory process.
+
+Use GitHub issues or discussions in this repository for preview bugs, docs
+confusion, local setup problems, and test feedback.
+
+For production use, security-sensitive evaluation, or supported deployments,
+use the main Zitadel project and its published policies instead.

--- a/VISION.md
+++ b/VISION.md
@@ -11,16 +11,18 @@ dashboard detours, or hand-copied client IDs. When the project is ready to be
 shared, deployed, or governed, a human claims it, the work stays in place, and
 the system becomes a team-owned identity platform configured like code.
 
-This preview is not the finished product, and its public name may change. The
-direction is clear: ship auth before signup, claim ownership when it matters,
-and grow into production trust without surprising developers, agents, or
-downstream applications.
+This preview is not the finished product, and its public name may change. It is
+not production software: APIs, storage, CLI flags, package surfaces, and docs
+may change without a migration guarantee. The direction is clear: ship auth
+before signup, claim ownership when it matters, and grow into production trust
+without surprising developers, agents, or downstream applications.
 
 ## Current Reality
 
 This repository is pre-release. The current checked-in CLI supports the local
-Docker-backed setup flow documented in [README.md](README.md); it does not
-currently ship a `zitadel claim` command.
+`@zitadel/server` npm-binary setup flow documented in [README.md](README.md);
+Docker remains an explicit fallback/operator-style runtime, and the repo does
+not currently ship a `zitadel claim` command.
 
 Create-first, claim-later remains the product direction. The previous mock-only
 claim lifecycle was removed until the real server-side claim contract exists;
@@ -33,6 +35,9 @@ claim flow, but those examples are target design, not shipped CLI behavior.
 - **Vision and naming:** Use "next-generation Zitadel preview" and say the
   public name may change. Avoid treating `nextgen` as a permanent product name
   outside literal repository, package, Docker, or artifact identifiers.
+- **Non-production honesty:** Say this preview is for testing and feedback, not
+  production use. Do not imply stable APIs, stable storage, migration
+  guarantees, production support, or production security-advisory coverage.
 - **Claim/link-first honesty:** Keep "ship auth before signup, claim later" as
   the direction, but label claim flow docs as target design until OpenAPI,
   server, and CLI support exist.

--- a/apps/cli-journey-e2e/AGENTS.md
+++ b/apps/cli-journey-e2e/AGENTS.md
@@ -21,15 +21,16 @@ generated app. It must not test the checked-in demo apps.
   temporary Verdaccio registry, not from public npm.
 - CI must run `npx @zitadel/cli@alpha doctor --runtime binary`,
   `start --runtime binary`, and
-  `setup --framework <next|nuxt|react|vue|angular> --server local` from the
-  fresh app directory with `--non-interactive --json`.
+  `setup --framework <next|nuxt|react|vue|angular|solid|svelte|qwik> --server
+  local` from the fresh app directory with `--non-interactive --json`.
 - Docker fallback coverage must opt in with `--runtime docker --image <tag>`.
 - Pack and upload only the public packages:
   `@zitadel/cli`, `@zitadel/server`, the `@zitadel/server-*` platform
   packages, `@zitadel/api`, `@zitadel/components`, `@zitadel/sdk-core`,
   `@zitadel/sdk-next`, `@zitadel/sdk-nuxt`, `@zitadel/sdk-react`,
-  `@zitadel/sdk-vue`, and `@zitadel/sdk-angular`. Private support packages
-  must stay out of the artifact set.
+  `@zitadel/sdk-vue`, `@zitadel/sdk-angular`, `@zitadel/sdk-solid`,
+  `@zitadel/sdk-svelte`, and `@zitadel/sdk-qwik`. Private support packages must
+  stay out of the artifact set.
 - Keep the generated app on `localhost` for browser tests. WebAuthn rejects IP
   address relying-party IDs such as `127.0.0.1`.
 - Keep each framework suite Playwright-serial and one-worker. Framework suites

--- a/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
+++ b/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
@@ -543,6 +543,9 @@ function validConfig(): { fixed: string[][] } {
         "@zitadel/sdk-react",
         "@zitadel/sdk-vue",
         "@zitadel/sdk-angular",
+        "@zitadel/sdk-solid",
+        "@zitadel/sdk-svelte",
+        "@zitadel/sdk-qwik",
       ],
     ],
   };

--- a/apps/docs/content/docs/get-started/quickstart.mdx
+++ b/apps/docs/content/docs/get-started/quickstart.mdx
@@ -5,6 +5,8 @@ description: Add the Zitadel preview to a local app with the alpha CLI and npm-b
 
 Use this path when you want to add Zitadel auth to a local app without a source checkout.
 
+This is preview software for testing and feedback, not production use. APIs, storage, CLI flags, packages, and docs may change without a migration guarantee.
+
 ## Prerequisites
 
 - Node.js 24 or newer.
@@ -40,7 +42,7 @@ By default this starts the matching `@zitadel/server` npm binary for the alpha t
 npx @zitadel/cli@alpha setup --server local
 ```
 
-In a fresh directory, setup asks which framework to scaffold. Scripted runs should pass `--framework next`, `--framework nuxt`, `--framework react`, `--framework vue`, or `--framework angular`.
+In a fresh directory, setup asks which framework to scaffold. Scripted runs should pass `--framework next`, `--framework nuxt`, `--framework react`, `--framework vue`, `--framework angular`, `--framework solid`, `--framework svelte`, or `--framework qwik`.
 
 Setup writes the app files, `.env.local`, `zitadel.json`, and `.zitadel/**`, then installs dependencies with the detected package manager unless `--skip-install` is passed.
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -5,7 +5,9 @@ description: Start here for the current Zitadel preview docs, shipped boundaries
 
 Zitadel's next-generation preview is the successor track for the platform, built around local-first setup, repo-owned configuration, and auth flows that are easy for humans and coding agents to prove end to end.
 
-Zitadel v4 remains maintained while this preview evolves. The preview is pre-release: APIs, CLI flags, packages, and docs can change before this becomes a future major version. The public product name may also change.
+Zitadel v4 remains maintained while this preview evolves. The preview is pre-release and is not production software: APIs, storage, CLI flags, packages, and docs can change without a migration guarantee before this becomes a future major version. The public product name may also change.
+
+This preview does not yet participate in Zitadel's production security advisory process. Use the main Zitadel project and policies for security-sensitive production evaluation.
 
 ## Current shipped boundary
 

--- a/docs/design/glossary.md
+++ b/docs/design/glossary.md
@@ -1,6 +1,12 @@
 # Zitadel Design Glossary
 
 > Canonical vocabulary for the next-generation design docs. All sub-areas (`api/`, `platform/`, `flowengine/`) reference this file rather than redefining terms. When in doubt, come back here.
+>
+> **Preview note:** These are design terms, not a shipped public contract. Claim
+> and pre-claim lifecycle entries describe target design only; the public
+> preview does not currently ship claim endpoints or a `zitadel claim` command.
+> See [ADR 003](../adrs/003-create-first-claim-later.md) for the current
+> implementation state.
 
 ## Conventions
 
@@ -72,8 +78,8 @@ Core nouns used across the API. Full endpoint map in [`api/resource-map.md`](api
 | **auth_attempt** | Ephemeral state machine driving a single authentication attempt. Exposes *auth primitives* (challenges, verify, handoff). OIDC context is owned by the OIDC adapter (`auth_requests`), not by auth_attempt. Long-form in [`api/authn-and-auth-flows.md`](api/authn-and-auth-flows.md). |
 | **handoff_token** | Short-lived, audience-bound token produced by `POST /auth_attempts/{id}/handoff`, consumed by `POST /sessions/exchange`. |
 | **challenge** | A single-factor challenge (password prompt, OTP, passkey, OIDC redirect) issued inside an auth_attempt. |
-| **bootstrap** | The `/bootstrap/*` endpoint family. Two distinct concepts share the prefix: *project bootstrap* (`POST /projects` for anonymous project creation — see [`platform/claim-flow.md`](platform/claim-flow.md)) and *challenge bootstrap* (`POST /bootstrap/challenge` for origin-bound browser nonces — see [`api/authn-and-auth-flows.md`](api/authn-and-auth-flows.md)). |
-| **claim** | The transaction that attaches a team (in the platform project) and an accountable human to a customer project. Free. Forced at first production deploy. See [`platform/claim-flow.md`](platform/claim-flow.md). |
+| **bootstrap** | The `/bootstrap/*` endpoint family. Two distinct concepts share the prefix: *project bootstrap* (`POST /projects` for anonymous project creation — target design, not currently shipped; see [`platform/claim-flow.md`](platform/claim-flow.md) and [ADR 003](../adrs/003-create-first-claim-later.md)) and *challenge bootstrap* (`POST /bootstrap/challenge` for origin-bound browser nonces — see [`api/authn-and-auth-flows.md`](api/authn-and-auth-flows.md)). |
+| **claim** | Target-design transaction that attaches a team (in the platform project) and an accountable human to a customer project. It is not currently exposed by the preview CLI or OpenAPI; see [ADR 003](../adrs/003-create-first-claim-later.md). |
 
 ---
 

--- a/docs/design/platform/README.md
+++ b/docs/design/platform/README.md
@@ -7,11 +7,12 @@
 > **What needs feedback:** The Model-A-only MVP, domains as a security + context primitive, the `preview_origins` declaration at project creation, the three deferred capability tiers (SPA, hosted login, white-label mapping).
 > **What's early draft:** OpenAPI stubs for claim and config APIs (endpoints and schemas marked `TODO` where the team still needs to converge). Flow v1 (the named versioned protocol between UI renderers and the flow engine) is referenced throughout but specified in a follow-up pass.
 >
-> **Current implementation note:** This folder describes target platform design.
-> The shipped CLI and server do not currently expose the claim lifecycle or a
-> `zitadel claim` command. ADR 003 records the current implementation state:
-> claim/link-first was removed from the CLI and api-mock until a real
-> server-side claim contract exists.
+> **Current implementation note:** This folder describes target platform design,
+> not the public preview's shipped contract. The shipped CLI and server do not
+> currently expose the claim lifecycle, claim endpoints, or a `zitadel claim`
+> command. ADR 003 records the current implementation state: claim/link-first
+> was removed from the CLI and api-mock until a real server-side claim contract
+> exists.
 
 ## How this relates to the flow engine
 

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -1,16 +1,20 @@
 # Quick start
 
-Add Zitadel to a local Next.js app with the published CLI and a Docker-managed
-local Zitadel runtime.
+Add Zitadel to a local Next.js app with the published CLI and the default
+`@zitadel/server` npm-binary local runtime.
+
+> **Preview status:** This is preview software for testing and feedback, not
+> production use. APIs, storage, CLI flags, packages, and docs may change
+> without a migration guarantee.
 
 ## Prerequisites
 
 - Node.js 24 or newer for `npx`
-- Docker Engine or a Docker-compatible runtime, only for the managed local
-  runtime (`start` / `--server local`)
+- Docker Engine or a Docker-compatible runtime only when you explicitly choose
+  `zitadel start --runtime docker` or the manual Docker Compose path
 
-If the Docker daemon is down, start Docker Desktop, Docker Engine, or Colima
-and rerun `doctor`. Remote-server setup can skip Docker by passing
+The default local runtime does not require Docker, Go, Moon, or a source
+checkout. Remote-server setup can skip the local runtime entirely by passing
 `--server <url>` instead of `--server local`.
 
 ## Steps
@@ -38,7 +42,7 @@ logout, and login across the supported frameworks.
 
 The managed local Zitadel server listens on http://localhost:8080 by default.
 The CLI stores runtime metadata in `.zitadel/local/runtime.json` and mounts
-`.zitadel/local/nextgen-data` into the container. If you start from a fresh
+`.zitadel/local/nextgen-data` for the server binary. If you start from a fresh
 directory, `setup --server local` asks which framework to scaffold and writes
 the app into the current directory. Stop preserves runtime data:
 

--- a/packages/api-mock/src/platform-handlers.ts
+++ b/packages/api-mock/src/platform-handlers.ts
@@ -50,6 +50,7 @@ import {
   ListFlowDefinitionsResponse,
   UpdateFlowDefinitionBody,
   UpdateFlowDefinitionParams,
+  UpdateFlowDefinitionQueryParams,
   UpdateFlowDefinitionResponse,
 } from "@zitadel/api/generated/endpoints/zitadelNextGen.zod";
 import { http, HttpResponse } from "msw";
@@ -391,14 +392,21 @@ export function setupPlatformHandlers() {
       return HttpResponse.json(out.data);
     }),
 
-    http.patch("*/flow_definitions/:id", async ({ params, request }) => {
+    http.put("*/flow_definitions/:id", async ({ params, request }) => {
       const path = parse(UpdateFlowDefinitionParams, params, "invalid_request");
       if (!path.ok) {
         return path.response;
       }
+      const query = parse(UpdateFlowDefinitionQueryParams, queryRecord(request), "invalid_query");
+      if (!query.ok) {
+        return query.response;
+      }
 
       const record = store.flowDefinitions.get(path.data.id);
       if (!record) {
+        return HttpResponse.json(errorBody("not_found", "resource not found"), { status: 404 });
+      }
+      if (record.projectId !== query.data.project_id) {
         return HttpResponse.json(errorBody("not_found", "resource not found"), { status: 404 });
       }
       const raw = await readJson(request);
@@ -410,7 +418,11 @@ export function setupPlatformHandlers() {
         return body.response;
       }
 
-      record.body = { ...record.body, ...(body.data as unknown as Record<string, unknown>) };
+      const flowDef = body.data.flow_definition as unknown as Record<string, unknown>;
+      record.name = flowDef.name as string;
+      record.schemaUri = body.data.schema_uri ?? record.schemaUri;
+      record.status = typeof flowDef.status === "string" ? flowDef.status : record.status;
+      record.body = flowDef;
       record.updatedAt = nowIso();
       const responseBody: UpdateFlowDefinition200 = flowDetailResponse(record);
       const out = parse(UpdateFlowDefinitionResponse, responseBody, "mock_response_invalid");

--- a/packages/api-mock/src/server.ts
+++ b/packages/api-mock/src/server.ts
@@ -23,7 +23,7 @@
  *   POST   /flow_definitions          — create flow definition
  *   GET    /flow_definitions          — list flow definitions
  *   GET    /flow_definitions/:id      — get flow definition
- *   PATCH  /flow_definitions/:id      — update flow definition
+ *   PUT    /flow_definitions/:id      — update flow definition
  *   DELETE /flow_definitions/:id      — delete flow definition
  */
 import { randomBytes, randomUUID } from "node:crypto";

--- a/packages/api-mock/src/spec-conformance.spec.ts
+++ b/packages/api-mock/src/spec-conformance.spec.ts
@@ -84,7 +84,7 @@ function validFlowDefinitionBody(): Record<string, unknown> {
       {
         name: "identifier",
         fields: ["email"],
-        actions: [{ name: "submit", text_key: "submit", primary: true }],
+        actions: [{ name: "submit", kind: "submit", text_key: "submit", primary: true }],
       },
     ],
   };
@@ -290,7 +290,7 @@ describe("api-mock spec conformance — responses match orval-generated zod", ()
     const res = await fetch(`${BASE}/flow_definitions/${id}`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(validFlowDefinitionBody()),
+      body: JSON.stringify({ flow_definition: validFlowDefinitionBody() }),
     });
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/packages/api-mock/src/spec-conformance.spec.ts
+++ b/packages/api-mock/src/spec-conformance.spec.ts
@@ -17,7 +17,7 @@
  *   - GET  /projects/:id                → GetProjectResponse
  *   - GET  /flow_definitions            → ListFlowDefinitionsResponse
  *   - GET  /flow_definitions/:id        → GetFlowDefinitionResponse
- *   - PATCH /flow_definitions/:id       → UpdateFlowDefinitionResponse
+ *   - PUT  /flow_definitions/:id        → UpdateFlowDefinitionResponse
  *
  * Endpoints covered structurally (orval emits no `*Response` zod for these
  * because they have no static response schema — POSTs that return only an
@@ -277,7 +277,7 @@ describe("api-mock spec conformance — responses match orval-generated zod", ()
     expect(() => GetFlowDefinitionResponse.parse(body)).not.toThrow();
   });
 
-  test("PATCH /flow_definitions/:id matches UpdateFlowDefinitionResponse", async () => {
+  test("PUT /flow_definitions/:id matches UpdateFlowDefinitionResponse", async () => {
     const create = await fetch(`${BASE}/flow_definitions`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -287,8 +287,8 @@ describe("api-mock spec conformance — responses match orval-generated zod", ()
       }),
     });
     const { id } = (await create.json()) as { id: string };
-    const res = await fetch(`${BASE}/flow_definitions/${id}`, {
-      method: "PATCH",
+    const res = await fetch(`${BASE}/flow_definitions/${id}?project_id=proj_conformance_patch`, {
+      method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ flow_definition: validFlowDefinitionBody() }),
     });

--- a/scripts/check-changesets-status.mjs
+++ b/scripts/check-changesets-status.mjs
@@ -23,6 +23,9 @@ export const publicPackages = [
   { name: "@zitadel/sdk-react", root: "packages/sdk-react/" },
   { name: "@zitadel/sdk-vue", root: "packages/sdk-vue/" },
   { name: "@zitadel/sdk-angular", root: "packages/sdk-angular/" },
+  { name: "@zitadel/sdk-solid", root: "packages/sdk-solid/" },
+  { name: "@zitadel/sdk-svelte", root: "packages/sdk-svelte/" },
+  { name: "@zitadel/sdk-qwik", root: "packages/sdk-qwik/" },
 ];
 
 const publicPackageNames = publicPackages.map((pkg) => pkg.name);


### PR DESCRIPTION
## Summary
- Mark the preview as non-production across README, VISION, docs, and support guidance
- Document the new public support and conduct files in licensing references
- Update changeset and release metadata to include the new SDK packages and set npm provenance from repository visibility
- Align CLI journey, TypeScript guidance, and api-mock conformance fixtures with the current contract

## Testing
- Not run (not requested)