### PR TITLE
feat(flow): engine-side back navigation

### DIFF
--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -19029,6 +19029,8 @@ func (s *StepActionKind) Decode(d *jx.Decoder) error {
 		*s = StepActionKindPasskeyRegister
 	case StepActionKindNavigate:
 		*s = StepActionKindNavigate
+	case StepActionKindBack:
+		*s = StepActionKindBack
 	default:
 		*s = StepActionKind(v)
 	}

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -10665,7 +10665,9 @@ type StepAction struct {
 	// - `passkey_register`: issue a WebAuthn registration challenge; the matching
 	// transition fires once the returned attestation verifies.
 	// - `navigate`: route through the transition without running the input
-	// pipeline. Used for back-navigation and similar pure-routing actions.
+	// pipeline. Used for pure-routing actions declared in the flow definition.
+	// - `back`: return the user to the previous step. Surfaced by the engine
+	// when going back is available.
 	Kind StepActionKind `json:"kind"`
 	// Marks this as the default/primary action. The runtime template uses
 	// this hint to choose visual emphasis. At most one action per step
@@ -10725,7 +10727,9 @@ func (s *StepAction) SetTextKey(val OptString) {
 // - `passkey_register`: issue a WebAuthn registration challenge; the matching
 // transition fires once the returned attestation verifies.
 // - `navigate`: route through the transition without running the input
-// pipeline. Used for back-navigation and similar pure-routing actions.
+// pipeline. Used for pure-routing actions declared in the flow definition.
+// - `back`: return the user to the previous step. Surfaced by the engine
+// when going back is available.
 type StepActionKind string
 
 const (
@@ -10733,6 +10737,7 @@ const (
 	StepActionKindPasskey         StepActionKind = "passkey"
 	StepActionKindPasskeyRegister StepActionKind = "passkey_register"
 	StepActionKindNavigate        StepActionKind = "navigate"
+	StepActionKindBack            StepActionKind = "back"
 )
 
 // AllValues returns all StepActionKind values.
@@ -10742,6 +10747,7 @@ func (StepActionKind) AllValues() []StepActionKind {
 		StepActionKindPasskey,
 		StepActionKindPasskeyRegister,
 		StepActionKindNavigate,
+		StepActionKindBack,
 	}
 }
 
@@ -10755,6 +10761,8 @@ func (s StepActionKind) MarshalText() ([]byte, error) {
 	case StepActionKindPasskeyRegister:
 		return []byte(s), nil
 	case StepActionKindNavigate:
+		return []byte(s), nil
+	case StepActionKindBack:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -10775,6 +10783,9 @@ func (s *StepActionKind) UnmarshalText(data []byte) error {
 		return nil
 	case StepActionKindNavigate:
 		*s = StepActionKindNavigate
+		return nil
+	case StepActionKindBack:
+		*s = StepActionKindBack
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/api/generated/oas_validators_gen.go
+++ b/api/generated/oas_validators_gen.go
@@ -2640,6 +2640,8 @@ func (s StepActionKind) Validate() error {
 		return nil
 	case "navigate":
 		return nil
+	case "back":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}

--- a/api/openapi/components/flows/step-action.yaml
+++ b/api/openapi/components/flows/step-action.yaml
@@ -11,7 +11,7 @@ properties:
     example: submit
   kind:
     type: string
-    enum: [submit, passkey, passkey_register, navigate]
+    enum: [submit, passkey, passkey_register, navigate, back]
     example: submit
     description: |
       Classifies how the engine handles this action:
@@ -21,7 +21,9 @@ properties:
       - `passkey_register`: issue a WebAuthn registration challenge; the matching
         transition fires once the returned attestation verifies.
       - `navigate`: route through the transition without running the input
-        pipeline. Used for back-navigation and similar pure-routing actions.
+        pipeline. Used for pure-routing actions declared in the flow definition.
+      - `back`: return the user to the previous step. Surfaced by the engine
+        when going back is available.
   primary:
     type: boolean
     default: false

--- a/internal/domain/flow_definition.go
+++ b/internal/domain/flow_definition.go
@@ -96,9 +96,14 @@ const (
 	// verifies.
 	FlowActionKindPasskeyRegister
 	// FlowActionKindNavigate routes through the transition without running
-	// the input pipeline. Used for back-navigation and similar pure-routing
-	// actions where the submitted fields are irrelevant.
+	// the input pipeline. Used for pure-routing actions declared in the flow
+	// definition where the submitted fields are irrelevant.
 	FlowActionKindNavigate
+	// FlowActionKindBack pops the previous step from runtime history and
+	// re-renders it. Injected by the engine on rendered step responses when
+	// history is non-empty and the current step is non-terminal; rejected by
+	// the validator on inbound flow definitions — flow authors never declare it.
+	FlowActionKindBack
 )
 
 // FlowDefinition is a customer-configured directed graph of authentication steps.

--- a/internal/domain/flow_definition_validator.go
+++ b/internal/domain/flow_definition_validator.go
@@ -126,6 +126,10 @@ func validateSteps(steps []FlowDefinitionStep, userSchema *jsonschema.Schema) er
 				return ErrFlowDefinitionInvalid(fmt.Sprintf(
 					"step %q: action %q has no kind", step.Name, a.Name), nil)
 			}
+			if a.Kind == FlowActionKindBack {
+				return ErrFlowDefinitionInvalid(fmt.Sprintf(
+					"step %q: action %q has kind=back, which is engine-injected and cannot be declared", step.Name, a.Name), nil)
+			}
 			actionNames[a.Name] = struct{}{}
 		}
 

--- a/internal/domain/flow_definition_validator_test.go
+++ b/internal/domain/flow_definition_validator_test.go
@@ -1247,3 +1247,27 @@ func TestValidator_MissingActionKindRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, errorDetails(t, err), `action "submit" has no kind`)
 }
+
+// TestValidator_DeclaredBackKindRejected guards against authors declaring
+// `kind: back` directly on a flow definition. The engine injects back on
+// rendered responses; declaring it on the definition would let an author
+// override the engine's reversibility rules and is not permitted.
+func TestValidator_DeclaredBackKindRejected(t *testing.T) {
+	schema := mustSchema(t, userSchemaIDAndPassword)
+	def := domain.FlowDefinition{
+		ProjectID: "p", Name: "f", SchemaVersion: "1",
+		UserSchema: "https://tenant.com/schemas/idpw-user.json",
+		Purposes:   map[domain.FlowDefinitionPurpose]string{domain.FlowDefinitionPurposeLogin: "step"},
+		Steps: []domain.FlowDefinitionStep{
+			{
+				Name: "step", Fields: []string{"email"},
+				Actions:     []domain.FlowStepAction{{Name: "back", Kind: domain.FlowActionKindBack}},
+				Transitions: map[string]domain.FlowStepTransition{"back": {Target: "done"}},
+			},
+			{Name: "done", Complete: gu.Ptr(domain.FlowStepCompleteShow)},
+		},
+	}
+	_, err := domain.ValidateFlowDefinition(schema, def)
+	require.Error(t, err)
+	assert.Contains(t, errorDetails(t, err), `action "back" has kind=back, which is engine-injected and cannot be declared`)
+}

--- a/internal/domain/flow_on_success.go
+++ b/internal/domain/flow_on_success.go
@@ -45,6 +45,11 @@ type FlowOnSuccessResult struct {
 	// UserID is set when a handler creates a new user. The state machine
 	// records it and registers the user on the auth attempt.
 	UserID string
+	// ClearBackStack signals the engine to drop the runtime back stack
+	// after this handler runs. Set when the mutation is irreversible
+	// (e.g. created a user) so subsequent steps don't surface `back`
+	// across the mutation boundary.
+	ClearBackStack bool
 }
 
 // FlowPasswordHasher hashes plaintext passwords into the PHC string

--- a/internal/domain/flow_state.go
+++ b/internal/domain/flow_state.go
@@ -143,9 +143,19 @@ type FlowProgress struct {
 	CurrentStep string
 
 	// History is the ordered list of step names visited within this
-	// progress entry (excluding any parents on PivotStack). Used for
-	// `back` navigation and diagnostics.
+	// progress entry (excluding any parents on PivotStack). Append-only;
+	// preserves the visitation trail across irreversible operations so
+	// helpers like dispatch skip-vs-verify can answer "did the user pass
+	// through step X" reliably.
 	History []string
+
+	// BackStack is the stack of step names the user can return to via the
+	// engine-injected `back` action. Pushed alongside History on each
+	// advance; cleared by the engine after an irreversible operation
+	// (user creation, credential rotation) so the user can't navigate
+	// back across a mutation boundary. An empty stack means no `back`
+	// action is surfaced on the rendered step.
+	BackStack []string
 
 	// CollectedData accumulates submitted field values for this
 	// progress entry, keyed by schema property name. A child flow's

--- a/internal/domain/flowactionkind_enumer.go
+++ b/internal/domain/flowactionkind_enumer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _FlowActionKindName = "submitpasskeypasskey_registernavigate"
+const _FlowActionKindName = "submitpasskeypasskey_registernavigateback"
 
-var _FlowActionKindIndex = [...]uint8{0, 6, 13, 29, 37}
+var _FlowActionKindIndex = [...]uint8{0, 6, 13, 29, 37, 41}
 
-const _FlowActionKindLowerName = "submitpasskeypasskey_registernavigate"
+const _FlowActionKindLowerName = "submitpasskeypasskey_registernavigateback"
 
 func (i FlowActionKind) String() string {
 	i -= 1
@@ -30,9 +30,10 @@ func _FlowActionKindNoOp() {
 	_ = x[FlowActionKindPasskey-(2)]
 	_ = x[FlowActionKindPasskeyRegister-(3)]
 	_ = x[FlowActionKindNavigate-(4)]
+	_ = x[FlowActionKindBack-(5)]
 }
 
-var _FlowActionKindValues = []FlowActionKind{FlowActionKindSubmit, FlowActionKindPasskey, FlowActionKindPasskeyRegister, FlowActionKindNavigate}
+var _FlowActionKindValues = []FlowActionKind{FlowActionKindSubmit, FlowActionKindPasskey, FlowActionKindPasskeyRegister, FlowActionKindNavigate, FlowActionKindBack}
 
 var _FlowActionKindNameToValueMap = map[string]FlowActionKind{
 	_FlowActionKindName[0:6]:        FlowActionKindSubmit,
@@ -43,6 +44,8 @@ var _FlowActionKindNameToValueMap = map[string]FlowActionKind{
 	_FlowActionKindLowerName[13:29]: FlowActionKindPasskeyRegister,
 	_FlowActionKindName[29:37]:      FlowActionKindNavigate,
 	_FlowActionKindLowerName[29:37]: FlowActionKindNavigate,
+	_FlowActionKindName[37:41]:      FlowActionKindBack,
+	_FlowActionKindLowerName[37:41]: FlowActionKindBack,
 }
 
 var _FlowActionKindNames = []string{
@@ -50,6 +53,7 @@ var _FlowActionKindNames = []string{
 	_FlowActionKindName[6:13],
 	_FlowActionKindName[13:29],
 	_FlowActionKindName[29:37],
+	_FlowActionKindName[37:41],
 }
 
 // FlowActionKindString retrieves an enum value from the enum constants string name.

--- a/internal/service/flow_definition_test.go
+++ b/internal/service/flow_definition_test.go
@@ -16,6 +16,13 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+// stubPool returns nil typed as database.Pool. The flow definition service
+// receives a pool but never calls into it under these mock-based tests;
+// the helper exists to keep call sites readable. Mirrors the helper in
+// the internal-package test file (flow_test.go) that this external-package
+// test cannot reach.
+func stubPool() database.Pool { return nil }
+
 var tenantUserSchema = []byte(`{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "metaSchema": "https://nextgen.com/schemas/user-meta-schema.json",

--- a/internal/service/flow_on_success_create_user.go
+++ b/internal/service/flow_on_success_create_user.go
@@ -83,6 +83,7 @@ func (h *FlowCreateUserHandler) Handle(ctx context.Context, in domain.FlowOnSucc
 	}
 
 	return domain.FlowOnSuccessResult{
-		UserID: createUserAction.User[domain.UserIDFieldName].(string),
+		UserID:         createUserAction.User[domain.UserIDFieldName].(string),
+		ClearBackStack: true,
 	}, nil
 }

--- a/internal/service/flow_state_machine.go
+++ b/internal/service/flow_state_machine.go
@@ -310,10 +310,26 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 	userSchemaURL := state.UserSchemaURL
 	actionKind := stepActionKind(currentStep, in.Action)
 
+	// The engine-injected back action is not declared on the step, so the
+	// lookup above won't see it. Recover its kind when the submission targets
+	// it by name and there is somewhere reversible to pop to. A future
+	// author-declared `back`-named action with a real kind wins, since
+	// stepActionKind would have returned a non-zero kind above.
+	if actionKind == 0 && in.Action == flowBackActionName && len(state.BackStack) > 0 {
+		actionKind = domain.FlowActionKindBack
+	}
+
+	// Back is engine-injected and pure routing: pop the back stack and
+	// re-render the previous step. The input pipeline is skipped entirely;
+	// CollectedData is preserved so the prior step's values prefill.
+	if actionKind == domain.FlowActionKindBack {
+		return r.processBack(ctx, client, def, state, userSchemaURL)
+	}
+
 	// Navigate actions skip the entire input pipeline (validation, dispatch,
 	// on_success) and route straight to the matching transition. Used for
-	// back-navigation and similar pure-routing actions where the submitted
-	// fields are irrelevant.
+	// pure-routing actions declared in the flow definition where the
+	// submitted fields are irrelevant.
 	if actionKind == domain.FlowActionKindNavigate {
 		return r.followTransition(ctx, client, def, state, currentStep, in.Action, userSchemaURL)
 	}
@@ -328,7 +344,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 		var errs domain.FlowFieldValidationErrors
 		if asValidationErrors(validationErr, &errs) {
 			msg := errs.Error()
-			step := r.buildStep(currentStep, resolved, &msg, nil, nil)
+			step := r.buildStep(state, currentStep, resolved, &msg, nil, nil)
 			state.IssuedAt = r.now()
 			return FlowStepResult{State: state, Step: step}, nil
 		}
@@ -338,6 +354,10 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 	mergeCollected(state, in.Fields)
 
 	routeOutcome := in.Action
+	// clearBackStack is set when the engine executes an irreversible action
+	// (user creation, credential rotation) on this submit. Applied after the
+	// advance below so the next step renders without `back`.
+	var clearBackStack bool
 
 	// For passkey Phase 1 (issue challenge, no proof yet), identify the user first
 	// so that IssuePasskeyChallenge can populate allowCredentials. Without this,
@@ -350,7 +370,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 			return FlowStepResult{}, err
 		}
 		if dispatch.StepError != nil {
-			step := r.buildStep(currentStep, resolved, dispatch.StepError, nil, nil)
+			step := r.buildStep(state, currentStep, resolved, dispatch.StepError, nil, nil)
 			state.IssuedAt = r.now()
 			return FlowStepResult{State: state, Step: step}, nil
 		}
@@ -378,7 +398,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 				return FlowStepResult{}, err
 			}
 			if dispatch.StepError != nil {
-				step := r.buildStep(currentStep, resolved, dispatch.StepError, nil, nil)
+				step := r.buildStep(state, currentStep, resolved, dispatch.StepError, nil, nil)
 				state.IssuedAt = r.now()
 				return FlowStepResult{State: state, Step: step}, nil
 			}
@@ -397,7 +417,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 					return FlowStepResult{}, err
 				}
 				if result.StepError != nil {
-					step := r.buildStep(currentStep, resolved, result.StepError, nil, nil)
+					step := r.buildStep(state, currentStep, resolved, result.StepError, nil, nil)
 					state.IssuedAt = r.now()
 					return FlowStepResult{State: state, Step: step}, nil
 				}
@@ -414,7 +434,13 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 						return FlowStepResult{}, fmt.Errorf("flow state machine: register created user on attempt: %w", err)
 					}
 				}
+				if result.ClearBackStack {
+					clearBackStack = true
+				}
 			}
+		}
+		if pk.clearBackStack {
+			clearBackStack = true
 		}
 	}
 
@@ -424,7 +450,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 		// unknown user-supplied action is a protocol-level mistake.
 		if routeOutcome != in.Action {
 			msg := routeOutcome
-			step := r.buildStep(currentStep, resolved, &msg, nil, nil)
+			step := r.buildStep(state, currentStep, resolved, &msg, nil, nil)
 			state.IssuedAt = r.now()
 			return FlowStepResult{State: state, Step: step}, nil
 		}
@@ -444,6 +470,9 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 	applyOutcomeFlip(state, routeOutcome)
 
 	r.advance(state, currentStep, nextStep.Name)
+	if clearBackStack {
+		state.BackStack = nil
+	}
 
 	if nextStep.Complete != nil {
 		step, handoff, err := r.terminate(ctx, client, def, state, userSchemaURL, nextStep)
@@ -584,10 +613,13 @@ func fieldValueByChallenge(resolved domain.FlowResolvedFields, fields map[string
 // with a submission. handled is true when a passkey leg ran (so the
 // field-shaped dispatch must be skipped); halt, when non-nil, is the result
 // to return immediately (challenge issued and awaiting proof, or a
-// verification error rendered on the step).
+// verification error rendered on the step); clearBackStack signals that an
+// irreversible passkey operation (registration verify) committed and the
+// engine must drop the back stack after advance.
 type passkeyPhaseResult struct {
-	handled bool
-	halt    *FlowStepResult
+	handled        bool
+	halt           *FlowStepResult
+	clearBackStack bool
 }
 
 // processPasskey runs all two-phase WebAuthn ceremonies (authentication and
@@ -612,7 +644,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			state.PendingChallenge = nil
 			return passkeyPhaseResult{}, nil
 		}
-		rendered := r.buildStep(step, resolved, nil, nil, nil)
+		rendered := r.buildStep(state, step, resolved, nil, nil, nil)
 		attachPendingChallenge(rendered, state.PendingChallenge)
 		state.IssuedAt = r.now()
 		return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
@@ -654,7 +686,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			if errors.Is(err, domain.ErrAuthAttemptProofRejected(nil)) {
 				state.PendingChallenge = nil
 				msg := "auth_attempt.passkey_registration_invalid"
-				rendered := r.buildStep(step, resolved, &msg, nil, nil)
+				rendered := r.buildStep(state, step, resolved, &msg, nil, nil)
 				state.IssuedAt = r.now()
 				return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
 			}
@@ -674,7 +706,9 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 				}
 			}
 			state.PendingChallenge = nil
-			return passkeyPhaseResult{handled: true}, nil
+			// Registering a passkey writes a credential — irreversible.
+			// Signal the caller to drop the back stack after advance.
+			return passkeyPhaseResult{handled: true, clearBackStack: true}, nil
 
 		default: // FlowChallengeMethodPasskey
 			userID, err := r.authAttempts.SubmitPasskey(ctx, domain.FlowSubmitPasskeyInput{
@@ -686,7 +720,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			if errors.Is(err, domain.ErrAuthAttemptProofRejected(nil)) {
 				state.PendingChallenge = nil
 				msg := "auth_attempt.passkey_invalid"
-				rendered := r.buildStep(step, resolved, &msg, nil, nil)
+				rendered := r.buildStep(state, step, resolved, &msg, nil, nil)
 				state.IssuedAt = r.now()
 				return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
 			}
@@ -721,7 +755,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			Options:  out.Options,
 			IssuedAt: r.now(),
 		}
-		rendered := r.buildStep(step, resolved, nil, nil, nil)
+		rendered := r.buildStep(state, step, resolved, nil, nil, nil)
 		attachPendingChallenge(rendered, state.PendingChallenge)
 		state.IssuedAt = r.now()
 		return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
@@ -765,7 +799,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			Options:  out.Options,
 			IssuedAt: r.now(),
 		}
-		rendered := r.buildStep(step, resolved, nil, nil, nil)
+		rendered := r.buildStep(state, step, resolved, nil, nil, nil)
 		attachPendingChallenge(rendered, state.PendingChallenge)
 		state.IssuedAt = r.now()
 		return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
@@ -862,8 +896,36 @@ func (r *FlowStateMachineRuntime) followTransition(ctx context.Context, client d
 	return FlowStepResult{State: state, Step: step}, nil
 }
 
+// processBack pops the last entry off [FlowProgress.BackStack] and
+// re-renders that step. The input pipeline is skipped: CollectedData is
+// preserved so the previous step's values prefill, and any pending
+// ceremony is dropped because its challenge id was bound to the step
+// the user is leaving behind. [FlowProgress.History] is left untouched —
+// it's the audit trail, not the navigation cursor.
+func (r *FlowStateMachineRuntime) processBack(ctx context.Context, client database.QueryExecutor, def *domain.FlowDefinition, state *domain.FlowState, userSchemaURL string) (FlowStepResult, error) {
+	if len(state.BackStack) == 0 {
+		return FlowStepResult{}, fmt.Errorf("%w: back submitted with empty back stack on step %q", ErrInvalidAction, state.CurrentStep)
+	}
+	prev := state.BackStack[len(state.BackStack)-1]
+	state.BackStack = state.BackStack[:len(state.BackStack)-1]
+	state.CurrentStep = prev
+	state.PendingChallenge = nil
+
+	prevStep, ok := def.FindStep(prev)
+	if !ok {
+		return FlowStepResult{}, fmt.Errorf("%w: back-stack step %q missing from definition", ErrIntegrity, prev)
+	}
+	step, err := r.renderStep(ctx, client, def, state, userSchemaURL, prevStep)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	state.IssuedAt = r.now()
+	return FlowStepResult{State: state, Step: step}, nil
+}
+
 func (r *FlowStateMachineRuntime) advance(state *domain.FlowState, prev *domain.FlowDefinitionStep, nextStepName string) {
 	state.History = append(state.History, prev.Name)
+	state.BackStack = append(state.BackStack, prev.Name)
 	state.CurrentStep = nextStepName
 	state.IssuedAt = r.now()
 }
@@ -916,7 +978,7 @@ func (r *FlowStateMachineRuntime) renderStep(ctx context.Context, client databas
 		return nil, err
 	}
 	prefillFromCollected(&resolved, state.CollectedData)
-	return r.buildStep(step, resolved, nil, nil, nil), nil
+	return r.buildStep(state, step, resolved, nil, nil, nil), nil
 }
 
 func (r *FlowStateMachineRuntime) resolveStepFields(ctx context.Context, client database.QueryExecutor, projectID, userSchemaURL string, step *domain.FlowDefinitionStep) (domain.FlowResolvedFields, error) {
@@ -964,22 +1026,32 @@ func (r *FlowStateMachineRuntime) resolveVisitedFields(ctx context.Context, clie
 	return resolved, nil
 }
 
-func (r *FlowStateMachineRuntime) buildStep(step *domain.FlowDefinitionStep, resolved domain.FlowResolvedFields, errorKey *string, complete *domain.FlowStepComplete, redirectURL *url.URL) *FlowStep {
+func (r *FlowStateMachineRuntime) buildStep(state *domain.FlowState, step *domain.FlowDefinitionStep, resolved domain.FlowResolvedFields, errorKey *string, complete *domain.FlowStepComplete, redirectURL *url.URL) *FlowStep {
 	// Surface only user-selectable actions declared on the step.
 	// Implicit outcomes (e.g. user_not_found) live in step.Transitions
 	// but are engine-emitted routing keys, not buttons for the client.
-	actions := make([]FlowAction, len(step.Actions))
-	for i, a := range step.Actions {
+	actions := make([]FlowAction, 0, len(step.Actions)+1)
+	for _, a := range step.Actions {
 		textKey := a.TextKey
 		if textKey == "" {
 			textKey = step.Name + ".action." + a.Name
 		}
-		actions[i] = FlowAction{
+		actions = append(actions, FlowAction{
 			Name:    a.Name,
 			Kind:    a.Kind,
 			TextKey: textKey,
 			Primary: a.Primary,
-		}
+		})
+	}
+	// Inject the engine-provided back action when the user has somewhere
+	// reversible to return to and the step is not terminal. The name is
+	// conventionally "back"; clients identify it by kind, not name.
+	if len(state.BackStack) > 0 && step.Complete == nil {
+		actions = append(actions, FlowAction{
+			Name:    flowBackActionName,
+			Kind:    domain.FlowActionKindBack,
+			TextKey: flowBackActionTextKey,
+		})
 	}
 	return &FlowStep{
 		Name:         step.Name,
@@ -992,6 +1064,15 @@ func (r *FlowStateMachineRuntime) buildStep(step *domain.FlowDefinitionStep, res
 		SSOProviders: nil,
 	}
 }
+
+// flowBackActionName is the conventional name surfaced for the
+// engine-injected back action. The wire contract is kind-driven: clients
+// route on FlowActionKindBack, never on the literal name.
+const flowBackActionName = "back"
+
+// flowBackActionTextKey is the localization key the client resolves for
+// the back action label.
+const flowBackActionTextKey = "action.back"
 
 // stepHasActionKind reports whether the step declares any action of the
 // given kind.

--- a/internal/service/flow_state_machine_test.go
+++ b/internal/service/flow_state_machine_test.go
@@ -1913,6 +1913,12 @@ func TestFlowStateMachine_Process_PasskeyRegisterIssueThenVerify(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, verified.State.PendingChallenge)
 	require.NotNil(t, verified.Step.Complete)
+	// Passkey registration writes a credential (and creates the user when
+	// provisional) — irreversible, so the back stack must be cleared.
+	// History is left intact so the visited-step audit still answers
+	// "did the user pass through register".
+	assert.Empty(t, verified.State.BackStack, "passkey-register verify must clear the back stack")
+	assert.Equal(t, []string{"register"}, verified.State.History, "audit history records the visit even after an irreversible advance")
 }
 
 func TestFlowStateMachine_Process_PasskeyRegisterRejectedKeepsStep(t *testing.T) {

--- a/internal/service/flow_state_machine_test.go
+++ b/internal/service/flow_state_machine_test.go
@@ -2141,3 +2141,216 @@ func TestFlowStateMachine_Process_SubmitKindRegression(t *testing.T) {
 		assert.Contains(t, *result.Step.Error, "email")
 	}
 }
+
+// navigateOnlyDefinition is a minimal multi-step fixture used by the
+// back-navigation tests: linear step1 → step2 → done routed by
+// navigate-kind actions, with no fields, challenges, or on_success.
+// Keeps the back-nav tests free of auth-attempt and schema mocks.
+func navigateOnlyDefinition() *domain.FlowDefinition {
+	show := domain.FlowStepCompleteShow
+	return &domain.FlowDefinition{
+		ProjectID:  testProjectID,
+		ID:         "def-back-nav",
+		UserSchema: defaultSchemaURL,
+		Purposes: map[domain.FlowDefinitionPurpose]string{
+			domain.FlowDefinitionPurposeLogin: "step1",
+		},
+		Steps: []domain.FlowDefinitionStep{
+			{
+				Name: "step1",
+				Actions: []domain.FlowStepAction{
+					{Name: "go", Kind: domain.FlowActionKindNavigate, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{
+					"go": {Target: "step2"},
+				},
+			},
+			{
+				Name: "step2",
+				Actions: []domain.FlowStepAction{
+					{Name: "go", Kind: domain.FlowActionKindNavigate, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{
+					"go": {Target: "done"},
+				},
+			},
+			{Name: "done", Complete: &show},
+		},
+	}
+}
+
+// findBackAction returns the engine-injected back action on a rendered
+// step, or nil when it is absent. Tests assert on kind, not name — the
+// wire contract is kind-driven.
+func findBackAction(step *service.FlowStep) *service.FlowAction {
+	if step == nil {
+		return nil
+	}
+	for i, a := range step.Actions {
+		if a.Kind == domain.FlowActionKindBack {
+			return &step.Actions[i]
+		}
+	}
+	return nil
+}
+
+func TestFlowStateMachine_Back_NotInjectedOnInitialStep(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := navigateOnlyDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+
+	start, err := w.sm.Start(t.Context(), nil, service.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeLogin,
+		Session:       service.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "step1", start.Step.Name)
+	assert.Empty(t, start.State.BackStack, "back stack must be empty on the initial step")
+	assert.Nil(t, findBackAction(start.Step), "back action must not appear on the initial step")
+}
+
+func TestFlowStateMachine_Back_InjectedAfterAdvance(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := navigateOnlyDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+
+	start, err := w.sm.Start(t.Context(), nil, service.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeLogin,
+		Session:       service.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+
+	result, err := w.sm.Process(t.Context(), nil, def, start.State, service.FlowSubmitInput{Action: "go"})
+	require.NoError(t, err)
+	require.Equal(t, "step2", result.Step.Name)
+	assert.Equal(t, []string{"step1"}, result.State.BackStack)
+	assert.Equal(t, []string{"step1"}, result.State.History)
+
+	back := findBackAction(result.Step)
+	if assert.NotNil(t, back, "back action must be injected after the first advance") {
+		assert.Equal(t, "action.back", back.TextKey)
+		assert.False(t, back.Primary, "back must never be primary")
+	}
+}
+
+func TestFlowStateMachine_Back_OmittedOnTerminalStep(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := navigateOnlyDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+	w.authAttemptService.EXPECT().Handoff(gomock.Any(), gomock.Any()).Times(0)
+
+	start, err := w.sm.Start(t.Context(), nil, service.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeLogin,
+		Session:       service.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+	mid, err := w.sm.Process(t.Context(), nil, def, start.State, service.FlowSubmitInput{Action: "go"})
+	require.NoError(t, err)
+	term, err := w.sm.Process(t.Context(), nil, def, mid.State, service.FlowSubmitInput{Action: "go"})
+	require.NoError(t, err)
+
+	require.Equal(t, "done", term.Step.Name)
+	require.NotNil(t, term.Step.Complete)
+	assert.NotEmpty(t, term.State.BackStack, "back stack persists across navigate-kind advances")
+	assert.Nil(t, findBackAction(term.Step), "terminal step must not carry an injected back action")
+}
+
+func TestFlowStateMachine_Back_PopsAndRendersPreviousStep(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := navigateOnlyDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+
+	start, err := w.sm.Start(t.Context(), nil, service.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeLogin,
+		Session:       service.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+	advanced, err := w.sm.Process(t.Context(), nil, def, start.State, service.FlowSubmitInput{Action: "go"})
+	require.NoError(t, err)
+	require.Equal(t, "step2", advanced.Step.Name)
+
+	back, err := w.sm.Process(t.Context(), nil, def, advanced.State, service.FlowSubmitInput{Action: "back"})
+	require.NoError(t, err)
+	require.Equal(t, "step1", back.Step.Name)
+	assert.Empty(t, back.State.BackStack, "back-stack pops on back submission")
+	// History is append-only; the audit trail still records that step1 was visited.
+	assert.Equal(t, []string{"step1"}, back.State.History)
+	assert.Nil(t, findBackAction(back.Step), "back action must be absent once the stack is empty")
+}
+
+func TestFlowStateMachine_Back_EmptyBackStackRejected(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := navigateOnlyDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+
+	start, err := w.sm.Start(t.Context(), nil, service.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeLogin,
+		Session:       service.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+
+	// A client that synthesizes `action: "back"` on the initial step (e.g. a
+	// stale cookie or a malicious submit) must be rejected — the action was
+	// never injected.
+	_, err = w.sm.Process(t.Context(), nil, def, start.State, service.FlowSubmitInput{Action: "back"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, service.ErrInvalidAction)
+}
+
+func TestFlowStateMachine_Back_StackClearedAfterCreateUser(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := signupDefinition()
+
+	const handoffToken = "handoff_01TEST"
+	const email = "alice@example.com"
+	const password = "correct-horse-battery-staple"
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+	w.authAttemptService.EXPECT().
+		SubmitIdentifier(gomock.Any(), gomock.Any()).
+		Return("", domain.ErrAuthAttemptProofRejected(nil)).
+		Times(1)
+	w.schemaRepo.EXPECT().GetByID(gomock.Any(), gomock.Any(), def.ProjectID, def.UserSchema).
+		Return(minimalSchema(def.ProjectID), nil).Times(1)
+	w.db.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(w.transaction, nil).Times(1)
+	w.userRepo.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	w.passwordRepo.EXPECT().DeleteByUserID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	w.passwordRepo.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	w.transaction.EXPECT().Commit(gomock.Any())
+	w.authAttemptService.EXPECT().RegisterCreatedUser(gomock.Any(), gomock.Any()).Times(1)
+	w.authAttemptService.EXPECT().Handoff(gomock.Any(), gomock.Any()).
+		Return(domain.FlowHandoffOutput{Token: handoffToken, ExpiresAt: time.Unix(1700000060, 0).UTC()}, nil).Times(1)
+
+	start, err := w.sm.Start(t.Context(), nil, service.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeRegister,
+		Session:       service.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+	result, err := w.sm.Process(t.Context(), nil, def, start.State, service.FlowSubmitInput{
+		Action: service.FlowActionSubmit,
+		Fields: map[string]any{"email": email, "password": password},
+	})
+	require.NoError(t, err)
+
+	// The audit trail records the visited step; the back stack is dropped
+	// because create_user committed an irreversible mutation.
+	assert.Equal(t, []string{"credentials"}, result.State.History)
+	assert.Empty(t, result.State.BackStack, "create_user must clear the back stack")
+}


### PR DESCRIPTION
## Summary

Implements the engine half of [ADR 022](docs/adrs/022-flow-back-navigation.md). The contract (kind enum + validator) shipped in #379 — cherry-picked here on top of `refactor/user-service-in-flow` since refactor hasn't absorbed main yet; will deduplicate when it does.

- Splits `FlowProgress.History` into two fields: `History` stays as the append-only audit trail; new `BackStack` is the navigation cursor for `back`. Keeps `History` correct across irreversible operations.
- `buildStep` injects `{name: "back", kind: back, text_key: "action.back"}` when `BackStack` is non-empty and the step is non-terminal.
- `Process` short-circuits on `kind: back`: pops `BackStack`, clears any in-flight ceremony, re-renders with prefill from `CollectedData`. Empty-stack submission errors.
- Irreversible operations (`create_user`, passkey-register verify) clear `BackStack` after advance via a new `ClearBackStack` flag on `FlowOnSuccessResult` and a sibling on `passkeyPhaseResult`.

Supersedes #380 (which was based on a merge of main and showed unrelated commits in the diff).

## Test plan

- [x] 6 new unit tests in `flow_state_machine_test.go` (`TestFlowStateMachine_Back_*`)
- [x] `go test ./...` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)