### PR TITLE
fix(ci): use github app token for pm auth

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -57,4 +57,4 @@ jobs:
         if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && steps.checkUserMember.outputs.is_staff != 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: gh pr edit "${{ github.event.pull_request.number }}" --add-label os-contribution
+        run: gh pr edit "${{ github.event.pull_request.html_url }}" --add-label os-contribution

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -8,32 +8,53 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     name: Add issue and community pr to project
     runs-on: ubuntu-latest
     steps:
+      - name: Generate project app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
+          owner: zitadel
+
       - name: add issue
-        uses: actions/add-to-project@v1.0.2
         if: ${{ github.event_name == 'issues' }}
-        with:
-          project-url: https://github.com/orgs/zitadel/projects/2
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-      - uses: tspascoal/get-user-teams-membership@v3
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh project item-add 2 --owner zitadel --url "${{ github.event.issue.html_url }}"
+
+      - name: check user team membership
         id: checkUserMember
-        if: github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]'
-        with:
-          username: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if gh api "orgs/zitadel/teams/engineers/memberships/${{ github.actor }}" >/dev/null 2>&1; then
+            echo "is_engineer=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_engineer=false" >> "$GITHUB_OUTPUT"
+          fi
+          if gh api "orgs/zitadel/teams/staff/memberships/${{ github.actor }}" >/dev/null 2>&1; then
+            echo "is_staff=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_staff=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: add pr
-        uses: actions/add-to-project@v1.0.2
-        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'engineers') }}
-        with:
-          project-url: https://github.com/orgs/zitadel/projects/2
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-      - uses: actions-ecosystem/action-add-labels@v1.1.3
-        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && !contains(steps.checkUserMember.outputs.teams, 'staff') }}
-        with:
-          github_token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          labels: |
-            os-contribution
+        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && steps.checkUserMember.outputs.is_engineer != 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh project item-add 2 --owner zitadel --url "${{ github.event.pull_request.html_url }}"
+
+      - name: add community label
+        if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && steps.checkUserMember.outputs.is_staff != 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr edit "${{ github.event.pull_request.number }}" --add-label os-contribution


### PR DESCRIPTION
## Summary

Replaced deprecated `actions/add-to-project` action and personal access token (PAT) authentication with GitHub CLI commands using a GitHub App token. This improves security by using short-lived app tokens instead of long-lived PATs, and modernizes the workflow to use the latest GitHub CLI capabilities.

Key changes:
- Added GitHub App token generation step using `actions/create-github-app-token@v2`
- Replaced `actions/add-to-project` with `gh project item-add` CLI commands for adding issues and PRs to project
- Replaced `tspascoal/get-user-teams-membership` action with direct `gh api` calls to check team membership
- Replaced `actions-ecosystem/action-add-labels` with `gh pr edit` CLI command for adding labels
- Updated conditional logic to use new output variable names (`is_engineer`, `is_staff`)
- Added explicit `permissions: contents: read` declaration

## Validation

No testing needed — this is a GitHub Actions workflow configuration change. The workflow will be validated when it runs on the next issue or pull request event.

## Release notes / changeset

No changeset required — no public npm package files changed.

## Notes

This change requires the following secrets to be configured in the repository:
- `PROJECT_APP_ID`: The GitHub App ID
- `PROJECT_APP_PRIVATE_KEY`: The GitHub App private key

The GitHub App must have appropriate permissions to manage project items and read team memberships in the zitadel organization.

https://claude.ai/code/session_01NYMgVHhtNv4D93os16ymcf