### PR TITLE
test: realign flow_definition conformance fixtures with schema

### DIFF
--- a/packages/api-mock/src/platform-handlers.ts
+++ b/packages/api-mock/src/platform-handlers.ts
@@ -50,6 +50,7 @@ import {
   ListFlowDefinitionsResponse,
   UpdateFlowDefinitionBody,
   UpdateFlowDefinitionParams,
+  UpdateFlowDefinitionQueryParams,
   UpdateFlowDefinitionResponse,
 } from "@zitadel/api/generated/endpoints/zitadelNextGen.zod";
 import { http, HttpResponse } from "msw";
@@ -391,10 +392,18 @@ export function setupPlatformHandlers() {
       return HttpResponse.json(out.data);
     }),
 
-    http.patch("*/flow_definitions/:id", async ({ params, request }) => {
+    http.put("*/flow_definitions/:id", async ({ params, request }) => {
       const path = parse(UpdateFlowDefinitionParams, params, "invalid_request");
       if (!path.ok) {
         return path.response;
+      }
+      const query = parse(
+        UpdateFlowDefinitionQueryParams,
+        queryRecord(request),
+        "invalid_query",
+      );
+      if (!query.ok) {
+        return query.response;
       }
 
       const record = store.flowDefinitions.get(path.data.id);

--- a/packages/api-mock/src/spec-conformance.spec.ts
+++ b/packages/api-mock/src/spec-conformance.spec.ts
@@ -17,7 +17,7 @@
  *   - GET  /projects/:id                → GetProjectResponse
  *   - GET  /flow_definitions            → ListFlowDefinitionsResponse
  *   - GET  /flow_definitions/:id        → GetFlowDefinitionResponse
- *   - PATCH /flow_definitions/:id       → UpdateFlowDefinitionResponse
+ *   - PUT  /flow_definitions/:id        → UpdateFlowDefinitionResponse
  *
  * Endpoints covered structurally (orval emits no `*Response` zod for these
  * because they have no static response schema — POSTs that return only an
@@ -277,21 +277,24 @@ describe("api-mock spec conformance — responses match orval-generated zod", ()
     expect(() => GetFlowDefinitionResponse.parse(body)).not.toThrow();
   });
 
-  test("PATCH /flow_definitions/:id matches UpdateFlowDefinitionResponse", async () => {
+  test("PUT /flow_definitions/:id matches UpdateFlowDefinitionResponse", async () => {
     const create = await fetch(`${BASE}/flow_definitions`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        project_id: "proj_conformance_patch",
+        project_id: "proj_conformance_update",
         flow_definition: validFlowDefinitionBody(),
       }),
     });
     const { id } = (await create.json()) as { id: string };
-    const res = await fetch(`${BASE}/flow_definitions/${id}`, {
-      method: "PATCH",
+    // Spec: `updateFlowDefinition` is `PUT /flow_definitions/{id}` with a
+    // required `project_id` query param (the generated client and CLI
+    // syncer both call it that way). The body wraps the definition under
+    // `flow_definition` (flow-definition-update-request.yaml), unlike the
+    // create envelope.
+    const res = await fetch(`${BASE}/flow_definitions/${id}?project_id=proj_conformance_update`, {
+      method: "PUT",
       headers: { "content-type": "application/json" },
-      // The update request envelope requires a `flow_definition` wrapper
-      // (flow-definition-update-request.yaml), unlike the create envelope.
       body: JSON.stringify({ flow_definition: validFlowDefinitionBody() }),
     });
     expect(res.status).toBe(200);


### PR DESCRIPTION
The spec defines `updateFlowDefinition` as `PUT /flow_definitions/{id}` with a required `project_id` query param, and both the generated client and the CLI syncer call it that way — but the api-mock only registered `http.patch` with no query validation, so real client/CLI update calls never matched the mock. This switches the handler to `http.put` and validates `project_id` via `UpdateFlowDefinitionQueryParams`, and updates the conformance test to issue a `PUT ...?project_id=…`. Fixtures/handler only; `moon run api-mock:test` stays green (36/36).
