### PR TITLE
fix: update service test stubs for direct-return statement APIs

### DIFF
--- a/docs/adrs/027-storage-v2-statements-and-dialects.md
+++ b/docs/adrs/027-storage-v2-statements-and-dialects.md
@@ -27,15 +27,17 @@ See also:
 
 ## Decision
 
-### 1. Statement objects over repository CRUD helpers
+### 1. Statement methods over repository CRUD helpers
 
-Dialect code returns deferred execution objects instead of calling the database
-immediately:
+Dialect `statement_<entity>.go` files implement [`service.*Statements`](../../internal/service/statement.go)
+methods directly. Each method takes `context.Context` and returns `(result, error)` or
+`error` immediately — there are no intermediate deferred execution objects.
 
-- [`Execution`](../../internal/storage/v2/database/database.go) — writes; callers
-  invoke `.Execute(ctx)`
-- [`Query[R]`](../../internal/storage/v2/database/database.go) — reads; callers
-  invoke `.Query(ctx)`
+Example signatures:
+
+- `CreateProject(ctx, *domain.Project) error`
+- `GetProjectByID(ctx, id) (*domain.Project, error)`
+- `ListProjects(ctx, *ListOptions) (*ListResult[*domain.Project], error)`
 
 Entity SQL lives in per-dialect `statement_<entity>.go` files rather than generic
 repository helpers.
@@ -76,9 +78,9 @@ responsibility.
 ### 5. Keyset pagination at the storage layer
 
 [`ListOptions`](../../internal/storage/v2/database/list.go) and
-[`CursorToken`](../../internal/storage/v2/database/list.go) implement the
+[`pagination.Cursor`](../../internal/storage/v2/dialect/pagination/cursor.go) implement the
 storage side of [ADR 009](009-cursor-based-pagination.md). The postgres compiler
-turns `Page.After` into a keyset predicate plus `ORDER BY` and `LIMIT`. API
+turns `Page.Cursor` into a keyset predicate plus `ORDER BY` and `LIMIT`. API
 token signing and opaqueness stay upstream of storage.
 
 ### 6. Unified dialect target (end state on `new-repo`)
@@ -108,9 +110,7 @@ flowchart TB
         serviceDB["service.DB"]
     end
     subgraph v2core [internal/storage/v2/database]
-        Filter["Filter + Column tokens"]
-        ListOpts["ListOptions + CursorToken"]
-        Contracts["Execution / Query R / Pool"]
+        CoreTypes["Filter + ListOptions + dialect registry"]
         DialectReg["Dialect registry + Config.Build"]
     end
     subgraph dialects [internal/storage/v2/dialect]
@@ -128,9 +128,7 @@ flowchart TB
     serviceDB --> StatementIfaces
     StatementIfaces --> pg
     StatementIfaces --> sp
-    pg --> Filter
-    pg --> ListOpts
-    pg --> Contracts
+    pg --> CoreTypes
     DialectReg --> pg
     pg --> v1Repos
     pg -.-> endState
@@ -211,9 +209,10 @@ everywhere until generics land.
 
 ```
 internal/storage/v2/
-  database/           # Dialect registry, Filter, ListOptions, Execution/Query contracts
+  database/           # Dialect registry, Filter, ListOptions, ListResult
   dialect/
     all/              # Blank-import registration (postgres + spanner)
+    pagination/       # Cursor marshal/unmarshal for keyset pagination
     postgres/         # Working reference: pool, tx, compiler, statement_*.go
     spanner/          # Early stub: native @param SQL, partial execution
 ```
@@ -242,9 +241,12 @@ Service call path:
 
 ```go
 err = s.v2Pool.Transaction(ctx, func(ctx context.Context, tx Statementer[AllStatements]) error {
-    return tx.Statements().CreateProject(project).Execute(ctx)
+    if err := tx.Statements().CreateProject(ctx, project); err != nil {
+        return err
+    }
+    return nil
 })
-project, err := s.v2Pool.Statements().GetProjectByID(id).Query(ctx)
+project, err := s.v2Pool.Statements().GetProjectByID(ctx, id)
 ```
 
 Dialect read compilation:
@@ -297,7 +299,7 @@ entries when no longer useful.
 
 | ADR | Relationship |
 |---|---|
-| [009 Cursor-Based Pagination](009-cursor-based-pagination.md) | v2 `ListOptions`/`CursorToken` is the storage implementation |
+| [009 Cursor-Based Pagination](009-cursor-based-pagination.md) | v2 `ListOptions`/`Page.Cursor` + `pagination.Cursor` is the storage implementation |
 | [011 Resource Identifiers](011-resource-identifiers.md) | ADR 027 refines § Package roles: `Identity` + ID generation move to v2 dialects |
 | [008 Users EAV Store](008-users-eav-store.md) | EAV SQL may remain specialized; port to v2 statements |
 | [010 Session/Auth Attempt](010-session-auth-attempt-check-model.md) | Future v2 port target |

--- a/internal/service/flow_test.go
+++ b/internal/service/flow_test.go
@@ -23,65 +23,48 @@ func stubPool() database.Pool { return nil }
 
 func stubV2Pool() *service.DB { return nil }
 
-type stubV2Execution struct {
-	err error
-}
-
-func (e stubV2Execution) Execute(context.Context) error {
-	return e.err
-}
-
-type stubV2Query[T any] struct {
-	result *T
-	err    error
-}
-
-func (q stubV2Query[T]) Query(context.Context) (*T, error) {
-	return q.result, q.err
-}
-
 type testAllStatements struct {
-	createProject  func(*domain.Project) v2database.Execution
-	getProjectByID func(string) v2database.Query[domain.Project]
+	createProject  func(context.Context, *domain.Project) error
+	getProjectByID func(context.Context, string) (*domain.Project, error)
 }
 
 func (testAllStatements) IsStatements() {}
 
-func (s testAllStatements) CreateProject(project *domain.Project) v2database.Execution {
+func (s testAllStatements) CreateProject(ctx context.Context, project *domain.Project) error {
 	if s.createProject != nil {
-		return s.createProject(project)
+		return s.createProject(ctx, project)
 	}
-	return stubV2Execution{}
+	return nil
 }
 
-func (s testAllStatements) GetProjectByID(id string) v2database.Query[domain.Project] {
+func (s testAllStatements) GetProjectByID(ctx context.Context, id string) (*domain.Project, error) {
 	if s.getProjectByID != nil {
-		return s.getProjectByID(id)
+		return s.getProjectByID(ctx, id)
 	}
-	return stubV2Query[domain.Project]{}
+	return nil, nil
 }
 
-func (testAllStatements) ListProjects(*v2database.ListOptions) v2database.Query[v2database.ListResult[*domain.Project]] {
+func (testAllStatements) ListProjects(context.Context, *v2database.ListOptions) (*v2database.ListResult[*domain.Project], error) {
 	panic("unexpected call to ListProjects")
 }
 
-func (testAllStatements) DeleteProjectByID(string) v2database.Execution {
+func (testAllStatements) DeleteProjectByID(context.Context, string) error {
 	panic("unexpected call to DeleteProjectByID")
 }
 
-func (testAllStatements) CreateFlowDefinition(*domain.FlowDefinition) v2database.Execution {
+func (testAllStatements) CreateFlowDefinition(context.Context, *domain.FlowDefinition) error {
 	panic("unexpected call to CreateFlowDefinition")
 }
 
-func (testAllStatements) GetFlowDefinitionByID(string) v2database.Query[domain.FlowDefinition] {
+func (testAllStatements) GetFlowDefinitionByID(context.Context, string) (*domain.FlowDefinition, error) {
 	panic("unexpected call to GetFlowDefinitionByID")
 }
 
-func (testAllStatements) ListFlowDefinitions(*v2database.ListOptions) v2database.Query[v2database.ListResult[*domain.FlowDefinition]] {
+func (testAllStatements) ListFlowDefinitions(context.Context, *v2database.ListOptions) (*v2database.ListResult[*domain.FlowDefinition], error) {
 	panic("unexpected call to ListFlowDefinitions")
 }
 
-func (testAllStatements) DeleteFlowDefinitionByID(string) v2database.Execution {
+func (testAllStatements) DeleteFlowDefinitionByID(context.Context, string) error {
 	panic("unexpected call to DeleteFlowDefinitionByID")
 }
 

--- a/internal/service/project_test.go
+++ b/internal/service/project_test.go
@@ -14,7 +14,6 @@ import (
 	servicemocks "github.com/zitadel/nextgen/internal/service/mocks"
 	"github.com/zitadel/nextgen/internal/storage/database"
 	"github.com/zitadel/nextgen/internal/storage/database/dbmock"
-	v2database "github.com/zitadel/nextgen/internal/storage/v2/database"
 	"go.uber.org/mock/gomock"
 )
 
@@ -35,8 +34,8 @@ func TestProjectService_Create(t *testing.T) {
 			previewOrigins: nil,
 			setupStatements: func(_ *domain.Project) testAllStatements {
 				return testAllStatements{
-					createProject: func(_ *domain.Project) v2database.Execution {
-						return stubV2Execution{}
+					createProject: func(_ context.Context, _ *domain.Project) error {
+						return nil
 					},
 				}
 			},
@@ -70,9 +69,9 @@ func TestProjectService_Create(t *testing.T) {
 			previewOrigins: []string{"*.vercel.app", "*.netlify.app"},
 			setupStatements: func(_ *domain.Project) testAllStatements {
 				return testAllStatements{
-					createProject: func(project *domain.Project) v2database.Execution {
+					createProject: func(_ context.Context, project *domain.Project) error {
 						assert.Equal(t, []string{"*.vercel.app", "*.netlify.app"}, project.PreviewOrigins)
-						return stubV2Execution{}
+						return nil
 					},
 				}
 			},
@@ -106,8 +105,8 @@ func TestProjectService_Create(t *testing.T) {
 			previewOrigins: nil,
 			setupStatements: func(_ *domain.Project) testAllStatements {
 				return testAllStatements{
-					createProject: func(_ *domain.Project) v2database.Execution {
-						return stubV2Execution{err: errors.New("db error")}
+					createProject: func(_ context.Context, _ *domain.Project) error {
+						return errors.New("db error")
 					},
 				}
 			},
@@ -199,15 +198,13 @@ func TestProjectService_Get(t *testing.T) {
 			id:   "proj_aaa",
 			setupStatements: func(id string) testAllStatements {
 				return testAllStatements{
-					getProjectByID: func(gotID string) v2database.Query[domain.Project] {
+					getProjectByID: func(_ context.Context, gotID string) (*domain.Project, error) {
 						assert.Equal(t, id, gotID)
-						return stubV2Query[domain.Project]{
-							result: &domain.Project{
-								ID:        "proj_aaa",
-								CreatedAt: now,
-								UpdatedAt: now,
-							},
-						}
+						return &domain.Project{
+							ID:        "proj_aaa",
+							CreatedAt: now,
+							UpdatedAt: now,
+						}, nil
 					},
 				}
 			},
@@ -224,11 +221,9 @@ func TestProjectService_Get(t *testing.T) {
 			id:   "proj_missing",
 			setupStatements: func(id string) testAllStatements {
 				return testAllStatements{
-					getProjectByID: func(gotID string) v2database.Query[domain.Project] {
+					getProjectByID: func(_ context.Context, gotID string) (*domain.Project, error) {
 						assert.Equal(t, id, gotID)
-						return stubV2Query[domain.Project]{
-							err: database.NewNoRowFoundError(nil),
-						}
+						return nil, database.NewNoRowFoundError(nil)
 					},
 				}
 			},

--- a/internal/storage/v2/dialect/spanner/statement.go
+++ b/internal/storage/v2/dialect/spanner/statement.go
@@ -2,7 +2,7 @@ package spanner
 
 import "github.com/zitadel/nextgen/internal/service"
 
-type queryExecutor interface {}
+type queryExecutor interface{}
 
 type statements struct {
 	projectStatements


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes non-compiling `internal/service` tests left behind after commit `537d6ae9`, which removed deferred `database.Execution` / `database.Query` types in favor of direct-return statement methods.

- Rewrites `testAllStatements` in `flow_test.go` to implement the current `service.AllStatements` contract (`context.Context` + direct `(result, error)` returns).
- Updates `project_test.go` create/get setup callbacks to match the new stub signatures.
- Aligns ADR 027 with the implemented statement API (removes `Execution`/`Query` references, updates worked example and pagination terminology).

## Validation

- `go test ./internal/service/...`

## Release notes / changeset

No changeset — test and documentation fixes only; no publishable package behavior changes.

## Notes

- Removes obsolete `stubV2Execution` / `stubV2Query` helpers from `flow_test.go`.
- ADR 027 cursor references updated from `CursorToken` to `Page.Cursor` + `pagination.Cursor`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-822cf6a3-1bd6-4df6-b6db-f35e713a9f9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-822cf6a3-1bd6-4df6-b6db-f35e713a9f9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

