### PR TITLE
fix(api): include enum in flow field validation

### DIFF
--- a/.changeset/fix-flow-field-validation-enum.md
+++ b/.changeset/fix-flow-field-validation-enum.md
@@ -1,0 +1,10 @@
+---
+"@zitadel/server": patch
+"@zitadel/server-linux-x64": patch
+"@zitadel/server-linux-arm64": patch
+"@zitadel/server-darwin-x64": patch
+"@zitadel/server-darwin-arm64": patch
+"@zitadel/server-win32-x64": patch
+---
+
+Fix flow API: select-typed step fields now include their `validation.enum` in the response. The API mapper was dropping the resolver-derived enum, so clients rendering a `select` had no option values to display.

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -408,7 +408,10 @@ func toFlowFieldValidation(v *domain.FlowFieldValidation) *api.FieldValidation {
 	if v.MaxLength > 0 {
 		out.MaxLength = api.NewOptInt(v.MaxLength)
 	}
-	if !out.Format.Set && !out.MinLength.Set && !out.MaxLength.Set {
+	if len(v.Enum) > 0 {
+		out.Enum = v.Enum
+	}
+	if !out.Format.Set && !out.MinLength.Set && !out.MaxLength.Set && len(out.Enum) == 0 {
 		return nil
 	}
 	return &out

--- a/internal/api/flow_internal_test.go
+++ b/internal/api/flow_internal_test.go
@@ -69,3 +69,18 @@ func TestToFlowField_UUIDFormatSurfacesAsText(t *testing.T) {
 	require.True(t, got.Validation.Set)
 	require.Equal(t, apigen.FieldValidationFormatUUID, got.Validation.Value.Format.Value)
 }
+
+func TestToFlowField_EnumSurfaces(t *testing.T) {
+	t.Parallel()
+
+	got := toFlowField(domain.FlowField{
+		Type:    domain.FlowFieldTypeSelect,
+		TextKey: "step.field.maritalStatus",
+		Validation: &domain.FlowFieldValidation{
+			Enum: []string{"Single", "Married", "Divorced", "Widowed"},
+		},
+	})
+
+	require.True(t, got.Validation.Set, "validation block emitted when only enum is set")
+	require.Equal(t, []string{"Single", "Married", "Divorced", "Widowed"}, got.Validation.Value.Enum)
+}


### PR DESCRIPTION
## Summary
- The API mapper `toFlowFieldValidation` was dropping the resolver-derived `Enum` slice, so clients receiving a `select`-typed step field had no option values to render.
- Plumbs `v.Enum` through to `out.Enum` and includes `len(out.Enum) == 0` in the "drop validation if empty" check so the block isn't elided when enum is the only rule.

## Repro
Schema like
```json
"maritalStatus": { "type": "string", "enum": ["Single", "Married", "Divorced", "Widowed"] }
```
used to surface in the flow step as
```json
{ "name": "maritalStatus", "type": "select" }
```
— `type: select` was correct, but the consumer had no enum to render. Now the response includes
```json
"validation": { "enum": ["Single", "Married", "Divorced", "Widowed"] }
```

## Test plan
- [x] New unit test `TestToFlowField_EnumSurfaces` in `internal/api/flow_internal_test.go`
- [x] Existing `TestToFlowField_*` tests still pass
- [ ] Manual: hit a flow with an enum-bearing user-schema property and confirm the response carries `validation.enum`

## Note
A related gap exists for `format: date` (the resolver carries it; the API enum has only `date-time`/`email`/`uuid`/`uri`). Not fixed here — it requires an OpenAPI spec change to extend the enum. Worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)