### PR TITLE
chore: drop x-password from user schema

### DIFF
--- a/.changeset/cleanup-x-password.md
+++ b/.changeset/cleanup-x-password.md
@@ -1,0 +1,11 @@
+---
+"@zitadel/cli": patch
+"@zitadel/server": patch
+"@zitadel/server-linux-x64": patch
+"@zitadel/server-linux-arm64": patch
+"@zitadel/server-darwin-x64": patch
+"@zitadel/server-darwin-arm64": patch
+"@zitadel/server-win32-x64": patch
+---
+
+Drop the `x-password` user-property annotation. The flow engine sources the password challenge from the reserved `x-auth-methods#password` field name combined with `x-auth-methods.password.enabled` at the schema root (introduced in #400); `x-password` is no longer read by any code path. Removed from the `user-property.json` meta-schema and the CLI's generated `password` preset; comments and docs updated to match.

--- a/api/openapi/endpoints/flow_definitions/examples/01-password-login/README.md
+++ b/api/openapi/endpoints/flow_definitions/examples/01-password-login/README.md
@@ -7,8 +7,8 @@ The minimal login flow. Collect an identifier, then a password, then complete.
 - Single-purpose definition (`login` only — no flip-table coverage required).
 - Identifier-shaped field (`email` is `x-unique` in the user schema) drives
   implicit identifier dispatch on submit.
-- Password-shaped field (`password` is `x-password`) drives implicit password
-  verification on submit.
+- Password-shaped field (the reserved `x-auth-methods#password` token) drives
+  implicit password verification on submit.
 - Terminal `complete: show` — the frontend renders a success screen and the
   flow handoff token is returned alongside the terminal step.
 
@@ -18,7 +18,7 @@ The minimal login flow. Collect an identifier, then a password, then complete.
 flowchart TD
     start([Start: purpose=login]) --> identifier
     identifier["identifier<br/>field: email<br/>action: submit"]
-    password["password<br/>field: password<br/>action: submit"]
+    password["password<br/>field: x-auth-methods#password<br/>action: submit"]
     done([done<br/>complete: show])
 
     identifier -- submit --> password

--- a/api/openapi/endpoints/flow_definitions/examples/README.md
+++ b/api/openapi/endpoints/flow_definitions/examples/README.md
@@ -33,8 +33,9 @@ A flow definition is a directed graph. The engine derives step behavior from
 the properties present on the step — there is no step `type`:
 
 - A step with `fields` collects user input validated against the
-  `user_schema`. Schema annotations (`x-unique`, `x-password`,
-  `x-auth-methods`) drive implicit dispatch behavior at runtime.
+  `user_schema`. Schema annotations (`x-unique`, `x-auth-methods`)
+  and reserved credential field names (`x-auth-methods#<method>`)
+  drive implicit dispatch behavior at runtime.
 - A step with `actions` exposes user-selectable buttons. Two action names are
   engine-handled — `passkey` (login) and `passkey_register` (signup) — and
   trigger the two-phase WebAuthn ceremony.

--- a/api/openapi/endpoints/schemas/user-property.json
+++ b/api/openapi/endpoints/schemas/user-property.json
@@ -14,11 +14,6 @@
       "const": "https://json-schema.org/draft/2020-12/schema",
       "description": "The JSON Schema version used for this schema."
     },
-    "x-password": {
-      "type": "boolean",
-      "default": false,
-      "description": "Whether this property carries the user's password proof."
-    },
     "x-verify": {
       "oneOf": [
         {

--- a/apps/cli/src/lib/user-schema/presets.ts
+++ b/apps/cli/src/lib/user-schema/presets.ts
@@ -39,19 +39,9 @@ const FIELD_PRESETS: Record<string, Record<string, unknown>> = {
     "x-sensitive": true,
     "x-editable": true,
   },
-  /**
-   * The password credential property. The platform identifies password
-   * properties by `x-password: true` (see
-   * `internal/domain/flow_field_resolver_schema.go`): combined with the
-   * schema-level `x-auth-methods.password.enabled = true`, the engine
-   * classifies the field as a password challenge and the
-   * `create_user` `on_success` handler uses its value to set the
-   * initial password.
-   */
   password: {
     type: "string",
     title: "Password",
-    "x-password": true,
     "x-sensitive": true,
     "x-editable": true,
     minLength: 1,

--- a/apps/cli/tests/unit/lib/user-schema/build.test.ts
+++ b/apps/cli/tests/unit/lib/user-schema/build.test.ts
@@ -15,11 +15,6 @@ describe("buildUserSchema", () => {
     expect(schema["x-auth-methods"].password).toEqual({ enabled: true, position: 0 });
   });
 
-  it("appends a password property with x-password: true (the engine's password marker)", () => {
-    const schema = buildUserSchema(["email"]);
-    expect(schema.properties?.password?.["x-password"]).toBe(true);
-  });
-
   it("returns a freshly allocated object on every call", () => {
     const a = buildUserSchema(["email"]);
     const b = buildUserSchema(["email"]);

--- a/docs/design/flowengine/architecture.md
+++ b/docs/design/flowengine/architecture.md
@@ -151,7 +151,7 @@ Errors that surface from `Process`:
 
 Interface (`Resolve` + `Validate`) plus a schema-backed implementation in `flow_field_resolver_schema.go`. Given a user schema URL and a list of property names, it returns:
 
-- `FlowField` per property — UI input `Type`, `TextKey`, `Required`, optional `Validation`, the field's uniqueness scope, and the `FlowFieldChallenge` it maps to (derived from `x-unique` and `x-password` annotations).
+- `FlowField` per property — UI input `Type`, `TextKey`, `Required`, optional `Validation`, the field's uniqueness scope, and the `FlowFieldChallenge` it maps to (derived from the property's `x-unique` annotation, or — for credential fields — the reserved `x-auth-methods#<method>` field name resolved against the schema root's `x-auth-methods`).
 - `ImplicitOutcomes` per field — the engine-emitted routing outcomes the field contributes (today: `user_not_found` and `user_already_exists` from identifier-shaped fields).
 
 `Validate` walks the resolved fields and returns `FlowFieldValidationErrors` on rule violations — the state machine surfaces those as step errors.

--- a/docs/design/flowengine/capabilities.md
+++ b/docs/design/flowengine/capabilities.md
@@ -33,7 +33,7 @@ to be a fast answer to "can I build flow X right now?"
 
 ### Steps & state machine
 
-- Schema-driven `fields`: type, validation, `required`, uniqueness scope, challenge mapping from `x-unique` / `x-password` annotations.
+- Schema-driven `fields`: type, validation, `required`, uniqueness scope, challenge mapping from the `x-unique` annotation on user properties, or — for credential fields — the reserved `x-auth-methods#<method>` field name resolved against the schema's `x-auth-methods`.
 - `actions` — user-selectable, surfaced on the capability payload. `passkey` and `passkey_register` are recognized action names that drive the passkey ceremony.
 - `on_success: create_user` — hashes the password (argon2id), writes the user and credential rows, then calls `auth-attempt.RegisterCreatedUser` so the new user counts as verified for the terminal handoff.
 - `complete: redirect` and `complete: show` — terminal step classifiers.

--- a/docs/design/flowengine/flow-definition-rules.md
+++ b/docs/design/flowengine/flow-definition-rules.md
@@ -94,7 +94,7 @@ Transition values:
 
 - **Steps don't have a kind.** Don't try to encode "this is the password step" in the name — encode it in the fields, the `on_success`, and the transitions.
 - **Reserved transition outcomes are part of the contract.** If the engine emits `user_not_found` on a step you didn't wire for it, the step errors instead of routing. Wire it explicitly even when the route is a same-target anti-enumeration redirect.
-- **Schema annotations drive behavior.** `x-unique` makes a field an identifier (and contributes `user_not_found`). `x-password` combined with `x-auth-methods.password.enabled` makes a field a password challenge. Adding annotations to the schema can change how every flow that references the field behaves.
+- **Schema annotations drive behavior.** `x-unique` makes a field an identifier (and contributes `user_not_found`). The reserved `x-auth-methods#password` field name combined with `x-auth-methods.password.enabled` makes a field a password challenge. Adding annotations to the schema can change how every flow that references the field behaves.
 - **`on_success` is a side effect, not a decision.** It can short-circuit a step error, but routing comes from transitions and it never authenticates the user — a terminal step after `create_user` mints no handoff unless an identifier dispatch happens later in the graph.
 
 ## Open questions

--- a/internal/domain/flow_field_resolver.go
+++ b/internal/domain/flow_field_resolver.go
@@ -49,8 +49,9 @@ type FlowField struct {
 
 	// Type is the UI input kind the client should render. It is
 	// derived from the property's JSON `type` and `format` in the user
-	// meta-schema. The property's `x-password: true` annotation forces
-	// a password input regardless of `format`.
+	// meta-schema. The reserved `x-auth-methods#<method>` field name
+	// forces the input kind matching that credential method
+	// (e.g. `x-auth-methods#password` → password).
 	Type FlowFieldType
 
 	// TextKey is a localization key for the field label (e.g.
@@ -79,15 +80,15 @@ type FlowField struct {
 	// identifier nor a credential proof. Derivation paths: a non-empty
 	// `x-unique` annotation on the property surfaces as
 	// [FlowFieldChallengeIdentifier] (any uniquely-keyed property can
-	// identify a user); `x-password: true` combined with schema-level
-	// `x-auth-methods.password.enabled = true` surfaces as
-	// [FlowFieldChallengePassword]. Other credential kinds (passkey,
-	// magic_link, sso, otp) do not have user-property-shaped proofs and
-	// are produced by the state machine as challenge steps, not by the
-	// resolver. The state machine consults Challenge on submit to route
-	// the value — identifier fields drive identifier resolution (and
-	// the `user_not_found` implicit outcome), password fields drive the
-	// password challenge.
+	// identify a user); the reserved `x-auth-methods#password` field
+	// name combined with `x-auth-methods.password.enabled = true` at
+	// the schema root surfaces as [FlowFieldChallengePassword]. Other
+	// credential kinds (passkey, magic_link, sso, otp) do not have
+	// field-shaped proofs and are produced by the state machine as
+	// challenge steps, not by the resolver. The state machine consults
+	// Challenge on submit to route the value — identifier fields drive
+	// identifier resolution (and the `user_not_found` implicit outcome),
+	// password fields drive the password challenge.
 	Challenge FlowFieldChallenge
 }
 
@@ -95,12 +96,13 @@ type FlowField struct {
 // to. Values mirror the keys of `x-auth-methods` in the user
 // meta-schema (api/openapi/endpoints/schemas/user-schema.yaml).
 // `identifier` is sourced from a non-empty `x-unique` scope on the
-// property; `password` is sourced from `x-password` on the property
-// combined with `x-auth-methods.password.enabled` at the schema root.
-// The remaining credential values (passkey, magic_link, sso, otp) have
-// no user-property-shaped proof and are produced by the state machine
-// as challenge steps rather than by the resolver. Empty means the
-// field maps to no challenge.
+// property; `password` is sourced from the reserved
+// `x-auth-methods#password` field name combined with
+// `x-auth-methods.password.enabled` at the schema root. The remaining
+// credential values (passkey, magic_link, sso, otp) have no
+// field-shaped proof and are produced by the state machine as
+// challenge steps rather than by the resolver. Empty means the field
+// maps to no challenge.
 type FlowFieldChallenge string
 
 const (


### PR DESCRIPTION
## Summary

Follow-up cleanup after #400. `x-password` is no longer read by the flow engine