### PR TITLE
fix: add user schema required fields check in flow definition validator

### DIFF
--- a/api/openapi/endpoints/flow_definitions/examples/03-passkey-login/flow-definition.json
+++ b/api/openapi/endpoints/flow_definitions/examples/03-passkey-login/flow-definition.json
@@ -10,6 +10,7 @@
     "steps": [
       {
         "name": "signin",
+        "fields": ["email"],
         "actions": [
           {
             "name": "passkey",

--- a/internal/api/integration_test/flow_definition_test.go
+++ b/internal/api/integration_test/flow_definition_test.go
@@ -188,7 +188,7 @@ func TestCreateFlowDefinition(t *testing.T) {
 					Steps: []api.FlowDefinitionStep{
 						{
 							Name:   "step_1",
-							Fields: []string{"username"},
+							Fields: []string{"email", "username"},
 							Transitions: api.NewOptFlowDefinitionStepTransitions(map[string]api.FlowDefinitionStepTransitionsItem{
 								"submit": {
 									Target: "step_2",

--- a/internal/api/integration_test/flow_definition_test.go
+++ b/internal/api/integration_test/flow_definition_test.go
@@ -216,6 +216,52 @@ func TestCreateFlowDefinition(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "invalid flow definition - missing required fields per user schema",
+			req: &api.CreateFlowDefinitionRequest{
+				ProjectID: api.ProjectID(project.ID),
+				FlowDefinition: api.FlowDefinition{
+					Name:       "invalid-flow",
+					UserSchema: *userSchemaURI,
+					Purposes:   map[string]string{"login": "step_1"},
+					Audience: api.OptFlowAudience{
+						Value: api.FlowAudience{
+							TeamIds: []string{"team-1", "team-2"},
+							AppIds:  []string{"app-1", "app-2"},
+						},
+						Set: true,
+					},
+					Steps: []api.FlowDefinitionStep{
+						{
+							Name:   "step_1",
+							Fields: []string{"username"},
+							Transitions: api.NewOptFlowDefinitionStepTransitions(map[string]api.FlowDefinitionStepTransitionsItem{
+								"submit": {
+									Target: "step_2",
+								},
+							}),
+							Actions: []api.StepAction{
+								{Name: "submit", Kind: api.StepActionKindSubmit, Primary: api.NewOptBool(true)},
+							},
+						},
+						{
+							Name:     "step_2",
+							Complete: api.NewOptFlowDefinitionStepComplete(api.FlowDefinitionStepCompleteRedirect),
+						},
+					},
+				},
+			},
+			wantResp: &api.CreateFlowDefinitionBadRequest{
+				Code:    "flowdef.invalid",
+				Message: "flow definition: invalid",
+				Details: api.OptErrorDetailsDetails{
+					Value: api.ErrorDetailsDetails{
+						"details": jx.Raw(`"required fields [email] in user schema are missing in the flow definition steps"`),
+					},
+					Set: true,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/integration_test/passkey_flow_test.go
+++ b/internal/api/integration_test/passkey_flow_test.go
@@ -106,7 +106,8 @@ func TestPasskeyFlowLogin(t *testing.T) {
 			Purposes:   api.FlowDefinitionPurposes{"login": "passkey-step"},
 			Steps: []api.FlowDefinitionStep{
 				{
-					Name: "passkey-step",
+					Name:   "passkey-step",
+					Fields: []string{"email"},
 					Actions: []api.StepAction{
 						{Name: "passkey", Kind: api.StepActionKindPasskey, Primary: api.NewOptBool(true)},
 					},

--- a/internal/api/integration_test/registration_flow_test.go
+++ b/internal/api/integration_test/registration_flow_test.go
@@ -112,10 +112,6 @@ func TestPasskeyRegistrationFlow(t *testing.T) {
 					Actions: []api.StepAction{
 						{Name: "passkey", Kind: api.StepActionKindPasskey, Primary: api.NewOptBool(true)},
 					},
-					Gates:        api.OptFlowDefinitionStepGates{},
-					SSOProviders: nil,
-					OnSuccess:    api.OptFlowDefinitionStepOnSuccess{},
-					Complete:     api.OptFlowDefinitionStepComplete{},
 					Transitions: api.NewOptFlowDefinitionStepTransitions(api.FlowDefinitionStepTransitions{
 						"passkey": api.FlowDefinitionStepTransitionsItem{Target: "register-step"},
 					}),

--- a/internal/api/integration_test/registration_flow_test.go
+++ b/internal/api/integration_test/registration_flow_test.go
@@ -107,10 +107,15 @@ func TestPasskeyRegistrationFlow(t *testing.T) {
 			Purposes:   api.FlowDefinitionPurposes{"login": "auth-step"},
 			Steps: []api.FlowDefinitionStep{
 				{
-					Name: "auth-step",
+					Name:   "auth-step",
+					Fields: []string{"email"},
 					Actions: []api.StepAction{
 						{Name: "passkey", Kind: api.StepActionKindPasskey, Primary: api.NewOptBool(true)},
 					},
+					Gates:        api.OptFlowDefinitionStepGates{},
+					SSOProviders: nil,
+					OnSuccess:    api.OptFlowDefinitionStepOnSuccess{},
+					Complete:     api.OptFlowDefinitionStepComplete{},
 					Transitions: api.NewOptFlowDefinitionStepTransitions(api.FlowDefinitionStepTransitions{
 						"passkey": api.FlowDefinitionStepTransitionsItem{Target: "register-step"},
 					}),

--- a/internal/domain/flow_definition_validator.go
+++ b/internal/domain/flow_definition_validator.go
@@ -135,6 +135,9 @@ func resolveAllStepFields(schema *jsonschema.Schema, steps []FlowDefinitionStep)
 // validateRequiredUserSchemaFields checks that all required fields in the
 // user schema are present in the flow definition.
 func validateRequiredUserSchemaFields(required map[string]struct{}, steps []FlowDefinitionStep) error {
+	if len(required) == 0 {
+		return nil
+	}
 	// gather all the fields set in the flow definition steps
 	fields := make(map[string]struct{})
 	for _, step := range steps {

--- a/internal/domain/flow_definition_validator.go
+++ b/internal/domain/flow_definition_validator.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/ianlancetaylor/jsonschema"
 )
@@ -96,8 +97,14 @@ func resolveAllStepFields(schema *jsonschema.Schema, steps []FlowDefinitionStep)
 	// Fail fast on schemas with no `properties` keyword at all. Without
 	// it the resolver would emit one ErrFlowFieldUnknown per user-property
 	// field; the structural defect is clearer surfaced once.
-	if newSchemaReader(schema).Properties() == nil {
+	sr := newSchemaReader(schema)
+	if sr.Properties() == nil {
 		return nil, ErrFlowDefinitionInvalid("user schema has no properties", nil)
+	}
+
+	// validate that all required fields in the schema are present in the flow definition
+	if err := validateRequiredUserSchemaFields(sr.RequiredSet(), steps); err != nil {
+		return nil, err
 	}
 
 	// SchemaFieldResolver is stateless; a zero-value instance is the
@@ -123,6 +130,29 @@ func resolveAllStepFields(schema *jsonschema.Schema, steps []FlowDefinitionStep)
 		out[step.Name] = resolved
 	}
 	return out, nil
+}
+
+// validateRequiredUserSchemaFields checks that all required fields in the
+// user schema are present in the flow definition.
+func validateRequiredUserSchemaFields(required map[string]struct{}, steps []FlowDefinitionStep) error {
+	// gather all the fields set in the flow definition steps
+	fields := make(map[string]struct{})
+	for _, step := range steps {
+		for _, f := range step.Fields {
+			fields[string(f)] = struct{}{}
+		}
+	}
+	missingFields := make([]string, 0, len(required))
+	for requiredField := range required {
+		if _, ok := fields[requiredField]; !ok {
+			missingFields = append(missingFields, requiredField)
+		}
+	}
+	if len(missingFields) > 0 {
+		slices.Sort(missingFields)
+		return ErrFlowDefinitionInvalid(fmt.Sprintf("required fields %v in user schema are missing in the flow definition steps", missingFields), nil)
+	}
+	return nil
 }
 
 // validateSteps checks the structural shape of each step (terminal vs

--- a/internal/domain/flow_definition_validator_test.go
+++ b/internal/domain/flow_definition_validator_test.go
@@ -347,6 +347,9 @@ func TestValidateFlowDefinition(t *testing.T) {
 					Steps: []domain.FlowDefinitionStep{
 						{
 							Name: "identify",
+							Fields: []domain.Field{
+								"email",
+							},
 							SSOProviders: []domain.FlowSSOProvider{
 								{
 									ID:       "google",
@@ -420,6 +423,9 @@ func TestValidateFlowDefinition(t *testing.T) {
 					Steps: []domain.FlowDefinitionStep{
 						{
 							Name: "enter",
+							Fields: []domain.Field{
+								"email",
+							},
 							Actions: []domain.FlowStepAction{
 								{Name: "next", Kind: domain.FlowActionKindSubmit},
 							},
@@ -912,7 +918,7 @@ func TestValidateFlowDefinition(t *testing.T) {
 					Steps: []domain.FlowDefinitionStep{
 						{
 							Name:   "step_1",
-							Fields: []domain.Field{"username", "firstName"},
+							Fields: []domain.Field{"email", "username", "firstName"},
 							Transitions: map[string]domain.FlowStepTransition{
 								"submit": {Target: "step_2"},
 							},

--- a/internal/domain/flow_definition_validator_test.go
+++ b/internal/domain/flow_definition_validator_test.go
@@ -81,6 +81,22 @@ var userSchemaIDAndPassword = []byte(`{
   }
 }`)
 
+var userSchemaRequiredProps = []byte(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tenant.com/schemas/idpw-user.json",
+  "type": "object",
+  "required": ["email", "first_name", "last_name"],
+  "x-auth-methods": {
+    "password": { "enabled": true, "position": 0 }
+  },
+  "properties": {
+    "email":    { "type": "string", "format": "email", "x-unique": "team" },
+	"first_name": { "type": "string" },
+	"last_name": { "type": "string" },
+	"age": { "type": "integer" }
+  }
+}`)
+
 var tenantUserSchema = []byte(`{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "metaSchema": "https://nextgen.com/schemas/user-meta-schema.json",
@@ -1487,4 +1503,33 @@ func TestValidator_DeclaredBackKindRejected(t *testing.T) {
 	_, err := domain.ValidateFlowDefinition(schema, def)
 	require.Error(t, err)
 	assert.Contains(t, errorDetails(t, err), `action "back" has kind=back, which is engine-injected and cannot be declared`)
+}
+
+func TestValidator_MissingRequiredUserSchemaFields(t *testing.T) {
+	schema := mustSchema(t, userSchemaRequiredProps)
+	def := domain.FlowDefinition{
+		ProjectID: "p", Name: "f", SchemaVersion: "1",
+		UserSchema: "https://tenant.com/schemas/idpw-user.json",
+		Purposes:   map[domain.FlowDefinitionPurpose]string{domain.FlowDefinitionPurposeLogin: "identifier"},
+		Steps: []domain.FlowDefinitionStep{
+			{
+				Name: "identifier", Fields: []domain.Field{"email"},
+				Actions: []domain.FlowStepAction{
+					{Name: "submit", Kind: domain.FlowActionKindSubmit, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{"submit": {Target: "profile"}},
+			},
+			{
+				Name: "profile", Fields: []domain.Field{"given_name", "family_name", "date_of_birth"},
+				Actions: []domain.FlowStepAction{
+					{Name: "submit", Kind: domain.FlowActionKindSubmit, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{"submit": {Target: "done"}},
+			},
+			{Name: "done", Complete: new(domain.FlowStepCompleteShow)},
+		},
+	}
+	_, err := domain.ValidateFlowDefinition(schema, def)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrFlowDefinitionInvalid(`required fields [first_name last_name] in user schema are missing in the flow definition steps`, nil))
 }

--- a/internal/storage/database/repository/flow_definition_test.go
+++ b/internal/storage/database/repository/flow_definition_test.go
@@ -46,7 +46,7 @@ func TestFlowDefinitionRepository_CreateAndGet(t *testing.T) {
 	}
 
 	identifier := stepsByName["identifier"]
-	assert.Equal(t, []string{"email"}, identifier.Fields)
+	assert.Equal(t, []domain.Field{"email"}, identifier.Fields)
 	assert.Nil(t, identifier.OnSuccess)
 	assert.Nil(t, identifier.Complete)
 	require.Len(t, identifier.Transitions, 2)


### PR DESCRIPTION
## Summary

This PR expands the flow definition validator functionality by adding a check to ensure that all fields marked as required in user schema are set in the flow definition as well.

Changes:
- Added `validateRequiredUserSchemaFields` to validate that all required fields in the user schema are present in the flow definition
- Added unit/integration tests
- Fixed other related unit/integration tests that are missing required fields

## Validation

- `go test ./...`
- `go test -v -tags postgres_integration -timeout=10m ./...`
- `go test -v -tags spanner_integration -timeout=10m ./...`

## Release notes / changeset
- No changeset required — no shipped behavior changed.

## Notes

