### PR TITLE
fix: repair passkey registration flow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -40,6 +40,7 @@
     "@zitadel/demo-next-e2e",
     "@zitadel/demo-nuxt",
     "@zitadel/demo-nuxt-e2e",
-    "@zitadel/login-ui"
+    "@zitadel/login-ui",
+    "@zitadel/storybook"
   ]
 }

--- a/.changeset/passkey-registration-labels.md
+++ b/.changeset/passkey-registration-labels.md
@@ -1,0 +1,7 @@
+---
+"@zitadel/server": patch
+"@zitadel/api": patch
+"@zitadel/components": patch
+---
+
+Label passkey registrations with collected identifiers and request discoverable credentials while keeping WebAuthn user handles opaque.

--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -8734,6 +8734,8 @@ func (s *FlowStepChallengeMethod) Decode(d *jx.Decoder) error {
 	switch FlowStepChallengeMethod(v) {
 	case FlowStepChallengeMethodPasskey:
 		*s = FlowStepChallengeMethodPasskey
+	case FlowStepChallengeMethodPasskeyRegister:
+		*s = FlowStepChallengeMethodPasskeyRegister
 	default:
 		*s = FlowStepChallengeMethod(v)
 	}

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -3919,13 +3919,15 @@ func (s *FlowStepChallenge) SetOptions(val OptFlowStepChallengeOptions) {
 type FlowStepChallengeMethod string
 
 const (
-	FlowStepChallengeMethodPasskey FlowStepChallengeMethod = "passkey"
+	FlowStepChallengeMethodPasskey         FlowStepChallengeMethod = "passkey"
+	FlowStepChallengeMethodPasskeyRegister FlowStepChallengeMethod = "passkey_register"
 )
 
 // AllValues returns all FlowStepChallengeMethod values.
 func (FlowStepChallengeMethod) AllValues() []FlowStepChallengeMethod {
 	return []FlowStepChallengeMethod{
 		FlowStepChallengeMethodPasskey,
+		FlowStepChallengeMethodPasskeyRegister,
 	}
 }
 
@@ -3933,6 +3935,8 @@ func (FlowStepChallengeMethod) AllValues() []FlowStepChallengeMethod {
 func (s FlowStepChallengeMethod) MarshalText() ([]byte, error) {
 	switch s {
 	case FlowStepChallengeMethodPasskey:
+		return []byte(s), nil
+	case FlowStepChallengeMethodPasskeyRegister:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -3944,6 +3948,9 @@ func (s *FlowStepChallengeMethod) UnmarshalText(data []byte) error {
 	switch FlowStepChallengeMethod(data) {
 	case FlowStepChallengeMethodPasskey:
 		*s = FlowStepChallengeMethodPasskey
+		return nil
+	case FlowStepChallengeMethodPasskeyRegister:
+		*s = FlowStepChallengeMethodPasskeyRegister
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/api/generated/oas_validators_gen.go
+++ b/api/generated/oas_validators_gen.go
@@ -1702,6 +1702,8 @@ func (s FlowStepChallengeMethod) Validate() error {
 	switch s {
 	case "passkey":
 		return nil
+	case "passkey_register":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}

--- a/api/openapi/components/flows/flow-step.yaml
+++ b/api/openapi/components/flows/flow-step.yaml
@@ -114,7 +114,7 @@ properties:
     properties:
       method:
         type: string
-        enum: [passkey]
+        enum: [passkey, passkey_register]
         description: Challenge method. Determines which component handles the ceremony.
       challenge_id:
         type: string

--- a/apps/cli-journey-e2e/src/user-journey.spec.ts
+++ b/apps/cli-journey-e2e/src/user-journey.spec.ts
@@ -1,5 +1,5 @@
 /* oxlint-disable playwright/expect-expect, playwright/no-conditional-in-test */
-import { expect, test, type Locator, type Page } from "@playwright/test";
+import { expect, test, type CDPSession, type Locator, type Page } from "@playwright/test";
 
 test.describe.configure({ mode: "serial" });
 test.setTimeout(60_000);
@@ -33,7 +33,7 @@ if (process.env.JOURNEY_ENABLE_PASSKEY !== "0") {
   test(`passkey-only registration, logout, and passkey login work in a fresh ${framework} app`, async ({
     page,
   }) => {
-    await enableVirtualAuthenticator(page);
+    const authenticator = await enableVirtualAuthenticator(page);
 
     const email = uniqueEmail("passkey");
 
@@ -41,13 +41,14 @@ if (process.env.JOURNEY_ENABLE_PASSKEY !== "0") {
     await registerWithPasskey(page, email);
     await expectSignedIn(page);
     await expectSessionCookie(page);
+    await expectVirtualCredentialCount(authenticator, 1);
 
     await logout(page);
     await loginWithPasskey(page, email);
     await expectSignedIn(page);
     await expectSessionCookie(page);
+    await expectVirtualCredentialCount(authenticator, 1);
   });
-
 }
 
 async function expectProtectedRouteToRedirect(page: Page): Promise<void> {
@@ -165,10 +166,15 @@ async function expectSessionCookie(page: Page): Promise<void> {
   expect(sessionCookie?.httpOnly).toBe(true);
 }
 
-async function enableVirtualAuthenticator(page: Page): Promise<void> {
+type VirtualAuthenticator = {
+  client: CDPSession;
+  authenticatorId: string;
+};
+
+async function enableVirtualAuthenticator(page: Page): Promise<VirtualAuthenticator> {
   const client = await page.context().newCDPSession(page);
   await client.send("WebAuthn.enable");
-  await client.send("WebAuthn.addVirtualAuthenticator", {
+  const { authenticatorId } = await client.send("WebAuthn.addVirtualAuthenticator", {
     options: {
       protocol: "ctap2",
       transport: "internal",
@@ -178,6 +184,21 @@ async function enableVirtualAuthenticator(page: Page): Promise<void> {
       automaticPresenceSimulation: true,
     },
   });
+  return { client, authenticatorId };
+}
+
+async function expectVirtualCredentialCount(
+  authenticator: VirtualAuthenticator,
+  expected: number,
+): Promise<void> {
+  await expect
+    .poll(async () => {
+      const { credentials } = await authenticator.client.send("WebAuthn.getCredentials", {
+        authenticatorId: authenticator.authenticatorId,
+      });
+      return credentials.length;
+    })
+    .toBe(expected);
 }
 
 async function logout(page: Page): Promise<void> {

--- a/apps/docs/content/docs/cli/troubleshooting.mdx
+++ b/apps/docs/content/docs/cli/troubleshooting.mdx
@@ -34,3 +34,9 @@ Capture stdout and stderr separately. The JSON envelope is on stdout; package-ma
 ## Browser proof stops at the form
 
 A rendered login or registration form is not enough. Complete registration, logout, login, and signed-in profile verification in a real browser.
+
+## Old localhost passkeys still appear
+
+Browser and OS passkeys for `localhost` can outlive `zitadel reset --force`, deleted app folders, and new local projects. If the passkey picker shows stale local accounts, remove the old `localhost` passkeys from your browser or operating system credential manager.
+
+Password managers can also keep their save or update sheet open after the app redirects to the signed-in profile. An `Update Existing` prompt usually means the manager found an old `localhost` item with the same account label. Update it, save a new item, or delete the stale local passkey before retrying.

--- a/internal/api/branding/default.liquid
+++ b/internal/api/branding/default.liquid
@@ -110,10 +110,10 @@
     {% endif %}
 
     {% if challenge %}
-      {% if challenge.method == "passkey" %}
+      {% if challenge.method == "passkey" or challenge.method == "passkey_register" %}
         {% assign ceremony = "authenticate" %}
         {% assign submit_method = "passkey" %}
-        {% if challenge.options.user %}
+        {% if challenge.method == "passkey_register" or challenge.options.user %}
           {% assign ceremony = "register" %}
           {% assign submit_method = "passkey_register" %}
         {% endif %}

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -306,7 +306,12 @@ func toFlowStep(step *domain.FlowStep) api.FlowStep {
 func toFlowStepChallenge(c domain.FlowStepChallenge) api.FlowStepChallenge {
 	out := api.FlowStepChallenge{}
 	if c.Method != "" {
-		out.Method = api.NewOptFlowStepChallengeMethod(api.FlowStepChallengeMethodPasskey)
+		switch c.Method {
+		case domain.FlowChallengeMethodPasskeyRegister:
+			out.Method = api.NewOptFlowStepChallengeMethod(api.FlowStepChallengeMethodPasskeyRegister)
+		default:
+			out.Method = api.NewOptFlowStepChallengeMethod(api.FlowStepChallengeMethodPasskey)
+		}
 	}
 	if c.ChallengeID != "" {
 		out.ChallengeID = api.NewOptString(c.ChallengeID)

--- a/internal/api/integration_test/passkey_upsell_flow_test.go
+++ b/internal/api/integration_test/passkey_upsell_flow_test.go
@@ -132,12 +132,24 @@ func TestPostCreateUserPasskeyUpsell(t *testing.T) {
 
 	require.True(t, issueOK.Response.Step.Challenge.Set, "expected challenge on passkey_register issue")
 	challenge := issueOK.Response.Step.Challenge.Value
+	method, methodSet := challenge.Method.Get()
+	require.True(t, methodSet)
+	require.Equal(t, api.FlowStepChallengeMethodPasskeyRegister, method)
 	challengeID, challengeIDSet := challenge.ChallengeID.Get()
 	require.True(t, challengeIDSet)
 	require.True(t, challenge.Options.Set, "expected creation options on passkey_register issue")
 
 	creationOptionsJSON, err := json.Marshal(challenge.Options.Value)
 	require.NoError(t, err)
+	var creationOptions struct {
+		User struct {
+			Name        string `json:"name"`
+			DisplayName string `json:"displayName"`
+		} `json:"user"`
+	}
+	require.NoError(t, json.Unmarshal(creationOptionsJSON, &creationOptions))
+	require.Equal(t, newEmail, creationOptions.User.Name)
+	require.Equal(t, newEmail, creationOptions.User.DisplayName)
 	attestOpts, err := virtualwebauthn.ParseAttestationOptions(string(creationOptionsJSON))
 	require.NoError(t, err)
 	attestationJSON := virtualwebauthn.CreateAttestationResponse(rp, auth, cred, *attestOpts)

--- a/internal/domain/flow_passkey_registration.go
+++ b/internal/domain/flow_passkey_registration.go
@@ -27,12 +27,15 @@ type FlowPasskeyRegistrationService interface {
 
 // FlowIssuePasskeyRegistrationChallengeInput carries the relying-party
 // parameters and the user context needed to begin a registration ceremony.
-// UserID must already be resolved on the attempt before this is called.
+// UserID is the stable WebAuthn user handle; Username and DisplayName are
+// browser-visible labels when the flow has a collected identifier.
 type FlowIssuePasskeyRegistrationChallengeInput struct {
-	ProjectID string
-	UserID    string
-	RPID      string
-	RPOrigins []string
+	ProjectID   string
+	UserID      string
+	Username    string
+	DisplayName string
+	RPID        string
+	RPOrigins   []string
 }
 
 // FlowPasskeyRegistrationChallengeOutput is the issued challenge.

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -765,16 +765,6 @@ func needsPasskeyRegistrationVisitedFields(state *FlowState, in FlowSubmitInput,
 }
 
 func passkeyRegistrationDisplay(resolved FlowResolvedFields, collected map[string]any) (string, string) {
-	for _, f := range resolved.Fields {
-		if f.Type != FlowFieldTypeEmail {
-			continue
-		}
-		label := strings.TrimSpace(asString(collected[f.Name]))
-		if label != "" {
-			return label, label
-		}
-	}
-
 	_, _, value, ok := findCollectedFieldByChallenge(resolved.Fields, collected, FlowFieldChallengeIdentifier)
 	if !ok {
 		return "", ""

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -332,11 +332,20 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 		}
 	}
 
+	passkeyResolved := resolved
+	if needsPasskeyRegistrationVisitedFields(state, in, actionKind) {
+		visitedResolved, err := r.resolveVisitedFields(ctx, client, state.ProjectID, userSchemaURL, def, state, currentStep)
+		if err != nil {
+			return FlowStepResult{}, err
+		}
+		passkeyResolved = visitedResolved
+	}
+
 	// Two-phase passkey ceremony (issue → client signs → verify) runs before the
 	// field-shaped dispatch and short-circuits it when engaged. Only proceed into
 	// processPasskey when no dispatch outcome already overrode the route.
 	if routeOutcome == in.Action {
-		pk, err := r.processPasskey(ctx, client, state, currentStep, resolved, in, actionKind)
+		pk, err := r.processPasskey(ctx, client, state, currentStep, resolved, passkeyResolved, in, actionKind)
 		if err != nil {
 			return FlowStepResult{}, err
 		}
@@ -574,8 +583,9 @@ type passkeyPhaseResult struct {
 //     mint an assertion challenge; discoverable login allowed when no user is
 //     yet identified.
 //   - issue leg (register): step offers a `passkey_register` action and it
-//     was selected → user must already be identified; mint a creation challenge.
-func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client database.QueryExecutor, state *FlowState, step *FlowDefinitionStep, resolved FlowResolvedFields, in FlowSubmitInput, actionKind FlowActionKind) (passkeyPhaseResult, error) {
+//     was selected → use the resolved user id or mint a provisional one, then
+//     issue a creation challenge.
+func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client database.QueryExecutor, state *FlowState, step *FlowDefinitionStep, resolved FlowResolvedFields, passkeyResolved FlowResolvedFields, in FlowSubmitInput, actionKind FlowActionKind) (passkeyPhaseResult, error) {
 	switch {
 	// A ceremony is in flight but no proof arrived: resume or abandon.
 	case state.PendingChallenge != nil && in.ChallengeResponse == nil:
@@ -608,7 +618,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			provisional := state.CollectedData.AuthMethods.HasProvisionedUserIDForPasskey
 			if provisional {
 				state.CollectedData.AuthMethods.HasProvisionedUserIDForPasskey = false
-				if err := r.createUser.HandleProvisional(ctx, client, userID, state, resolved); err != nil {
+				if err := r.createUser.HandleProvisional(ctx, client, userID, state, passkeyResolved); err != nil {
 					return passkeyPhaseResult{}, fmt.Errorf("flow state machine: ensure user exists: %w", err)
 				}
 			}
@@ -715,11 +725,14 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			// The verify leg will call HandleProvisional + RegisterCreatedUser.
 			state.CollectedData.AuthMethods.HasProvisionedUserIDForPasskey = true
 		}
+		username, displayName := passkeyRegistrationDisplay(passkeyResolved, state.CollectedData.UserData)
 		out, err := r.passkeyRegistration.IssuePasskeyRegistrationChallenge(ctx, FlowIssuePasskeyRegistrationChallengeInput{
-			ProjectID: state.ProjectID,
-			UserID:    userID,
-			RPID:      in.PasskeyRP.RPID,
-			RPOrigins: in.PasskeyRP.Origins,
+			ProjectID:   state.ProjectID,
+			UserID:      userID,
+			Username:    username,
+			DisplayName: displayName,
+			RPID:        in.PasskeyRP.RPID,
+			RPOrigins:   in.PasskeyRP.Origins,
 		})
 		if err != nil {
 			return passkeyPhaseResult{}, fmt.Errorf("flow state machine: issue passkey registration: %w", err)
@@ -736,6 +749,41 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 		return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
 	}
 	return passkeyPhaseResult{}, nil
+}
+
+func needsPasskeyRegistrationVisitedFields(state *FlowState, in FlowSubmitInput, actionKind FlowActionKind) bool {
+	if actionKind == FlowActionKindPasskeyRegister && in.ChallengeResponse == nil {
+		return true
+	}
+	if in.ChallengeResponse == nil {
+		return false
+	}
+	if state != nil && state.PendingChallenge != nil {
+		return state.PendingChallenge.Method == FlowChallengeMethodPasskeyRegister
+	}
+	return in.ChallengeResponse.Method == FlowChallengeMethodPasskeyRegister
+}
+
+func passkeyRegistrationDisplay(resolved FlowResolvedFields, collected map[string]any) (string, string) {
+	for _, f := range resolved.Fields {
+		if f.Type != FlowFieldTypeEmail {
+			continue
+		}
+		label := strings.TrimSpace(asString(collected[f.Name]))
+		if label != "" {
+			return label, label
+		}
+	}
+
+	_, _, value, ok := findCollectedFieldByChallenge(resolved.Fields, collected, FlowFieldChallengeIdentifier)
+	if !ok {
+		return "", ""
+	}
+	label := strings.TrimSpace(asString(value))
+	if label == "" {
+		return "", ""
+	}
+	return label, label
 }
 
 // pendingMatchesKind reports whether a no-proof POST should resume the

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -1798,6 +1798,74 @@ func passkeyRegisterDefinition() *domain.FlowDefinition {
 	}
 }
 
+func passkeyRegisterAfterIdentifierDefinition() *domain.FlowDefinition {
+	show := domain.FlowStepCompleteShow
+	return &domain.FlowDefinition{
+		ProjectID:  testProjectID,
+		ID:         "def-passkey-reg-with-identifier",
+		UserSchema: defaultSchemaURL,
+		Purposes: map[domain.FlowDefinitionPurpose]string{
+			domain.FlowDefinitionPurposeRegister: "identify",
+		},
+		Steps: []domain.FlowDefinitionStep{
+			{
+				Name:   "identify",
+				Fields: []domain.Field{"email"},
+				Actions: []domain.FlowStepAction{
+					{Name: domain.FlowActionSubmit, Kind: domain.FlowActionKindSubmit, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{
+					domain.FlowActionSubmit: {Target: "register"},
+				},
+			},
+			{
+				Name: "register",
+				Actions: []domain.FlowStepAction{
+					{Name: domain.FlowActionPasskeyRegister, Kind: domain.FlowActionKindPasskeyRegister, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{
+					domain.FlowActionPasskeyRegister: {Target: "done"},
+				},
+			},
+			{Name: "done", Complete: &show},
+		},
+	}
+}
+
+func passkeyRegisterAfterUsernameAndEmailDefinition() *domain.FlowDefinition {
+	show := domain.FlowStepCompleteShow
+	return &domain.FlowDefinition{
+		ProjectID:  testProjectID,
+		ID:         "def-passkey-reg-with-username-and-email",
+		UserSchema: defaultSchemaURL,
+		Purposes: map[domain.FlowDefinitionPurpose]string{
+			domain.FlowDefinitionPurposeRegister: "identify",
+		},
+		Steps: []domain.FlowDefinitionStep{
+			{
+				Name:   "identify",
+				Fields: []domain.Field{"username", "email"},
+				Actions: []domain.FlowStepAction{
+					{Name: domain.FlowActionSubmit, Kind: domain.FlowActionKindSubmit, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{
+					domain.FlowActionSubmit: {Target: "register"},
+				},
+			},
+			{
+				Name: "register",
+				Actions: []domain.FlowStepAction{
+					{Name: domain.FlowActionPasskeyRegister, Kind: domain.FlowActionKindPasskeyRegister, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{
+					domain.FlowActionPasskeyRegister: {Target: "done"},
+				},
+			},
+			{Name: "done", Complete: &show},
+		},
+	}
+}
+
 func TestFlowStateMachine_Process_PasskeyRegisterIssueThenVerify(t *testing.T) {
 	t.Parallel()
 	const userID = "user_01TEST"
@@ -1936,7 +2004,9 @@ func TestFlowStateMachine_Process_PasskeyRegisterGeneratesUserID(t *testing.T) {
 	// The provisional user ID should have been generated and passed to the service.
 	w.passkeyRegService.EXPECT().
 		IssuePasskeyRegistrationChallenge(gomock.Any(), gomock.Cond(func(in domain.FlowIssuePasskeyRegistrationChallengeInput) bool {
-			return assert.Equal(t, userID, in.UserID)
+			return assert.Equal(t, userID, in.UserID) &&
+				assert.Empty(t, in.Username) &&
+				assert.Empty(t, in.DisplayName)
 		})).
 		Return(domain.FlowPasskeyRegistrationChallengeOutput{
 			ChallengeID: challengeID,
@@ -1960,6 +2030,120 @@ func TestFlowStateMachine_Process_PasskeyRegisterGeneratesUserID(t *testing.T) {
 	require.NotNil(t, issued.Step.Challenge)
 	// The generated ID should be stored in CollectedData for use in the verify phase.
 	assert.Equal(t, userID, issued.State.CollectedData.UserID)
+}
+
+func TestFlowStateMachine_Process_PasskeyRegisterUsesCollectedIdentifierForDisplay(t *testing.T) {
+	t.Parallel()
+	const email = "alice@example.com"
+	const challengeID = "reg-1"
+	const registrationOpts = `{"rp":{"id":"example.com"}}`
+	const userID = "user_01TEST"
+	w := newFlowTestWorld(t)
+	def := passkeyRegisterAfterIdentifierDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("attempt-1", nil)
+	w.schemaResolver.EXPECT().
+		Resolve(gomock.Any(), gomock.Any(), gomock.Any(), defaultSchemaURL, gomock.Any()).
+		Return(mustUnmarshal[jsonschema.Schema](t, defaultSchemaContent), nil).
+		AnyTimes()
+	w.authAttemptService.EXPECT().
+		SubmitIdentifier(gomock.Any(), gomock.Cond(func(in domain.FlowSubmitIdentifierInput) bool {
+			return assert.Equal(t, "email", in.AttributeName) &&
+				assert.Equal(t, email, in.Value)
+		})).
+		Return("", domain.ErrAuthAttemptProofRejected(nil))
+	w.passkeyRegService.EXPECT().
+		IssuePasskeyRegistrationChallenge(gomock.Any(), gomock.Cond(func(in domain.FlowIssuePasskeyRegistrationChallengeInput) bool {
+			return assert.Equal(t, userID, in.UserID) &&
+				assert.Equal(t, email, in.Username) &&
+				assert.Equal(t, email, in.DisplayName)
+		})).
+		Return(domain.FlowPasskeyRegistrationChallengeOutput{
+			ChallengeID: challengeID,
+			Options:     []byte(registrationOpts),
+		}, nil)
+
+	start, err := w.sm.Start(t.Context(), nil, domain.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeRegister,
+		Session:       domain.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+
+	registerStep, err := w.sm.Process(t.Context(), nil, def, start.State, domain.FlowSubmitInput{
+		Action: domain.FlowActionSubmit,
+		Fields: map[string]any{"email": email},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "register", registerStep.Step.Name)
+
+	issued, err := w.sm.Process(t.Context(), nil, def, registerStep.State, domain.FlowSubmitInput{
+		Action:    domain.FlowActionPasskeyRegister,
+		PasskeyRP: &domain.FlowPasskeyRP{RPID: "example.com", Origins: []string{"https://example.com"}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, issued.Step.Challenge)
+	assert.Equal(t, challengeID, issued.Step.Challenge.ChallengeID)
+}
+
+func TestFlowStateMachine_Process_PasskeyRegisterPrefersEmailForDisplay(t *testing.T) {
+	t.Parallel()
+	const username = "alice"
+	const email = "alice@example.com"
+	const challengeID = "reg-1"
+	const registrationOpts = `{"rp":{"id":"example.com"}}`
+	const userID = "user_01TEST"
+	w := newFlowTestWorld(t)
+	def := passkeyRegisterAfterUsernameAndEmailDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("attempt-1", nil)
+	w.schemaResolver.EXPECT().
+		Resolve(gomock.Any(), gomock.Any(), gomock.Any(), defaultSchemaURL, gomock.Any()).
+		Return(mustUnmarshal[jsonschema.Schema](t, defaultSchemaContent), nil).
+		AnyTimes()
+	w.authAttemptService.EXPECT().
+		SubmitIdentifier(gomock.Any(), gomock.Cond(func(in domain.FlowSubmitIdentifierInput) bool {
+			return assert.Equal(t, "username", in.AttributeName) &&
+				assert.Equal(t, username, in.Value)
+		})).
+		Return("", domain.ErrAuthAttemptProofRejected(nil))
+	w.passkeyRegService.EXPECT().
+		IssuePasskeyRegistrationChallenge(gomock.Any(), gomock.Cond(func(in domain.FlowIssuePasskeyRegistrationChallengeInput) bool {
+			return assert.Equal(t, userID, in.UserID) &&
+				assert.Equal(t, email, in.Username) &&
+				assert.Equal(t, email, in.DisplayName)
+		})).
+		Return(domain.FlowPasskeyRegistrationChallengeOutput{
+			ChallengeID: challengeID,
+			Options:     []byte(registrationOpts),
+		}, nil)
+
+	start, err := w.sm.Start(t.Context(), nil, domain.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeRegister,
+		Session:       domain.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+
+	registerStep, err := w.sm.Process(t.Context(), nil, def, start.State, domain.FlowSubmitInput{
+		Action: domain.FlowActionSubmit,
+		Fields: map[string]any{
+			"username": username,
+			"email":    email,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "register", registerStep.Step.Name)
+
+	issued, err := w.sm.Process(t.Context(), nil, def, registerStep.State, domain.FlowSubmitInput{
+		Action:    domain.FlowActionPasskeyRegister,
+		PasskeyRP: &domain.FlowPasskeyRP{RPID: "example.com", Origins: []string{"https://example.com"}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, issued.Step.Challenge)
+	assert.Equal(t, challengeID, issued.Step.Challenge.ChallengeID)
 }
 
 // TestFlowStateMachine_Start_PreservesActionOrder pins ADR 021: the rendered

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/muhlemmer/gu"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
 	cryptomock "github.com/zitadel/nextgen/internal/crypto/mock"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/domain/idgen/idgenmock"
 	domainmock "github.com/zitadel/nextgen/internal/domain/mock"
-	"go.uber.org/mock/gomock"
 )
 
 func findAttribute(attrs []*domain.CreateAttribute, key string) *domain.CreateAttribute {
@@ -2074,65 +2075,6 @@ func TestFlowStateMachine_Process_PasskeyRegisterUsesCollectedIdentifierForDispl
 	registerStep, err := w.sm.Process(t.Context(), nil, def, start.State, domain.FlowSubmitInput{
 		Action: domain.FlowActionSubmit,
 		Fields: map[string]any{"email": email},
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "register", registerStep.Step.Name)
-
-	issued, err := w.sm.Process(t.Context(), nil, def, registerStep.State, domain.FlowSubmitInput{
-		Action:    domain.FlowActionPasskeyRegister,
-		PasskeyRP: &domain.FlowPasskeyRP{RPID: "example.com", Origins: []string{"https://example.com"}},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, issued.Step.Challenge)
-	assert.Equal(t, challengeID, issued.Step.Challenge.ChallengeID)
-}
-
-func TestFlowStateMachine_Process_PasskeyRegisterPrefersEmailForDisplay(t *testing.T) {
-	t.Parallel()
-	const username = "alice"
-	const email = "alice@example.com"
-	const challengeID = "reg-1"
-	const registrationOpts = `{"rp":{"id":"example.com"}}`
-	const userID = "user_01TEST"
-	w := newFlowTestWorld(t)
-	def := passkeyRegisterAfterUsernameAndEmailDefinition()
-
-	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("attempt-1", nil)
-	w.schemaResolver.EXPECT().
-		Resolve(gomock.Any(), gomock.Any(), gomock.Any(), defaultSchemaURL, gomock.Any()).
-		Return(mustUnmarshal[jsonschema.Schema](t, defaultSchemaContent), nil).
-		AnyTimes()
-	w.authAttemptService.EXPECT().
-		SubmitIdentifier(gomock.Any(), gomock.Cond(func(in domain.FlowSubmitIdentifierInput) bool {
-			return assert.Equal(t, "username", in.AttributeName) &&
-				assert.Equal(t, username, in.Value)
-		})).
-		Return("", domain.ErrAuthAttemptProofRejected(nil))
-	w.passkeyRegService.EXPECT().
-		IssuePasskeyRegistrationChallenge(gomock.Any(), gomock.Cond(func(in domain.FlowIssuePasskeyRegistrationChallengeInput) bool {
-			return assert.Equal(t, userID, in.UserID) &&
-				assert.Equal(t, email, in.Username) &&
-				assert.Equal(t, email, in.DisplayName)
-		})).
-		Return(domain.FlowPasskeyRegistrationChallengeOutput{
-			ChallengeID: challengeID,
-			Options:     []byte(registrationOpts),
-		}, nil)
-
-	start, err := w.sm.Start(t.Context(), nil, domain.FlowStartInput{
-		Definition:    def,
-		Purpose:       domain.FlowDefinitionPurposeRegister,
-		Session:       domain.FlowSessionRef{ID: "sess-1", Version: 1},
-		UserSchemaURL: defaultSchemaURL,
-	})
-	require.NoError(t, err)
-
-	registerStep, err := w.sm.Process(t.Context(), nil, def, start.State, domain.FlowSubmitInput{
-		Action: domain.FlowActionSubmit,
-		Fields: map[string]any{
-			"username": username,
-			"email":    email,
-		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "register", registerStep.Step.Name)

--- a/internal/domain/user_passkey.go
+++ b/internal/domain/user_passkey.go
@@ -436,7 +436,11 @@ func BuildPasskeyCreationOptions(c *AuthChallengePasskeyRegistration) ([]byte, e
 		Parameters:            c.CredParams,
 		CredentialExcludeList: excluded,
 		Attestation:           protocol.PreferNoAttestation,
-		Extensions:            c.Extensions,
+		AuthenticatorSelection: protocol.AuthenticatorSelection{
+			ResidentKey:      protocol.ResidentKeyRequirementRequired,
+			UserVerification: protocol.VerificationPreferred,
+		},
+		Extensions: c.Extensions,
 	}
 	return json.Marshal(opts)
 }

--- a/internal/service/flow_passkey_registration.go
+++ b/internal/service/flow_passkey_registration.go
@@ -24,10 +24,12 @@ var _ domain.FlowPasskeyRegistrationService = (*FlowPasskeyRegistrationAdapter)(
 // IssuePasskeyRegistrationChallenge implements [domain.FlowPasskeyRegistrationService].
 func (a *FlowPasskeyRegistrationAdapter) IssuePasskeyRegistrationChallenge(ctx context.Context, in domain.FlowIssuePasskeyRegistrationChallengeInput) (domain.FlowPasskeyRegistrationChallengeOutput, error) {
 	out, err := a.svc.Begin(ctx, BeginRegistrationInput{
-		ProjectID: in.ProjectID,
-		UserID:    in.UserID,
-		RPID:      in.RPID,
-		RPOrigins: in.RPOrigins,
+		ProjectID:   in.ProjectID,
+		UserID:      in.UserID,
+		Username:    in.Username,
+		DisplayName: in.DisplayName,
+		RPID:        in.RPID,
+		RPOrigins:   in.RPOrigins,
 	})
 	if err != nil {
 		return domain.FlowPasskeyRegistrationChallengeOutput{}, err

--- a/internal/service/passkey_registration.go
+++ b/internal/service/passkey_registration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/zitadel/nextgen/internal/domain"
@@ -12,6 +13,7 @@ import (
 )
 
 const passkeyRegistrationTTL = 5 * time.Minute
+const passkeyRegistrationDefaultUsername = "Passkey account"
 
 // PasskeyRegistrationService is the authoritative service for the passkey registration
 // ceremony. It exposes [Begin] and [Finish] for direct callers and is wrapped by
@@ -39,10 +41,12 @@ func NewPasskeyRegistrationService(
 
 // BeginRegistrationInput carries the parameters needed to start a passkey registration ceremony.
 type BeginRegistrationInput struct {
-	ProjectID string
-	UserID    string
-	RPID      string
-	RPOrigins []string
+	ProjectID   string
+	UserID      string
+	Username    string
+	DisplayName string
+	RPID        string
+	RPOrigins   []string
 }
 
 // BeginRegistrationOutput is returned by [PasskeyRegistrationService.Begin].
@@ -65,8 +69,9 @@ func (s *PasskeyRegistrationService) Begin(ctx context.Context, in BeginRegistra
 		return BeginRegistrationOutput{}, fmt.Errorf("passkey registration: list passkeys: %w", err)
 	}
 
+	username, displayName := passkeyRegistrationLabels(in.Username, in.DisplayName)
 	challenge, err := domain.CreatePasskeyRegistrationChallenge(
-		in.UserID, in.UserID, in.UserID, // username and displayName default to userID for MVP
+		in.UserID, username, displayName,
 		existing,
 		in.RPID, origins,
 	)
@@ -98,6 +103,18 @@ func (s *PasskeyRegistrationService) Begin(ctx context.Context, in BeginRegistra
 	}
 
 	return BeginRegistrationOutput{RegistrationID: regID, Options: options}, nil
+}
+
+func passkeyRegistrationLabels(username, displayName string) (string, string) {
+	username = strings.TrimSpace(username)
+	displayName = strings.TrimSpace(displayName)
+	if username == "" {
+		return passkeyRegistrationDefaultUsername, ""
+	}
+	if displayName == "" {
+		displayName = username
+	}
+	return username, displayName
 }
 
 // FinishRegistrationInput carries the parameters needed to complete a passkey registration.

--- a/internal/service/passkey_registration_test.go
+++ b/internal/service/passkey_registration_test.go
@@ -127,10 +127,12 @@ func TestPasskeyRegistrationService_Begin_StoresSession(t *testing.T) {
 	svc := buildTestRegistrationSvc(regRepo, pkRepo)
 
 	out, err := svc.Begin(context.Background(), service.BeginRegistrationInput{
-		ProjectID: "proj-1",
-		UserID:    "user-1",
-		RPID:      "example.com",
-		RPOrigins: []string{"https://example.com"},
+		ProjectID:   "proj-1",
+		UserID:      "user-1",
+		Username:    "alice@example.com",
+		DisplayName: "Alice Example",
+		RPID:        "example.com",
+		RPOrigins:   []string{"https://example.com"},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "pkreg_test01", out.RegistrationID)
@@ -141,13 +143,64 @@ func TestPasskeyRegistrationService_Begin_StoresSession(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out.Options, &optMap))
 	assert.Contains(t, optMap, "challenge")
 	assert.Contains(t, optMap, "rp")
+	user, ok := optMap["user"].(map[string]any)
+	require.True(t, ok, "creation options must include a user object")
+	assert.Equal(t, "alice@example.com", user["name"])
+	assert.Equal(t, "Alice Example", user["displayName"])
 
 	// Session must be persisted.
 	require.NotNil(t, regRepo.created)
 	assert.Equal(t, "proj-1", regRepo.created.ProjectID)
 	assert.Equal(t, "user-1", regRepo.created.UserID)
 	assert.Equal(t, "pkreg_test01", regRepo.created.ID)
+	assert.Equal(t, "alice@example.com", regRepo.created.Challenge.Username)
+	assert.Equal(t, "Alice Example", regRepo.created.Challenge.DisplayName)
 	assert.True(t, regRepo.created.ExpiresAt.After(time.Now()))
+}
+
+func TestPasskeyRegistrationService_Begin_UsesNeutralLabelWithoutUsername(t *testing.T) {
+	regRepo := &fakePasskeyRegRepo{}
+	pkRepo := &fakePasskeyRepo{}
+	svc := buildTestRegistrationSvc(regRepo, pkRepo)
+
+	out, err := svc.Begin(context.Background(), service.BeginRegistrationInput{
+		ProjectID: "proj-1",
+		UserID:    "user-1",
+		RPID:      "example.com",
+		RPOrigins: []string{"https://example.com"},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.Options)
+
+	var optMap map[string]any
+	require.NoError(t, json.Unmarshal(out.Options, &optMap))
+	user, ok := optMap["user"].(map[string]any)
+	require.True(t, ok, "creation options must include a user object")
+	assert.Equal(t, "Passkey account", user["name"])
+	assert.Empty(t, user["displayName"])
+	assert.Equal(t, "Passkey account", regRepo.created.Challenge.Username)
+	assert.Empty(t, regRepo.created.Challenge.DisplayName)
+}
+
+func TestPasskeyRegistrationService_Begin_RequestsDiscoverableCredential(t *testing.T) {
+	regRepo := &fakePasskeyRegRepo{}
+	pkRepo := &fakePasskeyRepo{}
+	svc := buildTestRegistrationSvc(regRepo, pkRepo)
+
+	out, err := svc.Begin(context.Background(), service.BeginRegistrationInput{
+		ProjectID: "proj-1",
+		UserID:    "user-1",
+		RPID:      "example.com",
+		RPOrigins: []string{"https://example.com"},
+	})
+	require.NoError(t, err)
+
+	var optMap map[string]any
+	require.NoError(t, json.Unmarshal(out.Options, &optMap))
+	selection, ok := optMap["authenticatorSelection"].(map[string]any)
+	require.True(t, ok, "creation options must include authenticatorSelection")
+	assert.Equal(t, "required", selection["residentKey"])
+	assert.Equal(t, "preferred", selection["userVerification"])
 }
 
 func TestPasskeyRegistrationService_Finish_NotFoundReturnsError(t *testing.T) {

--- a/packages/components/src/atoms/zl-passkey.spec.ts
+++ b/packages/components/src/atoms/zl-passkey.spec.ts
@@ -31,6 +31,19 @@ function fakeAssertion(): PublicKeyCredential {
   } as unknown as PublicKeyCredential;
 }
 
+function fakeAttestation(): PublicKeyCredential {
+  return {
+    id: "cred-id",
+    rawId: bytes("rawid"),
+    type: "public-key",
+    authenticatorAttachment: "platform",
+    response: {
+      clientDataJSON: bytes("{}"),
+      attestationObject: bytes("attestation"),
+    },
+  } as unknown as PublicKeyCredential;
+}
+
 describe("<zl-passkey>", () => {
   let host: HTMLDivElement;
   let credentials: CredentialsStub;
@@ -170,6 +183,41 @@ describe("<zl-passkey>", () => {
     const descriptor = arg.publicKey.allowCredentials[0];
     expect(descriptor?.id).toBeInstanceOf(ArrayBuffer);
     expect(descriptor?.type).toBe("public-key");
+  });
+
+  it("auto-starts registration once and passes user labels to create()", async () => {
+    credentials.create.mockResolvedValue(fakeAttestation());
+    const el = create({
+      ceremony: "register",
+      method: "passkey_register",
+      options: {
+        challenge: "AAAA",
+        rp: { id: "example.com", name: "example.com" },
+        user: { id: "dXNlci0x", name: "alice@example.com", displayName: "Alice" },
+        pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+      },
+    });
+    const detail = nextEvent<{
+      method: string;
+      proof: { response: { attestationObject?: string } };
+    }>(el, "zl-passkey-result");
+    host.appendChild(el);
+    const result = await detail;
+
+    expect(credentials.create).toHaveBeenCalledTimes(1);
+    expect(credentials.get).not.toHaveBeenCalled();
+    const arg = credentials.create.mock.calls[0]?.[0] as {
+      publicKey: {
+        user: { id: unknown; name: string; displayName: string };
+        pubKeyCredParams: Array<{ type: string; alg: number }>;
+      };
+    };
+    expect(arg.publicKey.user.id).toBeInstanceOf(ArrayBuffer);
+    expect(arg.publicKey.user.name).toBe("alice@example.com");
+    expect(arg.publicKey.user.displayName).toBe("Alice");
+    expect(arg.publicKey.pubKeyCredParams).toEqual([{ type: "public-key", alg: -7 }]);
+    expect(result.method).toBe("passkey_register");
+    expect(result.proof.response.attestationObject).toBeTypeOf("string");
   });
 
   it("aborts the in-flight ceremony when disconnected", async () => {

--- a/packages/components/src/orchestrator/liquid.spec.ts
+++ b/packages/components/src/orchestrator/liquid.spec.ts
@@ -180,6 +180,65 @@ describe("LiquidJS engine", () => {
     expect(result).not.toContain("invalid");
   });
 
+  it("renders passkey registration challenges with registration ceremony", () => {
+    const engine = createLiquidEngine({ locale: fullLocale });
+    const context = {
+      step: { name: "passkey-enroll", texts: { title_key: "passkey-enroll.title" } },
+      fields: [],
+      actions: [],
+      branding: {},
+      loading: false,
+      errors: [],
+      gates: {},
+      sso_providers: [],
+      messages: [],
+      identity: null,
+      challenge: {
+        method: "passkey_register",
+        challenge_id: "reg-1",
+        options: {
+          challenge: "AAAA",
+          rp: { id: "example.com", name: "example.com" },
+          user: { id: "dXNlci0x", name: "alice@example.com", displayName: "Alice" },
+          pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+        },
+      },
+    };
+
+    const result = engine.renderFileSync(TEMPLATE_NAMES.default, context);
+    expect(result).toContain("<zl-passkey");
+    expect(result).toContain('ceremony="register"');
+    expect(result).toContain('method="passkey_register"');
+    expect(result).toContain('challenge-id="reg-1"');
+  });
+
+  it("keeps legacy passkey registration challenges working when options.user is present", () => {
+    const engine = createLiquidEngine({ locale: fullLocale });
+    const context = {
+      step: { name: "passkey-enroll", texts: { title_key: "passkey-enroll.title" } },
+      fields: [],
+      actions: [],
+      branding: {},
+      loading: false,
+      errors: [],
+      gates: {},
+      sso_providers: [],
+      messages: [],
+      identity: null,
+      challenge: {
+        method: "passkey",
+        challenge_id: "reg-1",
+        options: {
+          user: { id: "dXNlci0x", name: "alice@example.com", displayName: "Alice" },
+        },
+      },
+    };
+
+    const result = engine.renderFileSync(TEMPLATE_NAMES.default, context);
+    expect(result).toContain('ceremony="register"');
+    expect(result).toContain('method="passkey_register"');
+  });
+
   it("renders the signed-in screen when the step is the signed-in confirmation", () => {
     const engine = createLiquidEngine({ locale });
     const context = {

--- a/packages/components/src/orchestrator/templates/default.liquid
+++ b/packages/components/src/orchestrator/templates/default.liquid
@@ -140,10 +140,14 @@
     {% if challenge %}
       {% if challenge.method == "passkey" or challenge.method == "passkey_register" %}
         {% assign ceremony = "authenticate" %}
-        {% if challenge.method == "passkey_register" %}{% assign ceremony = "register" %}{% endif %}
+        {% assign submit_method = challenge.method %}
+        {% if challenge.method == "passkey_register" or challenge.options.user %}
+          {% assign ceremony = "register" %}
+          {% assign submit_method = "passkey_register" %}
+        {% endif %}
         <zl-passkey
           ceremony="{{ ceremony }}"
-          method="{{ challenge.method }}"
+          method="{{ submit_method }}"
           challenge-id="{{ challenge.challenge_id }}"
           options='{{ challenge.options | json }}'
         ></zl-passkey>

--- a/packages/components/src/orchestrator/zitadel-login.spec.ts
+++ b/packages/components/src/orchestrator/zitadel-login.spec.ts
@@ -365,6 +365,124 @@ describe("<zitadel-login> against the typed Flow API", () => {
     });
   });
 
+  it("does not restart a passkey registration challenge while submitting the proof", async () => {
+    const originalCredentials = Object.getOwnPropertyDescriptor(navigator, "credentials");
+    const originalPublicKeyCredential = Object.getOwnPropertyDescriptor(
+      window,
+      "PublicKeyCredential",
+    );
+    const create = vi.fn(() => new Promise<PublicKeyCredential>(() => {}));
+    let releaseSubmit: (() => void) | undefined;
+
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      value: class PublicKeyCredentialStub {},
+    });
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: { create: create as unknown as CredentialsContainer["create"], get: vi.fn() },
+    });
+
+    try {
+      server.use(
+        http.post(
+          "*/flow/*/submit",
+          () =>
+            new Promise((resolve) => {
+              releaseSubmit = () =>
+                resolve(
+                  HttpResponse.json({
+                    id: "flow-1",
+                    session_token: "token-1",
+                    step: {
+                      name: "done",
+                      texts: {},
+                      fields: [],
+                      actions: [],
+                      gates: {},
+                      complete: { behavior: "show" },
+                    },
+                    branding: {},
+                  }),
+                );
+            }),
+        ),
+      );
+
+      const element = await mount(host);
+      Reflect.set(element, "response", {
+        id: "flow-1",
+        session_id: "sess-1",
+        session_token: "token-1",
+        step: {
+          name: "passkey-enroll",
+          texts: { title_key: "passkey-enroll.title" },
+          fields: [],
+          actions: [],
+          gates: {},
+          challenge: {
+            method: "passkey_register",
+            challenge_id: "reg-1",
+            options: {
+              challenge: "AAAA",
+              rp: { id: "localhost", name: "localhost" },
+              user: {
+                id: "dXNlcl8x",
+                name: "alice@example.com",
+                displayName: "alice@example.com",
+              },
+              pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+            },
+          },
+        },
+        branding: {},
+      });
+      Reflect.set(element, "loading", false);
+      await element.updateComplete;
+
+      await waitFor(() => (create.mock.calls.length === 1 ? true : null));
+      expect(element.shadowRoot?.querySelector("zl-passkey")).toBeTruthy();
+
+      element.shadowRoot?.dispatchEvent(
+        new CustomEvent("zl-passkey-result", {
+          bubbles: true,
+          composed: true,
+          detail: {
+            challenge_id: "reg-1",
+            method: "passkey_register",
+            proof: {
+              id: "cred_mock_123",
+              rawId: "Y3JlZF9tb2NrXzEyMw",
+              type: "public-key",
+              response: {
+                attestationObject: "AAAA",
+                clientDataJSON: "BBBB",
+              },
+            },
+          },
+        }),
+      );
+
+      await waitFor(() => (Reflect.get(element, "loading") === true ? true : null));
+      await element.updateComplete;
+
+      expect(element.shadowRoot?.querySelector("zl-passkey")).toBeNull();
+      expect(create).toHaveBeenCalledTimes(1);
+    } finally {
+      releaseSubmit?.();
+      if (originalCredentials) {
+        Object.defineProperty(navigator, "credentials", originalCredentials);
+      } else {
+        delete (navigator as unknown as Record<string, unknown>).credentials;
+      }
+      if (originalPublicKeyCredential) {
+        Object.defineProperty(window, "PublicKeyCredential", originalPublicKeyCredential);
+      } else {
+        delete (window as unknown as Record<string, unknown>).PublicKeyCredential;
+      }
+    }
+  });
+
   it("re-renders with error and strips challenge on zl-passkey-error", async () => {
     const element = await mount(host);
 

--- a/packages/components/src/orchestrator/zitadel-login.spec.ts
+++ b/packages/components/src/orchestrator/zitadel-login.spec.ts
@@ -371,7 +371,7 @@ describe("<zitadel-login> against the typed Flow API", () => {
       window,
       "PublicKeyCredential",
     );
-    const create = vi.fn(() => new Promise<PublicKeyCredential>(() => {}));
+    const create = vi.fn(() => Promise.race<PublicKeyCredential>([]));
     let releaseSubmit: (() => void) | undefined;
 
     Object.defineProperty(window, "PublicKeyCredential", {

--- a/packages/components/src/orchestrator/zitadel-login.ts
+++ b/packages/components/src/orchestrator/zitadel-login.ts
@@ -471,7 +471,10 @@ export class ZitadelLogin extends LitElement {
       actions,
       gates: step.gates ?? {},
       sso_providers: step.sso_providers ?? [],
-      challenge: step.challenge ?? null,
+      // While submitting a passkey proof, `loading` re-renders the current
+      // step before the server returns. Re-rendering the same challenge would
+      // reconnect `<zl-passkey>` and start a second WebAuthn ceremony.
+      challenge: this.loading ? null : (step.challenge ?? null),
       messages: [],
       identity: this.deriveIdentity(),
       errors,

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -12,6 +13,7 @@ import {
 } from "./release-automation.mjs";
 import {
   CONTAINER_PLATFORMS,
+  PUBLIC_PACKAGE_DIRS,
   buildContainerImage,
   buildServerBinaries,
   createArchives,
@@ -122,10 +124,19 @@ async function buildEmbeddedUI() {
  * `apps/cli/tsdown.config.ts`).
  */
 async function buildPublicPackageArtifacts() {
-  await run("moon", ["run", ...PUBLIC_PACKAGE_BUILD_TARGETS], {
+  await cleanPublicPackageDistArtifacts();
+  await run("moon", ["run", "--force", ...PUBLIC_PACKAGE_BUILD_TARGETS], {
     cwd: repoRoot,
     env: { ...process.env, ZITADEL_TELEMETRY_BUILD_CHANNEL: "production" },
   });
+}
+
+async function cleanPublicPackageDistArtifacts() {
+  await Promise.all(
+    PUBLIC_PACKAGE_DIRS.map((dir) =>
+      rm(join(repoRoot, dir, "dist"), { recursive: true, force: true }),
+    ),
+  );
 }
 
 async function commandPublish(options) {

--- a/tools/release/moon.yml
+++ b/tools/release/moon.yml
@@ -22,6 +22,7 @@ tasks:
     outputs:
       - "/dist/release/**/*"
     options:
+      cache: false
       runFromWorkspaceRoot: true
       runInCI: false
 
@@ -32,6 +33,7 @@ tasks:
     outputs:
       - "/dist/release/**/*"
     options:
+      cache: false
       runFromWorkspaceRoot: true
       runInCI: false
 


### PR DESCRIPTION
## Summary

- Label passkey registration challenges with the collected identifier when available, while keeping the generated user id as the WebAuthn user handle.
- Preserve `passkey_register` through the flow API/templates and request discoverable passkey credentials for registration.
- Prevent the login orchestrator from reconnecting `<zl-passkey>` and starting a second WebAuthn create ceremony while the registration proof submit is still loading.
- Make local CLI package artifacts deterministic by forcing release package rebuilds and cleaning package `dist` output before packing; keep private Storybook out of changeset bump planning.

## Validation

- `go test ./internal/domain ./internal/service ./internal/api`
- `moon run --force components:test`
- `moon run release:pack`
- `moon run workspace:cli -- setup --cwd /private/tmp/zitadel-fresh-hodor-codex --framework next --server local --non-interactive`
- `moon run release:changesets`
- `git diff --check`

## Release notes / changeset

- Added `.changeset/passkey-registration-labels.md` with patch bumps for `@zitadel/server`, `@zitadel/api`, and `@zitadel/components`.

## Notes

- Verified a fresh generated Next app installs the rebuilt component chunk with the loading guard instead of the stale orchestrator chunk.