### PR TITLE
fix: flow definition integration test

### DIFF
--- a/internal/api/integration_test/flow_definition_test.go
+++ b/internal/api/integration_test/flow_definition_test.go
@@ -225,6 +225,7 @@ func TestCreateFlowDefinition(t *testing.T) {
 				FlowDefinition: api.FlowDefinition{
 					Name:       "invalid-flow",
 					UserSchema: *userSchemaURI,
+					Status:     "active",
 					Purposes:   map[string]string{"login": "step_1"},
 					Audience: api.OptFlowAudience{
 						Value: api.FlowAudience{


### PR DESCRIPTION
## Summary

Fixes the following integration test: `TestCreateFlowDefinition/invalid_flow_definition_-_missing_required_fields_per_user_schema`


## Validation

- `go test ./...`
- `go test -v -tags postgres_integration -timeout=10m ./...`
- `go test -v -tags spanner_integration -timeout=10m ./...`

## Release notes / changeset

- No changeset required — no shipped behavior changed.

## Notes

- Follow up for https://github.com/zitadel/nextgen/pull/416
