### PR TITLE
feat: engine-side back navigation

### DIFF
--- a/internal/domain/flow_on_success.go
+++ b/internal/domain/flow_on_success.go
@@ -53,9 +53,11 @@ type FlowOnSuccessResult struct {
 	// UserID is set when a handler creates a new user. The state machine
 	// records it and registers the user on the auth attempt.
 	UserID string
-	// ClearBackStack signals the engine to drop the runtime back stack
-	// after this handler runs. Set when the mutation is irreversible
-	// (e.g. created a user) so subsequent steps don't surface `back`
-	// across the mutation boundary.
-	ClearBackStack bool
+	// Irreversible signals that this handler mutated persistent state in
+	// a way the user cannot back out of (e.g. created a user, rotated a
+	// credential). The engine drops the runtime back stack after advance
+	// so subsequent steps don't surface `back` across the mutation
+	// boundary. Defaults to false — handlers that only read or compute
+	// leave the back stack intact.
+	Irreversible bool
 }

--- a/internal/domain/flow_on_success.go
+++ b/internal/domain/flow_on_success.go
@@ -53,4 +53,9 @@ type FlowOnSuccessResult struct {
 	// UserID is set when a handler creates a new user. The state machine
 	// records it and registers the user on the auth attempt.
 	UserID string
+	// ClearBackStack signals the engine to drop the runtime back stack
+	// after this handler runs. Set when the mutation is irreversible
+	// (e.g. created a user) so subsequent steps don't surface `back`
+	// across the mutation boundary.
+	ClearBackStack bool
 }

--- a/internal/domain/flow_state.go
+++ b/internal/domain/flow_state.go
@@ -140,9 +140,19 @@ type FlowProgress struct {
 	CurrentStep string
 
 	// History is the ordered list of step names visited within this
-	// progress entry (excluding any parents on PivotStack). Used for
-	// `back` navigation and diagnostics.
+	// progress entry (excluding any parents on PivotStack). Append-only;
+	// preserves the visitation trail across irreversible operations so
+	// helpers like dispatch skip-vs-verify can answer "did the user pass
+	// through step X" reliably.
 	History []string
+
+	// BackStack is the stack of step names the user can return to via the
+	// engine-injected `back` action. Pushed alongside History on each
+	// advance; cleared by the engine after an irreversible operation
+	// (user creation, credential rotation) so the user can't navigate
+	// back across a mutation boundary. An empty stack means no `back`
+	// action is surfaced on the rendered step.
+	BackStack []string
 
 	// CollectedData accumulates submitted field values for this
 	// progress entry, keyed by schema property name. A child flow's

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -344,10 +344,12 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 	}
 
 	routeOutcome := in.Action
-	// clearBackStack is set when the engine executes an irreversible action
-	// (user creation, credential rotation) on this submit. Applied after the
-	// advance below so the next step renders without `back`.
-	var clearBackStack bool
+	// irreversible captures whether the operations run for this submit
+	// (on_success handler, passkey verify) mutated persistent state in a
+	// way the user cannot back out of. Applied after advance to drop the
+	// back stack so subsequent steps don't surface `back` across the
+	// mutation boundary.
+	var irreversible bool
 
 	// For passkey Phase 1 (issue challenge, no proof yet), identify the user first
 	// so that IssuePasskeyChallenge can populate allowCredentials. Without this,
@@ -433,13 +435,13 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 						return FlowStepResult{}, fmt.Errorf("flow state machine: register created user on attempt: %w", err)
 					}
 				}
-				if result.ClearBackStack {
-					clearBackStack = true
+				if result.Irreversible {
+					irreversible = true
 				}
 			}
 		}
-		if pk.clearBackStack {
-			clearBackStack = true
+		if pk.irreversible {
+			irreversible = true
 		}
 	}
 
@@ -469,7 +471,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 	applyOutcomeFlip(state, routeOutcome)
 
 	r.advance(state, currentStep, nextStep.Name)
-	if clearBackStack {
+	if irreversible {
 		state.BackStack = nil
 	}
 
@@ -612,13 +614,14 @@ func fieldValueByChallenge(resolved FlowResolvedFields, fields map[string]any, t
 // with a submission. handled is true when a passkey leg ran (so the
 // field-shaped dispatch must be skipped); halt, when non-nil, is the result
 // to return immediately (challenge issued and awaiting proof, or a
-// verification error rendered on the step); clearBackStack signals that an
-// irreversible passkey operation (registration verify) committed and the
-// engine must drop the back stack after advance.
+// verification error rendered on the step); irreversible is true when this
+// phase mutated persistent state the user cannot back out of (registration
+// verify writes a credential), so the engine clears the back stack on the
+// way out.
 type passkeyPhaseResult struct {
-	handled        bool
-	halt           *FlowStepResult
-	clearBackStack bool
+	handled      bool
+	halt         *FlowStepResult
+	irreversible bool
 }
 
 // processPasskey runs all two-phase WebAuthn ceremonies (authentication and
@@ -702,9 +705,10 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 				}
 			}
 			state.PendingChallenge = nil
-			// Registering a passkey writes a credential — irreversible.
-			// Signal the caller to drop the back stack after advance.
-			return passkeyPhaseResult{handled: true, clearBackStack: true}, nil
+			// Registering a passkey writes a credential — the user cannot
+			// back out of it. Signal irreversibility; the engine clears the
+			// back stack on the way out.
+			return passkeyPhaseResult{handled: true, irreversible: true}, nil
 
 		default: // FlowChallengeMethodPasskey
 			userID, err := r.authAttempts.SubmitPasskey(ctx, FlowSubmitPasskeyInput{

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -299,10 +299,26 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 	userSchemaURL := state.UserSchemaURL
 	actionKind := stepActionKind(currentStep, in.Action)
 
+	// The engine-injected back action is not declared on the step, so the
+	// lookup above won't see it. Recover its kind when the submission targets
+	// it by name and there is somewhere reversible to pop to. A future
+	// author-declared `back`-named action with a real kind wins, since
+	// stepActionKind would have returned a non-zero kind above.
+	if actionKind == 0 && in.Action == flowBackActionName && len(state.BackStack) > 0 {
+		actionKind = FlowActionKindBack
+	}
+
+	// Back is engine-injected and pure routing: pop the back stack and
+	// re-render the previous step. The input pipeline is skipped entirely;
+	// CollectedData is preserved so the prior step's values prefill.
+	if actionKind == FlowActionKindBack {
+		return r.processBack(ctx, client, def, state, userSchemaURL)
+	}
+
 	// Navigate actions skip the entire input pipeline (validation, dispatch,
 	// on_success) and route straight to the matching transition. Used for
-	// back-navigation and similar pure-routing actions where the submitted
-	// fields are irrelevant.
+	// pure-routing actions declared in the flow definition where the
+	// submitted fields are irrelevant.
 	if actionKind == FlowActionKindNavigate {
 		return r.followTransition(ctx, client, def, state, currentStep, in.Action, userSchemaURL)
 	}
@@ -315,7 +331,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 
 	if validationErr := r.fields.Validate(resolved, in.Fields); validationErr != nil {
 		if errs, ok := errors.AsType[FlowFieldValidationErrors](validationErr); ok {
-			step := r.buildStep(currentStep, resolved, new(errs.Error()), nil, nil)
+			step := r.buildStep(state, currentStep, resolved, new(errs.Error()), nil, nil)
 			state.IssuedAt = r.now()
 			return FlowStepResult{State: state, Step: step}, nil
 		}
@@ -328,6 +344,10 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 	}
 
 	routeOutcome := in.Action
+	// clearBackStack is set when the engine executes an irreversible action
+	// (user creation, credential rotation) on this submit. Applied after the
+	// advance below so the next step renders without `back`.
+	var clearBackStack bool
 
 	// For passkey Phase 1 (issue challenge, no proof yet), identify the user first
 	// so that IssuePasskeyChallenge can populate allowCredentials. Without this,
@@ -340,7 +360,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 			return FlowStepResult{}, err
 		}
 		if dispatch.StepError != nil {
-			step := r.buildStep(currentStep, resolved, dispatch.StepError, nil, nil)
+			step := r.buildStep(state, currentStep, resolved, dispatch.StepError, nil, nil)
 			state.IssuedAt = r.now()
 			return FlowStepResult{State: state, Step: step}, nil
 		}
@@ -377,7 +397,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 				return FlowStepResult{}, err
 			}
 			if dispatch.StepError != nil {
-				step := r.buildStep(currentStep, resolved, dispatch.StepError, nil, nil)
+				step := r.buildStep(state, currentStep, resolved, dispatch.StepError, nil, nil)
 				state.IssuedAt = r.now()
 				return FlowStepResult{State: state, Step: step}, nil
 			}
@@ -396,7 +416,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 					return FlowStepResult{}, err
 				}
 				if result.StepError != nil {
-					step := r.buildStep(currentStep, resolved, result.StepError, nil, nil)
+					step := r.buildStep(state, currentStep, resolved, result.StepError, nil, nil)
 					state.IssuedAt = r.now()
 					return FlowStepResult{State: state, Step: step}, nil
 				}
@@ -413,7 +433,13 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 						return FlowStepResult{}, fmt.Errorf("flow state machine: register created user on attempt: %w", err)
 					}
 				}
+				if result.ClearBackStack {
+					clearBackStack = true
+				}
 			}
+		}
+		if pk.clearBackStack {
+			clearBackStack = true
 		}
 	}
 
@@ -423,7 +449,7 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 		// unknown user-supplied action is a protocol-level mistake.
 		if routeOutcome != in.Action {
 			msg := routeOutcome
-			step := r.buildStep(currentStep, resolved, &msg, nil, nil)
+			step := r.buildStep(state, currentStep, resolved, &msg, nil, nil)
 			state.IssuedAt = r.now()
 			return FlowStepResult{State: state, Step: step}, nil
 		}
@@ -443,6 +469,9 @@ func (r *FlowStateMachineRuntime) Process(ctx context.Context, client database.Q
 	applyOutcomeFlip(state, routeOutcome)
 
 	r.advance(state, currentStep, nextStep.Name)
+	if clearBackStack {
+		state.BackStack = nil
+	}
 
 	if nextStep.Complete != nil {
 		step, handoff, err := r.terminate(ctx, client, def, state, userSchemaURL, nextStep)
@@ -583,10 +612,13 @@ func fieldValueByChallenge(resolved FlowResolvedFields, fields map[string]any, t
 // with a submission. handled is true when a passkey leg ran (so the
 // field-shaped dispatch must be skipped); halt, when non-nil, is the result
 // to return immediately (challenge issued and awaiting proof, or a
-// verification error rendered on the step).
+// verification error rendered on the step); clearBackStack signals that an
+// irreversible passkey operation (registration verify) committed and the
+// engine must drop the back stack after advance.
 type passkeyPhaseResult struct {
-	handled bool
-	halt    *FlowStepResult
+	handled        bool
+	halt           *FlowStepResult
+	clearBackStack bool
 }
 
 // processPasskey runs all two-phase WebAuthn ceremonies (authentication and
@@ -612,7 +644,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			state.PendingChallenge = nil
 			return passkeyPhaseResult{}, nil
 		}
-		rendered := r.buildStep(step, resolved, nil, nil, nil)
+		rendered := r.buildStep(state, step, resolved, nil, nil, nil)
 		attachPendingChallenge(rendered, state.PendingChallenge)
 		state.IssuedAt = r.now()
 		return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
@@ -650,7 +682,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			if errors.Is(err, ErrAuthAttemptProofRejected(nil)) {
 				state.PendingChallenge = nil
 				msg := "auth_attempt.passkey_registration_invalid"
-				rendered := r.buildStep(step, resolved, &msg, nil, nil)
+				rendered := r.buildStep(state, step, resolved, &msg, nil, nil)
 				state.IssuedAt = r.now()
 				return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
 			}
@@ -670,7 +702,9 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 				}
 			}
 			state.PendingChallenge = nil
-			return passkeyPhaseResult{handled: true}, nil
+			// Registering a passkey writes a credential — irreversible.
+			// Signal the caller to drop the back stack after advance.
+			return passkeyPhaseResult{handled: true, clearBackStack: true}, nil
 
 		default: // FlowChallengeMethodPasskey
 			userID, err := r.authAttempts.SubmitPasskey(ctx, FlowSubmitPasskeyInput{
@@ -682,7 +716,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			if errors.Is(err, ErrAuthAttemptProofRejected(nil)) {
 				state.PendingChallenge = nil
 				msg := "auth_attempt.passkey_invalid"
-				rendered := r.buildStep(step, resolved, &msg, nil, nil)
+				rendered := r.buildStep(state, step, resolved, &msg, nil, nil)
 				state.IssuedAt = r.now()
 				return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
 			}
@@ -717,7 +751,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			Options:  out.Options,
 			IssuedAt: r.now(),
 		}
-		rendered := r.buildStep(step, resolved, nil, nil, nil)
+		rendered := r.buildStep(state, step, resolved, nil, nil, nil)
 		attachPendingChallenge(rendered, state.PendingChallenge)
 		state.IssuedAt = r.now()
 		return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
@@ -763,7 +797,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			Options:  out.Options,
 			IssuedAt: r.now(),
 		}
-		rendered := r.buildStep(step, resolved, nil, nil, nil)
+		rendered := r.buildStep(state, step, resolved, nil, nil, nil)
 		attachPendingChallenge(rendered, state.PendingChallenge)
 		state.IssuedAt = r.now()
 		return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
@@ -883,8 +917,36 @@ func (r *FlowStateMachineRuntime) followTransition(ctx context.Context, client d
 	return FlowStepResult{State: state, Step: step}, nil
 }
 
+// processBack pops the last entry off [FlowProgress.BackStack] and
+// re-renders that step. The input pipeline is skipped: CollectedData is
+// preserved so the previous step's values prefill, and any pending
+// ceremony is dropped because its challenge id was bound to the step
+// the user is leaving behind. [FlowProgress.History] is left untouched —
+// it's the audit trail, not the navigation cursor.
+func (r *FlowStateMachineRuntime) processBack(ctx context.Context, client database.QueryExecutor, def *FlowDefinition, state *FlowState, userSchemaURL string) (FlowStepResult, error) {
+	if len(state.BackStack) == 0 {
+		return FlowStepResult{}, fmt.Errorf("%w: back submitted with empty back stack on step %q", ErrInvalidAction, state.CurrentStep)
+	}
+	prev := state.BackStack[len(state.BackStack)-1]
+	state.BackStack = state.BackStack[:len(state.BackStack)-1]
+	state.CurrentStep = prev
+	state.PendingChallenge = nil
+
+	prevStep, ok := def.FindStep(prev)
+	if !ok {
+		return FlowStepResult{}, fmt.Errorf("%w: back-stack step %q missing from definition", ErrIntegrity, prev)
+	}
+	step, err := r.renderStep(ctx, client, def, state, userSchemaURL, prevStep)
+	if err != nil {
+		return FlowStepResult{}, err
+	}
+	state.IssuedAt = r.now()
+	return FlowStepResult{State: state, Step: step}, nil
+}
+
 func (r *FlowStateMachineRuntime) advance(state *FlowState, prev *FlowDefinitionStep, nextStepName string) {
 	state.History = append(state.History, prev.Name)
+	state.BackStack = append(state.BackStack, prev.Name)
 	state.CurrentStep = nextStepName
 	state.IssuedAt = r.now()
 }
@@ -937,7 +999,7 @@ func (r *FlowStateMachineRuntime) renderStep(ctx context.Context, client databas
 		return nil, err
 	}
 	prefillFromCollected(&resolved, state.CollectedData.UserData)
-	return r.buildStep(step, resolved, nil, nil, nil), nil
+	return r.buildStep(state, step, resolved, nil, nil, nil), nil
 }
 
 func (r *FlowStateMachineRuntime) resolveStepFields(ctx context.Context, client database.QueryExecutor, projectID, userSchemaURL string, step *FlowDefinitionStep) (FlowResolvedFields, error) {
@@ -993,22 +1055,32 @@ func (r *FlowStateMachineRuntime) resolveVisitedFields(ctx context.Context, clie
 	return resolved, nil
 }
 
-func (r *FlowStateMachineRuntime) buildStep(step *FlowDefinitionStep, resolved FlowResolvedFields, errorKey *string, complete *FlowStepComplete, redirectURL *string) *FlowStep {
+func (r *FlowStateMachineRuntime) buildStep(state *FlowState, step *FlowDefinitionStep, resolved FlowResolvedFields, errorKey *string, complete *FlowStepComplete, redirectURL *string) *FlowStep {
 	// Surface only user-selectable actions declared on the step.
 	// Implicit outcomes (e.g. user_not_found) live in step.Transitions
 	// but are engine-emitted routing keys, not buttons for the client.
-	actions := make([]FlowAction, len(step.Actions))
-	for i, a := range step.Actions {
+	actions := make([]FlowAction, 0, len(step.Actions)+1)
+	for _, a := range step.Actions {
 		textKey := a.TextKey
 		if textKey == "" {
 			textKey = step.Name + ".action." + a.Name
 		}
-		actions[i] = FlowAction{
+		actions = append(actions, FlowAction{
 			Name:    a.Name,
 			Kind:    a.Kind,
 			TextKey: textKey,
 			Primary: a.Primary,
-		}
+		})
+	}
+	// Inject the engine-provided back action when the user has somewhere
+	// reversible to return to and the step is not terminal. The name is
+	// conventionally "back"; clients identify it by kind, not name.
+	if len(state.BackStack) > 0 && step.Complete == nil {
+		actions = append(actions, FlowAction{
+			Name:    flowBackActionName,
+			Kind:    FlowActionKindBack,
+			TextKey: flowBackActionTextKey,
+		})
 	}
 	return &FlowStep{
 		Name:         step.Name,
@@ -1021,6 +1093,15 @@ func (r *FlowStateMachineRuntime) buildStep(step *FlowDefinitionStep, resolved F
 		SSOProviders: nil,
 	}
 }
+
+// flowBackActionName is the conventional name surfaced for the
+// engine-injected back action. The wire contract is kind-driven: clients
+// route on FlowActionKindBack, never on the literal name.
+const flowBackActionName = "back"
+
+// flowBackActionTextKey is the localization key the client resolves for
+// the back action label.
+const flowBackActionTextKey = "action.back"
 
 // stepHasActionKind reports whether the step declares any action of the
 // given kind.

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -2434,13 +2434,14 @@ func TestFlowStateMachine_Back_StackClearedAfterCreateUser(t *testing.T) {
 		SubmitIdentifier(gomock.Any(), gomock.Any()).
 		Return("", domain.ErrAuthAttemptProofRejected(nil)).
 		Times(1)
-	// The create_user handler returns ClearBackStack: true on success — that
+	// The create_user handler returns Irreversible: true on success — that
 	// signal is what this test pins down. Production handlers
 	// ([FlowCreateUserWithPasswordHandler] and the passkey-register flow)
-	// already set it; the mock here mirrors that contract.
+	// already classify their action as irreversible; the mock mirrors
+	// that contract.
 	w.createUser.EXPECT().
 		Handle(gomock.Any(), gomock.Any()).
-		Return(domain.FlowOnSuccessResult{UserID: userID, ClearBackStack: true}, nil)
+		Return(domain.FlowOnSuccessResult{UserID: userID, Irreversible: true}, nil)
 	w.authAttemptService.EXPECT().RegisterCreatedUser(gomock.Any(), gomock.Any()).Times(1)
 	w.authAttemptService.EXPECT().
 		Handoff(gomock.Any(), gomock.Any()).
@@ -2466,5 +2467,5 @@ func TestFlowStateMachine_Back_StackClearedAfterCreateUser(t *testing.T) {
 	// The audit trail records the visited step; the back stack is dropped
 	// because create_user signalled an irreversible mutation.
 	assert.Equal(t, []string{"credentials"}, result.State.History)
-	assert.Empty(t, result.State.BackStack, "ClearBackStack from on_success must drop the back stack")
+	assert.Empty(t, result.State.BackStack, "an irreversible on_success must drop the back stack")
 }

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -1929,6 +1929,12 @@ func TestFlowStateMachine_Process_PasskeyRegisterIssueThenVerify(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, verified.State.PendingChallenge)
 	require.NotNil(t, verified.Step.Complete)
+	// Passkey registration writes a credential (and creates the user when
+	// provisional) — irreversible, so the back stack must be cleared.
+	// History is left intact so the visited-step audit still answers
+	// "did the user pass through register".
+	assert.Empty(t, verified.State.BackStack, "passkey-register verify must clear the back stack")
+	assert.Equal(t, []string{"register"}, verified.State.History, "audit history records the visit even after an irreversible advance")
 }
 
 func TestFlowStateMachine_Process_PasskeyRegisterRejectedKeepsStep(t *testing.T) {
@@ -2239,4 +2245,226 @@ func TestFlowStateMachine_Process_SubmitKindRegression(t *testing.T) {
 	if assert.NotNil(t, result.Step.Error, "submit kind must still run field validation") {
 		assert.Contains(t, *result.Step.Error, "email")
 	}
+}
+
+// navigateOnlyDefinition is a minimal multi-step fixture used by the
+// back-navigation tests: linear step1 → step2 → done routed by
+// navigate-kind actions, with no fields, challenges, or on_success.
+// Keeps the back-nav tests free of auth-attempt and schema mocks.
+func navigateOnlyDefinition() *domain.FlowDefinition {
+	show := domain.FlowStepCompleteShow
+	return &domain.FlowDefinition{
+		ProjectID:  testProjectID,
+		ID:         "def-back-nav",
+		UserSchema: defaultSchemaURL,
+		Purposes: map[domain.FlowDefinitionPurpose]string{
+			domain.FlowDefinitionPurposeLogin: "step1",
+		},
+		Steps: []domain.FlowDefinitionStep{
+			{
+				Name: "step1",
+				Actions: []domain.FlowStepAction{
+					{Name: "go", Kind: domain.FlowActionKindNavigate, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{
+					"go": {Target: "step2"},
+				},
+			},
+			{
+				Name: "step2",
+				Actions: []domain.FlowStepAction{
+					{Name: "go", Kind: domain.FlowActionKindNavigate, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{
+					"go": {Target: "done"},
+				},
+			},
+			{Name: "done", Complete: &show},
+		},
+	}
+}
+
+// findBackAction returns the engine-injected back action on a rendered
+// step, or nil when it is absent. Tests assert on kind, not name — the
+// wire contract is kind-driven.
+func findBackAction(step *domain.FlowStep) *domain.FlowAction {
+	if step == nil {
+		return nil
+	}
+	for i, a := range step.Actions {
+		if a.Kind == domain.FlowActionKindBack {
+			return &step.Actions[i]
+		}
+	}
+	return nil
+}
+
+func TestFlowStateMachine_Back_NotInjectedOnInitialStep(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := navigateOnlyDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+
+	start, err := w.sm.Start(t.Context(), nil, domain.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeLogin,
+		Session:       domain.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "step1", start.Step.Name)
+	assert.Empty(t, start.State.BackStack, "back stack must be empty on the initial step")
+	assert.Nil(t, findBackAction(start.Step), "back action must not appear on the initial step")
+}
+
+func TestFlowStateMachine_Back_InjectedAfterAdvance(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := navigateOnlyDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+
+	start, err := w.sm.Start(t.Context(), nil, domain.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeLogin,
+		Session:       domain.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+
+	result, err := w.sm.Process(t.Context(), nil, def, start.State, domain.FlowSubmitInput{Action: "go"})
+	require.NoError(t, err)
+	require.Equal(t, "step2", result.Step.Name)
+	assert.Equal(t, []string{"step1"}, result.State.BackStack)
+	assert.Equal(t, []string{"step1"}, result.State.History)
+
+	back := findBackAction(result.Step)
+	if assert.NotNil(t, back, "back action must be injected after the first advance") {
+		assert.Equal(t, "action.back", back.TextKey)
+		assert.False(t, back.Primary, "back must never be primary")
+	}
+}
+
+func TestFlowStateMachine_Back_OmittedOnTerminalStep(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := navigateOnlyDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+	w.authAttemptService.EXPECT().Handoff(gomock.Any(), gomock.Any()).Times(0)
+
+	start, err := w.sm.Start(t.Context(), nil, domain.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeLogin,
+		Session:       domain.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+	mid, err := w.sm.Process(t.Context(), nil, def, start.State, domain.FlowSubmitInput{Action: "go"})
+	require.NoError(t, err)
+	term, err := w.sm.Process(t.Context(), nil, def, mid.State, domain.FlowSubmitInput{Action: "go"})
+	require.NoError(t, err)
+
+	require.Equal(t, "done", term.Step.Name)
+	require.NotNil(t, term.Step.Complete)
+	assert.NotEmpty(t, term.State.BackStack, "back stack persists across navigate-kind advances")
+	assert.Nil(t, findBackAction(term.Step), "terminal step must not carry an injected back action")
+}
+
+func TestFlowStateMachine_Back_PopsAndRendersPreviousStep(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := navigateOnlyDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+
+	start, err := w.sm.Start(t.Context(), nil, domain.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeLogin,
+		Session:       domain.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+	advanced, err := w.sm.Process(t.Context(), nil, def, start.State, domain.FlowSubmitInput{Action: "go"})
+	require.NoError(t, err)
+	require.Equal(t, "step2", advanced.Step.Name)
+
+	back, err := w.sm.Process(t.Context(), nil, def, advanced.State, domain.FlowSubmitInput{Action: "back"})
+	require.NoError(t, err)
+	require.Equal(t, "step1", back.Step.Name)
+	assert.Empty(t, back.State.BackStack, "back-stack pops on back submission")
+	// History is append-only; the audit trail still records that step1 was visited.
+	assert.Equal(t, []string{"step1"}, back.State.History)
+	assert.Nil(t, findBackAction(back.Step), "back action must be absent once the stack is empty")
+}
+
+func TestFlowStateMachine_Back_EmptyBackStackRejected(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := navigateOnlyDefinition()
+
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+
+	start, err := w.sm.Start(t.Context(), nil, domain.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeLogin,
+		Session:       domain.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+
+	// A client that synthesizes `action: "back"` on the initial step (e.g. a
+	// stale cookie or a malicious submit) must be rejected — the action was
+	// never injected.
+	_, err = w.sm.Process(t.Context(), nil, def, start.State, domain.FlowSubmitInput{Action: "back"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrInvalidAction)
+}
+
+func TestFlowStateMachine_Back_StackClearedAfterCreateUser(t *testing.T) {
+	w := newFlowTestWorld(t)
+	def := signupDefinition()
+
+	const userID = "user_01TEST"
+	const email = "alice@example.com"
+	const password = "correct-horse-battery-staple"
+
+	w.schemaResolver.EXPECT().
+		Resolve(gomock.Any(), gomock.Any(), gomock.Any(), defaultSchemaURL, gomock.Any()).
+		Return(mustUnmarshal[jsonschema.Schema](t, defaultSchemaContent), nil).
+		AnyTimes()
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att_1", nil)
+	w.authAttemptService.EXPECT().
+		SubmitIdentifier(gomock.Any(), gomock.Any()).
+		Return("", domain.ErrAuthAttemptProofRejected(nil)).
+		Times(1)
+	// The create_user handler returns ClearBackStack: true on success — that
+	// signal is what this test pins down. Production handlers
+	// ([FlowCreateUserWithPasswordHandler] and the passkey-register flow)
+	// already set it; the mock here mirrors that contract.
+	w.createUser.EXPECT().
+		Handle(gomock.Any(), gomock.Any()).
+		Return(domain.FlowOnSuccessResult{UserID: userID, ClearBackStack: true}, nil)
+	w.authAttemptService.EXPECT().RegisterCreatedUser(gomock.Any(), gomock.Any()).Times(1)
+	w.authAttemptService.EXPECT().
+		Handoff(gomock.Any(), gomock.Any()).
+		Return(domain.FlowHandoffOutput{Token: "handoff_01TEST", ExpiresAt: time.Unix(1700000060, 0).UTC()}, nil).
+		Times(1)
+
+	start, err := w.sm.Start(t.Context(), nil, domain.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeRegister,
+		Session:       domain.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+	result, err := w.sm.Process(t.Context(), nil, def, start.State, domain.FlowSubmitInput{
+		Action: domain.FlowActionSubmit,
+		Fields: map[string]any{
+			"email":                   email,
+			"x-auth-methods#password": password,
+		},
+	})
+	require.NoError(t, err)
+
+	// The audit trail records the visited step; the back stack is dropped
+	// because create_user signalled an irreversible mutation.
+	assert.Equal(t, []string{"credentials"}, result.State.History)
+	assert.Empty(t, result.State.BackStack, "ClearBackStack from on_success must drop the back stack")
 }

--- a/internal/service/flow_create_user_with_password_handler.go
+++ b/internal/service/flow_create_user_with_password_handler.go
@@ -74,7 +74,7 @@ func (h *FlowCreateUserWithPasswordHandler) Handle(ctx context.Context, in domai
 	}
 
 	return domain.FlowOnSuccessResult{
-		UserID:         createUserAction.CreateUser.ID,
-		ClearBackStack: true,
+		UserID:       createUserAction.CreateUser.ID,
+		Irreversible: true,
 	}, nil
 }

--- a/internal/service/flow_create_user_with_password_handler.go
+++ b/internal/service/flow_create_user_with_password_handler.go
@@ -74,6 +74,7 @@ func (h *FlowCreateUserWithPasswordHandler) Handle(ctx context.Context, in domai
 	}
 
 	return domain.FlowOnSuccessResult{
-		UserID: createUserAction.CreateUser.ID,
+		UserID:         createUserAction.CreateUser.ID,
+		ClearBackStack: true,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Implements the engine half of [ADR 022](docs/adrs/022-flow-back-navigation.md). The contract (`kind: back` enum + validator rejection) shipped in #379.

Rebased onto current `main` after #415 (the `refactor/user-service-in-flow` rework) merged. Replaces the now-stale #385.

- Splits `FlowProgress.History` into two fields: `History` stays as the append-only audit trail; new `BackStack` is the navigation cursor for `back`. Decoupling them keeps `History` correct across irreversible operations.
- `buildStep` injects `{name: "back", kind: back, text_key: "action.back"}` when `BackStack` is non-empty and the step is non-terminal.
- `Process` short-circuits on `kind: back`: pops `BackStack`, clears any in-flight ceremony, re-renders with prefill from `CollectedData`. Empty-stack submission errors.
- Irreversible operations clear `BackStack` after advance via a new `ClearBackStack` flag on `FlowOnSuccessResult` (set by `FlowCreateUserWithPasswordHandler`) and a sibling on `passkeyPhaseResult` (set on passkey-register verify success).

## Test plan

- [x] 6 new unit tests in `flow_state_machine_test.go` (`TestFlowStateMachine_Back_*`)
- [x] Assertion appended to `TestFlowStateMachine_Process_PasskeyRegisterIssueThenVerify` locking the BackStack-cleared invariant
- [x] `go test ./...` clean
- [ ] CI integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)