### PR TITLE
fix: persist all collected attributes in passkey registration

### DIFF
--- a/internal/domain/flow_field_resolver.go
+++ b/internal/domain/flow_field_resolver.go
@@ -42,6 +42,18 @@ type FlowResolvedFields struct {
 	ImplicitOutcomes map[string][]string
 }
 
+// IdentifierField returns the first resolved field whose challenge is
+// [FlowFieldChallengeIdentifier]. Callers that also need the collected
+// value look it up themselves with the returned field's Name.
+func (r FlowResolvedFields) IdentifierField() (FlowField, bool) {
+	for _, f := range r.Fields {
+		if f.Challenge == FlowFieldChallengeIdentifier {
+			return f, true
+		}
+	}
+	return FlowField{}, false
+}
+
 // FlowField is the resolved per-field metadata.
 type FlowField struct {
 	// Name is the user-schema property name this field collects.

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -785,11 +785,11 @@ func needsPasskeyRegistrationVisitedFields(state *FlowState, in FlowSubmitInput,
 }
 
 func passkeyRegistrationDisplay(resolved FlowResolvedFields, collected map[string]any) (string, string) {
-	_, _, value, ok := FindCollectedFieldByChallenge(resolved.Fields, collected, FlowFieldChallengeIdentifier)
+	idField, ok := resolved.IdentifierField()
 	if !ok {
 		return "", ""
 	}
-	svalue, _ := value.(string)
+	svalue, _ := collected[idField.Name].(string)
 	label := strings.TrimSpace(svalue)
 	if label == "" {
 		return "", ""
@@ -1110,18 +1110,3 @@ func mergeCollected(state *FlowState, fields map[string]any) error {
 	return nil
 }
 
-// FindCollectedFieldByChallenge looks up a field whose resolved Challenge
-// matches target and whose name is present in collected. Returns the field
-// name, the matched [FlowField], and its collected value. Callers that don't
-// need the FlowField discard it.
-func FindCollectedFieldByChallenge(resolved []FlowField, collected map[string]any, target FlowFieldChallenge) (name string, field FlowField, value any, ok bool) {
-	for _, f := range resolved {
-		if f.Challenge != target {
-			continue
-		}
-		if v, present := collected[f.Name]; present {
-			return f.Name, f, v, true
-		}
-	}
-	return "", FlowField{}, nil, false
-}

--- a/internal/service/flow_create_user_for_passkey_handler.go
+++ b/internal/service/flow_create_user_for_passkey_handler.go
@@ -25,20 +25,36 @@ func NewFlowCreateUserForPasskeyHandler(
 }
 
 // CreateProvisionalUser creates a passwordless user with a pre-assigned ID from
-// state.CollectedData. If the user already exists (UniqueError from a prior
+// state.CollectedData. Every schema-known collected field is written as an
+// attribute; the identifier field falls back to team-level uniqueness when the
+// schema didn't pin it. If the user already exists (UniqueError from a prior
 // on_success handler), the call succeeds silently. Intended to be called
 // within the passkey verify phase, sharing the same client transaction as
 // the passkey save for atomicity.
 func (h *FlowCreateUserForPasskeyHandler) CreateProvisionalUser(ctx context.Context, client database.QueryExecutor, userID string, state *domain.FlowState, resolved domain.FlowResolvedFields) error {
-	var attrs []*domain.CreateAttribute
-	if name, field, value, ok := domain.FindCollectedFieldByChallenge(resolved.Fields, state.CollectedData.UserData, domain.FlowFieldChallengeIdentifier); ok {
-		uniqueScope := attributeUniquenessFor(name, name, field.Unique)
+	identifierName, _, _, ok := domain.FindCollectedFieldByChallenge(resolved.Fields, state.CollectedData.UserData, domain.FlowFieldChallengeIdentifier)
+	if !ok {
+		return fmt.Errorf("%w: provisional passkey user has no identifier in collected data", domain.ErrIntegrity)
+	}
+
+	byName := make(map[string]domain.FlowField, len(resolved.Fields))
+	for _, f := range resolved.Fields {
+		byName[f.Name] = f
+	}
+	attrs := make([]*domain.CreateAttribute, 0, len(state.CollectedData.UserData))
+	for name, value := range state.CollectedData.UserData {
+		field, known := byName[name]
+		if !known || field.Challenge == domain.FlowFieldChallengePassword {
+			continue
+		}
+		uniqueScope := attributeUniquenessFor(name, identifierName, field.Unique)
 		attr, err := domain.NewCreateAttribute(name, value, uniqueScope)
 		if err != nil {
-			return fmt.Errorf("flow create provisional user: build attribute: %w", err)
+			return fmt.Errorf("flow create provisional user: build attribute %q: %w", name, err)
 		}
 		attrs = append(attrs, attr)
 	}
+
 	// TODO: use UserService to create users.
 	err := h.users.Create(ctx, client, &domain.CreateUser{
 		ProjectID:  state.ProjectID,

--- a/internal/service/flow_create_user_for_passkey_handler.go
+++ b/internal/service/flow_create_user_for_passkey_handler.go
@@ -32,10 +32,14 @@ func NewFlowCreateUserForPasskeyHandler(
 // within the passkey verify phase, sharing the same client transaction as
 // the passkey save for atomicity.
 func (h *FlowCreateUserForPasskeyHandler) CreateProvisionalUser(ctx context.Context, client database.QueryExecutor, userID string, state *domain.FlowState, resolved domain.FlowResolvedFields) error {
-	identifierName, _, _, ok := domain.FindCollectedFieldByChallenge(resolved.Fields, state.CollectedData.UserData, domain.FlowFieldChallengeIdentifier)
+	idField, ok := resolved.IdentifierField()
 	if !ok {
+		return fmt.Errorf("%w: provisional passkey user has no identifier field", domain.ErrIntegrity)
+	}
+	if _, present := state.CollectedData.UserData[idField.Name]; !present {
 		return fmt.Errorf("%w: provisional passkey user has no identifier in collected data", domain.ErrIntegrity)
 	}
+	identifierName := idField.Name
 
 	byName := make(map[string]domain.FlowField, len(resolved.Fields))
 	for _, f := range resolved.Fields {

--- a/internal/service/flow_create_user_for_passkey_handler_test.go
+++ b/internal/service/flow_create_user_for_passkey_handler_test.go
@@ -120,7 +120,23 @@ func TestFlowCreateUserForPasskey_IdentifierUniquenessHonorsSchemaScope(t *testi
 	assert.Equal(t, domain.AttributeUniquenessProject, attrByKey(t, writer.created.Attributes, "email").UniqueScope)
 }
 
-func TestFlowCreateUserForPasskey_MissingIdentifierIsIntegrityError(t *testing.T) {
+func TestFlowCreateUserForPasskey_NoIdentifierFieldIsIntegrityError(t *testing.T) {
+	writer := &fakeFlowUserWriter{}
+	h := service.NewFlowCreateUserForPasskeyHandler(writer)
+
+	state := provisionalState(t, map[string]any{"givenName": "Alice"})
+	resolved := domain.FlowResolvedFields{
+		Fields: []domain.FlowField{
+			{Name: "givenName"},
+		},
+	}
+
+	err := h.CreateProvisionalUser(t.Context(), nil, "user_1", state, resolved)
+	assert.ErrorIs(t, err, domain.ErrIntegrity)
+	assert.Equal(t, 0, writer.calls, "must not call the writer when the step declares no identifier")
+}
+
+func TestFlowCreateUserForPasskey_IdentifierMissingFromCollectedIsIntegrityError(t *testing.T) {
 	writer := &fakeFlowUserWriter{}
 	h := service.NewFlowCreateUserForPasskeyHandler(writer)
 
@@ -134,7 +150,7 @@ func TestFlowCreateUserForPasskey_MissingIdentifierIsIntegrityError(t *testing.T
 
 	err := h.CreateProvisionalUser(t.Context(), nil, "user_1", state, resolved)
 	assert.ErrorIs(t, err, domain.ErrIntegrity)
-	assert.Equal(t, 0, writer.calls, "must not call the writer when the identifier invariant fails")
+	assert.Equal(t, 0, writer.calls, "must not call the writer when the identifier value wasn't collected")
 }
 
 func TestFlowCreateUserForPasskey_SkipsCollectedKeysNotInResolvedFields(t *testing.T) {

--- a/internal/service/flow_create_user_for_passkey_handler_test.go
+++ b/internal/service/flow_create_user_for_passkey_handler_test.go
@@ -1,0 +1,210 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+	"github.com/zitadel/nextgen/internal/storage/database"
+)
+
+// fakeFlowUserWriter captures the [domain.CreateUser] the handler hands to
+// the repository so tests can inspect attribute shape and uniqueness scopes.
+type fakeFlowUserWriter struct {
+	created *domain.CreateUser
+	err     error
+	calls   int
+}
+
+func (f *fakeFlowUserWriter) Create(_ context.Context, _ database.QueryExecutor, u *domain.CreateUser) error {
+	f.calls++
+	if f.err != nil {
+		return f.err
+	}
+	f.created = u
+	return nil
+}
+
+func attrByKey(t *testing.T, attrs []*domain.CreateAttribute, key string) *domain.CreateAttribute {
+	t.Helper()
+	for _, a := range attrs {
+		if a.Key == key {
+			return a
+		}
+	}
+	t.Fatalf("attribute %q not found in %d collected attributes", key, len(attrs))
+	return nil
+}
+
+func provisionalState(t *testing.T, collected map[string]any) *domain.FlowState {
+	t.Helper()
+	return &domain.FlowState{
+		ProjectID:     "proj_1",
+		UserSchemaURL: "https://example.test/schema.json",
+		FlowProgress: domain.FlowProgress{
+			CollectedData: domain.CollectedFlowData{
+				UserData: collected,
+			},
+		},
+	}
+}
+
+func registrationResolved() domain.FlowResolvedFields {
+	return domain.FlowResolvedFields{
+		Fields: []domain.FlowField{
+			{Name: "email", Challenge: domain.FlowFieldChallengeIdentifier, Unique: domain.AttributeUniquenessUnspecified},
+			{Name: "givenName"},
+			{Name: "familyName"},
+			{Name: "dateOfBirth"},
+			{Name: "maritalStatus"},
+			{Name: "newsletterOptIn"},
+		},
+	}
+}
+
+func TestFlowCreateUserForPasskey_WritesEveryCollectedSchemaField(t *testing.T) {
+	writer := &fakeFlowUserWriter{}
+	h := service.NewFlowCreateUserForPasskeyHandler(writer)
+
+	collected := map[string]any{
+		"email":           "alice@example.com",
+		"givenName":       "Alice",
+		"familyName":      "Doe",
+		"dateOfBirth":     "1990-01-02",
+		"maritalStatus":   "single",
+		"newsletterOptIn": true,
+	}
+	state := provisionalState(t, collected)
+	resolved := registrationResolved()
+
+	err := h.CreateProvisionalUser(t.Context(), nil, "user_provisional", state, resolved)
+	require.NoError(t, err)
+	require.NotNil(t, writer.created)
+
+	got := writer.created
+	assert.Equal(t, "proj_1", got.ProjectID)
+	assert.Equal(t, "https://example.test/schema.json", got.SchemaURL)
+	assert.Equal(t, "user_provisional", got.ID)
+	require.Len(t, got.Attributes, len(collected), "every collected field must be written as an attribute")
+
+	// Identifier gets the team-level uniqueness fallback.
+	assert.Equal(t, domain.AttributeUniquenessTeam, attrByKey(t, got.Attributes, "email").UniqueScope)
+
+	// Non-identifier fields keep AttributeUniquenessUnspecified.
+	for _, key := range []string{"givenName", "familyName", "dateOfBirth", "maritalStatus", "newsletterOptIn"} {
+		assert.Equal(t, domain.AttributeUniquenessUnspecified, attrByKey(t, got.Attributes, key).UniqueScope, "field %q", key)
+	}
+}
+
+func TestFlowCreateUserForPasskey_IdentifierUniquenessHonorsSchemaScope(t *testing.T) {
+	writer := &fakeFlowUserWriter{}
+	h := service.NewFlowCreateUserForPasskeyHandler(writer)
+
+	collected := map[string]any{"email": "alice@example.com"}
+	state := provisionalState(t, collected)
+	resolved := domain.FlowResolvedFields{
+		Fields: []domain.FlowField{
+			{Name: "email", Challenge: domain.FlowFieldChallengeIdentifier, Unique: domain.AttributeUniquenessProject},
+		},
+	}
+
+	err := h.CreateProvisionalUser(t.Context(), nil, "user_1", state, resolved)
+	require.NoError(t, err)
+	require.NotNil(t, writer.created)
+
+	// Schema-pinned scope wins over the identifier fallback.
+	assert.Equal(t, domain.AttributeUniquenessProject, attrByKey(t, writer.created.Attributes, "email").UniqueScope)
+}
+
+func TestFlowCreateUserForPasskey_MissingIdentifierIsIntegrityError(t *testing.T) {
+	writer := &fakeFlowUserWriter{}
+	h := service.NewFlowCreateUserForPasskeyHandler(writer)
+
+	state := provisionalState(t, map[string]any{"givenName": "Alice"})
+	resolved := domain.FlowResolvedFields{
+		Fields: []domain.FlowField{
+			{Name: "email", Challenge: domain.FlowFieldChallengeIdentifier},
+			{Name: "givenName"},
+		},
+	}
+
+	err := h.CreateProvisionalUser(t.Context(), nil, "user_1", state, resolved)
+	assert.ErrorIs(t, err, domain.ErrIntegrity)
+	assert.Equal(t, 0, writer.calls, "must not call the writer when the identifier invariant fails")
+}
+
+func TestFlowCreateUserForPasskey_SkipsCollectedKeysNotInResolvedFields(t *testing.T) {
+	writer := &fakeFlowUserWriter{}
+	h := service.NewFlowCreateUserForPasskeyHandler(writer)
+
+	collected := map[string]any{
+		"email":      "alice@example.com",
+		"strayValue": "should be dropped",
+	}
+	state := provisionalState(t, collected)
+	resolved := domain.FlowResolvedFields{
+		Fields: []domain.FlowField{
+			{Name: "email", Challenge: domain.FlowFieldChallengeIdentifier},
+		},
+	}
+
+	err := h.CreateProvisionalUser(t.Context(), nil, "user_1", state, resolved)
+	require.NoError(t, err)
+	require.NotNil(t, writer.created)
+	require.Len(t, writer.created.Attributes, 1)
+	assert.Equal(t, "email", writer.created.Attributes[0].Key)
+}
+
+func TestFlowCreateUserForPasskey_SkipsPasswordChallengeFieldDefensively(t *testing.T) {
+	// Password challenge fields land in CollectedData.AuthMethods.Password,
+	// not UserData. This test pins the defensive skip in case a future
+	// caller routes a password-shaped field through UserData by mistake.
+	writer := &fakeFlowUserWriter{}
+	h := service.NewFlowCreateUserForPasskeyHandler(writer)
+
+	collected := map[string]any{
+		"email":               "alice@example.com",
+		"x-auth-methods#pwd":  "leaked plaintext",
+	}
+	state := provisionalState(t, collected)
+	resolved := domain.FlowResolvedFields{
+		Fields: []domain.FlowField{
+			{Name: "email", Challenge: domain.FlowFieldChallengeIdentifier},
+			{Name: "x-auth-methods#pwd", Challenge: domain.FlowFieldChallengePassword},
+		},
+	}
+
+	err := h.CreateProvisionalUser(t.Context(), nil, "user_1", state, resolved)
+	require.NoError(t, err)
+	require.NotNil(t, writer.created)
+	require.Len(t, writer.created.Attributes, 1)
+	assert.Equal(t, "email", writer.created.Attributes[0].Key)
+}
+
+func TestFlowCreateUserForPasskey_IdempotentOnUniqueError(t *testing.T) {
+	writer := &fakeFlowUserWriter{err: &database.UniqueError{}}
+	h := service.NewFlowCreateUserForPasskeyHandler(writer)
+
+	collected := map[string]any{"email": "alice@example.com"}
+	state := provisionalState(t, collected)
+
+	err := h.CreateProvisionalUser(t.Context(), nil, "user_1", state, registrationResolved())
+	assert.NoError(t, err, "a prior on_success having created the row must not surface as an error")
+	assert.Equal(t, 1, writer.calls)
+}
+
+func TestFlowCreateUserForPasskey_PropagatesNonUniqueWriterError(t *testing.T) {
+	sentinel := errors.New("repo exploded")
+	writer := &fakeFlowUserWriter{err: sentinel}
+	h := service.NewFlowCreateUserForPasskeyHandler(writer)
+
+	collected := map[string]any{"email": "alice@example.com"}
+	state := provisionalState(t, collected)
+
+	err := h.CreateProvisionalUser(t.Context(), nil, "user_1", state, registrationResolved())
+	assert.ErrorIs(t, err, sentinel)
+}

--- a/internal/service/flow_create_user_for_passkey_handler_test.go
+++ b/internal/service/flow_create_user_for_passkey_handler_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
 	"github.com/zitadel/nextgen/internal/storage/database"
@@ -183,8 +184,8 @@ func TestFlowCreateUserForPasskey_SkipsPasswordChallengeFieldDefensively(t *test
 	h := service.NewFlowCreateUserForPasskeyHandler(writer)
 
 	collected := map[string]any{
-		"email":               "alice@example.com",
-		"x-auth-methods#pwd":  "leaked plaintext",
+		"email":              "alice@example.com",
+		"x-auth-methods#pwd": "leaked plaintext",
 	}
 	state := provisionalState(t, collected)
 	resolved := domain.FlowResolvedFields{


### PR DESCRIPTION
## Summary

Two changes in one PR, both against the same handler.

### 1. Fix: persist all collected attributes in passkey registration

The provisional-user write on the passkey-register verify leg (`FlowCreateUserForPasskeyHandler.CreateProvisionalUser`) only extracted the identifier from `state.CollectedData.UserData` and silently dropped every other schema field the user filled in on the registration step. With the default flow definition (`api/openapi/endpoints/flow_definitions/examples/default-login-flow-definition.json`), the `register` step collects `email, givenName, familyName, dateOfBirth, maritalStatus, newsletterOptIn`. Pre-fix, only `email` survived the passkey branch; the password branch (via `FlowCreateUserWithPasswordHandler` → `CreateUserAction`) correctly persisted all of them.

The fix mirrors the loop the password `on_success` handler used to use before #415: look up the identifier name once, then iterate every collected schema-known field and build a `CreateAttribute` with the right uniqueness scope.

Three behavior changes inside that one function:

1. Every schema-known collected field is now written as an attribute (the bug fix).
2. `attributeUniquenessFor(name, name, …)` is now `attributeUniquenessFor(name, identifierName, …)` — the prior call would have flipped every collected field to team-scoped uniqueness once the loop expanded beyond the identifier.
3. Missing identifier returns `domain.ErrIntegrity` (was a silent skip), matching the password handler's invariant. The flow-definition validator's `on_success` manifest cross-check already guarantees an identifier is collected on a reachable step.

The `// TODO: streamline the passkey registration process like passwords` and `// TODO: use UserService to create users.` markers from #415 are preserved — that follow-up refactor is tracked separately and has open design calls (pre-assigned user IDs in `domain.NewCreateUser`, a tx-borrowing variant of `UserService.ApplyActions`, identifier-uniqueness fallback semantics). This fix decouples the live correctness bug from those decisions; the new tests act as behavior-pinning regression armor when the larger refactor lands.

### 2. Refactor: replace `FindCollectedFieldByChallenge` with `FlowResolvedFields.IdentifierField`

The exported helper returned a 4-tuple `(name, field, value, ok)` and fanned out to two callers that each discarded most of the tuple:

| Caller | What it actually wanted |
|---|---|
| `flow_create_user_for_passkey_handler.go` | identifier field **name** |
| `flow_state_machine.go:passkeyRegistrationDisplay` | identifier **value** |

Different intents threaded through a single generic shape.

Replace it with a focused `FlowResolvedFields.IdentifierField()` method that returns just the `FlowField`. Each caller does its own collected-data lookup with intent visible. The provisional-user path now distinguishes "no identifier field declared" from "identifier not collected" — both still surface as `ErrIntegrity` but the messages are precise.

The unrelated `fieldValueByChallenge` helper (state-machine-private) stays in place — that one is a genuine by-challenge iterator over identifier and password, and `dispatchChallenges` needs its multi-kind shape.

## Validation

- `go build ./...` — clean
- `go vet ./internal/service/...` — clean
- `go test ./internal/service/... ./internal/domain/... -count=1` — green
- 8 unit tests in `flow_create_user_for_passkey_handler_test.go` cover: every collected field is written, schema-pinned identifier scope wins over the team fallback, "no identifier field declared" → `ErrIntegrity`, "identifier not in collected" → `ErrIntegrity`, schema-unknown collected keys are skipped, password-challenge fields are defensively skipped, idempotent on `*database.UniqueError`, non-unique writer errors propagate.

## Release notes / changeset

- No changeset required.

## Notes

- The bug pre-dates #415 — the original `domain.FlowCreateUserHandler.HandleProvisional` had the same single-identifier extraction. #415 moved the function from `domain` to `service` and preserved the behavior; this PR fixes it.
- See sibling docs at `docs/design/flowengine/architecture.md` L177–184 for why the passkey verify leg shares one `database.QueryExecutor` with the credential save — the atomicity story is unchanged.