### PR TITLE
refactor: route passkey CreateProvisionalUser through UserService

### DIFF
--- a/.changeset/fix-passkey-signup-saves-collected-attributes.md
+++ b/.changeset/fix-passkey-signup-saves-collected-attributes.md
@@ -1,0 +1,10 @@
+---
+"@zitadel/server": patch
+"@zitadel/server-linux-x64": patch
+"@zitadel/server-linux-arm64": patch
+"@zitadel/server-darwin-x64": patch
+"@zitadel/server-darwin-arm64": patch
+"@zitadel/server-win32-x64": patch
+---
+
+Fix passkey signup silently dropping every collected user attribute except the identifier. The passkey-register now routes user creation through `UserService`.

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -211,7 +211,7 @@ func run(ctx context.Context, cfg Config, userFiles []string) error {
 		userService,
 		schemaRepo,
 	)
-	createUserForPasskeyHandler := service.NewFlowCreateUserForPasskeyHandler(userRepo)
+	createUserForPasskeyHandler := service.NewFlowCreateUserForPasskeyHandler(userRepo, userService, schemaRepo)
 	passkeyRegSvc := service.NewPasskeyRegistrationService(pool, passkeyRegRepo, userPasskeyRepo, ids)
 	passkeyRegAdapter := service.NewFlowPasskeyRegistrationAdapter(passkeyRegSvc)
 	stateMachine := domain.NewFlowStateMachine(

--- a/internal/api/integration_test/helpers/flow.go
+++ b/internal/api/integration_test/helpers/flow.go
@@ -25,6 +25,8 @@ func (h *Harness) EnsureFlowCreateUserForPasskeyHandler(t *testing.T) *service.F
 	t.Helper()
 	return service.NewFlowCreateUserForPasskeyHandler(
 		h.EnsureUserRepo(t),
+		h.EnsureUserService(t),
+		h.EnsureSchemaRepo(t),
 	)
 }
 

--- a/internal/domain/flow_on_success.go
+++ b/internal/domain/flow_on_success.go
@@ -2,8 +2,6 @@ package domain
 
 import (
 	"context"
-
-	"github.com/zitadel/nextgen/internal/storage/database"
 )
 
 //go:generate go tool mockgen -typed -package domainmock -destination ./mock/flow_on_success.mock.go . FlowOnSuccessHandler,FlowPasskeyUserCreater
@@ -19,7 +17,7 @@ type FlowOnSuccessHandler interface {
 }
 
 type FlowPasskeyUserCreater interface {
-	CreateProvisionalUser(ctx context.Context, client database.QueryExecutor, userID string, state *FlowState, resolved FlowResolvedFields) error
+	CreateProvisionalUser(ctx context.Context, userID string, state *FlowState, resolved FlowResolvedFields) error
 }
 
 // ManifestForOnSuccess returns the credential kinds a mutation establishes.

--- a/internal/domain/flow_on_success.go
+++ b/internal/domain/flow_on_success.go
@@ -17,7 +17,7 @@ type FlowOnSuccessHandler interface {
 }
 
 type FlowPasskeyUserCreater interface {
-	CreateProvisionalUser(ctx context.Context, userID string, state *FlowState, resolved FlowResolvedFields) error
+	CreateProvisionalUser(ctx context.Context, userID string, state *FlowState) error
 }
 
 // ManifestForOnSuccess returns the credential kinds a mutation establishes.

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -637,7 +637,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			provisional := state.CollectedData.AuthMethods.HasProvisionedUserIDForPasskey
 			if provisional {
 				state.CollectedData.AuthMethods.HasProvisionedUserIDForPasskey = false
-				if err := r.userForPasskeyCreater.CreateProvisionalUser(ctx, userID, state, passkeyResolved); err != nil {
+				if err := r.userForPasskeyCreater.CreateProvisionalUser(ctx, userID, state); err != nil {
 					return passkeyPhaseResult{}, fmt.Errorf("flow state machine: ensure user exists: %w", err)
 				}
 			}

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -637,7 +637,7 @@ func (r *FlowStateMachineRuntime) processPasskey(ctx context.Context, client dat
 			provisional := state.CollectedData.AuthMethods.HasProvisionedUserIDForPasskey
 			if provisional {
 				state.CollectedData.AuthMethods.HasProvisionedUserIDForPasskey = false
-				if err := r.userForPasskeyCreater.CreateProvisionalUser(ctx, client, userID, state, passkeyResolved); err != nil {
+				if err := r.userForPasskeyCreater.CreateProvisionalUser(ctx, userID, state, passkeyResolved); err != nil {
 					return passkeyPhaseResult{}, fmt.Errorf("flow state machine: ensure user exists: %w", err)
 				}
 			}

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -1875,7 +1875,7 @@ func TestFlowStateMachine_Process_PasskeyRegisterIssueThenVerify(t *testing.T) {
 	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("attempt-1", nil)
 	w.ids.EXPECT().New(gomock.Any()).Return(userID, nil)
 	w.createUserForPasskey.EXPECT().
-		CreateProvisionalUser(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+		CreateProvisionalUser(gomock.Any(), userID, gomock.Any()).
 		Times(1)
 	w.passkeyRegService.EXPECT().
 		IssuePasskeyRegistrationChallenge(gomock.Any(), gomock.Cond(func(in domain.FlowIssuePasskeyRegistrationChallengeInput) bool {

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -1875,7 +1875,7 @@ func TestFlowStateMachine_Process_PasskeyRegisterIssueThenVerify(t *testing.T) {
 	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("attempt-1", nil)
 	w.ids.EXPECT().New(gomock.Any()).Return(userID, nil)
 	w.createUserForPasskey.EXPECT().
-		CreateProvisionalUser(gomock.Any(), gomock.Any(), userID, gomock.Any(), gomock.Any()).
+		CreateProvisionalUser(gomock.Any(), userID, gomock.Any(), gomock.Any()).
 		Times(1)
 	w.passkeyRegService.EXPECT().
 		IssuePasskeyRegistrationChallenge(gomock.Any(), gomock.Cond(func(in domain.FlowIssuePasskeyRegistrationChallengeInput) bool {

--- a/internal/domain/mock/flow_on_success.mock.go
+++ b/internal/domain/mock/flow_on_success.mock.go
@@ -105,17 +105,17 @@ func (m *MockFlowPasskeyUserCreater) EXPECT() *MockFlowPasskeyUserCreaterMockRec
 }
 
 // CreateProvisionalUser mocks base method.
-func (m *MockFlowPasskeyUserCreater) CreateProvisionalUser(ctx context.Context, userID string, state *domain.FlowState, resolved domain.FlowResolvedFields) error {
+func (m *MockFlowPasskeyUserCreater) CreateProvisionalUser(ctx context.Context, userID string, state *domain.FlowState) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateProvisionalUser", ctx, userID, state, resolved)
+	ret := m.ctrl.Call(m, "CreateProvisionalUser", ctx, userID, state)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateProvisionalUser indicates an expected call of CreateProvisionalUser.
-func (mr *MockFlowPasskeyUserCreaterMockRecorder) CreateProvisionalUser(ctx, userID, state, resolved any) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
+func (mr *MockFlowPasskeyUserCreaterMockRecorder) CreateProvisionalUser(ctx, userID, state any) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProvisionalUser", reflect.TypeOf((*MockFlowPasskeyUserCreater)(nil).CreateProvisionalUser), ctx, userID, state, resolved)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProvisionalUser", reflect.TypeOf((*MockFlowPasskeyUserCreater)(nil).CreateProvisionalUser), ctx, userID, state)
 	return &MockFlowPasskeyUserCreaterCreateProvisionalUserCall{Call: call}
 }
 
@@ -131,13 +131,13 @@ func (c *MockFlowPasskeyUserCreaterCreateProvisionalUserCall) Return(arg0 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFlowPasskeyUserCreaterCreateProvisionalUserCall) Do(f func(context.Context, string, *domain.FlowState, domain.FlowResolvedFields) error) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
+func (c *MockFlowPasskeyUserCreaterCreateProvisionalUserCall) Do(f func(context.Context, string, *domain.FlowState) error) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFlowPasskeyUserCreaterCreateProvisionalUserCall) DoAndReturn(f func(context.Context, string, *domain.FlowState, domain.FlowResolvedFields) error) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
+func (c *MockFlowPasskeyUserCreaterCreateProvisionalUserCall) DoAndReturn(f func(context.Context, string, *domain.FlowState) error) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/domain/mock/flow_on_success.mock.go
+++ b/internal/domain/mock/flow_on_success.mock.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	domain "github.com/zitadel/nextgen/internal/domain"
-	database "github.com/zitadel/nextgen/internal/storage/database"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -106,17 +105,17 @@ func (m *MockFlowPasskeyUserCreater) EXPECT() *MockFlowPasskeyUserCreaterMockRec
 }
 
 // CreateProvisionalUser mocks base method.
-func (m *MockFlowPasskeyUserCreater) CreateProvisionalUser(ctx context.Context, client database.QueryExecutor, userID string, state *domain.FlowState, resolved domain.FlowResolvedFields) error {
+func (m *MockFlowPasskeyUserCreater) CreateProvisionalUser(ctx context.Context, userID string, state *domain.FlowState, resolved domain.FlowResolvedFields) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateProvisionalUser", ctx, client, userID, state, resolved)
+	ret := m.ctrl.Call(m, "CreateProvisionalUser", ctx, userID, state, resolved)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateProvisionalUser indicates an expected call of CreateProvisionalUser.
-func (mr *MockFlowPasskeyUserCreaterMockRecorder) CreateProvisionalUser(ctx, client, userID, state, resolved any) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
+func (mr *MockFlowPasskeyUserCreaterMockRecorder) CreateProvisionalUser(ctx, userID, state, resolved any) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProvisionalUser", reflect.TypeOf((*MockFlowPasskeyUserCreater)(nil).CreateProvisionalUser), ctx, client, userID, state, resolved)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProvisionalUser", reflect.TypeOf((*MockFlowPasskeyUserCreater)(nil).CreateProvisionalUser), ctx, userID, state, resolved)
 	return &MockFlowPasskeyUserCreaterCreateProvisionalUserCall{Call: call}
 }
 
@@ -132,13 +131,13 @@ func (c *MockFlowPasskeyUserCreaterCreateProvisionalUserCall) Return(arg0 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFlowPasskeyUserCreaterCreateProvisionalUserCall) Do(f func(context.Context, database.QueryExecutor, string, *domain.FlowState, domain.FlowResolvedFields) error) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
+func (c *MockFlowPasskeyUserCreaterCreateProvisionalUserCall) Do(f func(context.Context, string, *domain.FlowState, domain.FlowResolvedFields) error) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFlowPasskeyUserCreaterCreateProvisionalUserCall) DoAndReturn(f func(context.Context, database.QueryExecutor, string, *domain.FlowState, domain.FlowResolvedFields) error) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
+func (c *MockFlowPasskeyUserCreaterCreateProvisionalUserCall) DoAndReturn(f func(context.Context, string, *domain.FlowState, domain.FlowResolvedFields) error) *MockFlowPasskeyUserCreaterCreateProvisionalUserCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -57,7 +57,11 @@ type CreateUser struct {
 	Attributes []*CreateAttribute
 }
 
-func NewCreateUser(projectID string, teamID *string, schemabs []byte, muser map[string]any) (*CreateUser, error) {
+// NewCreateUser builds a [CreateUser] from a schema-validated user map.
+// When id is empty a fresh ID is minted; callers with a pre-bound ID
+// (e.g. the passkey-register ceremony, which keys its WebAuthn challenge
+// to a provisional user id at issue time) pass it through here.
+func NewCreateUser(projectID string, teamID *string, id string, schemabs []byte, muser map[string]any) (*CreateUser, error) {
 	schemaURL, err := SchemaFromUserMap(muser)
 	if err != nil {
 		return nil, err
@@ -80,9 +84,11 @@ func NewCreateUser(projectID string, teamID *string, schemabs []byte, muser map[
 		return nil, ErrInternal(err).WithMessage("failed to unmarshal schema map")
 	}
 
-	id, err := newID(PrefixUser)
-	if err != nil {
-		return nil, ErrInternal(err).WithMessage("failed to create user id")
+	if id == "" {
+		id, err = newID(PrefixUser)
+		if err != nil {
+			return nil, ErrInternal(err).WithMessage("failed to create user id")
+		}
 	}
 
 	attrs, err := FlattenMapToCreateAttributes(muser, mschema, "")

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -58,9 +58,7 @@ type CreateUser struct {
 }
 
 // NewCreateUser builds a [CreateUser] from a schema-validated user map.
-// When id is empty a fresh ID is minted; callers with a pre-bound ID
-// (e.g. the passkey-register ceremony, which keys its WebAuthn challenge
-// to a provisional user id at issue time) pass it through here.
+// id passes through when non-empty; otherwise a fresh one is minted.
 func NewCreateUser(projectID string, teamID *string, id string, schemabs []byte, muser map[string]any) (*CreateUser, error) {
 	schemaURL, err := SchemaFromUserMap(muser)
 	if err != nil {

--- a/internal/domain/user_test.go
+++ b/internal/domain/user_test.go
@@ -1,0 +1,45 @@
+package domain_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+const minimalUserSchema = `{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://example.test/schema.json",
+	"type": "object",
+	"required": ["email"],
+	"properties": {
+		"email": {"type": "string", "format": "email", "x-unique": "project"},
+		"givenName": {"type": "string"}
+	}
+}`
+
+func TestNewCreateUser_HonorsCallerSuppliedID(t *testing.T) {
+	user := map[string]any{
+		"$schema":   "https://example.test/schema.json",
+		"email":     "alice@example.com",
+		"givenName": "Alice",
+	}
+
+	got, err := domain.NewCreateUser("proj_1", nil, "user_provisional", []byte(minimalUserSchema), user)
+	require.NoError(t, err)
+	assert.Equal(t, "user_provisional", got.ID, "caller-supplied id must pass through unchanged")
+}
+
+func TestNewCreateUser_MintsIDWhenCallerLeavesItEmpty(t *testing.T) {
+	user := map[string]any{
+		"$schema": "https://example.test/schema.json",
+		"email":   "alice@example.com",
+	}
+
+	got, err := domain.NewCreateUser("proj_1", nil, "", []byte(minimalUserSchema), user)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(got.ID, string(domain.PrefixUser)+"_"), "minted id must carry the user prefix, got %q", got.ID)
+	assert.Greater(t, len(got.ID), len(string(domain.PrefixUser))+1, "minted id must not be just the prefix")
+}

--- a/internal/domain/user_test.go
+++ b/internal/domain/user_test.go
@@ -20,26 +20,45 @@ const minimalUserSchema = `{
 	}
 }`
 
-func TestNewCreateUser_HonorsCallerSuppliedID(t *testing.T) {
-	user := map[string]any{
-		"$schema":   "https://example.test/schema.json",
-		"email":     "alice@example.com",
-		"givenName": "Alice",
+func TestNewCreateUser(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    string
+		user  map[string]any
+		check func(t *testing.T, got *domain.CreateUser)
+	}{
+		{
+			name: "caller-supplied id passes through",
+			id:   "user_provisional",
+			user: map[string]any{
+				"$schema":   "https://example.test/schema.json",
+				"email":     "alice@example.com",
+				"givenName": "Alice",
+			},
+			check: func(t *testing.T, got *domain.CreateUser) {
+				assert.Equal(t, "user_provisional", got.ID)
+			},
+		},
+		{
+			name: "empty id mints a fresh one with the user prefix",
+			id:   "",
+			user: map[string]any{
+				"$schema": "https://example.test/schema.json",
+				"email":   "alice@example.com",
+			},
+			check: func(t *testing.T, got *domain.CreateUser) {
+				prefix := string(domain.PrefixUser) + "_"
+				assert.True(t, strings.HasPrefix(got.ID, prefix), "want prefix %q, got id %q", prefix, got.ID)
+				assert.Greater(t, len(got.ID), len(prefix), "minted id must not be just the prefix")
+			},
+		},
 	}
 
-	got, err := domain.NewCreateUser("proj_1", nil, "user_provisional", []byte(minimalUserSchema), user)
-	require.NoError(t, err)
-	assert.Equal(t, "user_provisional", got.ID, "caller-supplied id must pass through unchanged")
-}
-
-func TestNewCreateUser_MintsIDWhenCallerLeavesItEmpty(t *testing.T) {
-	user := map[string]any{
-		"$schema": "https://example.test/schema.json",
-		"email":   "alice@example.com",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := domain.NewCreateUser("proj_1", nil, tt.id, []byte(minimalUserSchema), tt.user)
+			require.NoError(t, err)
+			tt.check(t, got)
+		})
 	}
-
-	got, err := domain.NewCreateUser("proj_1", nil, "", []byte(minimalUserSchema), user)
-	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(got.ID, string(domain.PrefixUser)+"_"), "minted id must carry the user prefix, got %q", got.ID)
-	assert.Greater(t, len(got.ID), len(string(domain.PrefixUser))+1, "minted id must not be just the prefix")
 }

--- a/internal/service/flow_create_user_for_passkey_handler.go
+++ b/internal/service/flow_create_user_for_passkey_handler.go
@@ -9,6 +9,7 @@ import (
 
 // FlowCreateUserForPasskeyHandler creates the user row on the passkey-register
 // verify leg using the userID bound to the WebAuthn challenge at issue time.
+// NOTE: user creation currently runs in a separate transaction from passkey registration persistence.
 type FlowCreateUserForPasskeyHandler struct {
 	userRepo    domain.UserRepository
 	userService *UserService

--- a/internal/service/flow_create_user_for_passkey_handler.go
+++ b/internal/service/flow_create_user_for_passkey_handler.go
@@ -27,9 +27,7 @@ func NewFlowCreateUserForPasskeyHandler(
 	}
 }
 
-// resolved is accepted for interface symmetry; attributes are derived from
-// the schema, not the resolved fields.
-func (h *FlowCreateUserForPasskeyHandler) CreateProvisionalUser(ctx context.Context, userID string, state *domain.FlowState, _ domain.FlowResolvedFields) error {
+func (h *FlowCreateUserForPasskeyHandler) CreateProvisionalUser(ctx context.Context, userID string, state *domain.FlowState) error {
 	state.CollectedData.UserData["$schema"] = state.UserSchemaURL
 	action := NewCreateUserAction(
 		CreateUserInput{

--- a/internal/service/flow_create_user_for_passkey_handler.go
+++ b/internal/service/flow_create_user_for_passkey_handler.go
@@ -3,65 +3,55 @@ package service
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/storage/database"
 )
 
-type flowUserWriter interface {
-	Create(ctx context.Context, client database.QueryExecutor, user *domain.CreateUser) error
-}
-
+// FlowCreateUserForPasskeyHandler creates the user row on the passkey-register
+// verify leg. The user id was bound to the WebAuthn registration challenge at
+// issue time, so the row is created with that pre-assigned id rather than a
+// freshly-minted one. A prior on_success handler having already created the
+// row is treated as success so the racing handler-then-ceremony order stays
+// safe.
 type FlowCreateUserForPasskeyHandler struct {
-	users flowUserWriter
+	userRepo    domain.UserRepository
+	userService *UserService
+	schemaRepo  domain.JSONSchemaRepository
 }
 
 func NewFlowCreateUserForPasskeyHandler(
-	users flowUserWriter,
+	userRepo domain.UserRepository,
+	userService *UserService,
+	schemaRepo domain.JSONSchemaRepository,
 ) *FlowCreateUserForPasskeyHandler {
-	// TODO: streamline the passkey registration process like passwords
-	return &FlowCreateUserForPasskeyHandler{users: users}
+	return &FlowCreateUserForPasskeyHandler{
+		userRepo:    userRepo,
+		userService: userService,
+		schemaRepo:  schemaRepo,
+	}
 }
 
-// CreateProvisionalUser creates a passwordless user with a pre-assigned ID from
-// state.CollectedData. If the user already exists (UniqueError from a prior
-// on_success handler), the call succeeds silently. Intended to be called
-// within the passkey verify phase, sharing the same client transaction as
-// the passkey save for atomicity.
-func (h *FlowCreateUserForPasskeyHandler) CreateProvisionalUser(ctx context.Context, client database.QueryExecutor, userID string, state *domain.FlowState, resolved domain.FlowResolvedFields) error {
-	var attrs []*domain.CreateAttribute
-	if name, field, value, ok := domain.FindCollectedFieldByChallenge(resolved.Fields, state.CollectedData.UserData, domain.FlowFieldChallengeIdentifier); ok {
-		uniqueScope := attributeUniquenessFor(name, name, field.Unique)
-		attr, err := domain.NewCreateAttribute(name, value, uniqueScope)
-		if err != nil {
-			return fmt.Errorf("flow create provisional user: build attribute: %w", err)
-		}
-		attrs = append(attrs, attr)
-	}
-	// TODO: use UserService to create users.
-	err := h.users.Create(ctx, client, &domain.CreateUser{
-		ProjectID:  state.ProjectID,
-		SchemaURL:  state.UserSchemaURL,
-		ID:         userID,
-		Attributes: attrs,
-	})
-	if _, ok := errors.AsType[*database.UniqueError](err); ok {
+// CreateProvisionalUser creates a passwordless user with the caller-supplied
+// userID through [UserService.ApplyActions], the same path the password
+// handler drives. The client and resolved arguments are accepted to satisfy
+// the [domain.FlowPasskeyUserCreater] contract and are intentionally unused:
+// the transaction lifecycle is owned by the user service, and the attribute
+// set is derived from the schema rather than the resolved fields.
+func (h *FlowCreateUserForPasskeyHandler) CreateProvisionalUser(ctx context.Context, _ database.QueryExecutor, userID string, state *domain.FlowState, _ domain.FlowResolvedFields) error {
+	state.CollectedData.UserData["$schema"] = state.UserSchemaURL
+	action := NewCreateUserAction(
+		CreateUserInput{
+			ProjectID: state.ProjectID,
+			User:      state.CollectedData.UserData,
+			ID:        userID,
+		},
+		h.userRepo,
+		h.schemaRepo,
+	)
+	err := h.userService.ApplyActions(ctx, action)
+	if derr, ok := errors.AsType[domain.Error](err); ok && derr.Code == domain.ErrUserAlreadyExists().Code {
 		return nil
 	}
 	return err
-}
-
-// attributeUniquenessFor picks the [AttributeUniqueness] the user
-// repository writes for a given field. The field's own scope passes
-// through; the identifier field falls back to team-level when the
-// schema didn't pin it, so two users can't share the same login.
-func attributeUniquenessFor(name, identifierName string, scope domain.AttributeUniqueness) domain.AttributeUniqueness {
-	if scope != domain.AttributeUniquenessUnspecified {
-		return scope
-	}
-	if name == identifierName {
-		return domain.AttributeUniquenessTeam
-	}
-	return domain.AttributeUniquenessUnspecified
 }

--- a/internal/service/flow_create_user_for_passkey_handler.go
+++ b/internal/service/flow_create_user_for_passkey_handler.go
@@ -5,15 +5,10 @@ import (
 	"errors"
 
 	"github.com/zitadel/nextgen/internal/domain"
-	"github.com/zitadel/nextgen/internal/storage/database"
 )
 
 // FlowCreateUserForPasskeyHandler creates the user row on the passkey-register
-// verify leg. The user id was bound to the WebAuthn registration challenge at
-// issue time, so the row is created with that pre-assigned id rather than a
-// freshly-minted one. A prior on_success handler having already created the
-// row is treated as success so the racing handler-then-ceremony order stays
-// safe.
+// verify leg using the userID bound to the WebAuthn challenge at issue time.
 type FlowCreateUserForPasskeyHandler struct {
 	userRepo    domain.UserRepository
 	userService *UserService
@@ -32,13 +27,9 @@ func NewFlowCreateUserForPasskeyHandler(
 	}
 }
 
-// CreateProvisionalUser creates a passwordless user with the caller-supplied
-// userID through [UserService.ApplyActions], the same path the password
-// handler drives. The client and resolved arguments are accepted to satisfy
-// the [domain.FlowPasskeyUserCreater] contract and are intentionally unused:
-// the transaction lifecycle is owned by the user service, and the attribute
-// set is derived from the schema rather than the resolved fields.
-func (h *FlowCreateUserForPasskeyHandler) CreateProvisionalUser(ctx context.Context, _ database.QueryExecutor, userID string, state *domain.FlowState, _ domain.FlowResolvedFields) error {
+// resolved is accepted for interface symmetry; attributes are derived from
+// the schema, not the resolved fields.
+func (h *FlowCreateUserForPasskeyHandler) CreateProvisionalUser(ctx context.Context, userID string, state *domain.FlowState, _ domain.FlowResolvedFields) error {
 	state.CollectedData.UserData["$schema"] = state.UserSchemaURL
 	action := NewCreateUserAction(
 		CreateUserInput{

--- a/internal/service/flow_create_user_for_passkey_handler_test.go
+++ b/internal/service/flow_create_user_for_passkey_handler_test.go
@@ -1,0 +1,184 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/domain"
+	domainmock "github.com/zitadel/nextgen/internal/domain/mock"
+	"github.com/zitadel/nextgen/internal/service"
+	"github.com/zitadel/nextgen/internal/storage/database"
+	"github.com/zitadel/nextgen/internal/storage/database/dbmock"
+	"go.uber.org/mock/gomock"
+)
+
+const passkeyHandlerTestSchema = `{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://example.test/schema.json",
+	"type": "object",
+	"required": ["email"],
+	"properties": {
+		"email": {"type": "string", "format": "email", "x-unique": "project"},
+		"givenName": {"type": "string"},
+		"familyName": {"type": "string"}
+	}
+}`
+
+type passkeyHandlerFixture struct {
+	handler      *service.FlowCreateUserForPasskeyHandler
+	userRepo     *domainmock.MockUserRepository
+	schemaRepo   *domainmock.MockJSONSchemaRepository
+	pool         *dbmock.MockPool
+	tx           *dbmock.MockTransaction
+	passwordRepo *domainmock.MockUserPasswordRepository
+}
+
+func newPasskeyHandlerFixture(t *testing.T) *passkeyHandlerFixture {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	userRepo := domainmock.NewMockUserRepository(ctrl)
+	passwordRepo := domainmock.NewMockUserPasswordRepository(ctrl)
+	schemaRepo := domainmock.NewMockJSONSchemaRepository(ctrl)
+	pool := dbmock.NewMockPool(ctrl)
+	tx := dbmock.NewMockTransaction(ctrl)
+
+	userService := service.NewUserService(pool, userRepo, passwordRepo, schemaRepo, nil, nil)
+	handler := service.NewFlowCreateUserForPasskeyHandler(userRepo, userService, schemaRepo)
+
+	return &passkeyHandlerFixture{
+		handler:      handler,
+		userRepo:     userRepo,
+		schemaRepo:   schemaRepo,
+		pool:         pool,
+		tx:           tx,
+		passwordRepo: passwordRepo,
+	}
+}
+
+func passkeyFlowState(collected map[string]any) *domain.FlowState {
+	return &domain.FlowState{
+		ProjectID:     "proj_1",
+		UserSchemaURL: "https://example.test/schema.json",
+		FlowProgress: domain.FlowProgress{
+			CollectedData: domain.CollectedFlowData{
+				UserData: collected,
+			},
+		},
+	}
+}
+
+func expectSchemaLookup(f *passkeyHandlerFixture) {
+	f.schemaRepo.EXPECT().
+		GetByID(gomock.Any(), gomock.Any(), "proj_1", "https://example.test/schema.json").
+		Return(&domain.JSONSchema{
+			ProjectID: "proj_1",
+			URL:       "https://example.test/schema.json",
+			Schema:    []byte(passkeyHandlerTestSchema),
+		}, nil)
+}
+
+func attributeByKey(t *testing.T, attrs []*domain.CreateAttribute, key string) *domain.CreateAttribute {
+	t.Helper()
+	for _, a := range attrs {
+		if a.Key == key {
+			return a
+		}
+	}
+	t.Fatalf("attribute %q not present in %d attributes", key, len(attrs))
+	return nil
+}
+
+func TestFlowCreateUserForPasskey_HonorsPreAssignedUserID(t *testing.T) {
+	f := newPasskeyHandlerFixture(t)
+	expectSchemaLookup(f)
+	f.pool.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(f.tx, nil)
+	f.tx.EXPECT().Commit(gomock.Any()).Return(nil)
+
+	var captured *domain.CreateUser
+	f.userRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ database.QueryExecutor, u *domain.CreateUser) error {
+			captured = u
+			return nil
+		})
+
+	state := passkeyFlowState(map[string]any{
+		"email":     "alice@example.com",
+		"givenName": "Alice",
+	})
+
+	err := f.handler.CreateProvisionalUser(t.Context(), nil, "user_provisional", state, domain.FlowResolvedFields{})
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	assert.Equal(t, "user_provisional", captured.ID, "pre-assigned id must reach the user repository unchanged")
+	assert.Equal(t, "https://example.test/schema.json", captured.SchemaURL)
+}
+
+func TestFlowCreateUserForPasskey_PersistsAllCollectedSchemaFields(t *testing.T) {
+	f := newPasskeyHandlerFixture(t)
+	expectSchemaLookup(f)
+	f.pool.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(f.tx, nil)
+	f.tx.EXPECT().Commit(gomock.Any()).Return(nil)
+
+	var captured *domain.CreateUser
+	f.userRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ database.QueryExecutor, u *domain.CreateUser) error {
+			captured = u
+			return nil
+		})
+
+	state := passkeyFlowState(map[string]any{
+		"email":      "alice@example.com",
+		"givenName":  "Alice",
+		"familyName": "Doe",
+	})
+
+	err := f.handler.CreateProvisionalUser(t.Context(), nil, "user_1", state, domain.FlowResolvedFields{})
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	emailAttr := attributeByKey(t, captured.Attributes, "email")
+	assert.Equal(t, "alice@example.com", emailAttr.Value)
+	assert.Equal(t, domain.AttributeUniquenessProject, emailAttr.UniqueScope, "x-unique on the schema must carry through")
+
+	givenAttr := attributeByKey(t, captured.Attributes, "givenName")
+	assert.Equal(t, "Alice", givenAttr.Value)
+
+	familyAttr := attributeByKey(t, captured.Attributes, "familyName")
+	assert.Equal(t, "Doe", familyAttr.Value)
+}
+
+func TestFlowCreateUserForPasskey_UserAlreadyExistsIsSilent(t *testing.T) {
+	f := newPasskeyHandlerFixture(t)
+	expectSchemaLookup(f)
+	f.pool.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(f.tx, nil)
+	f.tx.EXPECT().Rollback(gomock.Any()).Return(nil)
+	f.userRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&database.UniqueError{})
+
+	state := passkeyFlowState(map[string]any{"email": "alice@example.com"})
+
+	err := f.handler.CreateProvisionalUser(t.Context(), nil, "user_1", state, domain.FlowResolvedFields{})
+	assert.NoError(t, err, "racing prior on_success must not surface as an error")
+}
+
+func TestFlowCreateUserForPasskey_OtherErrorsPropagate(t *testing.T) {
+	f := newPasskeyHandlerFixture(t)
+	expectSchemaLookup(f)
+	f.pool.EXPECT().Begin(gomock.Any(), gomock.Any()).Return(f.tx, nil)
+	f.tx.EXPECT().Rollback(gomock.Any()).Return(nil)
+	sentinel := errors.New("repo exploded")
+	f.userRepo.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(sentinel)
+
+	state := passkeyFlowState(map[string]any{"email": "alice@example.com"})
+
+	err := f.handler.CreateProvisionalUser(t.Context(), nil, "user_1", state, domain.FlowResolvedFields{})
+	require.Error(t, err)
+}

--- a/internal/service/flow_create_user_for_passkey_handler_test.go
+++ b/internal/service/flow_create_user_for_passkey_handler_test.go
@@ -110,7 +110,7 @@ func TestFlowCreateUserForPasskey_HonorsPreAssignedUserID(t *testing.T) {
 		"givenName": "Alice",
 	})
 
-	err := f.handler.CreateProvisionalUser(t.Context(),"user_provisional", state, domain.FlowResolvedFields{})
+	err := f.handler.CreateProvisionalUser(t.Context(), "user_provisional", state)
 	require.NoError(t, err)
 	require.NotNil(t, captured)
 	assert.Equal(t, "user_provisional", captured.ID, "pre-assigned id must reach the user repository unchanged")
@@ -137,7 +137,7 @@ func TestFlowCreateUserForPasskey_PersistsAllCollectedSchemaFields(t *testing.T)
 		"familyName": "Doe",
 	})
 
-	err := f.handler.CreateProvisionalUser(t.Context(),"user_1", state, domain.FlowResolvedFields{})
+	err := f.handler.CreateProvisionalUser(t.Context(), "user_1", state)
 	require.NoError(t, err)
 	require.NotNil(t, captured)
 
@@ -163,7 +163,7 @@ func TestFlowCreateUserForPasskey_UserAlreadyExistsIsSilent(t *testing.T) {
 
 	state := passkeyFlowState(map[string]any{"email": "alice@example.com"})
 
-	err := f.handler.CreateProvisionalUser(t.Context(),"user_1", state, domain.FlowResolvedFields{})
+	err := f.handler.CreateProvisionalUser(t.Context(), "user_1", state)
 	assert.NoError(t, err, "racing prior on_success must not surface as an error")
 }
 
@@ -179,6 +179,6 @@ func TestFlowCreateUserForPasskey_OtherErrorsPropagate(t *testing.T) {
 
 	state := passkeyFlowState(map[string]any{"email": "alice@example.com"})
 
-	err := f.handler.CreateProvisionalUser(t.Context(),"user_1", state, domain.FlowResolvedFields{})
+	err := f.handler.CreateProvisionalUser(t.Context(), "user_1", state)
 	require.Error(t, err)
 }

--- a/internal/service/flow_create_user_for_passkey_handler_test.go
+++ b/internal/service/flow_create_user_for_passkey_handler_test.go
@@ -110,7 +110,7 @@ func TestFlowCreateUserForPasskey_HonorsPreAssignedUserID(t *testing.T) {
 		"givenName": "Alice",
 	})
 
-	err := f.handler.CreateProvisionalUser(t.Context(), nil, "user_provisional", state, domain.FlowResolvedFields{})
+	err := f.handler.CreateProvisionalUser(t.Context(),"user_provisional", state, domain.FlowResolvedFields{})
 	require.NoError(t, err)
 	require.NotNil(t, captured)
 	assert.Equal(t, "user_provisional", captured.ID, "pre-assigned id must reach the user repository unchanged")
@@ -137,7 +137,7 @@ func TestFlowCreateUserForPasskey_PersistsAllCollectedSchemaFields(t *testing.T)
 		"familyName": "Doe",
 	})
 
-	err := f.handler.CreateProvisionalUser(t.Context(), nil, "user_1", state, domain.FlowResolvedFields{})
+	err := f.handler.CreateProvisionalUser(t.Context(),"user_1", state, domain.FlowResolvedFields{})
 	require.NoError(t, err)
 	require.NotNil(t, captured)
 
@@ -163,7 +163,7 @@ func TestFlowCreateUserForPasskey_UserAlreadyExistsIsSilent(t *testing.T) {
 
 	state := passkeyFlowState(map[string]any{"email": "alice@example.com"})
 
-	err := f.handler.CreateProvisionalUser(t.Context(), nil, "user_1", state, domain.FlowResolvedFields{})
+	err := f.handler.CreateProvisionalUser(t.Context(),"user_1", state, domain.FlowResolvedFields{})
 	assert.NoError(t, err, "racing prior on_success must not surface as an error")
 }
 
@@ -179,6 +179,6 @@ func TestFlowCreateUserForPasskey_OtherErrorsPropagate(t *testing.T) {
 
 	state := passkeyFlowState(map[string]any{"email": "alice@example.com"})
 
-	err := f.handler.CreateProvisionalUser(t.Context(), nil, "user_1", state, domain.FlowResolvedFields{})
+	err := f.handler.CreateProvisionalUser(t.Context(),"user_1", state, domain.FlowResolvedFields{})
 	require.Error(t, err)
 }

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -17,6 +17,7 @@ type CreateUserInput struct {
 	ProjectID string
 	TeamID    *string
 	User      map[string]any
+	ID        string
 }
 
 type UserAction interface {
@@ -200,7 +201,7 @@ func (o *CreateUserAction) Prepare(ctx context.Context, db database.QueryExecuto
 		return domain.ErrInternal(err).WithMessage("failed to get schema from database")
 	}
 
-	o.CreateUser, err = domain.NewCreateUser(o.ProjectID, o.TeamID, schemaEntity.Schema, o.User)
+	o.CreateUser, err = domain.NewCreateUser(o.ProjectID, o.TeamID, o.ID, schemaEntity.Schema, o.User)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Route the passkey-register provisional-user write through `UserService.ApplyActions` + `CreateUserAction` (which provides schema-validation)
- Added support to optional pre-assigned ID to `domain.NewCreateUser` and `CreateUserInput`.
- Bugfix: Passkey registration was saving user with ID and email only, other attributes were dropped

Important: passkeys DB operations are not yet part of the same UserService transaction.