### PR TITLE
fix(telemetry): map Mixpanel event country property

### DIFF
--- a/.changeset/neat-mixpanel-countries.md
+++ b/.changeset/neat-mixpanel-countries.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/cli": patch
+---
+
+Map CLI telemetry events to Mixpanel's event country property so country appears correctly in analytics.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -102,9 +102,11 @@ wired into the user's app.
 `non_interactive`, `is_tty`, `is_ci`, `ci_provider`, `host_agent`,
 `invocation_channel`, `dry_run`, `force`, `server_kind` (bucketed
 `cloud`/`local`/`self_hosted` — **never the URL**), plus the reserved
-`$os`/`$country_code` (country derived from the timezone, not the IP — `ip: 0`
-keeps geolocation off). Built in `src/lib/oclif/command-telemetry.ts` (using the
-generic env/geo helpers in `src/lib/telemetry/`).
+event properties `$os`/`mp_country_code` (country derived from the timezone, not
+the IP — `ip: 0` keeps IP geolocation off). First-run user profiles use the
+People API's `$country_code` profile property for the same derived country. Built
+in `src/lib/oclif/command-telemetry.ts` (using the generic env/geo helpers in
+`src/lib/telemetry/`).
 
 ### Event shape
 
@@ -123,7 +125,7 @@ Mixpanel injects the transport fields (`time`, `$lib_version`,
     "command": "status",
     "cli_version": "0.1.0-alpha.11",
     "$os": "Mac OS X",
-    "$country_code": "AU",
+    "mp_country_code": "AU",
     "os": "darwin",
     "arch": "arm64",
     "node_version": "24.12.0",

--- a/apps/cli/src/lib/oclif/command-telemetry.ts
+++ b/apps/cli/src/lib/oclif/command-telemetry.ts
@@ -24,18 +24,51 @@ export const FIRST_RUN_NOTICE =
   "collected. Opt out any time with DO_NOT_TRACK=1, ZITADEL_TELEMETRY=0, or " +
   "the --no-telemetry flag.";
 
+type DeviceFacts = {
+  readonly osLabel: string;
+  readonly countryCode: string | undefined;
+  readonly platform: NodeJS.Platform;
+  readonly arch: string;
+  readonly nodeVersion: string;
+  readonly cliVersion: string;
+};
+
 /**
  * Process-stable device facts shared by both the event bag and the user
  * profile, so the two never disagree on the same install's OS/arch/version.
  */
-function deviceProperties(meta: GlobalOptions): Properties {
+function deviceFacts(meta: GlobalOptions): DeviceFacts {
   return {
-    $os: operatingSystem.value(process.platform),
-    $country_code: country.value(undefined),
-    os: process.platform,
+    osLabel: operatingSystem.value(process.platform),
+    countryCode: country.value(undefined),
+    platform: process.platform,
     arch: process.arch,
-    node_version: process.versions.node,
-    cli_version: meta.cliVersion,
+    nodeVersion: process.versions.node,
+    cliVersion: meta.cliVersion,
+  };
+}
+
+function eventDeviceProperties(meta: GlobalOptions): Properties {
+  const facts = deviceFacts(meta);
+  return {
+    $os: facts.osLabel,
+    mp_country_code: facts.countryCode,
+    os: facts.platform,
+    arch: facts.arch,
+    node_version: facts.nodeVersion,
+    cli_version: facts.cliVersion,
+  };
+}
+
+function profileDeviceProperties(meta: GlobalOptions): Properties {
+  const facts = deviceFacts(meta);
+  return {
+    $os: facts.osLabel,
+    $country_code: facts.countryCode,
+    os: facts.platform,
+    arch: facts.arch,
+    node_version: facts.nodeVersion,
+    cli_version: facts.cliVersion,
   };
 }
 
@@ -55,7 +88,7 @@ export function commandEventProperties(
   const { env } = meta;
   return {
     ...extra,
-    ...deviceProperties(meta),
+    ...eventDeviceProperties(meta),
     ip: 0,
     invocation_id: invocationId,
     command: meta.command,
@@ -81,7 +114,7 @@ export function deviceProfileProperties(meta: GlobalOptions, distinctId: string)
   const agent = hostAgent.value(meta.env);
   const label = agent === "unknown" ? process.platform : agent;
   return {
-    ...deviceProperties(meta),
+    ...profileDeviceProperties(meta),
     $name: `${label} · ${distinctId.slice(0, 8)}`,
     host_agent: agent,
   };

--- a/apps/cli/tests/unit/lib/oclif/command-telemetry.test.ts
+++ b/apps/cli/tests/unit/lib/oclif/command-telemetry.test.ts
@@ -34,7 +34,8 @@ describe("commandEventProperties", () => {
     expect(props.invocation_id).toBe("sess-1");
     expect(props.ip).toBe(0);
     expect(props.$os).toBeDefined();
-    expect("$country_code" in props).toBe(true);
+    expect("mp_country_code" in props).toBe(true);
+    expect("$country_code" in props).toBe(false);
   });
 
   it("merges per-command extras", () => {
@@ -49,6 +50,8 @@ describe("deviceProfileProperties", () => {
     const props = deviceProfileProperties(meta(), "09233195-cd34-468c-bb7b-151554e19fbc");
     expect(String(props.$name)).toContain("09233195");
     expect(props.cli_version).toBe("0.1.0-alpha.11");
+    expect("$country_code" in props).toBe(true);
+    expect("mp_country_code" in props).toBe(false);
     const serialized = JSON.stringify(props);
     expect(serialized).not.toContain("/work/app");
     expect(serialized).not.toContain("zitadel.cloud");


### PR DESCRIPTION
## Summary
- Map CLI telemetry events to Mixpanel's `mp_country_code` event property so the Live View Country column is populated from the timezone-derived country.
- Keep first-run People/profile updates on `$country_code`, which is the profile-side Mixpanel property.
- Update the CLI telemetry tracking-plan notes and unit coverage for the event/profile split.

## Validation
- `git diff --check`
- `corepack pnpm --filter @zitadel/cli exec vitest run tests/unit/lib/oclif/command-telemetry.test.ts`
- `corepack pnpm --filter @zitadel/cli run typecheck`
- `corepack pnpm exec changeset status --since origin/main`

## Release notes / changeset
- Added `.changeset/neat-mixpanel-countries.md` with a patch note for `@zitadel/cli`: CLI telemetry events now use Mixpanel's event country property so analytics country mapping appears correctly.

## Notes
- City remains intentionally unset because CLI telemetry keeps `ip: 0` and does not infer city-level location.