### PR TITLE
Prepare repository for public preview release

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -94,8 +94,8 @@ Publishing uses **npm trusted publishing (OIDC)** — there is no `NPM_TOKEN`. O
 per public package, a maintainer adds a trusted publisher on npmjs.com (Settings →
 Trusted Publishing): provider GitHub Actions, repo `zitadel/nextgen`, workflow
 `release-publish.yml`. The package must exist on npm first (publish `0.0.x` by
-hand if needed). Provenance stays off (`NPM_CONFIG_PROVENANCE=false`) while the
-repo is private; re-enable when public.
+hand if needed). Real publishes set npm provenance on
+(`NPM_CONFIG_PROVENANCE=true`); dry runs leave it off because they do not publish.
 
 Each public package must declare its license and ship a `LICENSE` file before its
 first publish — see [LICENSING.md](../LICENSING.md).

--- a/.changeset/public-readiness-api-metadata.md
+++ b/.changeset/public-readiness-api-metadata.md
@@ -1,0 +1,4 @@
+---
+---
+
+Public-readiness metadata only. No package behavior changes.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions
+    url: https://github.com/zitadel/zitadel/discussions/categories/q-a
+    about: Ask for help in the ZITADEL Q&A discussions.
+  - name: ZITADEL Community Chat
+    url: https://zitadel.com/chat
+    about: Join the ZITADEL community chat.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -148,8 +148,8 @@ jobs:
           if [ -n "$RECOVER_VERSION" ]; then
             args+=(--recover-version "$RECOVER_VERSION")
           fi
-          # Keep the GitHub Actions environment intact: npm trusted publishing
-          # uses it to exchange the workflow OIDC token during real publishes.
+          # Dry runs do not publish, so provenance stays off here. Real
+          # publishes keep the GitHub Actions environment intact for OIDC.
           moon run "${args[@]}"
         env:
           BASE_SHA: ${{ github.event.before || 'HEAD^' }}
@@ -165,10 +165,10 @@ jobs:
             args+=(-- --recover-version "$RECOVER_VERSION")
           fi
           # Keep the GitHub Actions environment intact: npm trusted publishing
-          # uses it to exchange the workflow OIDC token during real publishes.
+          # and provenance use it to exchange the workflow OIDC token.
           moon run "${args[@]}"
         env:
           BASE_SHA: ${{ github.event.before || 'HEAD^' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "false"
+          NPM_CONFIG_PROVENANCE: "true"
           RECOVER_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.recover_version || '' }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+legal@zitadel.com.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing
 
+This repository contains a pre-release Zitadel preview. It is public for
+visibility, feedback, and security reporting, but we are not yet accepting
+external code contributions here unless a maintainer explicitly asks for one.
+The workflows below are primarily for the Zitadel team and invited
+contributors while the preview stabilizes.
+
 If you want to add Zitadel to your own app rather than contribute here, see the
 [quick-start guide in README.md](README.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting Security Issues
+
+This repository contains a pre-release Zitadel preview. We are not yet accepting
+external code contributions here, but security reports are welcome and should
+follow the process below.
+
+We take the security of ZITADEL very seriously. If you believe you have found a
+security vulnerability in ZITADEL, report it to us immediately.
+
+**Please do not report security-related findings publicly via GitHub issues.**
+Public disclosure of a security vulnerability could put the ZITADEL community at
+risk. Instead, use our official vulnerability disclosure process.
+
+### Vulnerability Disclosure Process
+
+Vulnerabilities should be reported through our dedicated portal:
+**[zitadel.com/vulnerability](https://zitadel.com/vulnerability)**
+
+For more details on our vulnerability policy, including scope and expectations,
+refer to our official policy document:
+**[ZITADEL Vulnerability Disclosure Policy](https://trust.zitadel.com/resources?s=aw085mxrel3icmbmkphns3&name=zitadel-vulnerability-disclosure-policy)**
+
+### Definitive Source
+
+When in doubt, the authoritative and most up-to-date source for our security
+reporting information is always our `security.txt` file:
+**[zitadel.com/.well-known/security.txt](https://zitadel.com/.well-known/security.txt)**
+
+---
+
+We appreciate your help in keeping ZITADEL and its community safe.

--- a/VISION.md
+++ b/VISION.md
@@ -19,8 +19,9 @@ downstream applications.
 ## Current Reality
 
 This repository is pre-release. The current checked-in CLI supports the local
-Docker-backed setup flow documented in [README.md](README.md); it does not
-currently ship a `zitadel claim` command.
+npm-binary setup flow documented in [README.md](README.md); Docker remains
+available as an explicit fallback runtime. The CLI does not currently ship a
+`zitadel claim` command.
 
 Create-first, claim-later remains the product direction. The previous mock-only
 claim lifecycle was removed until the real server-side claim contract exists;

--- a/apps/demo-next/package.json
+++ b/apps/demo-next/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zitadel/demo-next",
   "version": "0.0.0",
-  "description": "Next.js demo app for Nextgen Auth",
+  "description": "Next.js demo app for the pre-release Zitadel preview.",
   "homepage": "https://github.com/zitadel/nextgen/tree/main/apps/demo-next#readme",
   "bugs": {
     "url": "https://github.com/zitadel/nextgen/issues"

--- a/apps/demo-nuxt/package.json
+++ b/apps/demo-nuxt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zitadel/demo-nuxt",
   "version": "0.0.0",
-  "description": "Nuxt demo app for Nextgen Auth",
+  "description": "Nuxt demo app for the pre-release Zitadel preview.",
   "homepage": "https://github.com/zitadel/nextgen/tree/main/apps/demo-nuxt#readme",
   "bugs": {
     "url": "https://github.com/zitadel/nextgen/issues"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@zitadel/api",
   "version": "0.1.0-alpha.13",
-  "description": "Generated TypeScript API client for Zitadel NextGen",
+  "description": "Generated TypeScript API client for the pre-release Zitadel preview.",
+  "homepage": "https://github.com/zitadel/nextgen/tree/main/packages/api#readme",
+  "bugs": {
+    "url": "https://github.com/zitadel/nextgen/issues"
+  },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zitadel/nextgen.git",
+    "directory": "packages/api"
+  },
   "type": "module",
   "files": [
     "dist",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -2,7 +2,7 @@
   "name": "@zitadel/design-tokens",
   "version": "0.1.0-alpha.0",
   "private": true,
-  "description": "Figma-driven design tokens for ZITADEL NextGen — CSS variables, typed TypeScript constants, and a Tailwind v4 @theme block built from the published Zitadel Design System library.",
+  "description": "Figma-driven design tokens for the pre-release Zitadel preview — CSS variables, typed TypeScript constants, and a Tailwind v4 @theme block built from the published Zitadel Design System library.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/sdk-nuxt/package.json
+++ b/packages/sdk-nuxt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zitadel/sdk-nuxt",
   "version": "0.1.0-alpha.13",
-  "description": "Nuxt proxy middleware and helpers for Nextgen Auth",
+  "description": "Nuxt proxy middleware and helpers for the pre-release Zitadel preview.",
   "homepage": "https://github.com/zitadel/nextgen/tree/main/packages/sdk-nuxt#readme",
   "bugs": {
     "url": "https://github.com/zitadel/nextgen/issues"


### PR DESCRIPTION
## Summary
- Update public-facing docs and package metadata to describe the repository as a pre-release Zitadel preview.
- Add contributor, security, and community policy files for public visibility.
- Align release publish workflow comments and provenance handling so real publishes enable npm provenance while dry runs stay off.

## Testing
- Not run (not requested)