### PR TITLE
build: split server generate into write and check tasks

### DIFF
--- a/.github/instructions/go-api.instructions.md
+++ b/.github/instructions/go-api.instructions.md
@@ -10,7 +10,8 @@ multi-file OpenAPI 3.1 under `api/openapi/`; generated server code lives under
 
 - Review Go changes for `gofmt`, `go vet ./...`, and `go test ./...`.
 - Do not hand-edit `api/generated/**`; update `api/openapi/**` and regenerate
-  with `go generate ./...`.
+  with `moon run server:generate` or `go generate ./...`. CI enforces drift
+  through `server:check-generate`.
 - Keep OpenAPI operation, schema, and security changes compatible with ogen and
   the generated handler interfaces.
 - Preserve clear boundaries between public API contracts in `api/` and server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,15 @@ jobs:
         id: ci-mode
         run: node scripts/ci-mode.mjs "${{ github.event.pull_request.base.sha || 'origin/main' }}"
 
+      - name: Check Go generated files
+        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        run: moon run server:check-generate
+
       - name: Run Moon build and test graph
         if: ${{ steps.ci-mode.outputs.mode == 'full' }}
         run: moon ci :lint :typecheck :build :test
 
-      - name: Run Go checks
+      - name: Run Go tests
         if: ${{ steps.ci-mode.outputs.mode == 'full' }}
         run: moon run server:test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,8 @@ changes.
 ## Generated Files
 
 - Do not hand-edit `api/generated/**`; update `api/openapi/**` and run
-  `go generate ./...`.
+  `moon run server:generate` or `go generate ./...`. CI enforces committed
+  generated output through `server:check-generate` (via `server:test`).
 - Do not hand-edit generated package output under `dist/`.
 - Do not hand-edit `apps/console/src/routeTree.gen.ts`; update route files and
   let the TanStack Router plugin regenerate it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ For changes to the Go server, APIs, or database layer.
 | Start the server (builds console + login-ui, then Go) | `moon run workspace:server`                |
 | Start the server (skip UI builds)                     | `go run . server`                          |
 | Debug and attach VSCode                               | `moon run workspace:server-debug`          |
+| Regenerate Go/OpenAPI artifacts                       | `moon run server:generate`                 |
+| Verify committed generated output                     | `moon run server:check-generate`             |
 | Run lint, type checks, and tests                      | `moon ci :lint :typecheck :build :test`    |
 | Preview planned Changesets bumps                      | `corepack pnpm exec changeset status --since origin/main` |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ For changes to the Go server, APIs, or database layer.
 | Start the server (skip UI builds)                     | `go run . server`                          |
 | Debug and attach VSCode                               | `moon run workspace:server-debug`          |
 | Regenerate Go/OpenAPI artifacts                       | `moon run server:generate`                 |
-| Verify committed generated output                     | `moon run server:check-generate`             |
+| Verify committed generated output                     | `moon run server:check-generate`           |
 | Run lint, type checks, and tests                      | `moon ci :lint :typecheck :build :test`    |
 | Preview planned Changesets bumps                      | `corepack pnpm exec changeset status --since origin/main` |
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ GitHub Actions context `full-pr`, shown in the pull request UI as
 without adding a blocking CI gate. `ci / full-pr` runs the Moon-driven PR
 confidence path on a 16-core Depot runner:
 
-- Go generated-file drift check and tests (`server:check-generate`, `server:test`).
+- Go generated-file drift check, vet, and tests (`server:check-generate`, `server:test`).
 - pnpm install and Moon lint/typecheck/build/test tasks.
 - Built CLI smoke checks.
 - npm package dry-run/pack checks.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ GitHub Actions context `full-pr`, shown in the pull request UI as
 without adding a blocking CI gate. `ci / full-pr` runs the Moon-driven PR
 confidence path on a 16-core Depot runner:
 
-- Go vet and tests.
+- Go generated-file drift check and tests (`server:check-generate`, `server:test`).
 - pnpm install and Moon lint/typecheck/build/test tasks.
 - Built CLI smoke checks.
 - npm package dry-run/pack checks.

--- a/apps/server/moon.yml
+++ b/apps/server/moon.yml
@@ -3,9 +3,24 @@ language: "go"
 layer: "application"
 stack: "backend"
 
+fileGroups:
+  serverInputs:
+    - "/**/*.go"
+    - "/go.mod"
+    - "/go.sum"
+    - "/api/**/*.yaml"
+    - "/api/**/*.json"
+    - "/api/.ogen.yaml"
+    - "/scripts/check-go-generate.mjs"
+    - "moon.yml"
+    - "package.json"
+    - "bin/**"
+
 tasks:
   openapi:
     command: "npx --yes @redocly/cli@2.31.5 lint api/openapi/openapi-spec.yaml --format=github-actions"
+    inputs:
+      - "@group(serverInputs)"
     options:
       runFromWorkspaceRoot: true
 
@@ -16,31 +31,37 @@ tasks:
         printf '%s\n' "$unformatted"
         exit 1
       fi
+    inputs:
+      - "@group(serverInputs)"
     options:
       runFromWorkspaceRoot: true
 
   generate:
     command: "go generate ./..."
+    inputs:
+      - "@group(serverInputs)"
     outputs:
       - "/api/generated/**"
       - "/api/openapi/components/schemas/errors/**"
-      - "/api/openapi/endpoints/**"
-      - "/internal/domain/**"
-      - "/internal/instrumentation/**"
-      - "/internal/service/mocks/**"
-      - "/internal/storage/database/**"
+      - "/api/openapi/endpoints/**/*-error-response.yaml"
+      - "/internal/**/*_enumer.go"
+      - "/internal/**/*.mock.go"
     options:
       runFromWorkspaceRoot: true
 
   check-generate:
     command: "node scripts/check-go-generate.mjs"
+    inputs:
+      - "@group(serverInputs)"
     options:
       runFromWorkspaceRoot: true
 
   vet:
     command: "go vet ./..."
     deps:
-      - "generate"
+      - "check-generate"
+    inputs:
+      - "@group(serverInputs)"
     options:
       runFromWorkspaceRoot: true
 
@@ -57,6 +78,8 @@ tasks:
       - "format"
       - "check-generate"
       - "vet"
+    inputs:
+      - "@group(serverInputs)"
     options:
       runFromWorkspaceRoot: true
 
@@ -71,6 +94,8 @@ tasks:
       - "-timeout"
       - "10m"
       - "./..."
+    inputs:
+      - "@group(serverInputs)"
     options:
       runFromWorkspaceRoot: true
       runInCI: false
@@ -85,6 +110,8 @@ tasks:
       - "-timeout"
       - "10m"
       - "./..."
+    inputs:
+      - "@group(serverInputs)"
     options:
       runFromWorkspaceRoot: true
       runInCI: false
@@ -92,7 +119,9 @@ tasks:
   build:
     command: "go build -trimpath -o dist/server/nextgen ."
     deps:
-      - "generate"
+      - "check-generate"
+    inputs:
+      - "@group(serverInputs)"
     outputs:
       - "/dist/server/nextgen"
     options:

--- a/apps/server/moon.yml
+++ b/apps/server/moon.yml
@@ -20,6 +20,19 @@ tasks:
       runFromWorkspaceRoot: true
 
   generate:
+    command: "go generate ./..."
+    outputs:
+      - "/api/generated/**"
+      - "/api/openapi/components/schemas/errors/**"
+      - "/api/openapi/endpoints/**"
+      - "/internal/domain/**"
+      - "/internal/instrumentation/**"
+      - "/internal/service/mocks/**"
+      - "/internal/storage/database/**"
+    options:
+      runFromWorkspaceRoot: true
+
+  check-generate:
     command: "node scripts/check-go-generate.mjs"
     options:
       runFromWorkspaceRoot: true
@@ -42,7 +55,7 @@ tasks:
     deps:
       - "openapi"
       - "format"
-      - "generate"
+      - "check-generate"
       - "vet"
     options:
       runFromWorkspaceRoot: true

--- a/scripts/check-go-generate.mjs
+++ b/scripts/check-go-generate.mjs
@@ -5,6 +5,7 @@ const GENERATED_PATHS = [
   "api/generated",
   "api/openapi/components/schemas/errors",
   "api/openapi/endpoints",
+  "internal/crypto/mock",
   "internal/domain",
   "internal/instrumentation",
   "internal/service/mocks",

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -87,6 +87,7 @@ async function phaseOpenApi() {
 }
 
 async function phaseGo() {
+  await run("moon", ["run", "server:check-generate"]);
   await run("moon", ["run", "server:test"]);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Split `server:generate` into write vs check tasks and wire CI to use the new commands explicitly:

- `server:generate` — runs `go generate ./...` and writes files (exits 0 on success)
- `server:check-generate` — preserves the existing drift guard for CI

CI now runs `server:check-generate` **before** the Moon Node graph for early drift failure and clearer logs. `server:test` still depends on `check-generate` so local `moon run server:test` enforces drift without a second command.

## Validation

- `corepack pnpm exec moon run server:generate` — passed (exit 0)
- `corepack pnpm exec moon run server:check-generate` — passed (exit 0)
- `corepack pnpm exec moon run server:test` — passed (exit 0)

## Release notes / changeset

No changeset — contributor tooling and CI wiring only.

## Notes

- `scripts/check.mjs` `go` phase mirrors CI ordering (`check-generate` then `server:test`).
- Direct `go generate ./...` remains valid.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c80b292-3c2d-4d2b-9699-b5a53db3d128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c80b292-3c2d-4d2b-9699-b5a53db3d128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

