### PR TITLE
fix(storage): address PR #315 review feedback for storage v2

### DIFF
--- a/internal/storage/v2/database/coerce_test.go
+++ b/internal/storage/v2/database/coerce_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestCoerceStringValue(t *testing.T) {
+	t.Parallel()
 	got, err := database.CoerceStringValue("proj_1")
 	require.NoError(t, err)
 	assert.Equal(t, "proj_1", got)
@@ -20,6 +21,7 @@ func TestCoerceStringValue(t *testing.T) {
 }
 
 func TestCoerceTimeValue(t *testing.T) {
+	t.Parallel()
 	createdAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 
 	got, err := database.CoerceTimeValue(createdAt)
@@ -35,6 +37,7 @@ func TestCoerceTimeValue(t *testing.T) {
 }
 
 func TestCoerceNumberValue(t *testing.T) {
+	t.Parallel()
 	got, err := database.CoerceNumberValue[domain.FlowDefinitionStatus](float64(domain.FlowDefinitionStatusActive))
 	require.NoError(t, err)
 	assert.Equal(t, domain.FlowDefinitionStatusActive, got)
@@ -45,6 +48,7 @@ func TestCoerceNumberValue(t *testing.T) {
 }
 
 func TestCoerceSliceString(t *testing.T) {
+	t.Parallel()
 	got, err := database.CoerceSlice([]any{"https://a.example", "https://b.example"}, database.CoerceStringValue)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"https://a.example", "https://b.example"}, got)
@@ -56,6 +60,7 @@ func TestCoerceSliceString(t *testing.T) {
 }
 
 func TestCoerceSliceAsAnyJSON(t *testing.T) {
+	t.Parallel()
 	raw := []any{map[string]any{"name": "login"}}
 	coerce := database.CoerceSliceAsAny(database.CoerceJSONValue[domain.FlowDefinitionStep])
 
@@ -68,6 +73,7 @@ func TestCoerceSliceAsAnyJSON(t *testing.T) {
 }
 
 func TestCoerceJSONValueStruct(t *testing.T) {
+	t.Parallel()
 	raw := map[string]any{
 		"AppIDs": []any{"app1"},
 	}
@@ -77,6 +83,7 @@ func TestCoerceJSONValueStruct(t *testing.T) {
 }
 
 func TestCoerceEnumKeyMap(t *testing.T) {
+	t.Parallel()
 	parseKey := func(s string) (domain.FlowDefinitionPurpose, error) {
 		return domain.FlowDefinitionPurposeString(s)
 	}

--- a/internal/storage/v2/database/column_test.go
+++ b/internal/storage/v2/database/column_test.go
@@ -10,11 +10,13 @@ import (
 )
 
 func TestColField(t *testing.T) {
+	t.Parallel()
 	col := database.Col(domain.ProjectFieldID)
 	assert.Equal(t, domain.ProjectFieldID, col.Field())
 }
 
 func TestColumnEquality(t *testing.T) {
+	t.Parallel()
 	a := database.Col(domain.ProjectFieldID)
 	b := database.Col(domain.ProjectFieldID)
 	c := database.Col(domain.ProjectFieldCreatedAt)
@@ -24,6 +26,7 @@ func TestColumnEquality(t *testing.T) {
 }
 
 func TestColumnJSONRoundTrip(t *testing.T) {
+	t.Parallel()
 	col := database.Col(domain.ProjectFieldUpdatedAt)
 	data, err := col.MarshalJSON()
 	require.NoError(t, err)

--- a/internal/storage/v2/database/filter.go
+++ b/internal/storage/v2/database/filter.go
@@ -69,7 +69,12 @@ type CompareFilter[F ~uint8] struct {
 	Terms []CompareTerm[F]
 }
 
-// Compare builds a single lexicographic comparison across one or more column/value terms.
+// Compare builds a comparison filter across one or more column/value terms.
+//
+// With a single term, Compare compiles to a simple column comparison
+// (for example, "created_at > $1"). With multiple terms, Compare compiles to
+// lexicographic tuple comparison (for example, "(created_at, id) > ($1, $2)").
+// Term order must match the corresponding OrderBy.Columns when used for keyset pagination.
 func Compare[F ~uint8](op CompareOp, terms ...CompareTerm[F]) *CompareFilter[F] {
 	return &CompareFilter[F]{
 		Op:    op,
@@ -93,16 +98,20 @@ func LessThan[F ~uint8](column Column[F], value any) *CompareFilter[F] {
 }
 
 // CompareEqual creates a tuple equality filter: "(col1, col2, ...) = (val1, val2, ...)".
+// With one term this is equivalent to Equal.
 func CompareEqual[F ~uint8](terms ...CompareTerm[F]) *CompareFilter[F] {
 	return Compare(OpEqual, terms...)
 }
 
-// CompareGreater creates a tuple greater-than filter for keyset pagination.
+// CompareGreater creates a greater-than filter for keyset pagination.
+// Pass one term per OrderBy column; for example, three terms restrict rows after
+// the cursor position in (col1, col2, col3) sort order.
 func CompareGreater[F ~uint8](terms ...CompareTerm[F]) *CompareFilter[F] {
 	return Compare(OpGreater, terms...)
 }
 
-// CompareLess creates a tuple less-than filter for keyset pagination.
+// CompareLess creates a less-than filter for keyset pagination.
+// Pass one term per OrderBy column; term order must match OrderBy.Columns.
 func CompareLess[F ~uint8](terms ...CompareTerm[F]) *CompareFilter[F] {
 	return Compare(OpLess, terms...)
 }

--- a/internal/storage/v2/database/filter_test.go
+++ b/internal/storage/v2/database/filter_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestEqualFilterRestricts(t *testing.T) {
+	t.Parallel()
+
 	filter := database.Equal(database.Col(domain.ProjectFieldID), "proj_1")
 	assert.True(t, filter.Restricts(database.Col(domain.ProjectFieldID)))
 	assert.False(t, filter.Restricts(database.Col(domain.ProjectFieldCreatedAt)))
@@ -17,17 +19,23 @@ func TestEqualFilterRestricts(t *testing.T) {
 }
 
 func TestCompareGreaterRestrictsAllTerms(t *testing.T) {
+	t.Parallel()
+
 	filter := database.CompareGreater(
 		database.Term(database.Col(domain.ProjectFieldCreatedAt), "t1"),
 		database.Term(database.Col(domain.ProjectFieldID), "proj_1"),
+		database.Term(database.Col(domain.ProjectFieldUpdatedAt), "t2"),
 	)
 	assert.True(t, filter.Restricts(database.Col(domain.ProjectFieldCreatedAt)))
 	assert.True(t, filter.Restricts(database.Col(domain.ProjectFieldID)))
-	assert.False(t, filter.Restricts(database.Col(domain.ProjectFieldUpdatedAt)))
+	assert.True(t, filter.Restricts(database.Col(domain.ProjectFieldUpdatedAt)))
+	assert.False(t, filter.Restricts(database.Col(domain.ProjectFieldProjectSecret)))
 	assert.Equal(t, database.OpGreater, filter.Op)
 }
 
 func TestAndFilterRestricts(t *testing.T) {
+	t.Parallel()
+
 	filter := database.And(
 		database.Equal(database.Col(domain.ProjectFieldID), "proj_1"),
 		database.Equal(database.Col(domain.ProjectFieldCreatedAt), "now"),
@@ -38,6 +46,8 @@ func TestAndFilterRestricts(t *testing.T) {
 }
 
 func TestOrFilterRestricts(t *testing.T) {
+	t.Parallel()
+
 	filter := database.Or(
 		database.Equal(database.Col(domain.ProjectFieldID), "proj_1"),
 		database.Equal(database.Col(domain.ProjectFieldCreatedAt), "now"),
@@ -48,6 +58,8 @@ func TestOrFilterRestricts(t *testing.T) {
 }
 
 func TestGreaterAndLessThanFilterRestricts(t *testing.T) {
+	t.Parallel()
+
 	gt := database.GreaterThan(database.Col(domain.ProjectFieldCreatedAt), "t1")
 	lt := database.LessThan(database.Col(domain.ProjectFieldID), "proj_1")
 	assert.True(t, gt.Restricts(database.Col(domain.ProjectFieldCreatedAt)))
@@ -55,6 +67,8 @@ func TestGreaterAndLessThanFilterRestricts(t *testing.T) {
 }
 
 func TestStringFilterConstructors(t *testing.T) {
+	t.Parallel()
+
 	col := database.Col(domain.FlowDefinitionFieldName)
 
 	equal := database.StringEqual(col, "login")
@@ -81,6 +95,8 @@ func TestStringFilterConstructors(t *testing.T) {
 }
 
 func TestStringFilterRestricts(t *testing.T) {
+	t.Parallel()
+
 	col := database.Col(domain.FlowDefinitionFieldName)
 	filter := database.StringContains(col, "login")
 	assert.True(t, filter.Restricts(col))

--- a/internal/storage/v2/database/schema_test.go
+++ b/internal/storage/v2/database/schema_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestSchemaSQLNameAndValuesFrom(t *testing.T) {
+	t.Parallel()
 	createdAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	project := &domain.Project{
 		ID:        "proj_1",
@@ -44,6 +45,7 @@ func TestSchemaSQLNameAndValuesFrom(t *testing.T) {
 }
 
 func TestSchemaCoerceCursorValues(t *testing.T) {
+	t.Parallel()
 	createdAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	schema := database.NewSchema(map[domain.ProjectField]database.FieldBinding[domain.Project]{
 		domain.ProjectFieldCreatedAt: {
@@ -72,6 +74,7 @@ func TestSchemaCoerceCursorValues(t *testing.T) {
 }
 
 func TestSchemaCoerceCursorValues_invalidTime(t *testing.T) {
+	t.Parallel()
 	schema := database.NewSchema(map[domain.ProjectField]database.FieldBinding[domain.Project]{
 		domain.ProjectFieldCreatedAt: {
 			SQLName:  "created_at",
@@ -88,6 +91,7 @@ func TestSchemaCoerceCursorValues_invalidTime(t *testing.T) {
 }
 
 func TestSchemaUnknownFieldPanics(t *testing.T) {
+	t.Parallel()
 	schema := database.NewSchema(map[domain.ProjectField]database.FieldBinding[domain.Project]{
 		domain.ProjectFieldID: {
 			SQLName:  "id",

--- a/internal/storage/v2/dialect/pagination/cursor_test.go
+++ b/internal/storage/v2/dialect/pagination/cursor_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestCursorMarshalRoundTrip(t *testing.T) {
+	t.Parallel()
 	createdAt := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
 	original := &pagination.Cursor[domain.ProjectField]{
 		Columns: []database.Column[domain.ProjectField]{
@@ -31,6 +32,7 @@ func TestCursorMarshalRoundTrip(t *testing.T) {
 }
 
 func TestCursorMatchesOrderByMismatch(t *testing.T) {
+	t.Parallel()
 	cursor := &pagination.Cursor[domain.ProjectField]{
 		Columns: []database.Column[domain.ProjectField]{
 			database.Col(domain.ProjectFieldCreatedAt),

--- a/internal/storage/v2/dialect/postgres/compiler.go
+++ b/internal/storage/v2/dialect/postgres/compiler.go
@@ -16,6 +16,7 @@ type statementCompiler struct {
 func compileRead[F ~uint8, T any](c *statementCompiler, stmt string, opt *database.ListOptions[F], schema database.Schema[F, T]) error {
 	c.WriteString(stmt)
 
+	filter := opt.Filter
 	if len(opt.Pagination.Cursor) != 0 {
 		cursor, err := pagination.CursorFromToken[F](opt.Pagination.Cursor)
 		if err != nil {
@@ -30,14 +31,14 @@ func compileRead[F ~uint8, T any](c *statementCompiler, stmt string, opt *databa
 		}
 		terms := compareTerms(cursor.Columns, values)
 		if opt.Pagination.OrderBy.Direction == database.OrderAsc {
-			opt.Filter = database.And(opt.Filter, database.CompareGreater(terms...))
+			filter = database.And(filter, database.CompareGreater(terms...))
 		} else {
-			opt.Filter = database.And(opt.Filter, database.CompareLess(terms...))
+			filter = database.And(filter, database.CompareLess(terms...))
 		}
 	}
-	if opt.Filter != nil {
+	if filter != nil {
 		c.WriteString(" WHERE ")
-		compileFilter(c, opt.Filter, schema)
+		compileFilter(c, filter, schema)
 	}
 
 	compileOrderBy(c, opt.Pagination.OrderBy, schema)
@@ -201,15 +202,6 @@ func compileLimit(c *statementCompiler, limit uint32) {
 	if limit > 0 {
 		c.WriteString(" LIMIT ")
 		writeArg(c, limit)
-	}
-}
-
-func writeArgs(c *statementCompiler, args ...any) {
-	for i, arg := range args {
-		if i > 0 {
-			c.WriteString(", ")
-		}
-		writeArg(c, arg)
 	}
 }
 

--- a/internal/storage/v2/dialect/postgres/compiler.go
+++ b/internal/storage/v2/dialect/postgres/compiler.go
@@ -13,6 +13,11 @@ type statementCompiler struct {
 	args []any
 }
 
+func (c *statementCompiler) Reset() {
+	c.Builder.Reset()
+	c.args = nil
+}
+
 func compileRead[F ~uint8, T any](c *statementCompiler, stmt string, opt *database.ListOptions[F], schema database.Schema[F, T]) error {
 	c.WriteString(stmt)
 
@@ -169,7 +174,7 @@ func compileStringFilter[F ~uint8, T any](c *statementCompiler, filter *database
 			writeArg(c, filter.Value)
 		}
 	case database.StringMatchStartsWith, database.StringMatchContains, database.StringMatchEndsWith:
-		pattern := likePattern(filter.Match, filter.Value)
+		likePattern(c, filter.Match, filter.Value)
 		if filter.IgnoreCase {
 			c.WriteString(col)
 			c.WriteString(" ILIKE ")
@@ -177,7 +182,7 @@ func compileStringFilter[F ~uint8, T any](c *statementCompiler, filter *database
 			c.WriteString(col)
 			c.WriteString(" LIKE ")
 		}
-		writeArg(c, pattern)
+		// writeArg(c, pattern)
 	default:
 		panic("unknown string match")
 	}

--- a/internal/storage/v2/dialect/postgres/compiler.go
+++ b/internal/storage/v2/dialect/postgres/compiler.go
@@ -174,15 +174,17 @@ func compileStringFilter[F ~uint8, T any](c *statementCompiler, filter *database
 			writeArg(c, filter.Value)
 		}
 	case database.StringMatchStartsWith, database.StringMatchContains, database.StringMatchEndsWith:
-		likePattern(c, filter.Match, filter.Value)
+		value := filter.Value
 		if filter.IgnoreCase {
+			c.WriteString("LOWER(")
 			c.WriteString(col)
-			c.WriteString(" ILIKE ")
+			c.WriteString(")")
+			value = strings.ToLower(filter.Value)
 		} else {
 			c.WriteString(col)
-			c.WriteString(" LIKE ")
 		}
-		// writeArg(c, pattern)
+		c.WriteString(" LIKE ")
+		compileLikePattern(c, filter.Match, value)
 	default:
 		panic("unknown string match")
 	}

--- a/internal/storage/v2/dialect/postgres/compiler_test.go
+++ b/internal/storage/v2/dialect/postgres/compiler_test.go
@@ -96,9 +96,9 @@ func TestCompileReadStringContains(t *testing.T) {
 		Filter: database.StringContains(database.Col(domain.FlowDefinitionFieldName), "login"),
 	})
 
-	assert.Contains(t, sql, "WHERE name LIKE $1")
+	assert.Contains(t, sql, "WHERE name LIKE '%' || $1 || '%'")
 	require.Len(t, args, 1)
-	assert.Equal(t, "%login%", args[0])
+	assert.Equal(t, "login", args[0])
 }
 
 func TestCompileReadCursorDoesNotMutateCallerFilter(t *testing.T) {

--- a/internal/storage/v2/dialect/postgres/compiler_test.go
+++ b/internal/storage/v2/dialect/postgres/compiler_test.go
@@ -15,6 +15,54 @@ const testProjectQuery = "SELECT id, created_at, updated_at, project_secret, pre
 
 const testFlowDefinitionQuery = "SELECT project_id, id, name FROM zitadel_nextgen.flow_definitions"
 
+func compileFilterOnly[F ~uint8, T any](t *testing.T, filter database.Filter[F], schema database.Schema[F, T]) (string, []any) {
+	t.Helper()
+
+	var compiler statementCompiler
+	compileFilter(&compiler, filter, schema)
+	return compiler.String(), compiler.args
+}
+
+func compileOrderByOnly[F ~uint8, T any](t *testing.T, orderBy database.OrderBy[F], schema database.Schema[F, T]) (string, []any) {
+	t.Helper()
+
+	var compiler statementCompiler
+	compileOrderBy(&compiler, orderBy, schema)
+	return compiler.String(), compiler.args
+}
+
+func compileLimitOnly(t *testing.T, limit uint32) (string, []any) {
+	t.Helper()
+
+	var compiler statementCompiler
+	compileLimit(&compiler, limit)
+	return compiler.String(), compiler.args
+}
+
+func compileReadExpectError[F ~uint8, T any](t *testing.T, stmt string, opts *database.ListOptions[F], schema database.Schema[F, T]) error {
+	t.Helper()
+
+	var compiler statementCompiler
+	return compileRead(&compiler, stmt, opts, schema)
+}
+
+func assertDomainErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+
+	require.Error(t, err)
+	var dbErr domain.Error
+	require.ErrorAs(t, err, &dbErr)
+	assert.Equal(t, code, dbErr.Code)
+}
+
+func TestCompileReadNoFilterNoOrderNoLimit(t *testing.T) {
+	t.Parallel()
+
+	sql, args := compileProjectRead(t, &database.ListOptions[domain.ProjectField]{})
+	assert.Equal(t, testProjectQuery, sql)
+	assert.Empty(t, args)
+}
+
 func TestCompileReadFilterAndOrderBy(t *testing.T) {
 	t.Parallel()
 
@@ -148,6 +196,498 @@ func TestCompileReadStringEqualFold(t *testing.T) {
 	assert.Contains(t, sql, "WHERE LOWER(name) = LOWER($1)")
 	require.Len(t, args, 1)
 	assert.Equal(t, "Login", args[0])
+}
+
+func TestCompileReadCursorDesc(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+	cursor := (&pagination.Cursor[domain.ProjectField]{
+		Columns: []database.Column[domain.ProjectField]{
+			database.Col(domain.ProjectFieldCreatedAt),
+			database.Col(domain.ProjectFieldID),
+		},
+		Values: []any{createdAt, "proj_1"},
+	}).Marshal()
+
+	sql, args := compileProjectRead(t, &database.ListOptions[domain.ProjectField]{
+		Pagination: database.Page[domain.ProjectField]{
+			OrderBy: database.OrderBy[domain.ProjectField]{
+				Columns: []database.Column[domain.ProjectField]{
+					database.Col(domain.ProjectFieldCreatedAt),
+					database.Col(domain.ProjectFieldID),
+				},
+				Direction: database.OrderDesc,
+			},
+			Cursor: cursor,
+		},
+	})
+
+	assert.Contains(t, sql, "(created_at, id) < ($1, $2)")
+	require.Len(t, args, 2)
+	assert.Equal(t, createdAt, args[0])
+	assert.Equal(t, "proj_1", args[1])
+}
+
+func TestCompileReadCursorWithBaseFilter(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+	cursor := (&pagination.Cursor[domain.ProjectField]{
+		Columns: []database.Column[domain.ProjectField]{
+			database.Col(domain.ProjectFieldCreatedAt),
+			database.Col(domain.ProjectFieldID),
+		},
+		Values: []any{createdAt, "proj_1"},
+	}).Marshal()
+
+	sql, args := compileProjectRead(t, &database.ListOptions[domain.ProjectField]{
+		Filter: database.Equal(database.Col(domain.ProjectFieldID), "proj_1"),
+		Pagination: database.Page[domain.ProjectField]{
+			OrderBy: database.OrderBy[domain.ProjectField]{
+				Columns: []database.Column[domain.ProjectField]{
+					database.Col(domain.ProjectFieldCreatedAt),
+					database.Col(domain.ProjectFieldID),
+				},
+				Direction: database.OrderAsc,
+			},
+			Cursor: cursor,
+		},
+	})
+
+	assert.Contains(t, sql, "WHERE (id = $1 AND (created_at, id) > ($2, $3))")
+	require.Len(t, args, 3)
+	assert.Equal(t, "proj_1", args[0])
+	assert.Equal(t, createdAt, args[1])
+	assert.Equal(t, "proj_1", args[2])
+}
+
+func TestCompileReadInvalidCursorToken(t *testing.T) {
+	t.Parallel()
+
+	err := compileReadExpectError(t, testProjectQuery, &database.ListOptions[domain.ProjectField]{
+		Pagination: database.Page[domain.ProjectField]{
+			Cursor: []byte("not-a-valid-cursor"),
+		},
+	}, projectSchema)
+	assertDomainErrorCode(t, err, "db.invalid_cursor")
+}
+
+func TestCompileReadCursorOrderMismatch(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+	cursor := (&pagination.Cursor[domain.ProjectField]{
+		Columns: []database.Column[domain.ProjectField]{
+			database.Col(domain.ProjectFieldCreatedAt),
+			database.Col(domain.ProjectFieldID),
+		},
+		Values: []any{createdAt, "proj_1"},
+	}).Marshal()
+
+	err := compileReadExpectError(t, testProjectQuery, &database.ListOptions[domain.ProjectField]{
+		Pagination: database.Page[domain.ProjectField]{
+			OrderBy: database.OrderBy[domain.ProjectField]{
+				Columns: []database.Column[domain.ProjectField]{
+					database.Col(domain.ProjectFieldID),
+				},
+				Direction: database.OrderAsc,
+			},
+			Cursor: cursor,
+		},
+	}, projectSchema)
+	assertDomainErrorCode(t, err, "db.cursor_order_mismatch")
+}
+
+func TestCompileReadCursorCoerceFailure(t *testing.T) {
+	t.Parallel()
+
+	cursor := (&pagination.Cursor[domain.ProjectField]{
+		Columns: []database.Column[domain.ProjectField]{
+			database.Col(domain.ProjectFieldCreatedAt),
+		},
+		Values: []any{"not-a-time"},
+	}).Marshal()
+
+	err := compileReadExpectError(t, testProjectQuery, &database.ListOptions[domain.ProjectField]{
+		Pagination: database.Page[domain.ProjectField]{
+			OrderBy: database.OrderBy[domain.ProjectField]{
+				Columns: []database.Column[domain.ProjectField]{
+					database.Col(domain.ProjectFieldCreatedAt),
+				},
+				Direction: database.OrderAsc,
+			},
+			Cursor: cursor,
+		},
+	}, projectSchema)
+	assertDomainErrorCode(t, err, "db.invalid_cursor")
+
+	var dbErr domain.Error
+	require.ErrorAs(t, err, &dbErr)
+	assert.Error(t, dbErr.Parent)
+}
+
+func TestCompileFilterNil(t *testing.T) {
+	t.Parallel()
+
+	sql, args := compileFilterOnly[domain.ProjectField](t, nil, projectSchema)
+	assert.Empty(t, sql)
+	assert.Empty(t, args)
+}
+
+func TestCompileAndFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		filter  database.Filter[domain.ProjectField]
+		wantSQL string
+		wantLen int
+	}{
+		{
+			name:    "empty",
+			filter:  database.AndFilter[domain.ProjectField]{},
+			wantSQL: "",
+			wantLen: 0,
+		},
+		{
+			name:    "single child",
+			filter:  database.And(database.Equal(database.Col(domain.ProjectFieldID), "proj_1")),
+			wantSQL: "id = $1",
+			wantLen: 1,
+		},
+		{
+			name: "two children",
+			filter: database.And(
+				database.Equal(database.Col(domain.ProjectFieldID), "proj_1"),
+				database.Equal(database.Col(domain.ProjectFieldCreatedAt), "now"),
+			),
+			wantSQL: "(id = $1 AND created_at = $2)",
+			wantLen: 2,
+		},
+		{
+			name: "three children",
+			filter: database.And(
+				database.Equal(database.Col(domain.ProjectFieldID), "proj_1"),
+				database.Equal(database.Col(domain.ProjectFieldCreatedAt), "t1"),
+				database.Equal(database.Col(domain.ProjectFieldUpdatedAt), "t2"),
+			),
+			wantSQL: "(id = $1 AND created_at = $2 AND updated_at = $3)",
+			wantLen: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, args := compileFilterOnly(t, tt.filter, projectSchema)
+			assert.Equal(t, tt.wantSQL, sql)
+			require.Len(t, args, tt.wantLen)
+		})
+	}
+}
+
+func TestCompileOrFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		filter  database.Filter[domain.ProjectField]
+		wantSQL string
+		wantLen int
+	}{
+		{
+			name:    "empty",
+			filter:  database.OrFilter[domain.ProjectField]{},
+			wantSQL: "",
+			wantLen: 0,
+		},
+		{
+			name:    "single child",
+			filter:  database.Or(database.Equal(database.Col(domain.ProjectFieldID), "proj_1")),
+			wantSQL: "id = $1",
+			wantLen: 1,
+		},
+		{
+			name: "two children",
+			filter: database.Or(
+				database.Equal(database.Col(domain.ProjectFieldID), "proj_1"),
+				database.Equal(database.Col(domain.ProjectFieldCreatedAt), "now"),
+			),
+			wantSQL: "(id = $1 OR created_at = $2)",
+			wantLen: 2,
+		},
+		{
+			name: "three children",
+			filter: database.Or(
+				database.Equal(database.Col(domain.ProjectFieldID), "proj_1"),
+				database.Equal(database.Col(domain.ProjectFieldCreatedAt), "t1"),
+				database.Equal(database.Col(domain.ProjectFieldUpdatedAt), "t2"),
+			),
+			wantSQL: "(id = $1 OR created_at = $2 OR updated_at = $3)",
+			wantLen: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, args := compileFilterOnly(t, tt.filter, projectSchema)
+			assert.Equal(t, tt.wantSQL, sql)
+			require.Len(t, args, tt.wantLen)
+		})
+	}
+}
+
+func TestCompileFilterNestedAndOr(t *testing.T) {
+	t.Parallel()
+
+	filter := database.And(
+		database.Equal(database.Col(domain.ProjectFieldID), "proj_1"),
+		database.Or(
+			database.Equal(database.Col(domain.ProjectFieldCreatedAt), "t1"),
+			database.Equal(database.Col(domain.ProjectFieldUpdatedAt), "t2"),
+		),
+	)
+
+	sql, args := compileFilterOnly(t, filter, projectSchema)
+	assert.Equal(t, "(id = $1 AND (created_at = $2 OR updated_at = $3))", sql)
+	require.Len(t, args, 3)
+}
+
+func TestCompileCompareFilterSingleColumn(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		filter  database.Filter[domain.ProjectField]
+		wantSQL string
+		wantArg any
+	}{
+		{
+			name:    "equal",
+			filter:  database.Equal(database.Col(domain.ProjectFieldID), "proj_1"),
+			wantSQL: "id = $1",
+			wantArg: "proj_1",
+		},
+		{
+			name:    "greater than",
+			filter:  database.GreaterThan(database.Col(domain.ProjectFieldCreatedAt), createdAt),
+			wantSQL: "created_at > $1",
+			wantArg: createdAt,
+		},
+		{
+			name:    "less than",
+			filter:  database.LessThan(database.Col(domain.ProjectFieldCreatedAt), createdAt),
+			wantSQL: "created_at < $1",
+			wantArg: createdAt,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, args := compileFilterOnly(t, tt.filter, projectSchema)
+			assert.Equal(t, tt.wantSQL, sql)
+			require.Len(t, args, 1)
+			assert.Equal(t, tt.wantArg, args[0])
+		})
+	}
+}
+
+func TestCompileCompareFilterTuple(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		filter  database.Filter[domain.ProjectField]
+		wantSQL string
+	}{
+		{
+			name: "compare less tuple",
+			filter: database.CompareLess(
+				database.Term(database.Col(domain.ProjectFieldCreatedAt), createdAt),
+				database.Term(database.Col(domain.ProjectFieldID), "proj_1"),
+			),
+			wantSQL: "(created_at, id) < ($1, $2)",
+		},
+		{
+			name: "compare equal tuple",
+			filter: database.CompareEqual(
+				database.Term(database.Col(domain.ProjectFieldCreatedAt), createdAt),
+				database.Term(database.Col(domain.ProjectFieldID), "proj_1"),
+			),
+			wantSQL: "(created_at, id) = ($1, $2)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, args := compileFilterOnly(t, tt.filter, projectSchema)
+			assert.Equal(t, tt.wantSQL, sql)
+			require.Len(t, args, 2)
+			assert.Equal(t, createdAt, args[0])
+			assert.Equal(t, "proj_1", args[1])
+		})
+	}
+}
+
+func TestCompileStringFilter(t *testing.T) {
+	t.Parallel()
+
+	col := database.Col(domain.FlowDefinitionFieldName)
+	tests := []struct {
+		name    string
+		filter  *database.StringFilter[domain.FlowDefinitionField]
+		wantSQL string
+		wantArg any
+	}{
+		{
+			name:    "equal",
+			filter:  database.StringEqual(col, "login"),
+			wantSQL: "name = $1",
+			wantArg: "login",
+		},
+		{
+			name:    "starts with",
+			filter:  database.StringStartsWith(col, "acme"),
+			wantSQL: "name LIKE $1 || '%'",
+			wantArg: "acme",
+		},
+		{
+			name:    "contains",
+			filter:  database.StringContains(col, "login"),
+			wantSQL: "name LIKE '%' || $1 || '%'",
+			wantArg: "login",
+		},
+		{
+			name:    "ends with",
+			filter:  database.StringEndsWith(col, "suffix"),
+			wantSQL: "name LIKE '%' || $1",
+			wantArg: "suffix",
+		},
+		{
+			name:    "equal fold",
+			filter:  database.StringEqualFold(col, "Login"),
+			wantSQL: "LOWER(name) = LOWER($1)",
+			wantArg: "Login",
+		},
+		{
+			name:    "starts with fold",
+			filter:  database.StringStartsWithFold(col, "Acme"),
+			wantSQL: "LOWER(name) LIKE $1 || '%'",
+			wantArg: "acme",
+		},
+		{
+			name:    "contains fold",
+			filter:  database.StringContainsFold(col, "Flow"),
+			wantSQL: "LOWER(name) LIKE '%' || $1 || '%'",
+			wantArg: "flow",
+		},
+		{
+			name:    "ends with fold",
+			filter:  database.StringEndsWithFold(col, "Suffix"),
+			wantSQL: "LOWER(name) LIKE '%' || $1",
+			wantArg: "suffix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, args := compileFilterOnly(t, tt.filter, flowDefinitionSchema)
+			assert.Equal(t, tt.wantSQL, sql)
+			require.Len(t, args, 1)
+			assert.Equal(t, tt.wantArg, args[0])
+		})
+	}
+}
+
+func TestCompileOrderBy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		orderBy database.OrderBy[domain.ProjectField]
+		wantSQL string
+	}{
+		{
+			name:    "empty columns",
+			orderBy: database.OrderBy[domain.ProjectField]{},
+			wantSQL: "",
+		},
+		{
+			name: "single asc",
+			orderBy: database.OrderBy[domain.ProjectField]{
+				Columns: []database.Column[domain.ProjectField]{
+					database.Col(domain.ProjectFieldCreatedAt),
+				},
+				Direction: database.OrderAsc,
+			},
+			wantSQL: " ORDER BY created_at",
+		},
+		{
+			name: "multi asc",
+			orderBy: database.OrderBy[domain.ProjectField]{
+				Columns: []database.Column[domain.ProjectField]{
+					database.Col(domain.ProjectFieldCreatedAt),
+					database.Col(domain.ProjectFieldID),
+				},
+				Direction: database.OrderAsc,
+			},
+			wantSQL: " ORDER BY created_at, id",
+		},
+		{
+			name: "desc",
+			orderBy: database.OrderBy[domain.ProjectField]{
+				Columns: []database.Column[domain.ProjectField]{
+					database.Col(domain.ProjectFieldCreatedAt),
+					database.Col(domain.ProjectFieldID),
+				},
+				Direction: database.OrderDesc,
+			},
+			wantSQL: " ORDER BY created_at DESC, id DESC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, args := compileOrderByOnly(t, tt.orderBy, projectSchema)
+			assert.Equal(t, tt.wantSQL, sql)
+			assert.Empty(t, args)
+		})
+	}
+}
+
+func TestCompileLimit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero", func(t *testing.T) {
+		t.Parallel()
+
+		sql, args := compileLimitOnly(t, 0)
+		assert.Empty(t, sql)
+		assert.Empty(t, args)
+	})
+
+	t.Run("non zero", func(t *testing.T) {
+		t.Parallel()
+
+		sql, args := compileLimitOnly(t, 25)
+		assert.Equal(t, " LIMIT $1", sql)
+		require.Len(t, args, 1)
+		assert.Equal(t, uint32(25), args[0])
+	})
 }
 
 func compileProjectRead(t *testing.T, opts *database.ListOptions[domain.ProjectField]) (string, []any) {

--- a/internal/storage/v2/dialect/postgres/compiler_test.go
+++ b/internal/storage/v2/dialect/postgres/compiler_test.go
@@ -101,6 +101,43 @@ func TestCompileReadStringContains(t *testing.T) {
 	assert.Equal(t, "%login%", args[0])
 }
 
+func TestCompileReadCursorDoesNotMutateCallerFilter(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+	baseFilter := database.Equal(database.Col(domain.ProjectFieldID), "proj_1")
+	cursor := (&pagination.Cursor[domain.ProjectField]{
+		Columns: []database.Column[domain.ProjectField]{
+			database.Col(domain.ProjectFieldCreatedAt),
+			database.Col(domain.ProjectFieldID),
+		},
+		Values: []any{createdAt, "proj_1"},
+	}).Marshal()
+
+	opts := &database.ListOptions[domain.ProjectField]{
+		Filter: baseFilter,
+		Pagination: database.Page[domain.ProjectField]{
+			Limit: 5,
+			OrderBy: database.OrderBy[domain.ProjectField]{
+				Columns: []database.Column[domain.ProjectField]{
+					database.Col(domain.ProjectFieldCreatedAt),
+					database.Col(domain.ProjectFieldID),
+				},
+				Direction: database.OrderAsc,
+			},
+			Cursor: cursor,
+		},
+	}
+
+	sql1, args1 := compileProjectRead(t, opts)
+	assert.Equal(t, baseFilter, opts.Filter)
+
+	sql2, args2 := compileProjectRead(t, opts)
+	assert.Equal(t, baseFilter, opts.Filter)
+	assert.Equal(t, sql1, sql2)
+	assert.Equal(t, args1, args2)
+}
+
 func TestCompileReadStringEqualFold(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/v2/dialect/postgres/dialect.go
+++ b/internal/storage/v2/dialect/postgres/dialect.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/zitadel/nextgen/internal/storage/v2/database"
 )
@@ -58,19 +60,31 @@ func DecodeConfig(input any) (database.Dialect, error) {
 		}
 		return &Config{Config: config}, nil
 	case map[string]any:
-		connector := new(Config)
+		connMap := c
+		if nested, ok := c["ConnConfig"].(map[string]any); ok {
+			connMap = nested
+		}
+
+		pgconnConfig := &pgconn.Config{}
 		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 			DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
 			WeaklyTypedInput: true,
-			Result:           connector,
+			Result:           pgconnConfig,
 		})
 		if err != nil {
 			return nil, err
 		}
-		if err = decoder.Decode(c); err != nil {
+		if err = decoder.Decode(connMap); err != nil {
 			return nil, err
 		}
-		return connector, nil
+
+		return &Config{
+			Config: &pgxpool.Config{
+				ConnConfig: &pgx.ConnConfig{
+					Config: *pgconnConfig,
+				},
+			},
+		}, nil
 	}
 	return nil, database.ErrInvalidDialectConfig(input)
 }

--- a/internal/storage/v2/dialect/postgres/dialect_test.go
+++ b/internal/storage/v2/dialect/postgres/dialect_test.go
@@ -1,0 +1,56 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("connection string", func(t *testing.T) {
+		t.Parallel()
+
+		dialect, err := DecodeConfig("postgres://user:pass@localhost:5432/dbname?sslmode=disable")
+		require.NoError(t, err)
+		assert.Equal(t, "postgres", dialect.Name())
+
+		pgConfig, ok := dialect.(*Config)
+		require.True(t, ok)
+		assert.Equal(t, "localhost", pgConfig.ConnConfig.Host)
+		assert.Equal(t, uint16(5432), pgConfig.ConnConfig.Port)
+		assert.Equal(t, "dbname", pgConfig.ConnConfig.Database)
+	})
+
+	t.Run("map configuration", func(t *testing.T) {
+		t.Parallel()
+
+		dialect, err := DecodeConfig(map[string]any{
+			"ConnConfig": map[string]any{
+				"Host":     "db.example",
+				"Port":     5433,
+				"Database": "zitadel",
+				"User":     "zitadel",
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "postgres", dialect.Name())
+
+		pgConfig, ok := dialect.(*Config)
+		require.True(t, ok)
+		require.NotNil(t, pgConfig.ConnConfig)
+		assert.Equal(t, "db.example", pgConfig.ConnConfig.Host)
+		assert.Equal(t, uint16(5433), pgConfig.ConnConfig.Port)
+		assert.Equal(t, "zitadel", pgConfig.ConnConfig.Database)
+		assert.Equal(t, "zitadel", pgConfig.ConnConfig.User)
+	})
+
+	t.Run("invalid input type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := DecodeConfig(123)
+		assert.Error(t, err)
+	})
+}

--- a/internal/storage/v2/dialect/postgres/error_test.go
+++ b/internal/storage/v2/dialect/postgres/error_test.go
@@ -1,0 +1,67 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/storage/database"
+)
+
+func TestWrapError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: nil,
+		},
+		{
+			name: "no rows",
+			err:  pgx.ErrNoRows,
+			want: new(database.NoRowFoundError),
+		},
+		{
+			name: "too many rows",
+			err:  pgx.ErrTooManyRows,
+			want: new(database.MultipleRowsFoundError),
+		},
+		{
+			name: "unique violation",
+			err:  &pgconn.PgError{Code: "23505", TableName: "projects", ConstraintName: "projects_pkey"},
+			want: new(database.UniqueError),
+		},
+		{
+			name: "foreign key violation",
+			err:  &pgconn.PgError{Code: "23503", TableName: "projects", ConstraintName: "projects_fk"},
+			want: new(database.ForeignKeyError),
+		},
+		{
+			name: "unknown error",
+			err:  errors.New("driver exploded"),
+			want: new(database.UnknownError),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := wrapError(tt.err)
+			if tt.want == nil {
+				assert.NoError(t, got)
+				return
+			}
+			require.Error(t, got)
+			assert.ErrorIs(t, got, tt.want)
+		})
+	}
+}

--- a/internal/storage/v2/dialect/postgres/pattern.go
+++ b/internal/storage/v2/dialect/postgres/pattern.go
@@ -20,7 +20,7 @@ func escapeLikePattern(value string) string {
 	return b.String()
 }
 
-func likePattern(c *statementCompiler, match database.StringMatch, value string) {
+func compileLikePattern(c *statementCompiler, match database.StringMatch, value string) {
 	escaped := escapeLikePattern(value)
 	switch match {
 	case database.StringMatchStartsWith:

--- a/internal/storage/v2/dialect/postgres/pattern.go
+++ b/internal/storage/v2/dialect/postgres/pattern.go
@@ -20,17 +20,21 @@ func escapeLikePattern(value string) string {
 	return b.String()
 }
 
-func likePattern(match database.StringMatch, value string) string {
+func likePattern(c *statementCompiler, match database.StringMatch, value string) {
 	escaped := escapeLikePattern(value)
 	switch match {
 	case database.StringMatchStartsWith:
-		return escaped + "%"
+		writeArg(c, escaped)
+		c.WriteString(" || '%'")
 	case database.StringMatchContains:
-		return "%" + escaped + "%"
+		c.WriteString("'%' || ")
+		writeArg(c, escaped)
+		c.WriteString(" || '%'")
 	case database.StringMatchEndsWith:
-		return "%" + escaped
+		c.WriteString("'%' || ")
+		writeArg(c, escaped)
 	case database.StringMatchEqual:
-		return escaped
+		writeArg(c, escaped)
 	default:
 		panic("unknown string match")
 	}

--- a/internal/storage/v2/dialect/postgres/pattern_test.go
+++ b/internal/storage/v2/dialect/postgres/pattern_test.go
@@ -19,9 +19,30 @@ func TestEscapeLikePattern(t *testing.T) {
 func TestLikePattern(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, `acme%`, likePattern(database.StringMatchStartsWith, "acme"))
-	assert.Equal(t, `%login%`, likePattern(database.StringMatchContains, "login"))
-	assert.Equal(t, `%suffix`, likePattern(database.StringMatchEndsWith, "suffix"))
-	assert.Equal(t, `exact`, likePattern(database.StringMatchEqual, "exact"))
-	assert.Equal(t, `%100\%%`, likePattern(database.StringMatchContains, "100%"))
+	var c statementCompiler
+
+	c.Reset()
+	likePattern(&c, database.StringMatchStartsWith, "acme")
+	assert.Equal(t, `$1 || '%'`, c.String())
+	assert.ElementsMatch(t, c.args, []any{"acme"})
+
+	c.Reset()
+	likePattern(&c, database.StringMatchContains, "login")
+	assert.Equal(t, `'%' || $1 || '%'`, c.String())
+	assert.ElementsMatch(t, c.args, []any{"login"})
+
+	c.Reset()
+	likePattern(&c, database.StringMatchEndsWith, "suffix")
+	assert.Equal(t, `'%' || $1`, c.String())
+	assert.ElementsMatch(t, c.args, []any{"suffix"})
+
+	c.Reset()
+	likePattern(&c, database.StringMatchEqual, "exact")
+	assert.Equal(t, `$1`, c.String())
+	assert.ElementsMatch(t, c.args, []any{"exact"})
+
+	c.Reset()
+	likePattern(&c, database.StringMatchContains, "100%")
+	assert.Equal(t, `'%' || $1 || '%'`, c.String())
+	assert.ElementsMatch(t, c.args, []any{"100\\%"})
 }

--- a/internal/storage/v2/dialect/postgres/pattern_test.go
+++ b/internal/storage/v2/dialect/postgres/pattern_test.go
@@ -22,5 +22,6 @@ func TestLikePattern(t *testing.T) {
 	assert.Equal(t, `acme%`, likePattern(database.StringMatchStartsWith, "acme"))
 	assert.Equal(t, `%login%`, likePattern(database.StringMatchContains, "login"))
 	assert.Equal(t, `%suffix`, likePattern(database.StringMatchEndsWith, "suffix"))
+	assert.Equal(t, `exact`, likePattern(database.StringMatchEqual, "exact"))
 	assert.Equal(t, `%100\%%`, likePattern(database.StringMatchContains, "100%"))
 }

--- a/internal/storage/v2/dialect/postgres/pattern_test.go
+++ b/internal/storage/v2/dialect/postgres/pattern_test.go
@@ -16,33 +16,33 @@ func TestEscapeLikePattern(t *testing.T) {
 	assert.Equal(t, `\\path`, escapeLikePattern(`\path`))
 }
 
-func TestLikePattern(t *testing.T) {
+func TestCompileLikePattern(t *testing.T) {
 	t.Parallel()
 
 	var c statementCompiler
 
 	c.Reset()
-	likePattern(&c, database.StringMatchStartsWith, "acme")
+	compileLikePattern(&c, database.StringMatchStartsWith, "acme")
 	assert.Equal(t, `$1 || '%'`, c.String())
 	assert.ElementsMatch(t, c.args, []any{"acme"})
 
 	c.Reset()
-	likePattern(&c, database.StringMatchContains, "login")
+	compileLikePattern(&c, database.StringMatchContains, "login")
 	assert.Equal(t, `'%' || $1 || '%'`, c.String())
 	assert.ElementsMatch(t, c.args, []any{"login"})
 
 	c.Reset()
-	likePattern(&c, database.StringMatchEndsWith, "suffix")
+	compileLikePattern(&c, database.StringMatchEndsWith, "suffix")
 	assert.Equal(t, `'%' || $1`, c.String())
 	assert.ElementsMatch(t, c.args, []any{"suffix"})
 
 	c.Reset()
-	likePattern(&c, database.StringMatchEqual, "exact")
+	compileLikePattern(&c, database.StringMatchEqual, "exact")
 	assert.Equal(t, `$1`, c.String())
 	assert.ElementsMatch(t, c.args, []any{"exact"})
 
 	c.Reset()
-	likePattern(&c, database.StringMatchContains, "100%")
+	compileLikePattern(&c, database.StringMatchContains, "100%")
 	assert.Equal(t, `'%' || $1 || '%'`, c.String())
 	assert.ElementsMatch(t, c.args, []any{"100\\%"})
 }

--- a/internal/storage/v2/dialect/spanner/dialect.go
+++ b/internal/storage/v2/dialect/spanner/dialect.go
@@ -7,6 +7,10 @@ import (
 	"github.com/zitadel/nextgen/internal/storage/v2/database"
 )
 
+func init() {
+	database.MustRegisterDialect("spanner", DecodeConfig)
+}
+
 type Dialect struct {
 	// Database is the Spanner database string, in the format "projects/{project}/instances/{instance}/databases/{database}".
 	Database string
@@ -27,3 +31,13 @@ func (d *Dialect) Name() string {
 }
 
 var _ database.Dialect = (*Dialect)(nil)
+
+// DecodeConfig parses a Spanner database DSN string.
+// Expected format: projects/<project>/instances/<instance>/databases/<database>
+func DecodeConfig(input any) (database.Dialect, error) {
+	dsn, ok := input.(string)
+	if !ok {
+		return nil, database.ErrInvalidDialectConfig(input)
+	}
+	return &Dialect{Database: dsn}, nil
+}

--- a/internal/storage/v2/dialect/spanner/dialect_test.go
+++ b/internal/storage/v2/dialect/spanner/dialect_test.go
@@ -1,0 +1,44 @@
+package spanner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/storage/v2/database"
+)
+
+func TestDecodeConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid DSN string", func(t *testing.T) {
+		t.Parallel()
+
+		dialect, err := DecodeConfig("projects/p/instances/i/databases/d")
+		require.NoError(t, err)
+		assert.Equal(t, "spanner", dialect.Name())
+
+		spannerDialect, ok := dialect.(*Dialect)
+		require.True(t, ok)
+		assert.Equal(t, "projects/p/instances/i/databases/d", spannerDialect.Database)
+	})
+
+	t.Run("invalid input type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := DecodeConfig(123)
+		assert.Error(t, err)
+	})
+}
+
+func TestConfigBuildSpanner(t *testing.T) {
+	t.Parallel()
+
+	dialect, err := database.Config{
+		Raw: map[string]any{
+			"spanner": "projects/p/instances/i/databases/d",
+		},
+	}.Build()
+	require.NoError(t, err)
+	assert.Equal(t, "spanner", dialect.Name())
+}

--- a/internal/storage/v2/dialect/spanner/statement.go
+++ b/internal/storage/v2/dialect/spanner/statement.go
@@ -2,7 +2,7 @@ package spanner
 
 import "github.com/zitadel/nextgen/internal/service"
 
-type queryExecutor interface{}
+type queryExecutor any
 
 type statements struct {
 	projectStatements


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the remaining open review feedback on #315 from IAM-marco and Copilot:

- **compileRead correctness:** cursor predicates are merged into a local filter copy so reused `*ListOptions` do not accumulate WHERE clauses across pages.
- **Spanner startup regression:** register v2 `spanner` dialect decoding so `v2db.Config.Build()` succeeds for Spanner configs.
- **Postgres map decode:** fix `DecodeConfig` map parsing by decoding into `pgconn.Config` (embedded in `pgx.ConnConfig`).
- **Filter docs/tests:** clarify tuple comparison helpers (`CompareGreater` / `CompareLess`) and add a 3-term `Restricts()` test.
- **Test coverage:** add postgres `DecodeConfig` + `wrapError` tests, spanner dialect tests, `StringMatchEqual` pattern case, and `t.Parallel()` across v2 database/pagination tests.
- **Compiler tests:** comprehensive coverage for all `compile*` functions in postgres `compiler.go` (read/filter/and/or/compare/string/order/limit paths, cursor error cases, LIKE concat patterns).
- **Cleanup:** remove unused `writeArgs`; use `any` for spanner `queryExecutor`.

Copilot fixes already on `new-repo` (`IsStatements` no-op, `GetProjectByID` error wrapping, transaction callback handling) are unchanged.

## Validation

```sh
go test ./internal/storage/v2/...
go test ./internal/storage/v2/dialect/postgres/... -run Compile -v
```

## Release notes / changeset

No changeset — internal Go storage work with no published npm surface impact.

## Notes

- Skipped replacing `golang.org/x/exp/constraints` per plan decision.
- This PR targets `new-repo` so it can land into #315.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e87f1218-a40c-410d-ac16-2f273488dbc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e87f1218-a40c-410d-ac16-2f273488dbc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

