### PR TITLE
fix: user_schema is an opaque server-assigned id, not a URI

### DIFF
--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -6313,7 +6313,7 @@ func (s *FlowDefinition) encodeFields(e *jx.Encoder) {
 	}
 	{
 		e.FieldStart("user_schema")
-		json.EncodeURI(e, s.UserSchema)
+		e.Str(s.UserSchema)
 	}
 	{
 		e.FieldStart("purposes")
@@ -6378,8 +6378,8 @@ func (s *FlowDefinition) Decode(d *jx.Decoder) error {
 		case "user_schema":
 			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
-				v, err := json.DecodeURI(d)
-				s.UserSchema = v
+				v, err := d.Str()
+				s.UserSchema = string(v)
 				if err != nil {
 					return err
 				}

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -2773,10 +2773,13 @@ type FlowDefinition struct {
 	// reference. Acts as the human display label as well; no separate slug.
 	Name   string               `json:"name"`
 	Status FlowDefinitionStatus `json:"status"`
-	// User schema this flow operates on. Step `fields` reference properties
-	// defined in this schema. The engine resolves field types, validation,
-	// and implicit outcomes from schema annotations at runtime.
-	UserSchema url.URL `json:"user_schema"`
+	// Server-assigned identifier of the user schema this flow operates on,
+	// as returned by `POST /schemas`. Opaque to the client — the shape is a
+	// server implementation detail (URL-shaped today, ULID-shaped in some
+	// deployments). Step `fields` reference properties defined in the
+	// resolved schema; the engine resolves field types, validation, and
+	// implicit outcomes from schema annotations at runtime.
+	UserSchema string `json:"user_schema"`
 	// Maps each purpose this definition handles to its entry-point step.
 	// Keys are purpose names; values must match a `name` in `steps`. A
 	// definition can serve multiple purposes (e.g. a combined login/register
@@ -2799,7 +2802,7 @@ func (s *FlowDefinition) GetStatus() FlowDefinitionStatus {
 }
 
 // GetUserSchema returns the value of UserSchema.
-func (s *FlowDefinition) GetUserSchema() url.URL {
+func (s *FlowDefinition) GetUserSchema() string {
 	return s.UserSchema
 }
 
@@ -2829,7 +2832,7 @@ func (s *FlowDefinition) SetStatus(val FlowDefinitionStatus) {
 }
 
 // SetUserSchema sets the value of UserSchema.
-func (s *FlowDefinition) SetUserSchema(val url.URL) {
+func (s *FlowDefinition) SetUserSchema(val string) {
 	s.UserSchema = val
 }
 

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -2775,9 +2775,8 @@ type FlowDefinition struct {
 	Status FlowDefinitionStatus `json:"status"`
 	// Server-assigned identifier of the user schema this flow operates on,
 	// as returned by `POST /schemas`. Opaque to the client — the shape is a
-	// server implementation detail (URL-shaped today, ULID-shaped in some
-	// deployments). Step `fields` reference properties defined in the
-	// resolved schema; the engine resolves field types, validation, and
+	// server implementation detail. Step `fields` reference properties
+	// defined in the resolved schema; the engine resolves field types, validation, and
 	// implicit outcomes from schema annotations at runtime.
 	UserSchema string `json:"user_schema"`
 	// Maps each purpose this definition handles to its entry-point step.

--- a/api/openapi/components/flows/flow-definition.yaml
+++ b/api/openapi/components/flows/flow-definition.yaml
@@ -25,12 +25,14 @@ properties:
 
   user_schema:
     type: string
-    format: uri
     description: |
-      User schema this flow operates on. Step `fields` reference properties
-      defined in this schema. The engine resolves field types, validation,
-      and implicit outcomes from schema annotations at runtime.
-    example: https://raw.githubusercontent.com/zitadel/nextgen/refs/heads/main/api/openapi/endpoints/schemas/human-user.yaml
+      Server-assigned identifier of the user schema this flow operates on,
+      as returned by `POST /schemas`. Opaque to the client — the shape is a
+      server implementation detail (URL-shaped today, ULID-shaped in some
+      deployments). Step `fields` reference properties defined in the
+      resolved schema; the engine resolves field types, validation, and
+      implicit outcomes from schema annotations at runtime.
+    example: sch_01KWHF18816ZQESRCS7Z2STJ05
 
   purposes:
     type: object

--- a/api/openapi/components/flows/flow-definition.yaml
+++ b/api/openapi/components/flows/flow-definition.yaml
@@ -28,9 +28,8 @@ properties:
     description: |
       Server-assigned identifier of the user schema this flow operates on,
       as returned by `POST /schemas`. Opaque to the client — the shape is a
-      server implementation detail (URL-shaped today, ULID-shaped in some
-      deployments). Step `fields` reference properties defined in the
-      resolved schema; the engine resolves field types, validation, and
+      server implementation detail. Step `fields` reference properties
+      defined in the resolved schema; the engine resolves field types, validation, and
       implicit outcomes from schema annotations at runtime.
     example: sch_01KWHF18816ZQESRCS7Z2STJ05
 

--- a/api/openapi/endpoints/flow_definitions/embed.go
+++ b/api/openapi/endpoints/flow_definitions/embed.go
@@ -56,7 +56,7 @@ func DefaultLoginFlowDefinitions(serverURL string, projectID string, userSchemaU
 			projectID,
 			req.FlowDefinition.GetName(),
 			new(url.URL(req.GetSchemaURI().Value)).String(),
-			new(req.FlowDefinition.GetUserSchema()).String(),
+			req.FlowDefinition.GetUserSchema(),
 			purposes,
 			domain.FlowDefinitionAudience{
 				AppIDs:  req.FlowDefinition.GetAudience().Value.AppIds,

--- a/api/openapi/endpoints/flow_definitions/examples_test.go
+++ b/api/openapi/endpoints/flow_definitions/examples_test.go
@@ -100,7 +100,7 @@ func TestExampleFlowDefinitions(t *testing.T) {
 				projectID,
 				req.FlowDefinition.GetName(),
 				schemaURI.String(),
-				userSchemaRef.String(),
+				userSchemaRef,
 				purposes,
 				domain.FlowDefinitionAudience{
 					AppIDs:  req.FlowDefinition.GetAudience().Value.AppIds,

--- a/api/openapi/endpoints/schemas/flow-definition.json
+++ b/api/openapi/endpoints/schemas/flow-definition.json
@@ -22,11 +22,10 @@
     },
     "user_schema": {
       "type": "string",
-      "format": "uri",
       "examples": [
-        "https://raw.githubusercontent.com/zitadel/nextgen/refs/heads/main/api/openapi/endpoints/schemas/human-user.yaml"
+        "sch_01KWHF18816ZQESRCS7Z2STJ05"
       ],
-      "description": "URL of the user schema this flow operates on. Step `fields` reference property names defined in that schema; the engine resolves field type, validation, and implicit transition outcomes from the schema's `x-*` annotations at runtime. URLs follow the same publishing convention as this document."
+      "description": "Server-assigned identifier of the user schema this flow operates on, as returned by `POST /schemas`. Opaque to the client — the shape is a server implementation detail. Step `fields` reference property names defined in that schema; the engine resolves field type, validation, and implicit transition outcomes from the schema's `x-*` annotations at runtime."
     },
     "purposes": {
       "type": "object",

--- a/internal/api/flow_definition.go
+++ b/internal/api/flow_definition.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/muhlemmer/gu"
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
@@ -91,11 +90,10 @@ func mapUpdateRequestToService(params api.UpdateFlowDefinitionParams, req *api.F
 }
 
 func mapFlowDefinitionRequestToService(projectID string, schemaURI api.OptSchemaURI, definition api.FlowDefinition, status string) (service.FlowDefinitionRequest, error) {
-	userSchemaURI := definition.GetUserSchema()
 	svcReq := service.FlowDefinitionRequest{
 		ProjectID:     projectID,
 		Name:          definition.GetName(),
-		UserSchema:    userSchemaURI.String(),
+		UserSchema:    definition.GetUserSchema(),
 		Status:        status,
 		SchemaVersion: "1.0.0", // todo (grvijayan): find a way to set this based on the schema URI or the request (currently not set in the request)
 	}
@@ -265,8 +263,6 @@ func flowDefinitionDetailResponse(flowDefinition *domain.FlowDefinition) *api.Fl
 	}
 	steps := mapDomainStepsToAPI(flowDefinition.Steps)
 
-	userSchemaURI, _ := url.Parse(flowDefinition.UserSchema)
-
 	return &api.FlowDefinitionDetailResponse{
 		ID:        flowDefinition.ID,
 		ProjectID: flowDefinition.ProjectID,
@@ -276,7 +272,7 @@ func flowDefinitionDetailResponse(flowDefinition *domain.FlowDefinition) *api.Fl
 			Steps:      steps,
 			Purposes:   purposes,
 			Audience:   audience,
-			UserSchema: gu.Value(userSchemaURI),
+			UserSchema: flowDefinition.UserSchema,
 		},
 		CreatedAt: flowDefinition.CreatedAt,
 		UpdatedAt: flowDefinition.UpdatedAt,


### PR DESCRIPTION
Drop `format: uri` from the flow-definition's `user_schema`. The value is whatever id the server allocates on `POST /schemas`.

Relates to #458.