### PR TITLE
ci: add diagnostics summaries

### DIFF
--- a/.github/workflows/ci-summary-comment.yml
+++ b/.github/workflows/ci-summary-comment.yml
@@ -1,0 +1,36 @@
+name: ci-summary-comment
+
+on:
+  workflow_run:
+    workflows:
+      - ci
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  pr-comment:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download CI diagnostics
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: ci-diagnostics
+          path: ci-diagnostics
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Comment on PR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/comment-ci-summary.mjs --summary ci-diagnostics/pr-comment.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
   full-pr:
     runs-on: depot-ubuntu-24.04-16
     timeout-minutes: 120
+    env:
+      CI_DIAGNOSTICS_DIR: ${{ runner.temp }}/ci-diagnostics
     steps:
       - uses: actions/checkout@v6
         with:
@@ -38,27 +40,27 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: corepack pnpm install --frozen-lockfile
+        run: node scripts/ci-run.mjs --id install --name "Install dependencies" --rerun "corepack pnpm install --frozen-lockfile" -- corepack pnpm install --frozen-lockfile
 
       - name: Detect CI mode
         id: ci-mode
-        run: node scripts/ci-mode.mjs "${{ github.event.pull_request.base.sha || 'origin/main' }}"
+        run: node scripts/ci-run.mjs --id ci-mode --name "Detect CI mode" --rerun "node scripts/ci-mode.mjs origin/main" -- node scripts/ci-mode.mjs "${{ github.event.pull_request.base.sha || 'origin/main' }}"
 
       - name: Check Go generated files
         if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: moon run server:check-generate
+        run: node scripts/ci-run.mjs --id go-generate --name "Check Go generated files" --rerun "moon run server:check-generate" -- moon run --summary detailed server:check-generate
 
       - name: Run Moon build and test graph
         if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: moon ci :lint :typecheck :build :test
+        run: node scripts/ci-run.mjs --id moon-graph --name "Run Moon build and test graph" --rerun "moon ci :lint :typecheck :build :test" -- moon ci --summary detailed :lint :typecheck :build :test
 
       - name: Run Go tests
         if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: moon run server:test
+        run: node scripts/ci-run.mjs --id go-test --name "Run Go tests" --rerun "moon run server:test" -- moon run --summary detailed server:test
 
       - name: Run Go integration tests (postgres)
         if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: moon run server:test-postgres
+        run: node scripts/ci-run.mjs --id go-postgres --name "Run Go integration tests (postgres)" --rerun "moon run server:test-postgres" -- moon run --summary detailed server:test-postgres
 
       # Spanner integration tests are not run in CI yet: the v2 spanner statement
       # layer is unimplemented (see zitadel/nextgen#457). Re-enable via
@@ -66,31 +68,58 @@ jobs:
 
       - name: Build release snapshot without container
         if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: env -u CI -u GITHUB_ACTIONS moon run release:snapshot -- --skip-container
+        run: node scripts/ci-run.mjs --id release-snapshot --name "Build release snapshot without container" --rerun "moon run release:snapshot -- --skip-container" -- env -u CI -u GITHUB_ACTIONS moon run --summary detailed release:snapshot -- --skip-container
 
       - name: Run binary fresh-app journey
         if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: |
-          version="$(node -p "require('./apps/server/package.json').version")"
-          env -u CI -u GITHUB_ACTIONS moon run cli-journey-e2e:e2e-local -- \
-            --runtime binary \
-            --concurrency 5 \
-            --work-dir "${RUNNER_TEMP}/ci-journey" \
-            --tarballs-dir "dist/release/${version}/npm"
+        run: >
+          node scripts/ci-run.mjs
+          --id journey
+          --name "Run binary fresh-app journey"
+          --rerun "moon run cli-journey-e2e:e2e-local -- --runtime binary --concurrency 5 --work-dir <tmp>/ci-journey --tarballs-dir dist/release/<version>/npm"
+          --
+          bash -euo pipefail -c
+          'version="$(node -p "require(\"./apps/server/package.json\").version")";
+          env -u CI -u GITHUB_ACTIONS moon run --summary detailed cli-journey-e2e:e2e-local --
+          --runtime binary
+          --concurrency 5
+          --work-dir "${RUNNER_TEMP}/ci-journey"
+          --tarballs-dir "dist/release/${version}/npm"'
 
       - name: Validate version PR
         if: ${{ steps.ci-mode.outputs.mode == 'version-only' }}
-        run: env -u CI -u GITHUB_ACTIONS moon run release:version
+        run: node scripts/ci-run.mjs --id release-version --name "Validate version PR" --rerun "moon run release:version" -- env -u CI -u GITHUB_ACTIONS moon run --summary detailed release:version
 
       - name: Pack version PR artifacts
         if: ${{ steps.ci-mode.outputs.mode == 'version-only' }}
-        run: env -u CI -u GITHUB_ACTIONS moon run release:pack
+        run: node scripts/ci-run.mjs --id release-pack --name "Pack version PR artifacts" --rerun "moon run release:pack" -- env -u CI -u GITHUB_ACTIONS moon run --summary detailed release:pack
 
       - name: Verify version PR tarballs
         if: ${{ steps.ci-mode.outputs.mode == 'version-only' }}
-        run: |
-          version="$(node -p "require('./apps/server/package.json').version")"
-          node apps/cli-journey-e2e/scripts/verify-tarballs.mjs "dist/release/${version}/npm"
+        run: >
+          node scripts/ci-run.mjs
+          --id verify-version-tarballs
+          --name "Verify version PR tarballs"
+          --rerun "node apps/cli-journey-e2e/scripts/verify-tarballs.mjs dist/release/<version>/npm"
+          --
+          bash -euo pipefail -c
+          'version="$(node -p "require(\"./apps/server/package.json\").version")";
+          node apps/cli-journey-e2e/scripts/verify-tarballs.mjs "dist/release/${version}/npm"'
+
+      - name: Write CI diagnostics summary
+        if: ${{ always() }}
+        env:
+          CI_MODE: ${{ steps.ci-mode.outputs.mode || 'unknown' }}
+        run: node scripts/ci-summary.mjs --artifact-name ci-diagnostics
+
+      - name: Upload CI diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-diagnostics
+          path: ${{ runner.temp }}/ci-diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload release snapshot
         if: ${{ always() }}

--- a/scripts/ci-run.mjs
+++ b/scripts/ci-run.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+import { createWriteStream } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+
+import { formatCommand, forwardedArgs } from "./dev-process.mjs";
+
+const args = forwardedArgs();
+const separator = args.indexOf("--");
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+}
+
+if (separator === -1 || separator === args.length - 1) {
+  usage("missing command after --");
+}
+
+const options = parseOptions(args.slice(0, separator));
+const command = args[separator + 1];
+const commandArgs = args.slice(separator + 2);
+const diagnosticsDir = process.env.CI_DIAGNOSTICS_DIR || join(process.cwd(), "dist", "ci-diagnostics");
+const logFile = `logs/${options.id}.log`;
+const stepFile = join(diagnosticsDir, "steps", `${options.id}.json`);
+const startedAt = new Date();
+
+await mkdir(join(diagnosticsDir, "logs"), { recursive: true });
+await mkdir(join(diagnosticsDir, "steps"), { recursive: true });
+
+const result = await runAndTee({
+  command,
+  args: commandArgs,
+  logPath: join(diagnosticsDir, logFile),
+});
+const finishedAt = new Date();
+const status = result.code === 0 && !result.signal && !result.error ? "passed" : "failed";
+
+await writeFile(
+  stepFile,
+  `${JSON.stringify(
+    {
+      id: options.id,
+      name: options.name,
+      command: formatCommand(command, commandArgs),
+      rerun: options.rerun || formatCommand(command, commandArgs),
+      status,
+      exitCode: result.code,
+      signal: result.signal,
+      error: result.error?.message,
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      durationMs: finishedAt.getTime() - startedAt.getTime(),
+      logFile,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+if (result.error) {
+  console.error(result.error.message);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+} else {
+  process.exit(result.code ?? (result.error ? 1 : 0));
+}
+
+function parseOptions(values) {
+  const parsed = { id: "", name: "", rerun: "" };
+  for (let index = 0; index < values.length; index += 1) {
+    const arg = values[index];
+    switch (arg) {
+      case "--id":
+        parsed.id = values[++index] ?? "";
+        break;
+      case "--name":
+        parsed.name = values[++index] ?? "";
+        break;
+      case "--rerun":
+        parsed.rerun = values[++index] ?? "";
+        break;
+      default:
+        usage(`unknown option: ${arg}`);
+    }
+  }
+
+  if (!parsed.id) {
+    usage("--id is required");
+  }
+  if (!/^[A-Za-z0-9_.-]+$/.test(parsed.id)) {
+    usage("--id may only contain letters, numbers, underscore, dot, and dash");
+  }
+  if (!parsed.name) {
+    parsed.name = parsed.id;
+  }
+  return parsed;
+}
+
+function runAndTee(input) {
+  return new Promise((resolve) => {
+    const log = createWriteStream(input.logPath, { flags: "a" });
+    const child = spawn(input.command, input.args, {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const signals = ["SIGINT", "SIGTERM"];
+    const handlers = signals.map((signal) => {
+      const handler = () => {
+        if (child.exitCode === null && !child.killed) {
+          child.kill(signal);
+        }
+      };
+      process.once(signal, handler);
+      return [signal, handler];
+    });
+
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      for (const [signal, handler] of handlers) {
+        process.off(signal, handler);
+      }
+      log.end(() => resolve(result));
+    };
+
+    child.stdout.on("data", (chunk) => {
+      process.stdout.write(chunk);
+      log.write(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      process.stderr.write(chunk);
+      log.write(chunk);
+    });
+    child.on("error", (error) => {
+      log.write(`${error.message}\n`);
+      finish({ code: 1, signal: null, error });
+    });
+    child.on("close", (code, signal) => {
+      finish({ code, signal, error: null });
+    });
+  });
+}
+
+function usage(error) {
+  if (error) {
+    console.error(error);
+    console.error("");
+  }
+  console.log(`usage: node scripts/ci-run.mjs --id <id> [--name <label>] [--rerun <command>] -- <command> [args...]
+
+Runs a CI phase, tees output into CI_DIAGNOSTICS_DIR/logs/<id>.log, and writes
+structured step metadata for the final CI diagnostics summary.`);
+  process.exit(error ? 1 : 0);
+}

--- a/scripts/ci-summary.mjs
+++ b/scripts/ci-summary.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+import { appendFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { forwardedArgs } from "./dev-process.mjs";
+
+const options = parseArgs(forwardedArgs());
+const diagnosticsDir = process.env.CI_DIAGNOSTICS_DIR || join(process.cwd(), "dist", "ci-diagnostics");
+const artifactName = options.artifactName || "ci-diagnostics";
+const runUrl = options.runUrl || defaultRunUrl();
+const mode = process.env.CI_MODE || "unknown";
+const steps = await readSteps(diagnosticsDir);
+const status = overallStatus(steps);
+const failed = steps.filter((step) => step.status !== "passed");
+const summary = await renderSummary({ artifactName, diagnosticsDir, failed, mode, runUrl, status, steps });
+const prComment = renderPrComment({ artifactName, failed, mode, runUrl, status, steps });
+
+await mkdir(diagnosticsDir, { recursive: true });
+await writeFile(join(diagnosticsDir, "summary.md"), summary);
+await writeFile(join(diagnosticsDir, "pr-comment.md"), prComment);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, summary);
+} else {
+  console.log(summary);
+}
+
+function parseArgs(args) {
+  const parsed = { artifactName: "", runUrl: "" };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--artifact-name":
+        parsed.artifactName = args[++index] ?? "";
+        break;
+      case "--run-url":
+        parsed.runUrl = args[++index] ?? "";
+        break;
+      case "--help":
+      case "-h":
+        usage();
+        break;
+      default:
+        usage(`unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+async function readSteps(root) {
+  const dir = join(root, "steps");
+  let files;
+  try {
+    files = await readdir(dir);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+
+  const steps = [];
+  for (const file of files.filter((entry) => entry.endsWith(".json")).sort()) {
+    try {
+      steps.push(JSON.parse(await readFile(join(dir, file), "utf8")));
+    } catch (error) {
+      steps.push({
+        id: file.replace(/\.json$/, ""),
+        name: file,
+        status: "failed",
+        durationMs: 0,
+        rerun: "",
+        error: `could not read step metadata: ${error.message}`,
+      });
+    }
+  }
+  return steps.sort((left, right) => String(left.startedAt || "").localeCompare(String(right.startedAt || "")));
+}
+
+async function renderSummary(input) {
+  const lines = [
+    "# CI diagnostics",
+    "",
+    `Status: ${input.status}`,
+    `Mode: ${input.mode}`,
+    `Diagnostics artifact: \`${input.artifactName}\``,
+    "",
+    "## Steps",
+    "",
+  ];
+  if (input.runUrl) {
+    lines.splice(4, 0, `Run: [${input.runUrl}](${input.runUrl})`);
+  }
+
+  if (input.steps.length === 0) {
+    lines.push("No instrumented CI steps wrote diagnostics.", "");
+  } else {
+    lines.push("| Step | Status | Duration | Rerun |", "| --- | --- | ---: | --- |");
+    for (const step of input.steps) {
+      lines.push(
+        `| ${escapeTable(step.name || step.id)} | ${escapeTable(step.status || "unknown")} | ${formatDuration(step.durationMs)} | ${inlineCode(step.rerun || step.command || "")} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  if (input.failed.length > 0) {
+    lines.push("## Failed step logs", "");
+    for (const step of input.failed) {
+      lines.push(`### ${step.name || step.id}`, "");
+      if (step.error) {
+        lines.push(`Error: ${inlineCode(step.error)}`, "");
+      }
+      if (step.rerun) {
+        lines.push(`Rerun: ${inlineCode(step.rerun)}`, "");
+      }
+      const tail = await readLogTail(join(input.diagnosticsDir, step.logFile || ""), 120);
+      if (tail) {
+        lines.push("```text", tail, "```", "");
+      } else {
+        lines.push("No log output was captured for this step.", "");
+      }
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function renderPrComment(input) {
+  const firstFailed = input.failed[0];
+  const lines = [
+    "<!-- zitadel-ci-diagnostics -->",
+    "### CI diagnostics",
+    "",
+    `Status: ${input.status}`,
+    `Mode: ${input.mode}`,
+    `Diagnostics artifact: \`${input.artifactName}\``,
+    "",
+  ];
+  if (input.runUrl) {
+    lines.splice(5, 0, `Run: [open workflow run](${input.runUrl})`);
+  }
+
+  if (firstFailed) {
+    lines.push(`First failing step: \`${firstFailed.name || firstFailed.id}\``);
+    if (firstFailed.rerun) {
+      lines.push(`Rerun locally: ${inlineCode(firstFailed.rerun)}`);
+    }
+    lines.push("");
+  }
+
+  if (input.steps.length > 0) {
+    lines.push("| Step | Status | Rerun |", "| --- | --- | --- |");
+    for (const step of input.steps) {
+      lines.push(
+        `| ${escapeTable(step.name || step.id)} | ${escapeTable(step.status || "unknown")} | ${inlineCode(step.rerun || step.command || "")} |`,
+      );
+    }
+    lines.push("");
+  } else {
+    lines.push("No instrumented CI steps wrote diagnostics.", "");
+  }
+
+  lines.push("Full logs are in the CI diagnostics artifact and the workflow run summary.");
+  return `${lines.join("\n")}\n`;
+}
+
+async function readLogTail(path, maxLines) {
+  if (!path) return "";
+  try {
+    const text = await readFile(path, "utf8");
+    return text.split(/\r?\n/).slice(-maxLines).join("\n").trimEnd();
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+
+function overallStatus(steps) {
+  if (steps.length === 0) {
+    return "unknown";
+  }
+  return steps.some((step) => step.status !== "passed") ? "failed" : "passed";
+}
+
+function formatDuration(value) {
+  const ms = Number(value) || 0;
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function inlineCode(value) {
+  const text = String(value || "");
+  if (!text) return "";
+  return `\`${text.replaceAll("`", "\\`")}\``;
+}
+
+function escapeTable(value) {
+  return String(value ?? "").replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function defaultRunUrl() {
+  const server = process.env.GITHUB_SERVER_URL;
+  const repo = process.env.GITHUB_REPOSITORY;
+  const runId = process.env.GITHUB_RUN_ID;
+  return server && repo && runId ? `${server}/${repo}/actions/runs/${runId}` : "";
+}
+
+function usage(error) {
+  if (error) {
+    console.error(error);
+    console.error("");
+  }
+  console.log(`usage: node scripts/ci-summary.mjs [--artifact-name <name>] [--run-url <url>]
+
+Reads CI_DIAGNOSTICS_DIR/steps/*.json and writes summary.md plus pr-comment.md.`);
+  process.exit(error ? 1 : 0);
+}

--- a/scripts/comment-ci-summary.mjs
+++ b/scripts/comment-ci-summary.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+
+import { forwardedArgs } from "./dev-process.mjs";
+
+const MARKER = "<!-- zitadel-ci-diagnostics -->";
+const MAX_COMMENT_LENGTH = 60_000;
+
+const options = parseArgs(forwardedArgs());
+const event = JSON.parse(await readFile(process.env.GITHUB_EVENT_PATH, "utf8"));
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.GITHUB_REPOSITORY || event.repository?.full_name;
+const run = event.workflow_run;
+const pr = run?.pull_requests?.[0];
+
+if (!token) {
+  throw new Error("GITHUB_TOKEN is required");
+}
+if (!repo) {
+  throw new Error("GITHUB_REPOSITORY is required");
+}
+if (!run || run.event !== "pull_request" || !pr?.number) {
+  console.log("No pull request workflow run found; skipping CI diagnostics comment.");
+  process.exit(0);
+}
+
+const headRepo = run.head_repository?.full_name || pr.head?.repo?.full_name || "";
+if (headRepo !== repo) {
+  console.log(`Skipping CI diagnostics comment for untrusted head repository: ${headRepo || "unknown"}`);
+  process.exit(0);
+}
+
+const body = await commentBody({ pr, run, summaryPath: options.summaryPath });
+await upsertComment({ body, prNumber: pr.number, repo, token });
+console.log(`Updated CI diagnostics comment on PR #${pr.number}.`);
+
+function parseArgs(args) {
+  const parsed = { summaryPath: "ci-diagnostics/pr-comment.md" };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--summary":
+        parsed.summaryPath = args[++index] ?? "";
+        if (!parsed.summaryPath) usage("--summary requires a path");
+        break;
+      case "--help":
+      case "-h":
+        usage();
+        break;
+      default:
+        usage(`unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+async function commentBody(input) {
+  let summary;
+  try {
+    summary = await readFile(input.summaryPath, "utf8");
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+    summary = fallbackSummary(input.run);
+  }
+
+  const withMarker = summary.includes(MARKER) ? summary : `${MARKER}\n${summary}`;
+  if (withMarker.length <= MAX_COMMENT_LENGTH) {
+    return withMarker;
+  }
+  return `${withMarker.slice(0, MAX_COMMENT_LENGTH - 200)}\n\n...truncated. Open the workflow run for the full summary.\n`;
+}
+
+function fallbackSummary(run) {
+  return `${MARKER}
+### CI diagnostics
+
+Status: ${run.conclusion || "unknown"}
+Run: [open workflow run](${run.html_url})
+
+No diagnostics artifact was available. Open the workflow run for logs.
+`;
+}
+
+async function upsertComment(input) {
+  const comments = await githubJson({
+    method: "GET",
+    path: `/repos/${input.repo}/issues/${input.prNumber}/comments?per_page=100`,
+    token: input.token,
+  });
+  const existing = comments.find((comment) => comment.body?.includes(MARKER));
+  if (existing) {
+    await githubJson({
+      method: "PATCH",
+      path: `/repos/${input.repo}/issues/comments/${existing.id}`,
+      token: input.token,
+      body: { body: input.body },
+    });
+    return;
+  }
+  await githubJson({
+    method: "POST",
+    path: `/repos/${input.repo}/issues/${input.prNumber}/comments`,
+    token: input.token,
+    body: { body: input.body },
+  });
+}
+
+async function githubJson(input) {
+  const response = await fetch(`https://api.github.com${input.path}`, {
+    method: input.method,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${input.token}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: input.body ? JSON.stringify(input.body) : undefined,
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub API ${input.method} ${input.path} failed: ${response.status} ${text}`);
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  return await response.json();
+}
+
+function usage(error) {
+  if (error) {
+    console.error(error);
+    console.error("");
+  }
+  console.log("usage: node scripts/comment-ci-summary.mjs [--summary <path>]");
+  process.exit(error ? 1 : 0);
+}


### PR DESCRIPTION
## Summary

- Wrap the `ci / full-pr` phases with `scripts/ci-run.mjs` so each phase tees logs and writes structured diagnostics metadata.
- Add `scripts/ci-summary.mjs` to render a GitHub step summary plus a `ci-diagnostics` artifact containing logs, step metadata, and a short PR-comment body.
- Add a guarded `workflow_run` comment workflow that updates one sticky CI diagnostics PR comment for same-repository PRs without granting the code-running CI job a write token.

## Validation

- `node --check scripts/ci-run.mjs`
- `node --check scripts/ci-summary.mjs`
- `node --check scripts/comment-ci-summary.mjs`
- `CI_DIAGNOSTICS_DIR=/private/tmp/nextgen-ci-diag-smoke node scripts/ci-run.mjs --id pass --name "Passing smoke" --rerun "node --version" -- node --version`
- `CI_DIAGNOSTICS_DIR=/private/tmp/nextgen-ci-diag-smoke CI_MODE=full GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=zitadel/nextgen GITHUB_RUN_ID=123 node scripts/ci-summary.mjs --artifact-name ci-diagnostics`
- `CI_DIAGNOSTICS_DIR=/private/tmp/nextgen-ci-diag-fail-smoke node scripts/ci-run.mjs --id fail --name "Failing smoke" --rerun "node -e fail" -- node -e "process.stderr.write('boom\\n'); process.exit(7)"` (expected exit 7, verified diagnostics were still written)
- `CI_DIAGNOSTICS_DIR=/private/tmp/nextgen-ci-diag-fail-smoke CI_MODE=full GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=zitadel/nextgen GITHUB_RUN_ID=456 node scripts/ci-summary.mjs --artifact-name ci-diagnostics`
- `node scripts/check-changesets-status.mjs --base origin/main`
- `git diff --check`

Not run: targeted `corepack pnpm exec oxlint ...` and `corepack pnpm exec prettier --check ...` because this worktree does not have those binaries installed (`Command "oxlint" not found`, `Command "prettier" not found`).

## Release notes / changeset

No changeset required — no shipped behavior changed.

## Notes

- The comment workflow intentionally skips external fork heads rather than reposting artifact text with a write-capable token.
- The updated `ci.yml` can upload diagnostics on this PR, but the new `workflow_run` PR-comment workflow starts applying after the workflow file exists on the default branch.