### PR TITLE
Mcp auth tests

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -16,6 +16,7 @@ projects:
     mock-zitadel: "apps/mock-zitadel"
     api: "packages/api"
     api-mock: "packages/api-mock"
+    mcp-mock-server: "packages/mcp-mock-server"
     components: "packages/components"
     design-tokens: "packages/design-tokens"
     sdk-angular: "packages/sdk-angular"

--- a/packages/mcp-mock-server/.gitignore
+++ b/packages/mcp-mock-server/.gitignore
@@ -1,0 +1,3 @@
+.mcp-token-probe-session.json
+node_modules/
+dist/

--- a/packages/mcp-mock-server/README.md
+++ b/packages/mcp-mock-server/README.md
@@ -1,0 +1,214 @@
+# @zitadel/mcp-mock-server
+
+Minimal MCP **resource server** for probing OAuth authorization against a Zitadel
+Authorization Server. It implements the MCP-relevant subset of
+[RFC 9728](https://www.rfc-editor.org/rfc/rfc9728.html) (Protected Resource
+Metadata) and returns `401` + `WWW-Authenticate` on unauthenticated MCP requests.
+
+Use it together with a running Zitadel instance (for example
+`http://localhost:8080`) when investigating issue
+[#375](https://github.com/zitadel/nextgen/issues/375).
+
+## Run
+
+```sh
+corepack pnpm install
+AUTHORIZATION_SERVER=http://localhost:8080 corepack pnpm --filter @zitadel/mcp-mock-server start
+```
+
+Or via Moon:
+
+```sh
+AUTHORIZATION_SERVER=http://localhost:8080 moon run mcp-mock-server:start
+```
+
+Default listen address: `http://localhost:9090`.
+
+## Endpoints
+
+
+| Path                                        | Purpose                                           |
+| ------------------------------------------- | ------------------------------------------------- |
+| `GET /`                                     | Human-readable status                             |
+| `GET /healthz`                              | Liveness probe                                    |
+| `GET /.well-known/oauth-protected-resource` | RFC 9728 metadata pointing at your Zitadel AS     |
+| `GET` / `POST` `/mcp`                       | Mock MCP HTTP endpoint (401 without bearer token) |
+
+
+
+
+## Environment
+
+
+| Variable                           | Default                        | Description                                                                                    |
+| ---------------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `PORT`                             | `9090`                         | Listen port                                                                                    |
+| `MCP_MOCK_HOST`                    | `localhost`                    | Bind host                                                                                      |
+| `AUTHORIZATION_SERVER`             | `http://localhost:8080`        | Zitadel issuer / AS base URL                                                                   |
+| `MCP_RESOURCE_URI`                 | `http://<host>:<port>/mcp`     | Canonical MCP resource URI (RFC 8707)                                                          |
+| `MCP_PUBLIC_ORIGIN`                | origin from `MCP_RESOURCE_URI` | Public origin used in `resource_metadata` URLs, useful when exposing the mock through a tunnel |
+| `ZITADEL_INTROSPECT`               | off                            | Set to `1` to validate tokens via Zitadel introspection                                        |
+| `ZITADEL_INTROSPECT_CLIENT_ID`     | —                              | Required when introspection is enabled                                                         |
+| `ZITADEL_INTROSPECT_CLIENT_SECRET` | —                              | Required when introspection is enabled                                                         |
+
+
+## Quick probe
+
+```sh
+# Protected resource metadata
+curl -s http://localhost:9090/.well-known/oauth-protected-resource | jq .
+
+# Path-specific protected resource metadata for the default /mcp resource
+curl -s http://localhost:9090/.well-known/oauth-protected-resource/mcp | jq .
+
+# MCP request without token → 401 + WWW-Authenticate
+curl -si -X POST http://localhost:9090/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"initialize","id":1}'
+```
+
+
+
+## MCP client wiring
+
+Point an MCP client at `http://localhost:9090/mcp`. The client should:
+
+1. Receive `401` + `WWW-Authenticate` with `resource_metadata=…`
+2. Fetch `/.well-known/oauth-protected-resource`
+3. Discover `authorization_servers` → your Zitadel instance
+4. Continue the OAuth flow against Zitadel (`/oauth/v2/authorize`, `/oauth/v2/token`, DCR, etc.)
+
+By default this mock accepts **any** bearer token so you can test the discovery
+and authorization legs independently. Enable `ZITADEL_INTROSPECT=1` once you
+have a real access token and introspection client credentials.
+
+## OAuth probe script
+
+Prerequisites:
+
+```sh
+# Terminal 1 — mock MCP resource server (must match how you will probe)
+AUTHORIZATION_SERVER=http://localhost:8080 corepack pnpm --filter @zitadel/mcp-mock-server start
+
+# Terminal 2 — Zitadel on the same AUTHORIZATION_SERVER URL, then:
+corepack pnpm --filter @zitadel/mcp-mock-server probe
+```
+
+The probe discovers the authorization server from the mock server's RFC 9728
+metadata by default. Set `AUTHORIZATION_SERVER` in terminal 2 only when you
+want to override that discovery (for example to probe a different AS than the
+one the mock server advertises).
+
+If you previously started the mock server with `MCP_PUBLIC_ORIGIN` (ngrok/tunnel),
+either keep that server running and probe against it, or restart without tunnel
+env vars so `resource_metadata` points at `http://localhost:9090` again.
+
+```sh
+corepack pnpm --filter @zitadel/mcp-mock-server probe
+```
+
+This chains the MCP client discovery steps automatically:
+
+1. `POST /mcp` without a token → parse `WWW-Authenticate`
+2. `GET /.well-known/oauth-protected-resource`
+3. `GET /.well-known/oauth-authorization-server` (RFC 8414)
+4. `GET /.well-known/openid-configuration` (fallback)
+5. `POST /oauth/v2/register` (RFC 7591 DCR) with a native public MCP client
+6. `GET /oauth/v2/authorize` using the **freshly registered** `client_id` + `resource=` (RFC 8707)
+
+Optional env vars:
+
+
+| Variable               | Default                     | Description                                                 |
+| ---------------------- | --------------------------- | ----------------------------------------------------------- |
+| `PROBE_CLIENT_ID`      | —                           | Fallback authorize client when DCR fails                    |
+| `PROBE_REDIRECT_URI`   | `http://127.0.0.1/callback` | Redirect URI used for DCR and authorize                     |
+| `AUTHORIZATION_SERVER` | from server config          | Override the AS discovered from protected-resource metadata |
+
+
+Machine-readable output:
+
+```sh
+corepack pnpm --filter @zitadel/mcp-mock-server probe -- --json
+```
+
+
+
+## Token probe (full login flow)
+
+This script runs the MCP client flow through a real browser login and token
+exchange:
+
+1. DCR register a native public client
+2. Open `/oauth/v2/authorize` with PKCE + `resource=`
+3. Catch the callback on `http://127.0.0.1:8765/callback`
+4. Exchange the code at `/oauth/v2/token` (also sends `resource`)
+5. Decode JWT claims and check whether `aud` matches the MCP resource URI
+6. Call the mock MCP server with the access token
+
+If Zitadel issues an opaque access token, the JWT claim check is reported as a
+warning and the MCP call still runs. Enable introspection on the mock server to
+validate opaque tokens against Zitadel.
+
+Prerequisites:
+
+```sh
+# Terminal 1
+AUTHORIZATION_SERVER=http://localhost:8080 corepack pnpm --filter @zitadel/mcp-mock-server start
+
+# Terminal 2 — Zitadel reachable at the AS advertised by the mock server, then:
+corepack pnpm --filter @zitadel/mcp-mock-server probe-token
+```
+
+Like `probe`, `probe-token` discovers the authorization server and canonical
+resource URI from the running mock server's RFC 9728 metadata. Set
+`AUTHORIZATION_SERVER` only to override AS discovery; set `MCP_RESOURCE_URI` only
+to override the RFC 8707 resource parameter.
+
+```sh
+# optional overrides
+AUTHORIZATION_SERVER=http://localhost:8080 corepack pnpm --filter @zitadel/mcp-mock-server probe-token
+```
+
+Flags:
+
+
+| Flag                     | Description                                           |
+| ------------------------ | ----------------------------------------------------- |
+| `--no-open`              | Print the authorize URL without launching a browser   |
+| `--code <code>`          | Skip the callback server and exchange a code manually |
+| `--callback-port <port>` | Callback listener port (default `8765`)               |
+| `--json`                 | Machine-readable output with tokens redacted          |
+
+
+Example manual code exchange:
+
+```sh
+corepack pnpm --filter @zitadel/mcp-mock-server probe-token -- --no-open
+# complete login in browser, then:
+corepack pnpm --filter @zitadel/mcp-mock-server probe-token -- --code '<authorization_code>'
+```
+
+
+
+## MCP Inspector
+
+Config file: `packages/mcp-mock-server/mcp-inspector.json`
+
+```sh
+# Terminal 1: mock MCP resource server
+AUTHORIZATION_SERVER=http://localhost:8080 corepack pnpm --filter @zitadel/mcp-mock-server start
+
+# Terminal 2: MCP Inspector UI
+corepack pnpm --filter @zitadel/mcp-mock-server inspector
+```
+
+Or directly:
+
+```sh
+npx @modelcontextprotocol/inspector --config packages/mcp-mock-server/mcp-inspector.json
+```
+
+In the Inspector UI, connect with transport **Streamable HTTP** and URL
+`http://localhost:9090/mcp`. An unauthenticated connect attempt should surface
+the OAuth discovery challenge against your Zitadel instance.

--- a/packages/mcp-mock-server/README.md
+++ b/packages/mcp-mock-server/README.md
@@ -114,7 +114,9 @@ This chains the MCP client discovery steps automatically:
 3. `GET /.well-known/oauth-authorization-server` (RFC 8414)
 4. `GET /.well-known/openid-configuration` (fallback)
 5. `POST /oauth/v2/register` (RFC 7591 DCR) with a native public MCP client
-6. `GET /oauth/v2/authorize` using the **freshly registered** `client_id` + `resource=` (RFC 8707)
+6. When `client_id_metadata_document_supported` is true and `MCP_PUBLIC_ORIGIN` is
+   `https://…`, probe the mock server's CIMD document and a URL-form `client_id`
+7. `GET /oauth/v2/authorize` using the **freshly registered** `client_id` + `resource=` (RFC 8707)
 
 Optional env vars:
 
@@ -177,8 +179,48 @@ Flags:
 | ------------------------ | ----------------------------------------------------- |
 | `--no-open`              | Print the authorize URL without launching a browser   |
 | `--code <code>`          | Skip the callback server and exchange a code manually |
-| `--callback-port <port>` | Callback listener port (default `8765`)               |
-| `--json`                 | Machine-readable output with tokens redacted          |
+| `--callback-port <port>` | Callback listener port for DCR mode (default `8765`)      |
+| `--cimd`                 | Use Client ID Metadata Document registration (see below) |
+| `--json`                 | Machine-readable output with tokens redacted              |
+
+
+## CIMD probe (Zitadel PR #12316)
+
+[Client ID Metadata Documents](https://modelcontextprotocol.io/community/seps/991-enable-url-based-client-registration-using-oauth-c.md)
+use an HTTPS URL as `client_id`. Zitadel fetches the JSON document from that URL,
+so **pure localhost will not work** — Zitadel's outbound client blocks loopback and
+requires a valid TLS certificate.
+
+Prerequisites on Zitadel (`feat/oidc-cimd` / PR #12316):
+
+1. Enable `oidc_client_id_metadata_document` on the instance (feature API)
+2. Ensure v2 login is configured
+3. Run Zitadel so the mock server can reach it as `AUTHORIZATION_SERVER`
+
+Tunnel setup (two ngrok tunnels or one tunnel to the mock server):
+
+```sh
+# Terminal 1 — expose mock MCP + CIMD document + callback on HTTPS
+MCP_PUBLIC_ORIGIN=https://<mcp-tunnel> \
+AUTHORIZATION_SERVER=https://<zitadel-tunnel> \
+corepack pnpm --filter @zitadel/mcp-mock-server start
+
+# Terminal 2 — non-interactive CIMD checklist
+corepack pnpm --filter @zitadel/mcp-mock-server probe
+
+# Terminal 3 — full browser login via CIMD (callback via mock server /oauth/callback)
+corepack pnpm --filter @zitadel/mcp-mock-server probe-token -- --cimd
+```
+
+The mock server serves:
+
+| Path | Purpose |
+| ---- | ------- |
+| `/.well-known/oauth-client` | CIMD metadata (`client_id` = this URL) |
+| `/oauth/callback` | OAuth redirect target (same origin as `MCP_PUBLIC_ORIGIN`) |
+| `/_probe/oauth/callback?state=…` | Local poll endpoint used by `probe-token --cimd` |
+
+DCR mode (`probe-token` without `--cimd`) still uses `http://127.0.0.1:8765/callback`.
 
 
 Example manual code exchange:

--- a/packages/mcp-mock-server/bin/probe-oauth.ts
+++ b/packages/mcp-mock-server/bin/probe-oauth.ts
@@ -1,0 +1,40 @@
+import { loadConfig } from "../src/config.js";
+import { formatOAuthProbeReport, runOAuthProbe } from "../src/oauth-probe.js";
+
+function parseArgs(argv: string[]): { json: boolean } {
+  return { json: argv.includes("--json") };
+}
+
+async function main(): Promise<void> {
+  const { json } = parseArgs(process.argv.slice(2));
+  const config = loadConfig();
+  const mcpBaseUrl = `http://${config.host}:${config.port}`;
+
+  const report = await runOAuthProbe({
+    // Only override discovery when AUTHORIZATION_SERVER is explicitly set.
+    // Otherwise use authorization_servers from RFC 9728 metadata (must match the
+    // running mock server).
+    ...(process.env.AUTHORIZATION_SERVER
+      ? { authorizationServerOverride: config.authorizationServer }
+      : {}),
+    mcpBaseUrl,
+    probeClientId: process.env.PROBE_CLIENT_ID,
+    probeRedirectUri: process.env.PROBE_REDIRECT_URI,
+  });
+
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatOAuthProbeReport(report));
+  }
+
+  if (report.summary.fail > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[mcp-oauth-probe] ${message}`);
+  process.exit(1);
+});

--- a/packages/mcp-mock-server/bin/probe-token.ts
+++ b/packages/mcp-mock-server/bin/probe-token.ts
@@ -1,15 +1,17 @@
-import { loadConfig } from "../src/config.js";
+import { loadConfig, originFromResourceUri } from "../src/config.js";
 import { discoverMcpResourceContext } from "../src/mcp-discovery.js";
 import { formatTokenProbeReport, runTokenProbe } from "../src/token-probe.js";
 
 function parseArgs(argv: string[]): {
   authorizationCode?: string;
   callbackPort: number;
+  cimd: boolean;
   json: boolean;
   noOpen: boolean;
 } {
   let json = false;
   let noOpen = false;
+  let cimd = false;
   let callbackPort = 8765;
   let authorizationCode: string | undefined;
 
@@ -19,6 +21,8 @@ function parseArgs(argv: string[]): {
       json = true;
     } else if (arg === "--no-open") {
       noOpen = true;
+    } else if (arg === "--cimd") {
+      cimd = true;
     } else if (arg === "--code") {
       authorizationCode = argv[index + 1];
       index += 1;
@@ -32,11 +36,11 @@ function parseArgs(argv: string[]): {
     }
   }
 
-  return { authorizationCode, callbackPort, json, noOpen };
+  return { authorizationCode, callbackPort, cimd, json, noOpen };
 }
 
 async function main(): Promise<void> {
-  const { authorizationCode, callbackPort, json, noOpen } = parseArgs(process.argv.slice(2));
+  const { authorizationCode, callbackPort, cimd, json, noOpen } = parseArgs(process.argv.slice(2));
   const config = loadConfig();
   const mcpBaseUrl = `http://${config.host}:${config.port}`;
   const context = await discoverMcpResourceContext({
@@ -45,13 +49,20 @@ async function main(): Promise<void> {
       ? { authorizationServerOverride: config.authorizationServer }
       : {}),
   });
+  const publicOrigin =
+    process.env.MCP_PUBLIC_ORIGIN || process.env.MCP_RESOURCE_URI
+      ? config.publicOrigin
+      : (originFromResourceUri(context.resourceUri) ?? config.publicOrigin);
 
   const report = await runTokenProbe({
     authorizationCode,
     authorizationServer: context.authorizationServer,
     callbackPort,
+    clientRegistration: cimd ? "cimd" : "dcr",
+    mcpBaseUrl,
     mcpEndpoint: context.mcpEndpoint,
     openBrowser: !noOpen,
+    publicOrigin,
     resourceUri: process.env.MCP_RESOURCE_URI ? config.resourceUri : context.resourceUri,
   });
 

--- a/packages/mcp-mock-server/bin/probe-token.ts
+++ b/packages/mcp-mock-server/bin/probe-token.ts
@@ -1,0 +1,88 @@
+import { loadConfig } from "../src/config.js";
+import { discoverMcpResourceContext } from "../src/mcp-discovery.js";
+import { formatTokenProbeReport, runTokenProbe } from "../src/token-probe.js";
+
+function parseArgs(argv: string[]): {
+  authorizationCode?: string;
+  callbackPort: number;
+  json: boolean;
+  noOpen: boolean;
+} {
+  let json = false;
+  let noOpen = false;
+  let callbackPort = 8765;
+  let authorizationCode: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--no-open") {
+      noOpen = true;
+    } else if (arg === "--code") {
+      authorizationCode = argv[index + 1];
+      index += 1;
+    } else if (arg === "--callback-port") {
+      const raw = argv[index + 1];
+      callbackPort = Number.parseInt(raw ?? "", 10);
+      if (!Number.isFinite(callbackPort)) {
+        throw new Error(`invalid --callback-port value: ${raw}`);
+      }
+      index += 1;
+    }
+  }
+
+  return { authorizationCode, callbackPort, json, noOpen };
+}
+
+async function main(): Promise<void> {
+  const { authorizationCode, callbackPort, json, noOpen } = parseArgs(process.argv.slice(2));
+  const config = loadConfig();
+  const mcpBaseUrl = `http://${config.host}:${config.port}`;
+  const context = await discoverMcpResourceContext({
+    mcpBaseUrl,
+    ...(process.env.AUTHORIZATION_SERVER
+      ? { authorizationServerOverride: config.authorizationServer }
+      : {}),
+  });
+
+  const report = await runTokenProbe({
+    authorizationCode,
+    authorizationServer: context.authorizationServer,
+    callbackPort,
+    mcpEndpoint: context.mcpEndpoint,
+    openBrowser: !noOpen,
+    resourceUri: process.env.MCP_RESOURCE_URI ? config.resourceUri : context.resourceUri,
+  });
+
+  if (json) {
+    const printable = {
+      ...report,
+      accessToken: report.accessToken ? "<redacted>" : undefined,
+      tokenResponse: report.tokenResponse
+        ? {
+            ...report.tokenResponse,
+            access_token:
+              typeof report.tokenResponse.access_token === "string" ? "<redacted>" : undefined,
+            id_token:
+              typeof report.tokenResponse.id_token === "string" ? "<redacted>" : undefined,
+            refresh_token:
+              typeof report.tokenResponse.refresh_token === "string" ? "<redacted>" : undefined,
+          }
+        : undefined,
+    };
+    console.log(JSON.stringify(printable, null, 2));
+  } else {
+    console.log(formatTokenProbeReport(report));
+  }
+
+  if (report.steps.some((probeStep) => probeStep.status === "fail")) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[mcp-token-probe] ${message}`);
+  process.exit(1);
+});

--- a/packages/mcp-mock-server/bin/start.ts
+++ b/packages/mcp-mock-server/bin/start.ts
@@ -1,0 +1,24 @@
+import { loadConfig } from "../src/config.js";
+import { startMcpMockServer } from "../src/server.js";
+
+let server: ReturnType<typeof startMcpMockServer>;
+
+try {
+  server = startMcpMockServer(loadConfig());
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[mcp-mock-server] ${message}`);
+  process.exit(1);
+}
+
+function shutdown(signal: string): void {
+  console.log(`\n[mcp-mock-server] received ${signal}, shutting down…`);
+  server.closeAllConnections();
+  server.close(() => {
+    console.log("[mcp-mock-server] server closed");
+    process.exit(0);
+  });
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/packages/mcp-mock-server/mcp-inspector.json
+++ b/packages/mcp-mock-server/mcp-inspector.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "zitadel-probe": {
+      "type": "streamable-http",
+      "url": "http://localhost:9090/mcp",
+      "note": "Start @zitadel/mcp-mock-server first. Unauthenticated requests should trigger OAuth discovery against AUTHORIZATION_SERVER (default http://localhost:8080)."
+    }
+  }
+}

--- a/packages/mcp-mock-server/moon.yml
+++ b/packages/mcp-mock-server/moon.yml
@@ -1,0 +1,40 @@
+id: "mcp-mock-server"
+language: "typescript"
+layer: "library"
+stack: "backend"
+
+tasks:
+  lint:
+    command: "corepack pnpm exec oxlint ."
+
+  typecheck:
+    command: "corepack pnpm exec tsc --noEmit -p tsconfig.json"
+
+  build:
+    command: "node -e \"process.exit(0)\""
+
+  test:
+    command: "corepack pnpm run test"
+
+  probe:
+    command: "corepack pnpm run probe"
+    options:
+      runInCI: false
+
+  probe-token:
+    command: "corepack pnpm run probe-token"
+    options:
+      runInCI: false
+      persistent: true
+
+  inspector:
+    command: "corepack pnpm run inspector"
+    options:
+      persistent: true
+      runInCI: false
+
+  start:
+    command: "corepack pnpm run start"
+    options:
+      persistent: true
+      runInCI: false

--- a/packages/mcp-mock-server/package.json
+++ b/packages/mcp-mock-server/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@zitadel/mcp-mock-server",
+  "version": "0.0.0",
+  "description": "Minimal MCP resource server for probing OAuth authorization against Zitadel",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/server.ts",
+      "import": "./src/server.ts"
+    }
+  },
+  "bin": {
+    "mcp-mock-server": "./bin/start.ts",
+    "mcp-oauth-probe": "./bin/probe-oauth.ts",
+    "mcp-token-probe": "./bin/probe-token.ts"
+  },
+  "scripts": {
+    "start": "tsx bin/start.ts",
+    "dev": "tsx watch bin/start.ts",
+    "probe": "tsx bin/probe-oauth.ts",
+    "probe-token": "tsx bin/probe-token.ts",
+    "inspector": "npx @modelcontextprotocol/inspector --config ./mcp-inspector.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "express": "catalog:",
+    "tslib": "catalog:"
+  },
+  "devDependencies": {
+    "@types/express": "catalog:",
+    "@types/node": "catalog:",
+    "@types/supertest": "^6.0.3",
+    "supertest": "^7.1.4",
+    "tsx": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/mcp-mock-server/src/cimd.spec.ts
+++ b/packages/mcp-mock-server/src/cimd.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCimdClientMetadata,
+  cimdClientIdUrl,
+  cimdRedirectUri,
+  isCimdCompatibleOrigin,
+} from "./cimd.js";
+
+describe("cimd helpers", () => {
+  it("detects https public origins", () => {
+    expect(isCimdCompatibleOrigin("https://mcp.example.com")).toBe(true);
+    expect(isCimdCompatibleOrigin("http://localhost:9090")).toBe(false);
+    expect(isCimdCompatibleOrigin("https://fc12.ngrok-free.app")).toBe(true);
+  });
+
+  it("builds origin-matched client metadata URLs", () => {
+    const origin = "https://mcp.example.com";
+    expect(cimdClientIdUrl(origin)).toBe("https://mcp.example.com/.well-known/oauth-client");
+    expect(cimdRedirectUri(origin)).toBe("https://mcp.example.com/oauth/callback");
+    expect(buildCimdClientMetadata(origin).redirect_uris).toEqual([
+      "https://mcp.example.com/oauth/callback",
+    ]);
+  });
+});

--- a/packages/mcp-mock-server/src/cimd.ts
+++ b/packages/mcp-mock-server/src/cimd.ts
@@ -1,0 +1,41 @@
+export const CIMD_METADATA_PATH = "/.well-known/oauth-client";
+export const CIMD_CALLBACK_PATH = "/oauth/callback";
+
+export type CimdClientMetadata = {
+  client_name: string;
+  grant_types: string[];
+  redirect_uris: string[];
+  response_types: string[];
+  token_endpoint_auth_method: "none";
+};
+
+export function isCimdCompatibleOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return url.protocol === "https:" && url.hostname.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function cimdClientIdUrl(publicOrigin: string): string {
+  return `${trimTrailingSlash(publicOrigin)}${CIMD_METADATA_PATH}`;
+}
+
+export function cimdRedirectUri(publicOrigin: string): string {
+  return `${trimTrailingSlash(publicOrigin)}${CIMD_CALLBACK_PATH}`;
+}
+
+export function buildCimdClientMetadata(publicOrigin: string): CimdClientMetadata {
+  return {
+    client_name: "mcp-mock-server CIMD probe client",
+    grant_types: ["authorization_code", "refresh_token"],
+    redirect_uris: [cimdRedirectUri(publicOrigin)],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+  };
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}

--- a/packages/mcp-mock-server/src/config.ts
+++ b/packages/mcp-mock-server/src/config.ts
@@ -1,0 +1,67 @@
+export type McpMockServerConfig = {
+  authorizationServer: string;
+  host: string;
+  introspect: boolean;
+  introspectClientId?: string;
+  introspectClientSecret?: string;
+  port: number;
+  publicOrigin: string;
+  resourceUri: string;
+};
+
+function parsePort(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const port = Number.parseInt(raw, 10);
+  if (!Number.isFinite(port) || port < 1 || port > 65535) {
+    throw new Error(`invalid PORT="${raw}" — must be an integer between 1 and 65535`);
+  }
+  return port;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function originFromResourceUri(resourceUri: string): string | undefined {
+  try {
+    const url = new URL(resourceUri);
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): McpMockServerConfig {
+  const host = env.MCP_MOCK_HOST ?? "localhost";
+  const port = parsePort(env.PORT, 9090);
+  const origin = `http://${host}:${port}`;
+  const authorizationServer = trimTrailingSlash(
+    env.AUTHORIZATION_SERVER ?? "http://localhost:8080",
+  );
+  const resourceUri = trimTrailingSlash(env.MCP_RESOURCE_URI ?? `${origin}/mcp`);
+  const publicOrigin = trimTrailingSlash(
+    env.MCP_PUBLIC_ORIGIN ?? originFromResourceUri(resourceUri) ?? origin,
+  );
+  const introspect = env.ZITADEL_INTROSPECT === "1" || env.ZITADEL_INTROSPECT === "true";
+  const introspectClientId = env.ZITADEL_INTROSPECT_CLIENT_ID;
+  const introspectClientSecret = env.ZITADEL_INTROSPECT_CLIENT_SECRET;
+
+  if (introspect && (!introspectClientId || !introspectClientSecret)) {
+    throw new Error(
+      "ZITADEL_INTROSPECT is enabled but ZITADEL_INTROSPECT_CLIENT_ID or ZITADEL_INTROSPECT_CLIENT_SECRET is missing",
+    );
+  }
+
+  return {
+    authorizationServer,
+    host,
+    introspect,
+    introspectClientId,
+    introspectClientSecret,
+    port,
+    publicOrigin,
+    resourceUri,
+  };
+}

--- a/packages/mcp-mock-server/src/config.ts
+++ b/packages/mcp-mock-server/src/config.ts
@@ -33,6 +33,8 @@ function originFromResourceUri(resourceUri: string): string | undefined {
   }
 }
 
+export { originFromResourceUri };
+
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): McpMockServerConfig {
   const host = env.MCP_MOCK_HOST ?? "localhost";
   const port = parsePort(env.PORT, 9090);

--- a/packages/mcp-mock-server/src/jwt.ts
+++ b/packages/mcp-mock-server/src/jwt.ts
@@ -1,0 +1,38 @@
+export type DecodedJwt = {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+};
+
+function decodePart(part: string): Record<string, unknown> {
+  const json = Buffer.from(part, "base64url").toString("utf8");
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+export function decodeJwt(token: string): DecodedJwt | undefined {
+  const parts = token.split(".");
+  if (parts.length < 2) {
+    return undefined;
+  }
+  try {
+    return {
+      header: decodePart(parts[0] ?? ""),
+      payload: decodePart(parts[1] ?? ""),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function audienceMatchesResource(
+  payload: Record<string, unknown>,
+  resourceUri: string,
+): boolean {
+  const aud = payload.aud;
+  if (typeof aud === "string") {
+    return aud === resourceUri;
+  }
+  if (Array.isArray(aud)) {
+    return aud.includes(resourceUri);
+  }
+  return false;
+}

--- a/packages/mcp-mock-server/src/mcp-discovery.spec.ts
+++ b/packages/mcp-mock-server/src/mcp-discovery.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { discoverMcpResourceContext, parseResourceMetadataUrl } from "./mcp-discovery.js";
+
+describe("mcp discovery", () => {
+  it("parses resource_metadata from WWW-Authenticate", () => {
+    expect(
+      parseResourceMetadataUrl(
+        'Bearer error="invalid_token", resource_metadata="http://mcp.local/.well-known/oauth-protected-resource/mcp"',
+      ),
+    ).toBe("http://mcp.local/.well-known/oauth-protected-resource/mcp");
+  });
+
+  it("discovers authorization server and resource URI from MCP metadata", async () => {
+    const mcpBaseUrl = "http://mcp.local";
+    const asBase = "http://auth.local";
+    const resourceUri = `${mcpBaseUrl}/mcp`;
+
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+      if (url === `${mcpBaseUrl}/mcp`) {
+        return new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 401,
+          headers: {
+            "WWW-Authenticate": `Bearer resource_metadata="${mcpBaseUrl}/.well-known/oauth-protected-resource/mcp"`,
+          },
+        });
+      }
+
+      if (url === `${mcpBaseUrl}/.well-known/oauth-protected-resource/mcp`) {
+        return Response.json({
+          resource: resourceUri,
+          authorization_servers: [asBase],
+        });
+      }
+
+      throw new Error(`unexpected fetch: ${url}`);
+    };
+
+    const context = await discoverMcpResourceContext({ fetchImpl, mcpBaseUrl });
+    expect(context.authorizationServer).toBe(asBase);
+    expect(context.resourceUri).toBe(resourceUri);
+    expect(context.mcpEndpoint).toBe(`${mcpBaseUrl}/mcp`);
+  });
+
+  it("honors authorization server override", async () => {
+    const mcpBaseUrl = "http://mcp.local";
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+      if (url === `${mcpBaseUrl}/mcp`) {
+        return new Response("", {
+          status: 401,
+          headers: {
+            "WWW-Authenticate": `Bearer resource_metadata="${mcpBaseUrl}/.well-known/oauth-protected-resource"`,
+          },
+        });
+      }
+
+      if (url === `${mcpBaseUrl}/.well-known/oauth-protected-resource`) {
+        return Response.json({
+          resource: `${mcpBaseUrl}/mcp`,
+          authorization_servers: ["http://discovered.local"],
+        });
+      }
+
+      throw new Error(`unexpected fetch: ${url}`);
+    };
+
+    const context = await discoverMcpResourceContext({
+      authorizationServerOverride: "http://override.local",
+      fetchImpl,
+      mcpBaseUrl,
+    });
+    expect(context.authorizationServer).toBe("http://override.local");
+  });
+});

--- a/packages/mcp-mock-server/src/mcp-discovery.ts
+++ b/packages/mcp-mock-server/src/mcp-discovery.ts
@@ -1,0 +1,109 @@
+export type ProtectedResourceMetadata = {
+  authorization_servers?: string[];
+  resource?: string;
+};
+
+export type McpResourceContext = {
+  authorizationServer: string;
+  mcpEndpoint: string;
+  protectedResourceMetadataUrl: string;
+  resourceUri: string;
+};
+
+export type DiscoverMcpResourceContextOptions = {
+  authorizationServerOverride?: string;
+  fetchImpl?: typeof fetch;
+  mcpBaseUrl: string;
+};
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+export function parseResourceMetadataUrl(wwwAuthenticate: string | null): string | undefined {
+  if (!wwwAuthenticate) {
+    return undefined;
+  }
+  const match = wwwAuthenticate.match(/resource_metadata="([^"]+)"/i);
+  return match?.[1];
+}
+
+function formatFetchError(url: string, method: string, error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  const cause = error instanceof Error ? error.cause : undefined;
+  const code =
+    cause instanceof Error && "code" in cause
+      ? String((cause as NodeJS.ErrnoException).code)
+      : undefined;
+  let hint = "";
+  if (code === "ECONNREFUSED") {
+    if (url.includes("/mcp")) {
+      hint =
+        " — is the mock MCP server running? Start it with: corepack pnpm --filter @zitadel/mcp-mock-server start";
+    } else {
+      hint =
+        " — is the metadata URL reachable? Restart the mock server without stale tunnel env vars, or set AUTHORIZATION_SERVER explicitly";
+    }
+  }
+  return new Error(`${method} ${url} failed: ${message}${hint}`, { cause: error });
+}
+
+export async function probeFetch(
+  fetchImpl: typeof fetch,
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const method = (init?.method ?? "GET").toUpperCase();
+  try {
+    return await fetchImpl(url, init);
+  } catch (error: unknown) {
+    throw formatFetchError(url, method, error);
+  }
+}
+
+export async function discoverMcpResourceContext(
+  options: DiscoverMcpResourceContextOptions,
+): Promise<McpResourceContext> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const mcpBaseUrl = trimTrailingSlash(options.mcpBaseUrl);
+  const mcpEndpoint = `${mcpBaseUrl}/mcp`;
+
+  const mcpResponse = await probeFetch(fetchImpl, mcpEndpoint, {
+    body: JSON.stringify({ id: 1, jsonrpc: "2.0", method: "initialize" }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+  const wwwAuthenticate = mcpResponse.headers.get("www-authenticate");
+  const protectedResourceMetadataUrl =
+    parseResourceMetadataUrl(wwwAuthenticate) ??
+    `${mcpBaseUrl}/.well-known/oauth-protected-resource`;
+
+  const metadataResponse = await probeFetch(fetchImpl, protectedResourceMetadataUrl);
+  const metadataBody = await metadataResponse.text();
+  let metadata: ProtectedResourceMetadata | undefined;
+  try {
+    metadata = JSON.parse(metadataBody) as ProtectedResourceMetadata;
+  } catch {
+    metadata = undefined;
+  }
+
+  if (metadataResponse.status !== 200 || !metadata?.authorization_servers?.length) {
+    throw new Error(
+      `protected resource metadata unavailable at ${protectedResourceMetadataUrl} (HTTP ${metadataResponse.status})`,
+    );
+  }
+
+  const authorizationServer = trimTrailingSlash(
+    options.authorizationServerOverride ?? metadata.authorization_servers[0] ?? "",
+  );
+  if (!authorizationServer) {
+    throw new Error("protected resource metadata did not include authorization_servers");
+  }
+
+  return {
+    authorizationServer,
+    mcpEndpoint,
+    protectedResourceMetadataUrl,
+    resourceUri: trimTrailingSlash(metadata.resource ?? mcpEndpoint),
+  };
+}

--- a/packages/mcp-mock-server/src/mcp-protocol.spec.ts
+++ b/packages/mcp-mock-server/src/mcp-protocol.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { createSessionId, dispatchMcpBody, isKnownSession } from "./mcp-protocol.js";
+
+describe("mcp protocol", () => {
+  it("handles initialize with session id", () => {
+    const outcome = dispatchMcpBody({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "test", version: "1.0" },
+        protocolVersion: "2025-06-18",
+      },
+    });
+
+    expect(outcome.httpStatus).toBe(200);
+    expect(outcome.sessionId).toBeTruthy();
+    expect(outcome.body).toMatchObject({
+      id: 1,
+      result: {
+        protocolVersion: "2025-06-18",
+        serverInfo: { name: "zitadel-mcp-mock-server" },
+      },
+    });
+    expect(isKnownSession(outcome.sessionId)).toBe(true);
+  });
+
+  it("accepts notifications/initialized with 202", () => {
+    const outcome = dispatchMcpBody({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+
+    expect(outcome.httpStatus).toBe(202);
+    expect(outcome.body).toBeUndefined();
+  });
+
+  it("lists probe_echo tool", () => {
+    const outcome = dispatchMcpBody({
+      id: 2,
+      jsonrpc: "2.0",
+      method: "tools/list",
+    });
+
+    expect(outcome.body).toMatchObject({
+      id: 2,
+      result: {
+        tools: [{ name: "probe_echo" }],
+      },
+    });
+  });
+
+  it("creates unique session ids", () => {
+    const first = createSessionId();
+    const second = createSessionId();
+    expect(first).not.toBe(second);
+  });
+});

--- a/packages/mcp-mock-server/src/mcp-protocol.ts
+++ b/packages/mcp-mock-server/src/mcp-protocol.ts
@@ -1,0 +1,208 @@
+import { randomUUID } from "node:crypto";
+
+export type JsonRpcId = string | number | null;
+
+export type JsonRpcRequest = {
+  id?: JsonRpcId;
+  jsonrpc?: string;
+  method: string;
+  params?: unknown;
+};
+
+export type JsonRpcResponse = {
+  id: JsonRpcId;
+  jsonrpc: "2.0";
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+  };
+};
+
+type InitializeParams = {
+  capabilities?: Record<string, unknown>;
+  clientInfo?: {
+    name?: string;
+    version?: string;
+  };
+  protocolVersion?: string;
+};
+
+const SUPPORTED_PROTOCOL_VERSIONS = ["2025-11-25", "2025-06-18", "2025-03-26"] as const;
+
+const sessions = new Set<string>();
+
+function negotiateProtocolVersion(requested?: string): string {
+  if (requested && SUPPORTED_PROTOCOL_VERSIONS.includes(requested as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number])) {
+    return requested;
+  }
+  return "2025-06-18";
+}
+
+function isNotification(message: JsonRpcRequest): boolean {
+  return message.id === undefined;
+}
+
+function jsonRpcResult(id: JsonRpcId, result: unknown): JsonRpcResponse {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function jsonRpcError(id: JsonRpcId, code: number, message: string): JsonRpcResponse {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+export function createSessionId(): string {
+  const sessionId = randomUUID();
+  sessions.add(sessionId);
+  return sessionId;
+}
+
+export function isKnownSession(sessionId: string | undefined): boolean {
+  return sessionId !== undefined && sessions.has(sessionId);
+}
+
+export function handleMcpMessage(
+  message: JsonRpcRequest,
+): { httpStatus: number; body?: JsonRpcResponse; sessionId?: string } {
+  if (message.jsonrpc !== undefined && message.jsonrpc !== "2.0") {
+    return {
+      httpStatus: 200,
+      body: jsonRpcError(message.id ?? null, -32600, "Invalid Request"),
+    };
+  }
+
+  if (isNotification(message)) {
+    if (message.method === "notifications/initialized") {
+      return { httpStatus: 202 };
+    }
+    return { httpStatus: 202 };
+  }
+
+  const id = message.id ?? null;
+
+  switch (message.method) {
+    case "initialize": {
+      const params = (message.params ?? {}) as InitializeParams;
+      const sessionId = createSessionId();
+      return {
+        httpStatus: 200,
+        sessionId,
+        body: jsonRpcResult(id, {
+          capabilities: {
+            tools: {
+              listChanged: false,
+            },
+          },
+          protocolVersion: negotiateProtocolVersion(params.protocolVersion),
+          serverInfo: {
+            name: "zitadel-mcp-mock-server",
+            version: "0.0.0",
+          },
+        }),
+      };
+    }
+    case "tools/list":
+      return {
+        httpStatus: 200,
+        body: jsonRpcResult(id, {
+          tools: [
+            {
+              description: "Echo probe tool for OAuth and MCP handshake testing",
+              inputSchema: {
+                additionalProperties: false,
+                properties: {
+                  message: {
+                    description: "Message to echo back",
+                    type: "string",
+                  },
+                },
+                type: "object",
+              },
+              name: "probe_echo",
+            },
+          ],
+        }),
+      };
+    case "tools/call": {
+      const params = (message.params ?? {}) as { arguments?: { message?: string }; name?: string };
+      if (params.name !== "probe_echo") {
+        return {
+          httpStatus: 200,
+          body: jsonRpcError(id, -32602, `Unknown tool: ${params.name ?? "(missing)"}`),
+        };
+      }
+      const echoed = params.arguments?.message ?? "ok";
+      return {
+        httpStatus: 200,
+        body: jsonRpcResult(id, {
+          content: [
+            {
+              text: echoed,
+              type: "text",
+            },
+          ],
+          isError: false,
+        }),
+      };
+    }
+    case "ping":
+      return {
+        httpStatus: 200,
+        body: jsonRpcResult(id, {}),
+      };
+    default:
+      return {
+        httpStatus: 200,
+        body: jsonRpcError(id, -32601, `Method not found: ${message.method}`),
+      };
+  }
+}
+
+export function parseJsonRpcBody(body: unknown): JsonRpcRequest[] {
+  if (Array.isArray(body)) {
+    return body.filter((entry): entry is JsonRpcRequest => typeof entry === "object" && entry !== null);
+  }
+  if (typeof body === "object" && body !== null) {
+    return [body as JsonRpcRequest];
+  }
+  return [];
+}
+
+export function dispatchMcpBody(body: unknown): {
+  httpStatus: number;
+  body?: JsonRpcResponse | JsonRpcResponse[];
+  sessionId?: string;
+} {
+  const messages = parseJsonRpcBody(body);
+  if (messages.length === 0) {
+    return {
+      httpStatus: 400,
+      body: jsonRpcError(null, -32700, "Parse error"),
+    };
+  }
+
+  const outcomes = messages.map((message) => handleMcpMessage(message));
+  const sessionId = outcomes.find((outcome) => outcome.sessionId)?.sessionId;
+
+  if (outcomes.every((outcome) => outcome.httpStatus === 202)) {
+    return { httpStatus: 202, sessionId };
+  }
+
+  const responses = outcomes
+    .map((outcome) => outcome.body)
+    .filter((response): response is JsonRpcResponse => response !== undefined);
+
+  if (responses.length === 1) {
+    return {
+      httpStatus: outcomes[0]?.httpStatus ?? 200,
+      body: responses[0],
+      sessionId,
+    };
+  }
+
+  return {
+    httpStatus: 200,
+    body: responses,
+    sessionId,
+  };
+}

--- a/packages/mcp-mock-server/src/oauth-callback-store.ts
+++ b/packages/mcp-mock-server/src/oauth-callback-store.ts
@@ -1,0 +1,39 @@
+type CallbackEntry = {
+  code: string;
+  receivedAt: number;
+};
+
+const callbacks = new Map<string, CallbackEntry>();
+
+export function storeOAuthCallback(state: string, code: string): void {
+  callbacks.set(state, { code, receivedAt: Date.now() });
+}
+
+export function takeOAuthCallback(state: string): string | undefined {
+  const entry = callbacks.get(state);
+  if (!entry) {
+    return undefined;
+  }
+  callbacks.delete(state);
+  return entry.code;
+}
+
+export function clearOAuthCallbacks(): void {
+  callbacks.clear();
+}
+
+export async function waitForOAuthCallbackFromStore(
+  state: string,
+  timeoutMs: number,
+  pollIntervalMs = 250,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const code = takeOAuthCallback(state);
+    if (code) {
+      return code;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for OAuth callback state=${state}`);
+}

--- a/packages/mcp-mock-server/src/oauth-probe.spec.ts
+++ b/packages/mcp-mock-server/src/oauth-probe.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import { formatOAuthProbeReport, runOAuthProbe } from "./oauth-probe.js";
+
+describe("oauth probe", () => {
+  it("reports MCP and authorization-server gaps", async () => {
+    const mcpBaseUrl = "http://mcp.local";
+    const asBase = "http://auth.local";
+    const resourceUri = `${mcpBaseUrl}/mcp`;
+
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url === `${mcpBaseUrl}/mcp` && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            error: "unauthorized",
+            resource_metadata: `${mcpBaseUrl}/.well-known/oauth-protected-resource`,
+          }),
+          {
+            status: 401,
+            headers: {
+              "WWW-Authenticate": `Bearer realm="mcp", resource_metadata="${mcpBaseUrl}/.well-known/oauth-protected-resource"`,
+            },
+          },
+        );
+      }
+
+      if (url === `${mcpBaseUrl}/.well-known/oauth-protected-resource`) {
+        return Response.json({
+          resource: resourceUri,
+          authorization_servers: [asBase],
+          bearer_methods_supported: ["header"],
+          scopes_supported: ["openid"],
+        });
+      }
+
+      if (url === `${asBase}/.well-known/oauth-authorization-server`) {
+        return new Response(JSON.stringify({ code: 5, message: "Not Found" }), { status: 404 });
+      }
+
+      if (url === `${asBase}/.well-known/openid-configuration`) {
+        return Response.json({
+          issuer: asBase,
+          authorization_endpoint: `${asBase}/oauth/v2/authorize`,
+          token_endpoint: `${asBase}/oauth/v2/token`,
+          registration_endpoint: `${asBase}/oauth/v2/register`,
+          code_challenge_methods_supported: ["S256"],
+          response_types_supported: ["code", "id_token token"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+        });
+      }
+
+      if (url === `${asBase}/oauth/v2/register` && method === "POST") {
+        return new Response("404 page not found", { status: 404 });
+      }
+
+      if (url.startsWith(`${asBase}/oauth/v2/authorize?`)) {
+        return new Response("", {
+          status: 302,
+          headers: { Location: `${asBase}/ui/login?authRequest=test` },
+        });
+      }
+
+      return new Response("not found", { status: 404 });
+    };
+
+    const report = await runOAuthProbe({
+      authorizationServerOverride: asBase,
+      fetchImpl,
+      mcpBaseUrl,
+    });
+
+    expect(report.summary.pass).toBeGreaterThan(0);
+    expect(report.summary.fail).toBeGreaterThan(0);
+    expect(report.steps.find((step) => step.name.includes("RFC 8414"))?.status).toBe("fail");
+    expect(report.steps.find((step) => step.name.includes("Dynamic client registration"))?.status).toBe(
+      "fail",
+    );
+    expect(formatOAuthProbeReport(report)).toContain("MCP OAuth probe report");
+  });
+
+  it("uses a freshly registered client for authorize when DCR succeeds", async () => {
+    const mcpBaseUrl = "http://mcp.local";
+    const asBase = "http://auth.local";
+    const resourceUri = `${mcpBaseUrl}/mcp`;
+    const dcrClientId = "dcr-client-123";
+    const mcpRedirectUri = "http://127.0.0.1/callback";
+    let authorizeUrl = "";
+
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url === `${mcpBaseUrl}/mcp` && method === "POST") {
+        return new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 401,
+          headers: {
+            "WWW-Authenticate": `Bearer realm="mcp", resource_metadata="${mcpBaseUrl}/.well-known/oauth-protected-resource"`,
+          },
+        });
+      }
+
+      if (url === `${mcpBaseUrl}/.well-known/oauth-protected-resource`) {
+        return Response.json({
+          resource: resourceUri,
+          authorization_servers: [asBase],
+        });
+      }
+
+      if (url === `${asBase}/.well-known/oauth-authorization-server`) {
+        return Response.json({
+          issuer: asBase,
+          authorization_endpoint: `${asBase}/oauth/v2/authorize`,
+          registration_endpoint: `${asBase}/oauth/v2/register`,
+          code_challenge_methods_supported: ["S256"],
+          response_types_supported: ["code"],
+        });
+      }
+
+      if (url === `${asBase}/oauth/v2/register` && method === "POST") {
+        return Response.json(
+          {
+            client_id: dcrClientId,
+            redirect_uris: [mcpRedirectUri],
+            grant_types: ["authorization_code"],
+            response_types: ["code"],
+            token_endpoint_auth_method: "none",
+            application_type: "native",
+          },
+          { status: 201 },
+        );
+      }
+
+      if (url.startsWith(`${asBase}/oauth/v2/authorize?`)) {
+        authorizeUrl = url;
+        return new Response("", {
+          status: 302,
+          headers: { Location: `${asBase}/ui/login?authRequest=test` },
+        });
+      }
+
+      return new Response("not found", { status: 404 });
+    };
+
+    const report = await runOAuthProbe({
+      authorizationServerOverride: asBase,
+      fetchImpl,
+      mcpBaseUrl,
+    });
+
+    expect(report.registeredClientId).toBe(dcrClientId);
+    expect(report.authorizeClientId).toBe(dcrClientId);
+    expect(report.authorizeRedirectUri).toBe(mcpRedirectUri);
+    expect(authorizeUrl).toContain(`client_id=${dcrClientId}`);
+    expect(authorizeUrl).toContain(`redirect_uri=${encodeURIComponent(mcpRedirectUri)}`);
+    expect(authorizeUrl).toContain(`resource=${encodeURIComponent(resourceUri)}`);
+    expect(
+      report.steps.find((step) => step.name.includes("Authorization request"))?.status,
+    ).toBe("pass");
+  });
+});

--- a/packages/mcp-mock-server/src/oauth-probe.ts
+++ b/packages/mcp-mock-server/src/oauth-probe.ts
@@ -1,0 +1,505 @@
+import { parseResourceMetadataUrl, probeFetch } from "./mcp-discovery.js";
+
+export type ProbeStatus = "pass" | "fail" | "warn" | "skip";
+
+export type ProbeStep = {
+  detail?: string;
+  name: string;
+  note?: string;
+  status: ProbeStatus;
+  url: string;
+};
+
+export type OAuthProbeReport = {
+  authorizationServer?: string;
+  authorizeClientId?: string;
+  authorizeRedirectUri?: string;
+  mcpBaseUrl: string;
+  mcpEndpoint: string;
+  protectedResourceMetadataUrl?: string;
+  registeredClientId?: string;
+  resourceUri?: string;
+  steps: ProbeStep[];
+  summary: {
+    fail: number;
+    pass: number;
+    skip: number;
+    warn: number;
+  };
+};
+
+export type OAuthProbeOptions = {
+  authorizationServerOverride?: string;
+  fetchImpl?: typeof fetch;
+  mcpBaseUrl: string;
+  probeClientId?: string;
+  probeRedirectUri?: string;
+};
+
+async function discoverProbeClientId(
+  authorizationServer: string,
+  fetchImpl: typeof fetch,
+): Promise<{ clientId?: string; redirectUri?: string }> {
+  const envUrl = `${trimTrailingSlash(authorizationServer)}/ui/console/assets/environment.json`;
+  try {
+    const response = await fetchImpl(envUrl);
+    if (!response.ok) {
+      return {};
+    }
+    const payload = (await response.json()) as { clientid?: string };
+    if (!payload.clientid) {
+      return {};
+    }
+    return {
+      clientId: payload.clientid,
+      redirectUri: `${trimTrailingSlash(authorizationServer)}/ui/console/auth/callback`,
+    };
+  } catch {
+    return {};
+  }
+}
+
+type DynamicClientRegistrationResponse = {
+  client_id?: string;
+  redirect_uris?: string[];
+};
+
+type AuthorizeClientSource = "dcr" | "explicit" | "console-fallback" | "placeholder";
+
+type ProtectedResourceMetadata = {
+  authorization_servers?: string[];
+  resource?: string;
+};
+
+type AuthorizationServerMetadata = {
+  authorization_endpoint?: string;
+  code_challenge_methods_supported?: string[];
+  grant_types_supported?: string[];
+  issuer?: string;
+  registration_endpoint?: string;
+  response_types_supported?: string[];
+  token_endpoint?: string;
+};
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function summarize(steps: ProbeStep[]): OAuthProbeReport["summary"] {
+  return steps.reduce(
+    (acc, step) => {
+      acc[step.status] += 1;
+      return acc;
+    },
+    { pass: 0, fail: 0, warn: 0, skip: 0 },
+  );
+}
+
+async function readResponse(
+  response: Response,
+): Promise<{ body: string; json?: unknown; status: number }> {
+  const body = await response.text();
+  try {
+    return { body, json: JSON.parse(body) as unknown, status: response.status };
+  } catch {
+    return { body, status: response.status };
+  }
+}
+
+function step(
+  name: string,
+  url: string,
+  status: ProbeStatus,
+  detail?: string,
+  note?: string,
+): ProbeStep {
+  return { name, url, status, detail, note };
+}
+
+export async function runOAuthProbe(options: OAuthProbeOptions): Promise<OAuthProbeReport> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const mcpBaseUrl = trimTrailingSlash(options.mcpBaseUrl);
+  const mcpEndpoint = `${mcpBaseUrl}/mcp`;
+  const steps: ProbeStep[] = [];
+
+  const mcpResponse = await probeFetch(fetchImpl, mcpEndpoint, {
+    body: JSON.stringify({ id: 1, jsonrpc: "2.0", method: "initialize" }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+  const mcpBody = await readResponse(mcpResponse);
+  const wwwAuthenticate = mcpResponse.headers.get("www-authenticate");
+  const resourceMetadataFromHeader = parseResourceMetadataUrl(wwwAuthenticate);
+  const resourceMetadataUrl =
+    resourceMetadataFromHeader ?? `${mcpBaseUrl}/.well-known/oauth-protected-resource`;
+
+  if (mcpResponse.status === 401 && wwwAuthenticate?.includes("resource_metadata=")) {
+    steps.push(
+      step(
+        "MCP resource server challenges unauthenticated requests",
+        mcpEndpoint,
+        "pass",
+        `HTTP ${mcpResponse.status}`,
+        wwwAuthenticate,
+      ),
+    );
+  } else {
+    steps.push(
+      step(
+        "MCP resource server challenges unauthenticated requests",
+        mcpEndpoint,
+        "fail",
+        `expected HTTP 401 with resource_metadata, got HTTP ${mcpResponse.status}`,
+        mcpBody.body.slice(0, 200),
+      ),
+    );
+  }
+
+  const metadataResponse = await probeFetch(fetchImpl, resourceMetadataUrl);
+  const metadataBody = await readResponse(metadataResponse);
+  const metadata = metadataBody.json as ProtectedResourceMetadata | undefined;
+
+  if (metadataResponse.status === 200 && metadata?.authorization_servers?.length) {
+    steps.push(
+      step(
+        "Protected resource metadata (RFC 9728)",
+        resourceMetadataUrl,
+        "pass",
+        `authorization_servers=${metadata.authorization_servers.join(", ")}`,
+        metadata.resource ? `resource=${metadata.resource}` : undefined,
+      ),
+    );
+  } else {
+    steps.push(
+      step(
+        "Protected resource metadata (RFC 9728)",
+        resourceMetadataUrl,
+        "fail",
+        `HTTP ${metadataResponse.status}`,
+        metadataBody.body.slice(0, 200),
+      ),
+    );
+  }
+
+  const authorizationServer = trimTrailingSlash(
+    options.authorizationServerOverride ??
+      metadata?.authorization_servers?.[0] ??
+      "http://localhost:8080",
+  );
+
+  const mcpRedirectUri = options.probeRedirectUri ?? "http://127.0.0.1/callback";
+
+  const rfc8414Url = `${authorizationServer}/.well-known/oauth-authorization-server`;
+  const rfc8414Response = await probeFetch(fetchImpl, rfc8414Url);
+  const rfc8414Body = await readResponse(rfc8414Response);
+  let asMetadata: AuthorizationServerMetadata | undefined;
+  let asMetadataUrl = rfc8414Url;
+
+  if (rfc8414Response.status === 200) {
+    asMetadata = rfc8414Body.json as AuthorizationServerMetadata;
+    steps.push(
+      step(
+        "Authorization server metadata (RFC 8414)",
+        rfc8414Url,
+        "pass",
+        `issuer=${asMetadata.issuer ?? authorizationServer}`,
+      ),
+    );
+  } else {
+    steps.push(
+      step(
+        "Authorization server metadata (RFC 8414)",
+        rfc8414Url,
+        "fail",
+        `HTTP ${rfc8414Response.status}`,
+        "MCP clients MUST use this path",
+      ),
+    );
+
+    const oidcUrl = `${authorizationServer}/.well-known/openid-configuration`;
+    const oidcResponse = await probeFetch(fetchImpl, oidcUrl);
+    const oidcBody = await readResponse(oidcResponse);
+    asMetadataUrl = oidcUrl;
+
+    if (oidcResponse.status === 200) {
+      asMetadata = oidcBody.json as AuthorizationServerMetadata;
+      steps.push(
+        step(
+          "OIDC discovery fallback",
+          oidcUrl,
+          "warn",
+          `issuer=${asMetadata.issuer ?? authorizationServer}`,
+          "Works for some clients, but MCP requires RFC 8414",
+        ),
+      );
+    } else {
+      steps.push(
+        step(
+          "OIDC discovery fallback",
+          oidcUrl,
+          "fail",
+          `HTTP ${oidcResponse.status}`,
+          oidcBody.body.slice(0, 200),
+        ),
+      );
+    }
+  }
+
+  const registrationEndpoint =
+    asMetadata?.registration_endpoint ?? `${authorizationServer}/oauth/v2/register`;
+  const dcrResponse = await probeFetch(fetchImpl, registrationEndpoint, {
+    body: JSON.stringify({
+      application_type: "native",
+      client_name: "mcp-oauth-probe",
+      grant_types: ["authorization_code"],
+      redirect_uris: [mcpRedirectUri],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+  const dcrBody = await readResponse(dcrResponse);
+  const dcrPayload = dcrBody.json as DynamicClientRegistrationResponse | undefined;
+  let registeredClientId: string | undefined;
+  let authorizeClientId: string | undefined;
+  let authorizeRedirectUri = mcpRedirectUri;
+  let authorizeClientSource: AuthorizeClientSource = "placeholder";
+
+  if (dcrResponse.status === 200 || dcrResponse.status === 201) {
+    registeredClientId = dcrPayload?.client_id;
+    authorizeClientId = registeredClientId;
+    authorizeRedirectUri = dcrPayload?.redirect_uris?.[0] ?? mcpRedirectUri;
+    authorizeClientSource = "dcr";
+    steps.push(
+      step(
+        "Dynamic client registration (RFC 7591)",
+        registrationEndpoint,
+        "pass",
+        `HTTP ${dcrResponse.status}${registeredClientId ? `, client_id=${registeredClientId}` : ""}`,
+        `redirect_uri=${authorizeRedirectUri}`,
+      ),
+    );
+  } else {
+    steps.push(
+      step(
+        "Dynamic client registration (RFC 7591)",
+        registrationEndpoint,
+        "fail",
+        `HTTP ${dcrResponse.status}`,
+        dcrBody.body.slice(0, 200),
+      ),
+    );
+
+    if (options.probeClientId) {
+      authorizeClientId = options.probeClientId;
+      authorizeRedirectUri = mcpRedirectUri;
+      authorizeClientSource = "explicit";
+      steps.push(
+        step(
+          "Authorize client selection",
+          registrationEndpoint,
+          "warn",
+          `using PROBE_CLIENT_ID=${authorizeClientId}`,
+          "DCR failed; explicit client override in use",
+        ),
+      );
+    } else {
+      const consoleClient = await discoverProbeClientId(authorizationServer, fetchImpl);
+      if (consoleClient.clientId) {
+        authorizeClientId = consoleClient.clientId;
+        authorizeRedirectUri = consoleClient.redirectUri ?? mcpRedirectUri;
+        authorizeClientSource = "console-fallback";
+        steps.push(
+          step(
+            "Authorize client selection",
+            `${authorizationServer}/ui/console/assets/environment.json`,
+            "warn",
+            `fallback client_id=${authorizeClientId}`,
+            "DCR failed; using console client instead of MCP self-registration flow",
+          ),
+        );
+      } else {
+        authorizeClientId = "mcp-oauth-probe-client";
+        authorizeClientSource = "placeholder";
+        steps.push(
+          step(
+            "Authorize client selection",
+            registrationEndpoint,
+            "warn",
+            "no DCR client and no fallback client discovered",
+            "authorize step will likely fail",
+          ),
+        );
+      }
+    }
+  }
+
+  const authorizeEndpoint =
+    asMetadata?.authorization_endpoint ?? `${authorizationServer}/oauth/v2/authorize`;
+  const resourceUri = metadata?.resource ?? mcpEndpoint;
+  const authorizeUrl = new URL(authorizeEndpoint);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set("client_id", authorizeClientId ?? "mcp-oauth-probe-client");
+  authorizeUrl.searchParams.set("redirect_uri", authorizeRedirectUri);
+  authorizeUrl.searchParams.set("scope", "openid");
+  authorizeUrl.searchParams.set("state", "mcp-oauth-probe");
+  authorizeUrl.searchParams.set(
+    "code_challenge",
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  );
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+  authorizeUrl.searchParams.set("resource", resourceUri);
+
+  let authorizeResponse: Response | undefined;
+  let authorizeBody: { body: string; json?: unknown; status: number } | undefined;
+  let authorizeAttempts = 0;
+  const maxAuthorizeAttempts = authorizeClientSource === "dcr" ? 15 : 1;
+
+  for (let attempt = 1; attempt <= maxAuthorizeAttempts; attempt += 1) {
+    authorizeAttempts = attempt;
+    authorizeResponse = await probeFetch(fetchImpl, authorizeUrl.toString(), { redirect: "manual" });
+    authorizeBody = await readResponse(authorizeResponse);
+    const appNotFound = authorizeBody.body.includes("App.NotFound");
+    if (!appNotFound || attempt === maxAuthorizeAttempts) {
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  if (!authorizeResponse || !authorizeBody) {
+    throw new Error("authorize probe did not run");
+  }
+
+  const location = authorizeResponse.headers.get("location") ?? "";
+
+  if (authorizeBody.body.includes("invalid_target")) {
+    steps.push(
+      step(
+        "Authorization request with RFC 8707 resource parameter",
+        authorizeUrl.toString(),
+        "fail",
+        "authorization server rejected resource parameter",
+        authorizeBody.body.slice(0, 200),
+      ),
+    );
+  } else if (
+    authorizeResponse.status === 302 ||
+    authorizeResponse.status === 303 ||
+    location.includes("authorize") ||
+    location.includes("login") ||
+    location.includes("authRequest=")
+  ) {
+    const authorizeStatus: ProbeStatus =
+      authorizeClientSource === "dcr" || authorizeClientSource === "explicit"
+        ? "pass"
+        : "warn";
+    const authorizeNote =
+      authorizeClientSource === "dcr"
+        ? authorizeAttempts > 1
+          ? `authorize accepted for freshly DCR-registered MCP client after ${authorizeAttempts} attempts; verify issued token aud separately`
+          : "authorize accepted for freshly DCR-registered MCP client; verify issued token aud separately"
+        : authorizeClientSource === "explicit"
+          ? "authorize accepted for explicit probe client; verify issued token aud separately"
+          : "authorize reached login, but client was not obtained via MCP self-registration";
+    steps.push(
+      step(
+        "Authorization request with RFC 8707 resource parameter",
+        authorizeUrl.toString(),
+        authorizeStatus,
+        `HTTP ${authorizeResponse.status}`,
+        authorizeNote,
+      ),
+    );
+  } else {
+    steps.push(
+      step(
+        "Authorization request with RFC 8707 resource parameter",
+        authorizeUrl.toString(),
+        "fail",
+        `HTTP ${authorizeResponse.status}`,
+        authorizeBody.body.slice(0, 200),
+      ),
+    );
+  }
+
+  if (asMetadata?.code_challenge_methods_supported?.includes("S256")) {
+    steps.push(
+      step("PKCE S256 support advertised", asMetadataUrl, "pass", "code_challenge_methods_supported includes S256"),
+    );
+  } else {
+    steps.push(
+      step(
+        "PKCE S256 support advertised",
+        asMetadataUrl,
+        "warn",
+        "S256 not advertised in discovery document",
+      ),
+    );
+  }
+
+  if (asMetadata?.response_types_supported?.includes("id_token token")) {
+    steps.push(
+      step(
+        "OAuth 2.1 profile (no implicit flow)",
+        asMetadataUrl,
+        "warn",
+        'response_types_supported still includes implicit-style "id_token token"',
+      ),
+    );
+  } else {
+    steps.push(step("OAuth 2.1 profile (no implicit flow)", asMetadataUrl, "pass"));
+  }
+
+  return {
+    authorizationServer,
+    authorizeClientId,
+    authorizeRedirectUri,
+    mcpBaseUrl,
+    mcpEndpoint,
+    protectedResourceMetadataUrl: resourceMetadataUrl,
+    registeredClientId,
+    resourceUri,
+    steps,
+    summary: summarize(steps),
+  };
+}
+
+export function formatOAuthProbeReport(report: OAuthProbeReport): string {
+  const lines = [
+    "MCP OAuth probe report",
+    "",
+    `MCP endpoint:              ${report.mcpEndpoint}`,
+    `Protected resource meta:   ${report.protectedResourceMetadataUrl ?? "(unknown)"}`,
+    `Authorization server:      ${report.authorizationServer ?? "(unknown)"}`,
+    `Canonical resource URI:    ${report.resourceUri ?? "(unknown)"}`,
+    `DCR client_id:           ${report.registeredClientId ?? "(not registered)"}`,
+    `Authorize client_id:       ${report.authorizeClientId ?? "(unknown)"}`,
+    `Authorize redirect_uri:    ${report.authorizeRedirectUri ?? "(unknown)"}`,
+    "",
+    `Summary: ${report.summary.pass} pass, ${report.summary.warn} warn, ${report.summary.fail} fail, ${report.summary.skip} skip`,
+    "",
+  ];
+
+  for (const probeStep of report.steps) {
+    const icon =
+      probeStep.status === "pass"
+        ? "✅"
+        : probeStep.status === "warn"
+          ? "⚠️"
+          : probeStep.status === "skip"
+            ? "⏭️"
+            : "❌";
+    lines.push(`${icon} ${probeStep.name}`);
+    lines.push(`   ${probeStep.url}`);
+    if (probeStep.detail) {
+      lines.push(`   ${probeStep.detail}`);
+    }
+    if (probeStep.note) {
+      lines.push(`   note: ${probeStep.note}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}

--- a/packages/mcp-mock-server/src/oauth-probe.ts
+++ b/packages/mcp-mock-server/src/oauth-probe.ts
@@ -1,4 +1,10 @@
+import { originFromResourceUri } from "./config.js";
 import { parseResourceMetadataUrl, probeFetch } from "./mcp-discovery.js";
+import {
+  cimdClientIdUrl,
+  cimdRedirectUri,
+  isCimdCompatibleOrigin,
+} from "./cimd.js";
 
 export type ProbeStatus = "pass" | "fail" | "warn" | "skip";
 
@@ -14,6 +20,7 @@ export type OAuthProbeReport = {
   authorizationServer?: string;
   authorizeClientId?: string;
   authorizeRedirectUri?: string;
+  cimdClientId?: string;
   mcpBaseUrl: string;
   mcpEndpoint: string;
   protectedResourceMetadataUrl?: string;
@@ -34,6 +41,7 @@ export type OAuthProbeOptions = {
   mcpBaseUrl: string;
   probeClientId?: string;
   probeRedirectUri?: string;
+  publicOrigin?: string;
 };
 
 async function discoverProbeClientId(
@@ -73,6 +81,7 @@ type ProtectedResourceMetadata = {
 
 type AuthorizationServerMetadata = {
   authorization_endpoint?: string;
+  client_id_metadata_document_supported?: boolean;
   code_challenge_methods_supported?: string[];
   grant_types_supported?: string[];
   issuer?: string;
@@ -243,6 +252,118 @@ export async function runOAuthProbe(options: OAuthProbeOptions): Promise<OAuthPr
         ),
       );
     }
+  }
+
+  const cimdSupported = asMetadata?.client_id_metadata_document_supported === true;
+  let cimdClientId: string | undefined;
+
+  if (cimdSupported) {
+    steps.push(
+      step(
+        "Client ID Metadata Document (CIMD) advertised",
+        asMetadataUrl,
+        "pass",
+        "client_id_metadata_document_supported=true",
+      ),
+    );
+  } else if (asMetadata) {
+    steps.push(
+      step(
+        "Client ID Metadata Document (CIMD) advertised",
+        asMetadataUrl,
+        "warn",
+        "client_id_metadata_document_supported is not true",
+        "Zitadel PR #12316 enables this via oidc_client_id_metadata_document",
+      ),
+    );
+  }
+
+  const discoveredResourceUri = metadata?.resource ?? mcpEndpoint;
+  const publicOrigin =
+    originFromResourceUri(discoveredResourceUri) ?? options.publicOrigin;
+  if (cimdSupported && publicOrigin && isCimdCompatibleOrigin(publicOrigin)) {
+    cimdClientId = cimdClientIdUrl(publicOrigin);
+    const localCimdUrl = `${mcpBaseUrl}/.well-known/oauth-client`;
+    const localCimdResponse = await probeFetch(fetchImpl, localCimdUrl);
+    const localCimdBody = await readResponse(localCimdResponse);
+    if (localCimdResponse.status === 200) {
+      steps.push(
+        step(
+          "Mock server serves CIMD metadata document",
+          localCimdUrl,
+          "pass",
+          `client_id=${cimdClientId}`,
+          `redirect_uri=${cimdRedirectUri(publicOrigin)}`,
+        ),
+      );
+    } else {
+      steps.push(
+        step(
+          "Mock server serves CIMD metadata document",
+          localCimdUrl,
+          "fail",
+          `HTTP ${localCimdResponse.status}`,
+          localCimdBody.body.slice(0, 200),
+        ),
+      );
+    }
+
+    const cimdAuthorizeEndpoint =
+      asMetadata?.authorization_endpoint ?? `${authorizationServer}/oauth/v2/authorize`;
+    const cimdAuthorizeUrl = new URL(cimdAuthorizeEndpoint);
+    cimdAuthorizeUrl.searchParams.set("response_type", "code");
+    cimdAuthorizeUrl.searchParams.set("client_id", cimdClientId);
+    cimdAuthorizeUrl.searchParams.set("redirect_uri", cimdRedirectUri(publicOrigin));
+    cimdAuthorizeUrl.searchParams.set("scope", "openid");
+    cimdAuthorizeUrl.searchParams.set("state", "mcp-oauth-probe-cimd");
+    cimdAuthorizeUrl.searchParams.set(
+      "code_challenge",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    cimdAuthorizeUrl.searchParams.set("code_challenge_method", "S256");
+    cimdAuthorizeUrl.searchParams.set("resource", discoveredResourceUri);
+
+    const cimdAuthorizeResponse = await probeFetch(fetchImpl, cimdAuthorizeUrl.toString(), {
+      redirect: "manual",
+    });
+    const cimdAuthorizeBody = await readResponse(cimdAuthorizeResponse);
+    const cimdLocation = cimdAuthorizeResponse.headers.get("location") ?? "";
+    if (
+      cimdAuthorizeResponse.status === 302 ||
+      cimdAuthorizeResponse.status === 303 ||
+      cimdLocation.includes("login") ||
+      cimdLocation.includes("authRequest=")
+    ) {
+      steps.push(
+        step(
+          "CIMD authorization request with RFC 8707 resource parameter",
+          cimdAuthorizeUrl.toString(),
+          "pass",
+          `HTTP ${cimdAuthorizeResponse.status}`,
+          "authorize accepted URL-form client_id; complete login with probe-token --cimd",
+        ),
+      );
+    } else {
+      steps.push(
+        step(
+          "CIMD authorization request with RFC 8707 resource parameter",
+          cimdAuthorizeUrl.toString(),
+          "fail",
+          `HTTP ${cimdAuthorizeResponse.status}`,
+          cimdAuthorizeBody.body.slice(0, 200),
+        ),
+      );
+    }
+  } else if (cimdSupported) {
+    steps.push(
+      step(
+        "CIMD authorization request",
+        asMetadataUrl,
+        "skip",
+        "requires MCP_PUBLIC_ORIGIN=https://… on the mock server",
+        "Start the mock server with MCP_RESOURCE_URI=https://<tunnel>/mcp (or set MCP_PUBLIC_ORIGIN); Zitadel rejects loopback origins",
+      ),
+    );
   }
 
   const registrationEndpoint =
@@ -455,6 +576,7 @@ export async function runOAuthProbe(options: OAuthProbeOptions): Promise<OAuthPr
     authorizationServer,
     authorizeClientId,
     authorizeRedirectUri,
+    cimdClientId,
     mcpBaseUrl,
     mcpEndpoint,
     protectedResourceMetadataUrl: resourceMetadataUrl,
@@ -474,6 +596,7 @@ export function formatOAuthProbeReport(report: OAuthProbeReport): string {
     `Authorization server:      ${report.authorizationServer ?? "(unknown)"}`,
     `Canonical resource URI:    ${report.resourceUri ?? "(unknown)"}`,
     `DCR client_id:           ${report.registeredClientId ?? "(not registered)"}`,
+    `CIMD client_id:          ${report.cimdClientId ?? "(not probed)"}`,
     `Authorize client_id:       ${report.authorizeClientId ?? "(unknown)"}`,
     `Authorize redirect_uri:    ${report.authorizeRedirectUri ?? "(unknown)"}`,
     "",

--- a/packages/mcp-mock-server/src/pkce.ts
+++ b/packages/mcp-mock-server/src/pkce.ts
@@ -1,0 +1,19 @@
+import { createHash, randomBytes } from "node:crypto";
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer.toString("base64url");
+}
+
+export type PkcePair = {
+  codeChallenge: string;
+  codeVerifier: string;
+};
+
+export function createPkcePair(): PkcePair {
+  const codeVerifier = base64UrlEncode(randomBytes(32));
+  return { codeChallenge: createCodeChallenge(codeVerifier), codeVerifier };
+}
+
+export function createCodeChallenge(codeVerifier: string): string {
+  return base64UrlEncode(createHash("sha256").update(codeVerifier).digest());
+}

--- a/packages/mcp-mock-server/src/protected-resource.ts
+++ b/packages/mcp-mock-server/src/protected-resource.ts
@@ -1,0 +1,39 @@
+import type { McpMockServerConfig } from "./config.js";
+
+export type ProtectedResourceMetadata = {
+  authorization_servers: string[];
+  bearer_methods_supported: string[];
+  resource: string;
+  scopes_supported: string[];
+};
+
+export function buildProtectedResourceMetadata(
+  config: McpMockServerConfig,
+): ProtectedResourceMetadata {
+  return {
+    resource: config.resourceUri,
+    authorization_servers: [config.authorizationServer],
+    bearer_methods_supported: ["header"],
+    scopes_supported: ["openid", "profile", "email"],
+  };
+}
+
+export function protectedResourceMetadataPath(config: McpMockServerConfig): string {
+  const resourcePath = new URL(config.resourceUri).pathname;
+  if (resourcePath === "/" || resourcePath === "") {
+    return "/.well-known/oauth-protected-resource";
+  }
+  return `/.well-known/oauth-protected-resource${resourcePath}`;
+}
+
+export function protectedResourceMetadataUrl(config: McpMockServerConfig): string {
+  return `${config.publicOrigin}${protectedResourceMetadataPath(config)}`;
+}
+
+export function buildWwwAuthenticateHeader(
+  config: McpMockServerConfig,
+  message = "Authorization required",
+): string {
+  const metadataUrl = protectedResourceMetadataUrl(config);
+  return `Bearer error="invalid_token", error_description="${message}", resource_metadata="${metadataUrl}"`;
+}

--- a/packages/mcp-mock-server/src/server.spec.ts
+++ b/packages/mcp-mock-server/src/server.spec.ts
@@ -66,6 +66,20 @@ describe("mcp mock server", () => {
     });
   });
 
+  it("serves CIMD metadata when public origin is https", async () => {
+    const httpsConfig: McpMockServerConfig = {
+      ...config,
+      publicOrigin: "https://mcp.example.com",
+      resourceUri: "https://mcp.example.com/mcp",
+    };
+    const httpsApp = createMcpMockApp(httpsConfig);
+    const response = await request(httpsApp).get("/.well-known/oauth-client");
+
+    expect(response.status).toBe(200);
+    expect(response.body.redirect_uris).toEqual(["https://mcp.example.com/oauth/callback"]);
+    expect(response.body.token_endpoint_auth_method).toBe("none");
+  });
+
   it("returns 202 for initialized notification", async () => {
     const init = await request(app)
       .post("/mcp")

--- a/packages/mcp-mock-server/src/server.spec.ts
+++ b/packages/mcp-mock-server/src/server.spec.ts
@@ -1,0 +1,96 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import type { McpMockServerConfig } from "./config.js";
+import { createMcpMockApp } from "./server.js";
+
+const config: McpMockServerConfig = {
+  authorizationServer: "http://localhost:8080",
+  host: "localhost",
+  introspect: false,
+  port: 9090,
+  publicOrigin: "http://localhost:9090",
+  resourceUri: "http://localhost:9090/mcp",
+};
+
+describe("mcp mock server", () => {
+  const app = createMcpMockApp(config);
+
+  it("serves RFC 9728 protected resource metadata", async () => {
+    const response = await request(app).get("/.well-known/oauth-protected-resource/mcp");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      resource: "http://localhost:9090/mcp",
+      authorization_servers: ["http://localhost:8080"],
+      bearer_methods_supported: ["header"],
+      scopes_supported: ["openid", "profile", "email"],
+    });
+  });
+
+  it("returns 401 with WWW-Authenticate for unauthenticated MCP requests", async () => {
+    const response = await request(app).post("/mcp").send({ jsonrpc: "2.0", method: "initialize" });
+
+    expect(response.status).toBe(401);
+    expect(response.headers["www-authenticate"]).toBe(
+      'Bearer error="invalid_token", error_description="Authorization required", resource_metadata="http://localhost:9090/.well-known/oauth-protected-resource/mcp"',
+    );
+    expect(response.body.resource_metadata).toBe(
+      "http://localhost:9090/.well-known/oauth-protected-resource/mcp",
+    );
+  });
+
+  it("accepts any bearer token when introspection is disabled", async () => {
+    const response = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer probe-token")
+      .send({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0" },
+          protocolVersion: "2025-06-18",
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers["mcp-session-id"]).toBeTruthy();
+    expect(response.body).toMatchObject({
+      id: 1,
+      result: {
+        protocolVersion: "2025-06-18",
+        serverInfo: { name: "zitadel-mcp-mock-server" },
+      },
+    });
+  });
+
+  it("returns 202 for initialized notification", async () => {
+    const init = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer probe-token")
+      .send({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18" },
+      });
+
+    const sessionId = init.headers["mcp-session-id"];
+    if (typeof sessionId !== "string") {
+      throw new Error("initialize response did not include Mcp-Session-Id");
+    }
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer probe-token")
+      .set("Mcp-Session-Id", sessionId)
+      .send({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      });
+
+    expect(response.status).toBe(202);
+  });
+});

--- a/packages/mcp-mock-server/src/server.ts
+++ b/packages/mcp-mock-server/src/server.ts
@@ -4,12 +4,20 @@ import express, { type Express, type Request, type Response } from "express";
 
 import { type McpMockServerConfig, loadConfig } from "./config.js";
 import {
+  CIMD_CALLBACK_PATH,
+  CIMD_METADATA_PATH,
+  buildCimdClientMetadata,
+  cimdClientIdUrl,
+  isCimdCompatibleOrigin,
+} from "./cimd.js";
+import {
   buildProtectedResourceMetadata,
   buildWwwAuthenticateHeader,
   protectedResourceMetadataPath,
   protectedResourceMetadataUrl,
 } from "./protected-resource.js";
 import { dispatchMcpBody, isKnownSession } from "./mcp-protocol.js";
+import { storeOAuthCallback, takeOAuthCallback } from "./oauth-callback-store.js";
 import { validateAccessToken } from "./token-validation.js";
 
 function bearerToken(req: Request): string | undefined {
@@ -70,6 +78,7 @@ export function createMcpMockApp(config: McpMockServerConfig): Express {
         `MCP endpoint:        POST ${config.resourceUri}`,
         `Protected metadata:  ${protectedResourceMetadataUrl(config)}`,
         `Authorization server: ${config.authorizationServer}`,
+        `CIMD metadata:       ${isCimdCompatibleOrigin(config.publicOrigin) ? cimdClientIdUrl(config.publicOrigin) : "(requires MCP_PUBLIC_ORIGIN=https://…)"}`,
         `Token validation:    ${config.introspect ? "Zitadel introspection" : "accept any bearer token"}`,
         "",
         "Unauthenticated MCP requests return HTTP 401 with WWW-Authenticate.",
@@ -83,6 +92,52 @@ export function createMcpMockApp(config: McpMockServerConfig): Express {
 
   app.get("/.well-known/oauth-protected-resource", serveProtectedResourceMetadata);
   app.get(protectedResourceMetadataPath(config), serveProtectedResourceMetadata);
+
+  app.get(CIMD_METADATA_PATH, (_req, res) => {
+    if (!isCimdCompatibleOrigin(config.publicOrigin)) {
+      res.status(400).json({
+        error: "cimd_unavailable",
+        message: "Set MCP_PUBLIC_ORIGIN to an https URL reachable by Zitadel (for example an ngrok tunnel)",
+      });
+      return;
+    }
+    res.json(buildCimdClientMetadata(config.publicOrigin));
+  });
+
+  app.get(CIMD_CALLBACK_PATH, (req, res) => {
+    const error = typeof req.query.error === "string" ? req.query.error : undefined;
+    if (error) {
+      res.status(400).type("text/plain").send(`Authorization failed: ${error}`);
+      return;
+    }
+
+    const code = typeof req.query.code === "string" ? req.query.code : undefined;
+    const state = typeof req.query.state === "string" ? req.query.state : undefined;
+    if (!code || !state) {
+      res.status(400).type("text/plain").send("missing code or state");
+      return;
+    }
+
+    storeOAuthCallback(state, code);
+    res
+      .status(200)
+      .type("text/plain")
+      .send("Authorization complete. You can close this tab and return to the terminal.");
+  });
+
+  app.get("/_probe/oauth/callback", (req, res) => {
+    const state = typeof req.query.state === "string" ? req.query.state : undefined;
+    if (!state) {
+      res.status(400).json({ error: "missing_state" });
+      return;
+    }
+    const code = takeOAuthCallback(state);
+    if (!code) {
+      res.status(404).json({ error: "callback_pending" });
+      return;
+    }
+    res.json({ code, state });
+  });
 
   const handleMcpRequest = async (req: Request, res: Response): Promise<void> => {
     const token = bearerToken(req);

--- a/packages/mcp-mock-server/src/server.ts
+++ b/packages/mcp-mock-server/src/server.ts
@@ -1,0 +1,172 @@
+import { type Server } from "node:http";
+
+import express, { type Express, type Request, type Response } from "express";
+
+import { type McpMockServerConfig, loadConfig } from "./config.js";
+import {
+  buildProtectedResourceMetadata,
+  buildWwwAuthenticateHeader,
+  protectedResourceMetadataPath,
+  protectedResourceMetadataUrl,
+} from "./protected-resource.js";
+import { dispatchMcpBody, isKnownSession } from "./mcp-protocol.js";
+import { validateAccessToken } from "./token-validation.js";
+
+function bearerToken(req: Request): string | undefined {
+  const header = req.header("authorization");
+  if (!header?.startsWith("Bearer ")) {
+    return undefined;
+  }
+  const token = header.slice("Bearer ".length).trim();
+  return token.length > 0 ? token : undefined;
+}
+
+function sendUnauthorized(res: Response, config: McpMockServerConfig, message: string): void {
+  res.setHeader("WWW-Authenticate", buildWwwAuthenticateHeader(config));
+  res.status(401).json({
+    error: "unauthorized",
+    message,
+    resource_metadata: protectedResourceMetadataUrl(config),
+  });
+}
+
+function handleAuthenticatedGetMcp(req: Request, res: Response): void {
+  const accept = req.header("accept") ?? "";
+  if (!accept.includes("text/event-stream")) {
+    res.status(405).type("text/plain").send("Use POST for MCP requests or Accept: text/event-stream for SSE");
+    return;
+  }
+
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Connection", "keep-alive");
+  res.status(200);
+  res.flushHeaders();
+  res.write(": connected\n\n");
+
+  const keepalive = setInterval(() => {
+    res.write(": keepalive\n\n");
+  }, 30_000);
+
+  req.on("close", () => {
+    clearInterval(keepalive);
+  });
+}
+
+export function createMcpMockApp(config: McpMockServerConfig): Express {
+  const app = express();
+  app.disable("x-powered-by");
+  app.use(express.json({ limit: "1mb" }));
+
+  app.get("/healthz", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
+  app.get("/", (_req, res) => {
+    res.type("text/plain").send(
+      [
+        "Zitadel MCP mock resource server",
+        "",
+        `MCP endpoint:        POST ${config.resourceUri}`,
+        `Protected metadata:  ${protectedResourceMetadataUrl(config)}`,
+        `Authorization server: ${config.authorizationServer}`,
+        `Token validation:    ${config.introspect ? "Zitadel introspection" : "accept any bearer token"}`,
+        "",
+        "Unauthenticated MCP requests return HTTP 401 with WWW-Authenticate.",
+      ].join("\n"),
+    );
+  });
+
+  const serveProtectedResourceMetadata = (_req: Request, res: Response): void => {
+    res.json(buildProtectedResourceMetadata(config));
+  };
+
+  app.get("/.well-known/oauth-protected-resource", serveProtectedResourceMetadata);
+  app.get(protectedResourceMetadataPath(config), serveProtectedResourceMetadata);
+
+  const handleMcpRequest = async (req: Request, res: Response): Promise<void> => {
+    const token = bearerToken(req);
+    if (!token) {
+      sendUnauthorized(res, config, "Authorization required");
+      return;
+    }
+
+    const validation = await validateAccessToken(token, config);
+    if (!validation.active) {
+      sendUnauthorized(res, config, validation.reason);
+      return;
+    }
+
+    if (req.method === "GET") {
+      handleAuthenticatedGetMcp(req, res);
+      return;
+    }
+
+    const sessionId = req.header("mcp-session-id");
+    const body = req.body as unknown;
+    const messages = Array.isArray(body) ? body : [body];
+    const isInitialize = messages.some(
+      (message) =>
+        typeof message === "object" &&
+        message !== null &&
+        "method" in message &&
+        (message as { method?: string }).method === "initialize",
+    );
+
+    if (!isInitialize) {
+      if (!sessionId) {
+        res.status(400).json({
+          error: "missing_session_id",
+          message: "Mcp-Session-Id header is required after initialization",
+        });
+        return;
+      }
+      if (!isKnownSession(sessionId)) {
+        res.status(404).json({
+          error: "session_not_found",
+          message: "Unknown or expired MCP session",
+        });
+        return;
+      }
+    }
+
+    const outcome = dispatchMcpBody(body);
+    if (outcome.sessionId) {
+      res.setHeader("Mcp-Session-Id", outcome.sessionId);
+    }
+
+    if (outcome.httpStatus === 202) {
+      res.status(202).end();
+      return;
+    }
+
+    if (outcome.body === undefined) {
+      res.status(outcome.httpStatus).end();
+      return;
+    }
+
+    res.status(outcome.httpStatus).json(outcome.body);
+  };
+
+  app.get("/mcp", handleMcpRequest);
+  app.post("/mcp", handleMcpRequest);
+
+  return app;
+}
+
+export function startMcpMockServer(config: McpMockServerConfig = loadConfig()): Server {
+  const app = createMcpMockApp(config);
+  const server = app.listen(config.port, config.host, () => {
+    const metadataUrl = protectedResourceMetadataUrl(config);
+    console.log(`[mcp-mock-server] listening on http://${config.host}:${config.port}`);
+    console.log(`[mcp-mock-server] MCP endpoint: ${config.resourceUri}`);
+    console.log(`[mcp-mock-server] protected resource metadata: ${metadataUrl}`);
+    console.log(`[mcp-mock-server] authorization server: ${config.authorizationServer}`);
+    console.log(
+      `[mcp-mock-server] token validation: ${
+        config.introspect ? "Zitadel introspection" : "accept any bearer token"
+      }`,
+    );
+  });
+  return server;
+}

--- a/packages/mcp-mock-server/src/token-probe.spec.ts
+++ b/packages/mcp-mock-server/src/token-probe.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { audienceMatchesResource, decodeJwt } from "./jwt.js";
+import { createPkcePair } from "./pkce.js";
+import { buildAuthorizeUrl, exchangeAuthorizationCode } from "./token-probe.js";
+
+describe("token probe helpers", () => {
+  it("creates PKCE pairs", () => {
+    const pair = createPkcePair();
+    expect(pair.codeVerifier.length).toBeGreaterThan(20);
+    expect(pair.codeChallenge.length).toBeGreaterThan(20);
+  });
+
+  it("builds authorize URLs with resource parameter", () => {
+    const url = buildAuthorizeUrl({
+      authorizationServer: "http://auth.local",
+      clientId: "client-1",
+      codeChallenge: "challenge",
+      redirectUri: "http://127.0.0.1:8765/callback",
+      resourceUri: "http://mcp.local/mcp",
+      state: "state-1",
+    });
+    expect(url).toContain("client_id=client-1");
+    expect(url).toContain("resource=http%3A%2F%2Fmcp.local%2Fmcp");
+  });
+
+  it("decodes jwt audience claims", () => {
+    const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+    const payload = Buffer.from(
+      JSON.stringify({ aud: "http://mcp.local/mcp", sub: "user-1" }),
+    ).toString("base64url");
+    const token = `${header}.${payload}.`;
+    const decoded = decodeJwt(token);
+    expect(decoded?.payload.sub).toBe("user-1");
+    expect(audienceMatchesResource(decoded?.payload ?? {}, "http://mcp.local/mcp")).toBe(true);
+    expect(audienceMatchesResource(decoded?.payload ?? {}, "http://other.local/mcp")).toBe(false);
+  });
+
+  it("sends resource to the token endpoint", async () => {
+    let tokenBody = "";
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      tokenBody = String(init?.body ?? "");
+      return Response.json({ access_token: "jwt.token.here", token_type: "Bearer" });
+    };
+
+    await exchangeAuthorizationCode({
+      authorizationServer: "http://auth.local",
+      clientId: "client-1",
+      code: "auth-code",
+      codeVerifier: "verifier",
+      fetchImpl,
+      redirectUri: "http://127.0.0.1:8765/callback",
+      resourceUri: "http://mcp.local/mcp",
+    });
+
+    expect(tokenBody).toContain("resource=http%3A%2F%2Fmcp.local%2Fmcp");
+    expect(tokenBody).toContain("code_verifier=verifier");
+  });
+});

--- a/packages/mcp-mock-server/src/token-probe.ts
+++ b/packages/mcp-mock-server/src/token-probe.ts
@@ -5,11 +5,16 @@ import path from "node:path";
 
 import { createCodeChallenge, createPkcePair } from "./pkce.js";
 import { audienceMatchesResource, decodeJwt } from "./jwt.js";
+import { cimdClientIdUrl, cimdRedirectUri, isCimdCompatibleOrigin } from "./cimd.js";
+
+export type ClientRegistrationMode = "dcr" | "cimd";
 
 export type TokenProbeSession = {
   authorizationServer: string;
   clientId: string;
+  clientRegistration: ClientRegistrationMode;
   codeVerifier: string;
+  mcpBaseUrl: string;
   mcpEndpoint: string;
   redirectUri: string;
   resourceUri: string;
@@ -42,9 +47,12 @@ export type TokenProbeOptions = {
   authorizationServer: string;
   callbackPort?: number;
   callbackTimeoutMs?: number;
+  clientRegistration?: ClientRegistrationMode;
   fetchImpl?: typeof fetch;
+  mcpBaseUrl: string;
   mcpEndpoint: string;
   openBrowser?: boolean;
+  publicOrigin?: string;
   redirectUri?: string;
   resourceUri: string;
   sessionFile?: string;
@@ -121,6 +129,31 @@ export async function registerDynamicClient(
     throw new Error("DCR succeeded but response did not include client_id");
   }
   return { clientId, registrationEndpoint };
+}
+
+export async function waitForOAuthCallbackViaMockServer(input: {
+  fetchImpl: typeof fetch;
+  mcpBaseUrl: string;
+  state: string;
+  timeoutMs: number;
+}): Promise<string> {
+  const deadline = Date.now() + input.timeoutMs;
+  const pollUrl = `${input.mcpBaseUrl}/_probe/oauth/callback`;
+  while (Date.now() < deadline) {
+    const response = await input.fetchImpl(
+      `${pollUrl}?state=${encodeURIComponent(input.state)}`,
+    );
+    if (response.status === 200) {
+      const payload = (await response.json()) as { code?: string };
+      if (payload.code) {
+        return payload.code;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(
+    `timed out after ${input.timeoutMs}ms waiting for OAuth callback on ${pollUrl}`,
+  );
 }
 
 export function buildAuthorizeUrl(input: {
@@ -270,13 +303,20 @@ async function openBrowser(url: string): Promise<void> {
 export async function runTokenProbe(options: TokenProbeOptions): Promise<TokenProbeReport> {
   const fetchImpl = options.fetchImpl ?? fetch;
   const callbackPort = options.callbackPort ?? 8765;
-  const redirectUri = options.redirectUri ?? `http://127.0.0.1:${callbackPort}/callback`;
+  const mcpBaseUrl = options.mcpBaseUrl.replace(/\/$/, "");
+  const clientRegistration = options.clientRegistration ?? "dcr";
+  const redirectUri =
+    options.redirectUri ??
+    (clientRegistration === "cimd"
+      ? cimdRedirectUri(options.publicOrigin ?? "")
+      : `http://127.0.0.1:${callbackPort}/callback`);
   const sessionFile = options.sessionFile ?? DEFAULT_SESSION_FILE;
   const steps: TokenProbeStep[] = [];
   const state = "mcp-token-probe";
 
   let clientId: string;
   let codeVerifier: string;
+  let activeRegistration = clientRegistration;
 
   if (options.authorizationCode) {
     const savedSession = await loadTokenProbeSession(sessionFile);
@@ -287,6 +327,7 @@ export async function runTokenProbe(options: TokenProbeOptions): Promise<TokenPr
     }
     clientId = savedSession.clientId;
     codeVerifier = savedSession.codeVerifier;
+    activeRegistration = savedSession.clientRegistration;
     steps.push(
       step(
         "Reuse persisted probe session",
@@ -295,6 +336,36 @@ export async function runTokenProbe(options: TokenProbeOptions): Promise<TokenPr
         sessionFile,
       ),
     );
+  } else if (clientRegistration === "cimd") {
+    if (!options.publicOrigin || !isCimdCompatibleOrigin(options.publicOrigin)) {
+      throw new Error(
+        "CIMD requires MCP_PUBLIC_ORIGIN=https://… so the mock server can host metadata and callbacks on a public HTTPS origin",
+      );
+    }
+    const pkce = createPkcePair();
+    codeVerifier = pkce.codeVerifier;
+    clientId = cimdClientIdUrl(options.publicOrigin);
+    steps.push(
+      step(
+        "Client ID Metadata Document (CIMD) client",
+        "pass",
+        `client_id=${clientId}`,
+        redirectUri,
+      ),
+    );
+
+    await saveTokenProbeSession(sessionFile, {
+      authorizationServer: options.authorizationServer,
+      clientId,
+      clientRegistration: "cimd",
+      codeVerifier,
+      mcpBaseUrl,
+      mcpEndpoint: options.mcpEndpoint,
+      redirectUri,
+      resourceUri: options.resourceUri,
+      state,
+    });
+    steps.push(step("Persist probe session", "pass", sessionFile));
   } else {
     const pkce = createPkcePair();
     codeVerifier = pkce.codeVerifier;
@@ -316,7 +387,9 @@ export async function runTokenProbe(options: TokenProbeOptions): Promise<TokenPr
     await saveTokenProbeSession(sessionFile, {
       authorizationServer: options.authorizationServer,
       clientId,
+      clientRegistration: "dcr",
       codeVerifier,
+      mcpBaseUrl,
       mcpEndpoint: options.mcpEndpoint,
       redirectUri,
       resourceUri: options.resourceUri,
@@ -371,13 +444,21 @@ export async function runTokenProbe(options: TokenProbeOptions): Promise<TokenPr
     }
 
     try {
-      const callback = await waitForAuthorizationCode(
-        redirectUri,
-        state,
-        options.callbackTimeoutMs ?? 5 * 60 * 1000,
-      );
-      authorizationCode = callback.code;
-      steps.push(step("Receive authorization callback", "pass", `code received for state=${callback.state}`));
+      const callback =
+        activeRegistration === "cimd"
+          ? await waitForOAuthCallbackViaMockServer({
+              fetchImpl,
+              mcpBaseUrl,
+              state,
+              timeoutMs: options.callbackTimeoutMs ?? 5 * 60 * 1000,
+            })
+          : await waitForAuthorizationCode(
+              redirectUri,
+              state,
+              options.callbackTimeoutMs ?? 5 * 60 * 1000,
+            );
+      authorizationCode = callback;
+      steps.push(step("Receive authorization callback", "pass", `code received for state=${state}`));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       steps.push(step("Receive authorization callback", "fail", message, authorizeUrl));

--- a/packages/mcp-mock-server/src/token-probe.ts
+++ b/packages/mcp-mock-server/src/token-probe.ts
@@ -1,0 +1,556 @@
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { createCodeChallenge, createPkcePair } from "./pkce.js";
+import { audienceMatchesResource, decodeJwt } from "./jwt.js";
+
+export type TokenProbeSession = {
+  authorizationServer: string;
+  clientId: string;
+  codeVerifier: string;
+  mcpEndpoint: string;
+  redirectUri: string;
+  resourceUri: string;
+  state: string;
+};
+
+export type TokenProbeStep = {
+  detail?: string;
+  name: string;
+  note?: string;
+  status: "pass" | "fail" | "warn" | "skip";
+};
+
+export type TokenProbeReport = {
+  accessToken?: string;
+  authorizationCode?: string;
+  authorizationServer: string;
+  authorizeUrl: string;
+  clientId?: string;
+  mcpEndpoint: string;
+  redirectUri: string;
+  resourceUri: string;
+  steps: TokenProbeStep[];
+  tokenClaims?: Record<string, unknown>;
+  tokenResponse?: Record<string, unknown>;
+};
+
+export type TokenProbeOptions = {
+  authorizationCode?: string;
+  authorizationServer: string;
+  callbackPort?: number;
+  callbackTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  mcpEndpoint: string;
+  openBrowser?: boolean;
+  redirectUri?: string;
+  resourceUri: string;
+  sessionFile?: string;
+};
+
+const DEFAULT_SESSION_FILE = path.join(process.cwd(), ".mcp-token-probe-session.json");
+
+export async function saveTokenProbeSession(
+  sessionFile: string,
+  session: TokenProbeSession,
+): Promise<void> {
+  await mkdir(path.dirname(sessionFile), { recursive: true });
+  await writeFile(sessionFile, `${JSON.stringify(session, null, 2)}\n`, "utf8");
+}
+
+export async function loadTokenProbeSession(sessionFile: string): Promise<TokenProbeSession | undefined> {
+  try {
+    const raw = await readFile(sessionFile, "utf8");
+    return JSON.parse(raw) as TokenProbeSession;
+  } catch {
+    return undefined;
+  }
+}
+
+type DynamicClientRegistrationResponse = {
+  client_id?: string;
+  redirect_uris?: string[];
+};
+
+function step(
+  name: string,
+  status: TokenProbeStep["status"],
+  detail?: string,
+  note?: string,
+): TokenProbeStep {
+  return { name, status, detail, note };
+}
+
+async function readJson(response: Response): Promise<{ body: string; json?: unknown; status: number }> {
+  const body = await response.text();
+  try {
+    return { body, json: JSON.parse(body) as unknown, status: response.status };
+  } catch {
+    return { body, status: response.status };
+  }
+}
+
+export async function registerDynamicClient(
+  authorizationServer: string,
+  redirectUri: string,
+  fetchImpl: typeof fetch,
+): Promise<{ clientId: string; registrationEndpoint: string }> {
+  const registrationEndpoint = `${authorizationServer}/oauth/v2/register`;
+  const response = await fetchImpl(registrationEndpoint, {
+    body: JSON.stringify({
+      application_type: "native",
+      client_name: "mcp-token-probe",
+      grant_types: ["authorization_code"],
+      redirect_uris: [redirectUri],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+  const payload = await readJson(response);
+  if (response.status !== 200 && response.status !== 201) {
+    throw new Error(
+      `DCR failed with HTTP ${response.status}: ${payload.body.slice(0, 300)}`,
+    );
+  }
+  const clientId = (payload.json as DynamicClientRegistrationResponse | undefined)?.client_id;
+  if (!clientId) {
+    throw new Error("DCR succeeded but response did not include client_id");
+  }
+  return { clientId, registrationEndpoint };
+}
+
+export function buildAuthorizeUrl(input: {
+  authorizationServer: string;
+  clientId: string;
+  codeChallenge: string;
+  redirectUri: string;
+  resourceUri: string;
+  state: string;
+}): string {
+  const url = new URL(`${input.authorizationServer}/oauth/v2/authorize`);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", input.clientId);
+  url.searchParams.set("redirect_uri", input.redirectUri);
+  url.searchParams.set("scope", "openid");
+  url.searchParams.set("state", input.state);
+  url.searchParams.set("code_challenge", input.codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("resource", input.resourceUri);
+  return url.toString();
+}
+
+export function waitForAuthorizationCode(
+  redirectUri: string,
+  expectedState: string,
+  timeoutMs: number,
+): Promise<{ code: string; state: string }> {
+  const callbackUrl = new URL(redirectUri);
+  const hostname = callbackUrl.hostname;
+  const port = callbackUrl.port
+    ? Number.parseInt(callbackUrl.port, 10)
+    : callbackUrl.protocol === "https:"
+      ? 443
+      : 80;
+  const pathname = callbackUrl.pathname;
+
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const requestUrl = new URL(req.url ?? "/", `http://${req.headers.host ?? "127.0.0.1"}`);
+      if (requestUrl.pathname !== pathname) {
+        res.statusCode = 404;
+        res.end("not found");
+        return;
+      }
+
+      const error = requestUrl.searchParams.get("error");
+      if (error) {
+        res.statusCode = 400;
+        res.end(`Authorization failed: ${error}`);
+        server.close();
+        reject(new Error(`authorization error: ${error}`));
+        return;
+      }
+
+      const code = requestUrl.searchParams.get("code");
+      const state = requestUrl.searchParams.get("state") ?? "";
+      if (!code) {
+        res.statusCode = 400;
+        res.end("missing code");
+        return;
+      }
+      if (state !== expectedState) {
+        res.statusCode = 400;
+        res.end("invalid state");
+        server.close();
+        reject(new Error("callback state mismatch"));
+        return;
+      }
+
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Authorization complete. You can close this tab and return to the terminal.");
+      server.close();
+      resolve({ code, state });
+    });
+
+    server.once("error", reject);
+    server.listen(port, hostname, () => {
+      // listener ready
+    });
+
+    setTimeout(() => {
+      server.close();
+      reject(new Error(`timed out after ${timeoutMs}ms waiting for OAuth callback`));
+    }, timeoutMs);
+  });
+}
+
+export async function exchangeAuthorizationCode(input: {
+  authorizationServer: string;
+  clientId: string;
+  code: string;
+  codeVerifier: string;
+  fetchImpl: typeof fetch;
+  redirectUri: string;
+  resourceUri: string;
+}): Promise<Record<string, unknown>> {
+  const body = new URLSearchParams({
+    client_id: input.clientId,
+    code: input.code,
+    code_verifier: input.codeVerifier,
+    grant_type: "authorization_code",
+    redirect_uri: input.redirectUri,
+    resource: input.resourceUri,
+  });
+  const response = await input.fetchImpl(`${input.authorizationServer}/oauth/v2/token`, {
+    body,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    method: "POST",
+  });
+  const payload = await readJson(response);
+  if (!response.ok) {
+    throw new Error(`token exchange failed with HTTP ${response.status}: ${payload.body.slice(0, 300)}`);
+  }
+  return (payload.json ?? {}) as Record<string, unknown>;
+}
+
+export async function callMcpEndpoint(
+  mcpEndpoint: string,
+  accessToken: string,
+  fetchImpl: typeof fetch,
+): Promise<{ body: string; status: number }> {
+  const response = await fetchImpl(mcpEndpoint, {
+    body: JSON.stringify({ id: 1, jsonrpc: "2.0", method: "initialize" }),
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+  const body = await response.text();
+  return { body, status: response.status };
+}
+
+async function openBrowser(url: string): Promise<void> {
+  const platform = process.platform;
+  const command = platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
+  const args = platform === "win32" ? ["/c", "start", "", url] : [url];
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    child.once("error", reject);
+    child.unref();
+    resolve();
+  });
+}
+
+export async function runTokenProbe(options: TokenProbeOptions): Promise<TokenProbeReport> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const callbackPort = options.callbackPort ?? 8765;
+  const redirectUri = options.redirectUri ?? `http://127.0.0.1:${callbackPort}/callback`;
+  const sessionFile = options.sessionFile ?? DEFAULT_SESSION_FILE;
+  const steps: TokenProbeStep[] = [];
+  const state = "mcp-token-probe";
+
+  let clientId: string;
+  let codeVerifier: string;
+
+  if (options.authorizationCode) {
+    const savedSession = await loadTokenProbeSession(sessionFile);
+    if (!savedSession) {
+      throw new Error(
+        `no persisted session at ${sessionFile}; run probe-token --no-open first and complete login with the printed URL`,
+      );
+    }
+    clientId = savedSession.clientId;
+    codeVerifier = savedSession.codeVerifier;
+    steps.push(
+      step(
+        "Reuse persisted probe session",
+        "pass",
+        `client_id=${clientId}`,
+        sessionFile,
+      ),
+    );
+  } else {
+    const pkce = createPkcePair();
+    codeVerifier = pkce.codeVerifier;
+    const registered = await registerDynamicClient(
+      options.authorizationServer,
+      redirectUri,
+      fetchImpl,
+    );
+    clientId = registered.clientId;
+    steps.push(
+      step(
+        "Dynamic client registration",
+        "pass",
+        `client_id=${clientId}`,
+        registered.registrationEndpoint,
+      ),
+    );
+
+    await saveTokenProbeSession(sessionFile, {
+      authorizationServer: options.authorizationServer,
+      clientId,
+      codeVerifier,
+      mcpEndpoint: options.mcpEndpoint,
+      redirectUri,
+      resourceUri: options.resourceUri,
+      state,
+    });
+    steps.push(step("Persist probe session", "pass", sessionFile));
+  }
+
+  const authorizeUrl = buildAuthorizeUrl({
+    authorizationServer: options.authorizationServer,
+    clientId,
+    codeChallenge: createCodeChallenge(codeVerifier),
+    redirectUri,
+    resourceUri: options.resourceUri,
+    state,
+  });
+
+  let authorizationCode = options.authorizationCode;
+  if (!authorizationCode) {
+    if (options.openBrowser !== false) {
+      try {
+        await openBrowser(authorizeUrl);
+        steps.push(step("Open authorize URL in browser", "pass", authorizeUrl));
+      } catch {
+        steps.push(
+          step(
+            "Open authorize URL in browser",
+            "warn",
+            authorizeUrl,
+            "could not launch a browser automatically; open the URL manually",
+          ),
+        );
+      }
+    } else {
+      steps.push(
+        step(
+          "Authorize in browser",
+          "skip",
+          authorizeUrl,
+          "complete login, then rerun with --code <authorization_code>",
+        ),
+      );
+      return {
+        authorizationServer: options.authorizationServer,
+        authorizeUrl,
+        clientId,
+        mcpEndpoint: options.mcpEndpoint,
+        redirectUri,
+        resourceUri: options.resourceUri,
+        steps,
+      };
+    }
+
+    try {
+      const callback = await waitForAuthorizationCode(
+        redirectUri,
+        state,
+        options.callbackTimeoutMs ?? 5 * 60 * 1000,
+      );
+      authorizationCode = callback.code;
+      steps.push(step("Receive authorization callback", "pass", `code received for state=${callback.state}`));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      steps.push(step("Receive authorization callback", "fail", message, authorizeUrl));
+      return {
+        authorizationServer: options.authorizationServer,
+        authorizeUrl,
+        clientId,
+        mcpEndpoint: options.mcpEndpoint,
+        redirectUri,
+        resourceUri: options.resourceUri,
+        steps,
+      };
+    }
+  } else {
+    steps.push(step("Use provided authorization code", "pass", "skipped callback server"));
+  }
+
+  if (!authorizationCode) {
+    throw new Error("authorization code missing");
+  }
+
+  let tokenResponse: Record<string, unknown>;
+  try {
+    tokenResponse = await exchangeAuthorizationCode({
+      authorizationServer: options.authorizationServer,
+      clientId,
+      code: authorizationCode,
+      codeVerifier,
+      fetchImpl,
+      redirectUri,
+      resourceUri: options.resourceUri,
+    });
+    steps.push(step("Exchange authorization code for tokens", "pass", "token endpoint returned 200"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    steps.push(step("Exchange authorization code for tokens", "fail", message));
+    return {
+      authorizationCode,
+      authorizationServer: options.authorizationServer,
+      authorizeUrl,
+      clientId,
+      mcpEndpoint: options.mcpEndpoint,
+      redirectUri,
+      resourceUri: options.resourceUri,
+      steps,
+    };
+  }
+
+  const accessToken = typeof tokenResponse.access_token === "string" ? tokenResponse.access_token : undefined;
+  if (!accessToken) {
+    steps.push(step("Read access_token from token response", "fail", JSON.stringify(tokenResponse).slice(0, 300)));
+    return {
+      authorizationCode,
+      authorizationServer: options.authorizationServer,
+      authorizeUrl,
+      clientId,
+      mcpEndpoint: options.mcpEndpoint,
+      redirectUri,
+      resourceUri: options.resourceUri,
+      steps,
+      tokenResponse,
+    };
+  }
+
+  const decoded = decodeJwt(accessToken);
+  const tokenClaims = decoded?.payload;
+  if (!tokenClaims) {
+    steps.push(
+      step(
+        "Decode access token claims",
+        "warn",
+        "token is opaque or not a JWT",
+        "audience check skipped",
+      ),
+    );
+  } else {
+    const audienceOk = audienceMatchesResource(tokenClaims, options.resourceUri);
+    steps.push(
+      step(
+        "Access token audience matches MCP resource URI (RFC 8707)",
+        audienceOk ? "pass" : "fail",
+        `aud=${JSON.stringify(tokenClaims.aud)}`,
+        `expected resource=${options.resourceUri}`,
+      ),
+    );
+  }
+
+  const mcpResult = await callMcpEndpoint(options.mcpEndpoint, accessToken, fetchImpl);
+  if (mcpResult.status === 200) {
+    steps.push(step("Call mock MCP server with access token", "pass", `HTTP ${mcpResult.status}`));
+  } else {
+    steps.push(
+      step(
+        "Call mock MCP server with access token",
+        mcpResult.status === 401 ? "fail" : "warn",
+        `HTTP ${mcpResult.status}`,
+        mcpResult.body.slice(0, 200),
+      ),
+    );
+  }
+
+  return {
+    accessToken,
+    authorizationCode,
+    authorizationServer: options.authorizationServer,
+    authorizeUrl,
+    clientId,
+    mcpEndpoint: options.mcpEndpoint,
+    redirectUri,
+    resourceUri: options.resourceUri,
+    steps,
+    tokenClaims,
+    tokenResponse,
+  };
+}
+
+export function formatTokenProbeReport(report: TokenProbeReport): string {
+  const lines = [
+    "MCP token probe report",
+    "",
+    `Authorization server: ${report.authorizationServer}`,
+    `MCP endpoint:         ${report.mcpEndpoint}`,
+    `Resource URI:         ${report.resourceUri}`,
+    `Redirect URI:         ${report.redirectUri}`,
+    `Client ID:            ${report.clientId ?? "(unknown)"}`,
+    "",
+  ];
+
+  if (report.authorizeUrl) {
+    lines.push(`Authorize URL:`);
+    lines.push(report.authorizeUrl);
+    lines.push("");
+  }
+
+  for (const probeStep of report.steps) {
+    const icon =
+      probeStep.status === "pass"
+        ? "✅"
+        : probeStep.status === "warn"
+          ? "⚠️"
+          : probeStep.status === "skip"
+            ? "⏭️"
+            : "❌";
+    lines.push(`${icon} ${probeStep.name}`);
+    if (probeStep.detail) {
+      lines.push(`   ${probeStep.detail}`);
+    }
+    if (probeStep.note) {
+      lines.push(`   note: ${probeStep.note}`);
+    }
+    lines.push("");
+  }
+
+  if (report.tokenClaims) {
+    lines.push("Token claims:");
+    lines.push(JSON.stringify(report.tokenClaims, null, 2));
+    lines.push("");
+  }
+
+  if (report.tokenResponse) {
+    lines.push("Token response (redacted access_token):");
+    const redacted = { ...report.tokenResponse };
+    if (typeof redacted.access_token === "string") {
+      redacted.access_token = "<redacted>";
+    }
+    if (typeof redacted.id_token === "string") {
+      redacted.id_token = "<redacted>";
+    }
+    if (typeof redacted.refresh_token === "string") {
+      redacted.refresh_token = "<redacted>";
+    }
+    lines.push(JSON.stringify(redacted, null, 2));
+  }
+
+  return lines.join("\n").trimEnd();
+}

--- a/packages/mcp-mock-server/src/token-validation.ts
+++ b/packages/mcp-mock-server/src/token-validation.ts
@@ -1,0 +1,57 @@
+import type { McpMockServerConfig } from "./config.js";
+
+export type TokenValidationResult =
+  | { active: true; subject?: string }
+  | { active: false; reason: string };
+
+type IntrospectionResponse = {
+  active?: boolean;
+  aud?: string | string[];
+  client_id?: string;
+  scope?: string;
+  sub?: string;
+  username?: string;
+};
+
+export async function validateAccessToken(
+  token: string,
+  config: McpMockServerConfig,
+): Promise<TokenValidationResult> {
+  if (!token) {
+    return { active: false, reason: "missing bearer token" };
+  }
+
+  if (!config.introspect) {
+    return { active: true, subject: "mock-subject" };
+  }
+
+  const credentials = Buffer.from(
+    `${config.introspectClientId}:${config.introspectClientSecret}`,
+  ).toString("base64");
+  const body = new URLSearchParams({ token });
+  const response = await fetch(`${config.authorizationServer}/oauth/v2/introspect`, {
+    body,
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    return {
+      active: false,
+      reason: `introspection failed with HTTP ${response.status}`,
+    };
+  }
+
+  const payload = (await response.json()) as IntrospectionResponse;
+  if (!payload.active) {
+    return { active: false, reason: "token is not active" };
+  }
+
+  return {
+    active: true,
+    subject: payload.sub ?? payload.username ?? payload.client_id,
+  };
+}

--- a/packages/mcp-mock-server/tsconfig.json
+++ b/packages/mcp-mock-server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["bin", "src"]
+}

--- a/packages/mcp-mock-server/vitest.config.ts
+++ b/packages/mcp-mock-server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.spec.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,7 +344,7 @@ importers:
         version: 8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/cli:
     dependencies:
@@ -423,7 +423,7 @@ importers:
         version: 0.21.10(@tsdown/css@0.21.10)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.20.0)(synckit@0.11.12)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   apps/cli-journey-e2e:
     devDependencies:
@@ -496,7 +496,7 @@ importers:
         version: 6.0.1(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       jsdom:
         specifier: 'catalog:'
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -505,7 +505,7 @@ importers:
         version: 8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/console-e2e:
     devDependencies:
@@ -587,7 +587,7 @@ importers:
         version: link:../../packages/shared-component-styles
       nuxt:
         specifier: ^4.4.6
-        version: 4.4.6(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
+        version: 4.4.6(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
     devDependencies:
       typescript:
         specifier: ^5.7.3
@@ -762,7 +762,7 @@ importers:
         version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/server:
     optionalDependencies:
@@ -878,7 +878,7 @@ importers:
         version: 8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       xstate:
         specifier: 'catalog:'
         version: 5.31.1
@@ -992,7 +992,7 @@ importers:
         version: link:../shared-component-styles
       jsdom:
         specifier: 'catalog:'
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       lightningcss:
         specifier: 'catalog:'
         version: 1.32.0
@@ -1024,6 +1024,34 @@ importers:
         specifier: 'catalog:'
         version: 4.21.0
 
+  packages/mcp-mock-server:
+    dependencies:
+      express:
+        specifier: 'catalog:'
+        version: 4.22.1
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
+      '@types/express':
+        specifier: 'catalog:'
+        version: 4.17.25
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.0
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
+      supertest:
+        specifier: ^7.1.4
+        version: 7.2.2
+      tsx:
+        specifier: 'catalog:'
+        version: 4.21.0
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/sdk-angular:
     dependencies:
       '@zitadel/api':
@@ -1041,13 +1069,13 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.6.1
-        version: 2.6.1(f5e0e36d1b888a809d2b0182f5e7de3a)
+        version: 2.6.1(37b21649e6c73f2dc91d091716a2e828)
       '@analogjs/vitest-angular':
         specifier: ^2.6.1
-        version: 2.6.1(@analogjs/vite-plugin-angular@2.6.1(f5e0e36d1b888a809d2b0182f5e7de3a))(@angular-devkit/architect@0.2200.2(chokidar@5.0.0))(@angular-devkit/schematics@22.0.2(chokidar@5.0.0))(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(zone.js@0.16.2)
+        version: 2.6.1(@analogjs/vite-plugin-angular@2.6.1(37b21649e6c73f2dc91d091716a2e828))(@angular-devkit/architect@0.2200.2(chokidar@5.0.0))(@angular-devkit/schematics@22.0.2(chokidar@5.0.0))(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(zone.js@0.16.2)
       '@angular/build':
         specifier: ^22.0.0
-        version: 22.0.2(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(@angular/compiler@22.0.0)(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.2(@angular/common@22.0.0(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(ng-packagr@22.0.0(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(tailwindcss@4.2.4)(tslib@2.8.1)(typescript@6.0.3))(postcss@8.5.15)(tailwindcss@4.2.4)(terser@5.48.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@6.0.3)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 22.0.2(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(@angular/compiler@22.0.0)(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.2(@angular/common@22.0.0(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(ng-packagr@22.0.0(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(tailwindcss@4.2.4)(tslib@2.8.1)(typescript@6.0.3))(postcss@8.5.15)(tailwindcss@4.2.4)(terser@5.48.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@6.0.3)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
       '@angular/common':
         specifier: ^22.0.0
         version: 22.0.0(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
@@ -1095,7 +1123,7 @@ importers:
         version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
       jsdom:
         specifier: 'catalog:'
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -1110,7 +1138,7 @@ importers:
         version: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: catalog:sdk
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       zone.js:
         specifier: ~0.16.0
         version: 0.16.2
@@ -1162,7 +1190,7 @@ importers:
         version: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: catalog:sdk
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/sdk-next:
     dependencies:
@@ -1235,7 +1263,7 @@ importers:
         version: 7.16.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       jsdom:
         specifier: 'catalog:'
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       next:
         specifier: ^16.2.4
         version: 16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.100.0)
@@ -1253,7 +1281,7 @@ importers:
         version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/sdk-nuxt:
     dependencies:
@@ -1268,7 +1296,7 @@ importers:
         version: link:../sdk-core
       nuxt:
         specifier: '>=4'
-        version: 4.4.5(@babel/core@7.29.7)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
+        version: 4.4.5(@babel/core@7.29.7)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'
@@ -1317,7 +1345,7 @@ importers:
         version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/sdk-qwik:
     dependencies:
@@ -1366,7 +1394,7 @@ importers:
         version: 1.20.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       jsdom:
         specifier: 'catalog:'
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -1384,7 +1412,7 @@ importers:
         version: 4.5.4(@types/node@25.6.0)(rollup@4.60.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: catalog:sdk
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/sdk-react:
     dependencies:
@@ -1448,7 +1476,7 @@ importers:
         version: 7.16.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       jsdom:
         specifier: 'catalog:'
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -1472,7 +1500,7 @@ importers:
         version: 4.5.4(@types/node@25.6.0)(rollup@4.60.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: catalog:sdk
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/sdk-solid:
     dependencies:
@@ -1524,7 +1552,7 @@ importers:
         version: 0.14.5(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       jsdom:
         specifier: 'catalog:'
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -1548,7 +1576,7 @@ importers:
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: catalog:sdk
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/sdk-svelte:
     dependencies:
@@ -1576,7 +1604,7 @@ importers:
         version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/svelte':
         specifier: ^5.3.1
-        version: 5.3.1(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.3.1(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.7.0)
@@ -1600,7 +1628,7 @@ importers:
         version: 3.19.0(eslint@9.39.4(jiti@2.7.0))(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       jsdom:
         specifier: 'catalog:'
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -1624,7 +1652,7 @@ importers:
         version: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: catalog:sdk
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/sdk-vue:
     dependencies:
@@ -1670,7 +1698,7 @@ importers:
         version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
       jsdom:
         specifier: 'catalog:'
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -1688,7 +1716,7 @@ importers:
         version: 4.5.4(@types/node@25.6.0)(rollup@4.60.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: catalog:sdk
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vue:
         specifier: ^3.5.0
         version: 3.5.35(typescript@6.0.3)
@@ -4030,6 +4058,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodable/entities@2.1.1':
     resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
 
@@ -5659,6 +5691,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@paralleldrive/cuid2@2.3.1':
+    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -7760,6 +7795,9 @@ packages:
     peerDependencies:
       '@types/express': '*'
 
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -7816,6 +7854,9 @@ packages:
 
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -7878,6 +7919,12 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/superagent@8.1.10':
+    resolution: {integrity: sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==}
+
+  '@types/supertest@6.0.3':
+    resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -8813,6 +8860,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
@@ -9363,6 +9413,9 @@ packages:
   compatx@0.2.0:
     resolution: {integrity: sha512-6gLRNt4ygsi5NyMVhceOCFv14CIdDFN7fQjX1U4+47qVE/+kjPoXMK65KWK+dWxmFzMTuKazoQ9sch6pM0p5oA==}
 
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
@@ -9461,6 +9514,9 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
@@ -9795,6 +9851,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
   didyoumean2@4.1.0:
     resolution: {integrity: sha512-qTBmfQoXvhKO75D/05C8m+fteQmn4U46FWYiLhXtZQInzitXLWY0EQ/2oKnpAz9g2lQWW8jYcLcT+hPJGT+kig==}
@@ -10390,6 +10449,9 @@ packages:
     resolution: {integrity: sha512-tWhw7z4jFuQgZB9tbQyUh5BY9nNd/wimM+fBLfmmJjakkJDNvbJKm0nQ5ruPKC0us1HGg7L6iBk1fxpSzcgSaA==}
     hasBin: true
 
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -10530,6 +10592,10 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -12296,6 +12362,11 @@ packages:
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
+    hasBin: true
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
     hasBin: true
 
   mime@3.0.0:
@@ -14567,6 +14638,14 @@ packages:
     resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
     engines: {node: '>=18'}
 
+  superagent@10.3.0:
+    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.2.2:
+    resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
+    engines: {node: '>=14.18.0'}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -16111,7 +16190,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@analogjs/vite-plugin-angular@2.6.1(f5e0e36d1b888a809d2b0182f5e7de3a)':
+  '@analogjs/vite-plugin-angular@2.6.1(37b21649e6c73f2dc91d091716a2e828)':
     dependencies:
       magic-string: 0.30.21
       obug: 2.1.1
@@ -16119,18 +16198,18 @@ snapshots:
       tinyglobby: 0.2.17
       ts-morph: 21.0.1
     optionalDependencies:
-      '@angular/build': 22.0.2(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(@angular/compiler@22.0.0)(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.2(@angular/common@22.0.0(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(ng-packagr@22.0.0(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(tailwindcss@4.2.4)(tslib@2.8.1)(typescript@6.0.3))(postcss@8.5.15)(tailwindcss@4.2.4)(terser@5.48.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@6.0.3)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      '@angular/build': 22.0.2(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(@angular/compiler@22.0.0)(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.2(@angular/common@22.0.0(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(ng-packagr@22.0.0(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(tailwindcss@4.2.4)(tslib@2.8.1)(typescript@6.0.3))(postcss@8.5.15)(tailwindcss@4.2.4)(terser@5.48.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@6.0.3)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
       vite: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@analogjs/vitest-angular@2.6.1(@analogjs/vite-plugin-angular@2.6.1(f5e0e36d1b888a809d2b0182f5e7de3a))(@angular-devkit/architect@0.2200.2(chokidar@5.0.0))(@angular-devkit/schematics@22.0.2(chokidar@5.0.0))(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(zone.js@0.16.2)':
+  '@analogjs/vitest-angular@2.6.1(@analogjs/vite-plugin-angular@2.6.1(37b21649e6c73f2dc91d091716a2e828))(@angular-devkit/architect@0.2200.2(chokidar@5.0.0))(@angular-devkit/schematics@22.0.2(chokidar@5.0.0))(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(zone.js@0.16.2)':
     dependencies:
-      '@analogjs/vite-plugin-angular': 2.6.1(f5e0e36d1b888a809d2b0182f5e7de3a)
+      '@analogjs/vite-plugin-angular': 2.6.1(37b21649e6c73f2dc91d091716a2e828)
       '@angular-devkit/architect': 0.2200.2(chokidar@5.0.0)
       '@angular-devkit/schematics': 22.0.2(chokidar@5.0.0)
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
       zone.js: 0.16.2
 
@@ -16162,7 +16241,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/build@22.0.2(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(@angular/compiler@22.0.0)(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.2(@angular/common@22.0.0(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(ng-packagr@22.0.0(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(tailwindcss@4.2.4)(tslib@2.8.1)(typescript@6.0.3))(postcss@8.5.15)(tailwindcss@4.2.4)(terser@5.48.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@6.0.3)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)':
+  '@angular/build@22.0.2(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(@angular/compiler@22.0.0)(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.2(@angular/common@22.0.0(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.0(@angular/compiler@22.0.0)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(ng-packagr@22.0.0(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(tailwindcss@4.2.4)(tslib@2.8.1)(typescript@6.0.3))(postcss@8.5.15)(tailwindcss@4.2.4)(terser@5.48.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@6.0.3)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2200.2(chokidar@5.0.0)
@@ -16201,7 +16280,7 @@ snapshots:
       ng-packagr: 22.0.0(@angular/compiler-cli@22.0.0(@angular/compiler@22.0.0)(typescript@6.0.3))(tailwindcss@4.2.4)(tslib@2.8.1)(typescript@6.0.3)
       postcss: 8.5.15
       tailwindcss: 4.2.4
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -17656,7 +17735,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@faker-js/faker@10.4.0': {}
 
@@ -18584,6 +18665,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
 
+  '@noble/hashes@1.8.0': {}
+
   '@nodable/entities@2.1.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -18797,7 +18880,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.5(b2fa80c2772017ec13a94c1d215cf28a)':
+  '@nuxt/nitro-server@4.4.5(426ac17d81bc69a5e25c0d35414ae577)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7)
       '@nuxt/devalue': 2.0.2
@@ -18815,8 +18898,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(encoding@0.1.13)(oxc-parser@0.128.0)(rolldown@1.0.3)
-      nuxt: 4.4.5(@babel/core@7.29.7)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
+      nitropack: 2.13.4(encoding@0.1.13)(oxc-parser@0.128.0)(rolldown@1.0.3)(srvx@0.11.16)
+      nuxt: 4.4.5(@babel/core@7.29.7)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -18870,7 +18953,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.6(e100d5dec403b5ca7a0246a503a67652)':
+  '@nuxt/nitro-server@4.4.6(9855214cb260b15249679160846982b7)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -18887,8 +18970,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(encoding@0.1.13)(oxc-parser@0.131.0)(rolldown@1.0.3)(srvx@0.11.16)
-      nuxt: 4.4.6(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
+      nitropack: 2.13.4(encoding@0.1.13)(oxc-parser@0.131.0)(rolldown@1.0.3)
+      nuxt: 4.4.6(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -18976,7 +19059,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/vite-builder@4.4.5(56f6d076f9b98c3f1e2eac586d5aa989)':
+  '@nuxt/vite-builder@4.4.5(cec2663e9303007c16533a42dd226044)':
     dependencies:
       '@nuxt/kit': 4.4.5(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
@@ -18994,7 +19077,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.5(@babel/core@7.29.7)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.4.5(@babel/core@7.29.7)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -19038,7 +19121,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.6(cfb5b43e8a7121b2d8a57764088d1f67)':
+  '@nuxt/vite-builder@4.4.6(904f9fedd36d09077343a307cbfb2df2)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
@@ -19056,7 +19139,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.6(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -20025,6 +20108,10 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.61.0':
     optional: true
+
+  '@paralleldrive/cuid2@2.3.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -21404,7 +21491,7 @@ snapshots:
       '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       '@vitest/runner': 4.1.7
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -21922,14 +22009,14 @@ snapshots:
     dependencies:
       svelte: 5.56.3(@typescript-eslint/types@8.59.3)
 
-  '@testing-library/svelte@5.3.1(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@testing-library/svelte@5.3.1(svelte@5.56.3(@typescript-eslint/types@8.59.3))(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.56.3(@typescript-eslint/types@8.59.3))
       svelte: 5.56.3(@typescript-eslint/types@8.59.3)
     optionalDependencies:
       vite: 7.3.5(@types/node@25.6.0)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -22017,6 +22104,8 @@ snapshots:
     dependencies:
       '@types/express': 4.17.25
 
+  '@types/cookiejar@2.1.5': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -22078,6 +22167,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdx@2.0.14': {}
+
+  '@types/methods@1.1.4': {}
 
   '@types/mime@1.3.5': {}
 
@@ -22147,6 +22238,18 @@ snapshots:
       '@types/node': 22.19.19
 
   '@types/statuses@2.0.6': {}
+
+  '@types/superagent@8.1.10':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 22.19.19
+      form-data: 4.0.6
+
+  '@types/supertest@6.0.3':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.10
 
   '@types/trusted-types@2.0.7': {}
 
@@ -22756,7 +22859,7 @@ snapshots:
       '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -22769,7 +22872,7 @@ snapshots:
       '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -22785,7 +22888,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -22802,7 +22905,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -23491,6 +23594,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asap@2.0.6: {}
+
   asn1@0.2.6:
     dependencies:
       safer-buffer: 2.1.2
@@ -24062,6 +24167,8 @@ snapshots:
 
   compatx@0.2.0: {}
 
+  component-emitter@1.3.1: {}
+
   compress-commons@6.0.2:
     dependencies:
       crc-32: 1.2.2
@@ -24147,6 +24254,8 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  cookiejar@2.1.4: {}
 
   copy-anything@3.0.5:
     dependencies:
@@ -24330,10 +24439,10 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -24479,6 +24588,11 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
 
   didyoumean2@4.1.0:
     dependencies:
@@ -25440,6 +25554,8 @@ snapshots:
 
   fast-npm-meta@1.5.1: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -25611,6 +25727,12 @@ snapshots:
       mime-types: 2.1.35
 
   format@0.2.2: {}
+
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.3.1
+      dezalgo: 1.0.4
+      once: 1.4.0
 
   forwarded@0.2.0: {}
 
@@ -26284,9 +26406,9 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -26832,17 +26954,17 @@ snapshots:
 
   jsbn@0.1.1: {}
 
-  jsdom@29.0.2:
+  jsdom@29.0.2(@noble/hashes@1.8.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.5
       parse5: 8.0.1
@@ -26853,7 +26975,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -27815,6 +27937,8 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mime@2.6.0: {}
+
   mime@3.0.0: {}
 
   mime@4.1.0: {}
@@ -28085,7 +28209,7 @@ snapshots:
       tailwindcss: 4.2.4
     optional: true
 
-  nitropack@2.13.4(encoding@0.1.13)(oxc-parser@0.128.0)(rolldown@1.0.3):
+  nitropack@2.13.4(encoding@0.1.13)(oxc-parser@0.128.0)(rolldown@1.0.3)(srvx@0.11.16):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.4)
@@ -28190,7 +28314,7 @@ snapshots:
       - supports-color
       - uploadthing
 
-  nitropack@2.13.4(encoding@0.1.13)(oxc-parser@0.131.0)(rolldown@1.0.3)(srvx@0.11.16):
+  nitropack@2.13.4(encoding@0.1.13)(oxc-parser@0.131.0)(rolldown@1.0.3):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.4)
@@ -28372,16 +28496,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.4.5(@babel/core@7.29.7)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0):
+  nuxt@4.4.5(@babel/core@7.29.7)(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@5.9.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.5)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))
       '@nuxt/kit': 4.4.5(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.5(b2fa80c2772017ec13a94c1d215cf28a)
+      '@nuxt/nitro-server': 4.4.5(426ac17d81bc69a5e25c0d35414ae577)
       '@nuxt/schema': 4.4.5
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.5(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.5(56f6d076f9b98c3f1e2eac586d5aa989)
+      '@nuxt/vite-builder': 4.4.5(cec2663e9303007c16533a42dd226044)
       '@unhead/vue': 2.1.15(vue@3.5.35(typescript@5.9.3))
       '@vue/shared': 3.5.34
       chokidar: 5.0.0
@@ -28502,16 +28626,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.6(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0):
+  nuxt@4.4.6(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.60.4))(@types/node@25.6.0)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.11.0)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.61.0)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@5.9.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.6(e100d5dec403b5ca7a0246a503a67652)
+      '@nuxt/nitro-server': 4.4.6(9855214cb260b15249679160846982b7)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.6(cfb5b43e8a7121b2d8a57764088d1f67)
+      '@nuxt/vite-builder': 4.4.6(904f9fedd36d09077343a307cbfb2df2)
       '@unhead/vue': 2.1.15(vue@3.5.35(typescript@5.9.3))
       '@vue/shared': 3.5.35
       chokidar: 5.0.0
@@ -31093,6 +31217,28 @@ snapshots:
       make-asynchronous: 1.1.0
       time-span: 5.1.0
 
+  superagent@10.3.0:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.3(supports-color@8.1.1)
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.6
+      formidable: 3.5.4
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.15.2
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.2.2:
+    dependencies:
+      cookie-signature: 1.2.2
+      methods: 1.1.2
+      superagent: 10.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   supports-color@10.2.2: {}
 
   supports-color@5.5.0:
@@ -32298,7 +32444,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@5.9.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -32326,7 +32472,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 25.6.0
-      jsdom: 29.0.2
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -32341,7 +32487,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -32369,7 +32515,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 25.6.0
-      jsdom: 29.0.2
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -32384,7 +32530,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2)(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.6.4)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -32412,7 +32558,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 25.6.0
-      jsdom: 29.0.2
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -32427,7 +32573,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -32453,11 +32599,11 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.6.0
       '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.14(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
-      jsdom: 29.0.2
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2)(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -32483,7 +32629,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.6.0
       '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
-      jsdom: 29.0.2
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
 
@@ -32701,9 +32847,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Adds `packages/mcp-mock-server`, a small MCP resource server and probe toolkit for testing Zitadel as an MCP OAuth authorization server.

It covers RFC 9728 protected resource metadata, DCR, CIMD, PKCE token exchange, RFC 8707 `resource=`, and basic MCP calls with bearer tokens.