### PR TITLE
fix(telemetry): route CLI telemetry to production during publish

### DIFF
--- a/.changeset/cli-production-mixpanel-publish.md
+++ b/.changeset/cli-production-mixpanel-publish.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/cli": patch
+---
+
+Route published CLI telemetry to the production Mixpanel project during npm publish.

--- a/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
+++ b/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
@@ -62,6 +62,7 @@ type ReleaseAutomationModule = {
 
 type ReleaseModule = {
   assertNoUnrecordedPendingChangesets: (repoRoot: string) => Promise<void>;
+  releasePublishEnv: (env?: NodeJS.ProcessEnv) => NodeJS.ProcessEnv;
 };
 
 type CheckChangesetStatus = {
@@ -506,6 +507,13 @@ describe("release-automation", () => {
 });
 
 describe("release publish guard", () => {
+  it("forces production telemetry while publishing npm packages", async () => {
+    const { releasePublishEnv } = await loadReleaseModule();
+    const env = releasePublishEnv({ ZITADEL_TELEMETRY_BUILD_CHANNEL: "development" });
+
+    expect(env.ZITADEL_TELEMETRY_BUILD_CHANNEL).toBe("production");
+  });
+
   it("allows prerelease-recorded pending changesets and rejects unrecorded ones", async () => {
     const { assertNoUnrecordedPendingChangesets } = await loadReleaseModule();
     const repoRoot = await mkdtemp(join(tmpdir(), "zitadel-release-guard-"));

--- a/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
+++ b/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
@@ -509,9 +509,24 @@ describe("release-automation", () => {
 describe("release publish guard", () => {
   it("forces production telemetry while publishing npm packages", async () => {
     const { releasePublishEnv } = await loadReleaseModule();
-    const env = releasePublishEnv({ ZITADEL_TELEMETRY_BUILD_CHANNEL: "development" });
+    const originalBase = process.env.ZITADEL_RELEASE_TEST_BASE;
+    process.env.ZITADEL_RELEASE_TEST_BASE = "preserved";
+    try {
+      const env = releasePublishEnv({
+        ZITADEL_RELEASE_TEST_OVERRIDE: "included",
+        ZITADEL_TELEMETRY_BUILD_CHANNEL: "development",
+      });
 
-    expect(env.ZITADEL_TELEMETRY_BUILD_CHANNEL).toBe("production");
+      expect(env.ZITADEL_RELEASE_TEST_BASE).toBe("preserved");
+      expect(env.ZITADEL_RELEASE_TEST_OVERRIDE).toBe("included");
+      expect(env.ZITADEL_TELEMETRY_BUILD_CHANNEL).toBe("production");
+    } finally {
+      if (originalBase === undefined) {
+        delete process.env.ZITADEL_RELEASE_TEST_BASE;
+      } else {
+        process.env.ZITADEL_RELEASE_TEST_BASE = originalBase;
+      }
+    }
   });
 
   it("allows prerelease-recorded pending changesets and rejects unrecorded ones", async () => {

--- a/apps/cli/tests/unit/scripts/release-artifacts.test.ts
+++ b/apps/cli/tests/unit/scripts/release-artifacts.test.ts
@@ -174,4 +174,49 @@ describe("release artifact helpers", () => {
       }),
     ).rejects.toThrow("requires apps/cli/dist before packing");
   });
+
+  it("stamps CLI release packs with the production telemetry channel", async () => {
+    const { packPublicPackages } = await loadModule();
+    const manifest = (await import(
+      new URL("../../../../../scripts/release-manifest.mjs", import.meta.url).href
+    )) as {
+      PUBLIC_RELEASE_PACKAGES: Array<{ name: string; dir: string; buildTarget?: string }>;
+    };
+    const repoRoot = await mkdtemp(join(tmpdir(), "zitadel-release-packages-"));
+    tempDirs.push(repoRoot);
+    const outDir = join(repoRoot, "dist/release/0.1.0-alpha.6");
+    for (const pkg of manifest.PUBLIC_RELEASE_PACKAGES) {
+      await mkdir(join(repoRoot, pkg.dir), { recursive: true });
+      if (pkg.buildTarget) {
+        await mkdir(join(repoRoot, pkg.dir, "dist"), { recursive: true });
+      }
+      await writeFile(
+        join(repoRoot, pkg.dir, "package.json"),
+        `${JSON.stringify({ license: "MIT", name: pkg.name, version: "0.1.0-alpha.6" }, null, 2)}\n`,
+      );
+    }
+
+    const originalChannel = process.env.ZITADEL_TELEMETRY_BUILD_CHANNEL;
+    process.env.ZITADEL_TELEMETRY_BUILD_CHANNEL = "development";
+    const calls: Array<{ args: string[]; env: NodeJS.ProcessEnv }> = [];
+    try {
+      await packPublicPackages({
+        repoRoot,
+        outDir,
+        version: "0.1.0-alpha.6",
+        run: async (_command, args, options) => {
+          calls.push({ args, env: options.env });
+        },
+      });
+    } finally {
+      if (originalChannel === undefined) {
+        delete process.env.ZITADEL_TELEMETRY_BUILD_CHANNEL;
+      } else {
+        process.env.ZITADEL_TELEMETRY_BUILD_CHANNEL = originalChannel;
+      }
+    }
+
+    const cliPack = calls.find((call) => call.args.includes("apps/cli"));
+    expect(cliPack?.env.ZITADEL_TELEMETRY_BUILD_CHANNEL).toBe("production");
+  });
 });

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -198,8 +198,8 @@ export async function assertNoUnrecordedPendingChangesets(root = repoRoot) {
   }
 }
 
-export function releasePublishEnv(env = process.env) {
-  return { ...env, ZITADEL_TELEMETRY_BUILD_CHANNEL: "production" };
+export function releasePublishEnv(overrides = {}) {
+  return { ...process.env, ...overrides, ZITADEL_TELEMETRY_BUILD_CHANNEL: "production" };
 }
 
 async function assertMainBranch(options, { allowDryRunBypass = true } = {}) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -134,7 +134,10 @@ async function commandPublish(options) {
   }
 
   await commandSnapshot({ skipContainer: true });
-  await run("corepack", ["pnpm", "exec", "changeset", "publish"], { cwd: repoRoot });
+  await run("corepack", ["pnpm", "exec", "changeset", "publish"], {
+    cwd: repoRoot,
+    env: releasePublishEnv(),
+  });
   await buildContainerImage({ repoRoot, outDir, release, push: true, platforms: CONTAINER_PLATFORMS });
   await commandVerify();
   await upsertProductGithubRelease({ repoRoot, outDir, log: console.log });
@@ -193,6 +196,10 @@ export async function assertNoUnrecordedPendingChangesets(root = repoRoot) {
       `release publish requires all pending changesets to be recorded in .changeset/pre.json: ${unrecorded.join(", ")}`,
     );
   }
+}
+
+export function releasePublishEnv(env = process.env) {
+  return { ...env, ZITADEL_TELEMETRY_BUILD_CHANNEL: "production" };
 }
 
 async function assertMainBranch(options, { allowDryRunBypass = true } = {}) {


### PR DESCRIPTION
## Summary
- Force `ZITADEL_TELEMETRY_BUILD_CHANNEL=production` during npm publish for the CLI release flow
- Add coverage for the publish env helper and pack step to ensure the CLI release artifacts inherit the production telemetry channel
- Include a patch changeset for `@zitadel/cli`

## Testing
- Unit tests added for the publish env helper and CLI pack environment propagation