### PR TITLE
build: rewire release clean graph

### DIFF
--- a/apps/cli/moon.yml
+++ b/apps/cli/moon.yml
@@ -38,18 +38,24 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      # Vitest drives oclif from apps/cli/dist. Clean only after those tests so
+      # the production build can rewrite dist without racing the reader.
+      - "test"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     env:
       ZITADEL_TELEMETRY_BUILD_CHANNEL: "production"
     deps:
+      - "clean-dist"
       - "api:build-release"
       - "sdk-next:build-release"
-      # Vitest drives oclif from apps/cli/dist. Run it before the production
-      # build, whose tsdown clean step rewrites that same directory. This dep
-      # also orders every writer of apps/cli/dist (build < test < build-release),
-      # so the cli dist needs no mutex of its own.
-      - "test"
     inputs:
       - "**/*"
       - "$ZITADEL_TELEMETRY_BUILD_CHANNEL"
@@ -57,10 +63,9 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
 
   test:

--- a/apps/cli/moon.yml
+++ b/apps/cli/moon.yml
@@ -38,22 +38,14 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
-    deps:
-      # Vitest drives oclif from apps/cli/dist. Clean only after those tests so
-      # the production build can rewrite dist without racing the reader.
-      - "test"
-    options:
-      cache: false
-      runInCI: false
-
   build-release:
-    command: "corepack pnpm run build"
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     env:
       ZITADEL_TELEMETRY_BUILD_CHANNEL: "production"
     deps:
-      - "clean-dist"
+      - "test"
       - "api:build-release"
       - "sdk-next:build-release"
     inputs:
@@ -63,9 +55,9 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
-      # the later release step instead of the normal build/test graph.
+      # Release builds remove stale package output and rebuild dist after
+      # cli:test has finished using the dev build. They stay out of `moon ci`;
+      # release:snapshot invokes them in the later release step instead.
       runInCI: false
 
   test:

--- a/apps/console/moon.yml
+++ b/apps/console/moon.yml
@@ -31,6 +31,20 @@ tasks:
     outputs:
       - "/internal/staticui/console/dist/**/*"
 
+  build-release:
+    command: "corepack pnpm run build"
+    deps:
+      - "api:build-release"
+      - "design-tokens:build"
+      - "ui-react:build"
+    outputs:
+      - "/internal/staticui/console/dist/**/*"
+    options:
+      cache: false
+      # Release UI builds consume package release output and run from the later
+      # release step instead of the normal `moon ci` build/test graph.
+      runInCI: false
+
   test:
     command: "corepack pnpm run test"
     deps:

--- a/apps/login-ui/moon.yml
+++ b/apps/login-ui/moon.yml
@@ -36,10 +36,8 @@ tasks:
       - "/internal/staticui/login/dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release UI builds consume package release output and run from the later
+      # release step instead of the normal `moon ci` build/test graph.
       runInCI: false
 
   dev:

--- a/packages/api/moon.yml
+++ b/packages/api/moon.yml
@@ -30,18 +30,26 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "generate"
     outputs:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # The release preclean is package-local and explicitly upstream of the
+      # release build. Do not rely on parent runDepsInParallel ordering; only
+      # task deps keep dist cleanup from racing builds that read or rewrite it.
       runInCI: false
       # cli:test drives the built oclif CLI, whose commands import this
       # package's dist at runtime. The shared mutex keeps this release build

--- a/packages/api/moon.yml
+++ b/packages/api/moon.yml
@@ -30,27 +30,20 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      mutex: "public-dist"
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "generate"
     outputs:
       - "dist/**/*"
     options:
       cache: false
-      # The release preclean is package-local and explicitly upstream of the
-      # release build. Do not rely on parent runDepsInParallel ordering; only
-      # task deps keep dist cleanup from racing builds that read or rewrite it.
+      # The release preclean and rebuild run in one mutex-held task. Do not
+      # rely on parent runDepsInParallel ordering; only task deps and mutexes
+      # keep dist cleanup from racing builds that read or rewrite it.
       runInCI: false
       # cli:test drives the built oclif CLI, whose commands import this
       # package's dist at runtime. The shared mutex keeps this release build

--- a/packages/api/moon.yml
+++ b/packages/api/moon.yml
@@ -36,6 +36,7 @@ tasks:
       - "build"
     options:
       cache: false
+      mutex: "public-dist"
       runInCI: false
 
   build-release:

--- a/packages/components/moon.yml
+++ b/packages/components/moon.yml
@@ -32,9 +32,18 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
       - "design-tokens:build"
       - "shared-component-styles:build"
@@ -42,10 +51,9 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
 
   test:

--- a/packages/components/moon.yml
+++ b/packages/components/moon.yml
@@ -32,18 +32,12 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
       - "design-tokens:build"
       - "shared-component-styles:build"
@@ -51,8 +45,8 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # Release builds remove stale package output and rebuild dist in one
+      # task. They stay out of `moon ci`; release:snapshot invokes them in
       # the later release step instead of the normal build/test graph.
       runInCI: false
 

--- a/packages/config/moon.yml
+++ b/packages/config/moon.yml
@@ -23,23 +23,31 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
     outputs:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
       # cli:test drives the built oclif CLI, whose commands import
       # @zitadel/config/defaults from this package's dist at runtime. The
-      # shared mutex keeps this release build (whose tsdown clean step
-      # rewrites dist/) from running while those tests are importing it.
+      # shared mutex keeps this release build from running while those tests
+      # are importing it.
       # A task dep on cli:test is not possible: cli dependsOn config, so
       # the reverse edge would cycle the project graph.
       mutex: "public-dist"

--- a/packages/config/moon.yml
+++ b/packages/config/moon.yml
@@ -23,32 +23,25 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      mutex: "public-dist"
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
     outputs:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
-      # the later release step instead of the normal build/test graph.
+      # Release builds remove stale package output and rebuild dist inside one
+      # mutex-held task. They stay out of `moon ci`; release:snapshot invokes
+      # them in the later release step instead of the normal build/test graph.
       runInCI: false
       # cli:test drives the built oclif CLI, whose commands import
       # @zitadel/config/defaults from this package's dist at runtime. The
-      # shared mutex keeps this release build from running while those tests
-      # are importing it.
+      # shared mutex keeps this release build and its preclean from running
+      # while those tests are importing it.
       # A task dep on cli:test is not possible: cli dependsOn config, so
       # the reverse edge would cycle the project graph.
       mutex: "public-dist"

--- a/packages/config/moon.yml
+++ b/packages/config/moon.yml
@@ -29,6 +29,7 @@ tasks:
       - "build"
     options:
       cache: false
+      mutex: "public-dist"
       runInCI: false
 
   build-release:

--- a/packages/sdk-angular/moon.yml
+++ b/packages/sdk-angular/moon.yml
@@ -31,18 +31,12 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -50,8 +44,8 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # Release builds remove stale package output and rebuild dist in one
+      # task. They stay out of `moon ci`; release:snapshot invokes them in
       # the later release step instead of the normal build/test graph.
       runInCI: false
 

--- a/packages/sdk-angular/moon.yml
+++ b/packages/sdk-angular/moon.yml
@@ -31,9 +31,18 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -41,10 +50,9 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
 
   test:

--- a/packages/sdk-core/moon.yml
+++ b/packages/sdk-core/moon.yml
@@ -21,18 +21,26 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
     outputs:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
 
   test:

--- a/packages/sdk-core/moon.yml
+++ b/packages/sdk-core/moon.yml
@@ -21,25 +21,19 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
     outputs:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # Release builds remove stale package output and rebuild dist in one
+      # task. They stay out of `moon ci`; release:snapshot invokes them in
       # the later release step instead of the normal build/test graph.
       runInCI: false
 

--- a/packages/sdk-next/moon.yml
+++ b/packages/sdk-next/moon.yml
@@ -37,6 +37,7 @@ tasks:
       - "build"
     options:
       cache: false
+      mutex: "public-dist"
       runInCI: false
 
   build-release:

--- a/packages/sdk-next/moon.yml
+++ b/packages/sdk-next/moon.yml
@@ -31,19 +31,12 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      mutex: "public-dist"
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -51,14 +44,14 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
-      # the later release step instead of the normal build/test graph.
+      # Release builds remove stale package output and rebuild dist inside one
+      # mutex-held task. They stay out of `moon ci`; release:snapshot invokes
+      # them in the later release step instead of the normal build/test graph.
       runInCI: false
       # cli:test drives the built oclif CLI, whose commands import this
       # package's dist at runtime. The shared mutex keeps this release build
-      # from running while those tests are importing it; a task dep on cli:test
-      # would cycle the project graph.
+      # and its preclean from running while those tests are importing it; a
+      # task dep on cli:test would cycle the project graph.
       mutex: "public-dist"
 
   test:

--- a/packages/sdk-next/moon.yml
+++ b/packages/sdk-next/moon.yml
@@ -31,9 +31,18 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -41,15 +50,14 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
       # cli:test drives the built oclif CLI, whose commands import this
       # package's dist at runtime. The shared mutex keeps this release build
-      # (whose clean step rewrites dist/) from running while those tests are
-      # importing it; a task dep on cli:test would cycle the project graph.
+      # from running while those tests are importing it; a task dep on cli:test
+      # would cycle the project graph.
       mutex: "public-dist"
 
   test:

--- a/packages/sdk-nuxt/moon.yml
+++ b/packages/sdk-nuxt/moon.yml
@@ -33,9 +33,18 @@ tasks:
     options:
       mutex: "sdk-nuxt-dist"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -43,12 +52,11 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
-      # build-release cleans the same dist/ that demo-nuxt:build resolves
+      # build-release rewrites the same dist/ that demo-nuxt:build resolves
       # modules from; the mutex keeps the two from overlapping in the full
       # CI graph.
       mutex: "sdk-nuxt-dist"

--- a/packages/sdk-nuxt/moon.yml
+++ b/packages/sdk-nuxt/moon.yml
@@ -39,6 +39,7 @@ tasks:
       - "build"
     options:
       cache: false
+      mutex: "sdk-nuxt-dist"
       runInCI: false
 
   build-release:

--- a/packages/sdk-nuxt/moon.yml
+++ b/packages/sdk-nuxt/moon.yml
@@ -33,19 +33,12 @@ tasks:
     options:
       mutex: "sdk-nuxt-dist"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      mutex: "sdk-nuxt-dist"
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -53,9 +46,9 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
-      # the later release step instead of the normal build/test graph.
+      # Release builds remove stale package output and rebuild dist inside one
+      # mutex-held task. They stay out of `moon ci`; release:snapshot invokes
+      # them in the later release step instead of the normal build/test graph.
       runInCI: false
       # build-release rewrites the same dist/ that demo-nuxt:build resolves
       # modules from; the mutex keeps the two from overlapping in the full

--- a/packages/sdk-qwik/moon.yml
+++ b/packages/sdk-qwik/moon.yml
@@ -31,18 +31,12 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -50,8 +44,8 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # Release builds remove stale package output and rebuild dist in one
+      # task. They stay out of `moon ci`; release:snapshot invokes them in
       # the later release step instead of the normal build/test graph.
       runInCI: false
 

--- a/packages/sdk-qwik/moon.yml
+++ b/packages/sdk-qwik/moon.yml
@@ -31,9 +31,18 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -41,10 +50,9 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
 
   test:

--- a/packages/sdk-react/moon.yml
+++ b/packages/sdk-react/moon.yml
@@ -31,18 +31,12 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -50,8 +44,8 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # Release builds remove stale package output and rebuild dist in one
+      # task. They stay out of `moon ci`; release:snapshot invokes them in
       # the later release step instead of the normal build/test graph.
       runInCI: false
 

--- a/packages/sdk-react/moon.yml
+++ b/packages/sdk-react/moon.yml
@@ -31,9 +31,18 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -41,10 +50,9 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
 
   test:

--- a/packages/sdk-solid/moon.yml
+++ b/packages/sdk-solid/moon.yml
@@ -31,18 +31,12 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -50,8 +44,8 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # Release builds remove stale package output and rebuild dist in one
+      # task. They stay out of `moon ci`; release:snapshot invokes them in
       # the later release step instead of the normal build/test graph.
       runInCI: false
 

--- a/packages/sdk-solid/moon.yml
+++ b/packages/sdk-solid/moon.yml
@@ -31,9 +31,18 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -41,10 +50,9 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
 
   test:

--- a/packages/sdk-svelte/moon.yml
+++ b/packages/sdk-svelte/moon.yml
@@ -31,18 +31,12 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -50,8 +44,8 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # Release builds remove stale package output and rebuild dist in one
+      # task. They stay out of `moon ci`; release:snapshot invokes them in
       # the later release step instead of the normal build/test graph.
       runInCI: false
 

--- a/packages/sdk-svelte/moon.yml
+++ b/packages/sdk-svelte/moon.yml
@@ -31,9 +31,18 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -41,10 +50,9 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
 
   test:

--- a/packages/sdk-vue/moon.yml
+++ b/packages/sdk-vue/moon.yml
@@ -31,18 +31,12 @@ tasks:
     outputs:
       - "dist/**/*"
 
-  clean-dist:
-    command: "node ../../scripts/release-clean.mjs local-dist"
+  build-release:
+    script: |
+      node ../../scripts/release-clean.mjs local-dist
+      corepack pnpm run build
     deps:
       - "build"
-    options:
-      cache: false
-      runInCI: false
-
-  build-release:
-    command: "corepack pnpm run build"
-    deps:
-      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -50,8 +44,8 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite dist after clean-dist removes stale package
-      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # Release builds remove stale package output and rebuild dist in one
+      # task. They stay out of `moon ci`; release:snapshot invokes them in
       # the later release step instead of the normal build/test graph.
       runInCI: false
 

--- a/packages/sdk-vue/moon.yml
+++ b/packages/sdk-vue/moon.yml
@@ -31,9 +31,18 @@ tasks:
     outputs:
       - "dist/**/*"
 
+  clean-dist:
+    command: "node ../../scripts/release-clean.mjs local-dist"
+    deps:
+      - "build"
+    options:
+      cache: false
+      runInCI: false
+
   build-release:
     command: "corepack pnpm run build"
     deps:
+      - "clean-dist"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"
@@ -41,10 +50,9 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
-      # Release builds rewrite the same dist/ that dev builds produce and
-      # consumer tasks read. They are excluded from `moon ci` (the
-      # release:snapshot workflow step builds them afterwards, serially)
-      # so a release clean step can never wipe a dist mid-consumption.
+      # Release builds rewrite dist after clean-dist removes stale package
+      # output. They stay out of `moon ci`; release:snapshot invokes them in
+      # the later release step instead of the normal build/test graph.
       runInCI: false
 
   test:

--- a/scripts/check-release-graph.mjs
+++ b/scripts/check-release-graph.mjs
@@ -11,15 +11,18 @@ import { PUBLIC_PACKAGE_BUILD_TARGETS } from "./release-manifest.mjs";
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const PUBLIC_AGGREGATE_TARGET = "release:build-public-packages";
 const LEGACY_GLOBAL_CLEAN_TARGET = "release:clean-public-package-dist";
-const RELEASE_UI_CLEAN_REQUIREMENTS = new Map([
-  ["console:build-release", ["api:clean-dist"]],
-  ["login-ui:build-release", ["api:clean-dist", "components:clean-dist"]],
+const RELEASE_UI_BUILD_REQUIREMENTS = new Map([
+  ["console:build-release", ["api:build-release"]],
+  // login-ui imports components directly; api is covered transitively through
+  // components:build-release, but keep both here so the graph check names the
+  // full package release chain that login-ui consumes.
+  ["login-ui:build-release", ["api:build-release", "components:build-release"]],
 ]);
-const CLEAN_MUTEX_REQUIREMENTS = new Map([
-  ["api:clean-dist", "public-dist"],
-  ["config:clean-dist", "public-dist"],
-  ["sdk-next:clean-dist", "public-dist"],
-  ["sdk-nuxt:clean-dist", "sdk-nuxt-dist"],
+const BUILD_MUTEX_REQUIREMENTS = new Map([
+  ["api:build-release", "public-dist"],
+  ["config:build-release", "public-dist"],
+  ["sdk-next:build-release", "public-dist"],
+  ["sdk-nuxt:build-release", "sdk-nuxt-dist"],
 ]);
 const RELEASE_ENTRYPOINT_TARGETS = [
   "release:pack",
@@ -52,9 +55,9 @@ export async function main(args = forwardedArgs()) {
 
   for (const target of PUBLIC_PACKAGE_BUILD_TARGETS) {
     assertTask(publicTasks, target);
-    const cleanTarget = cleanTargetFor(target);
-    assertTaskOption(publicTasks, cleanTarget, "runInCI", false);
-    assertCleanMutex(publicTasks, cleanTarget);
+    assertTaskOption(publicTasks, target, "runInCI", false);
+    assertReleaseBuildCleans(publicTasks, target);
+    assertBuildMutex(publicTasks, target);
 
     if (!aggregateDeps.has(target)) {
       throw new Error(
@@ -62,22 +65,24 @@ export async function main(args = forwardedArgs()) {
       );
     }
 
-    if (!reaches(publicTasks, target, cleanTarget)) {
-      throw new Error(`${target} does not depend on ${cleanTarget}`);
+    const readerTarget = readerTargetFor(target);
+    if (!reaches(publicTasks, target, readerTarget)) {
+      throw new Error(`${target} does not depend on ${readerTarget}`);
     }
   }
 
-  for (const [target, cleanTargets] of RELEASE_UI_CLEAN_REQUIREMENTS) {
+  for (const [target, releaseBuildTargets] of RELEASE_UI_BUILD_REQUIREMENTS) {
     const graph = await readTaskGraph(target);
     const tasks = indexTasks(graph);
     assertTask(tasks, target);
 
-    for (const cleanTarget of cleanTargets) {
-      assertTaskOption(tasks, cleanTarget, "runInCI", false);
-      assertCleanMutex(tasks, cleanTarget);
+    for (const releaseBuildTarget of releaseBuildTargets) {
+      assertTaskOption(tasks, releaseBuildTarget, "runInCI", false);
+      assertReleaseBuildCleans(tasks, releaseBuildTarget);
+      assertBuildMutex(tasks, releaseBuildTarget);
 
-      if (!reaches(tasks, target, cleanTarget)) {
-        throw new Error(`${target} does not depend on ${cleanTarget}`);
+      if (!reaches(tasks, target, releaseBuildTarget)) {
+        throw new Error(`${target} does not depend on ${releaseBuildTarget}`);
       }
     }
   }
@@ -93,7 +98,7 @@ export async function main(args = forwardedArgs()) {
     if (deps.has("console:build")) {
       throw new Error(`${target} must use console:build-release, not console:build`);
     }
-    for (const uiTarget of RELEASE_UI_CLEAN_REQUIREMENTS.keys()) {
+    for (const uiTarget of RELEASE_UI_BUILD_REQUIREMENTS.keys()) {
       if (!deps.has(uiTarget)) {
         throw new Error(`${target} must depend on ${uiTarget}`);
       }
@@ -101,9 +106,9 @@ export async function main(args = forwardedArgs()) {
   }
 
   console.log(
-    "release graph ok: every public package release build cleans its own " +
-      `dist, and ${RELEASE_UI_CLEAN_REQUIREMENTS.size} release UI builds ` +
-      "depend on the package release chain they consume",
+    "release graph ok: every public package release build cleans and rebuilds " +
+      `dist atomically, and ${RELEASE_UI_BUILD_REQUIREMENTS.size} release UI ` +
+      "builds depend on the package release chain they consume",
   );
 }
 
@@ -170,13 +175,23 @@ function assertTaskRunInCI(task, expected) {
   }
 }
 
-function assertCleanMutex(tasks, target) {
-  const expected = CLEAN_MUTEX_REQUIREMENTS.get(target);
+function assertBuildMutex(tasks, target) {
+  const expected = BUILD_MUTEX_REQUIREMENTS.get(target);
   if (!expected) {
     return;
   }
 
   assertTaskOption(tasks, target, "mutex", expected);
+}
+
+function assertReleaseBuildCleans(tasks, target) {
+  assertTask(tasks, target);
+  const task = tasks.get(target);
+  const script = task.script ?? [task.command, ...(task.args ?? [])].join(" ");
+
+  if (!script.includes("release-clean.mjs local-dist")) {
+    throw new Error(`${target} must clean local dist inside build-release`);
+  }
 }
 
 function directDeps(tasks, target) {
@@ -207,9 +222,9 @@ function reaches(tasks, start, target) {
   return false;
 }
 
-function cleanTargetFor(buildTarget) {
+function readerTargetFor(buildTarget) {
   const [project] = buildTarget.split(":");
-  return `${project}:clean-dist`;
+  return project === "cli" ? "cli:test" : `${project}:build`;
 }
 
 function formatError(error) {

--- a/scripts/check-release-graph.mjs
+++ b/scripts/check-release-graph.mjs
@@ -15,6 +15,12 @@ const RELEASE_UI_CLEAN_REQUIREMENTS = new Map([
   ["console:build-release", ["api:clean-dist"]],
   ["login-ui:build-release", ["api:clean-dist", "components:clean-dist"]],
 ]);
+const CLEAN_MUTEX_REQUIREMENTS = new Map([
+  ["api:clean-dist", "public-dist"],
+  ["config:clean-dist", "public-dist"],
+  ["sdk-next:clean-dist", "public-dist"],
+  ["sdk-nuxt:clean-dist", "sdk-nuxt-dist"],
+]);
 const RELEASE_ENTRYPOINT_TARGETS = [
   "release:pack",
   "release:snapshot",
@@ -48,6 +54,7 @@ export async function main(args = forwardedArgs()) {
     assertTask(publicTasks, target);
     const cleanTarget = cleanTargetFor(target);
     assertTaskOption(publicTasks, cleanTarget, "runInCI", false);
+    assertCleanMutex(publicTasks, cleanTarget);
 
     if (!aggregateDeps.has(target)) {
       throw new Error(
@@ -67,6 +74,7 @@ export async function main(args = forwardedArgs()) {
 
     for (const cleanTarget of cleanTargets) {
       assertTaskOption(tasks, cleanTarget, "runInCI", false);
+      assertCleanMutex(tasks, cleanTarget);
 
       if (!reaches(tasks, target, cleanTarget)) {
         throw new Error(`${target} does not depend on ${cleanTarget}`);
@@ -108,7 +116,7 @@ async function readTaskGraph(target) {
     return JSON.parse(result.stdout);
   } catch (error) {
     throw new Error(
-      `failed to parse moon task graph for ${target}: ${error.message}\n` +
+      `failed to parse moon task graph for ${target}: ${formatError(error)}\n` +
         result.stdout.slice(0, 1000),
     );
   }
@@ -123,7 +131,7 @@ async function readTask(target) {
     return JSON.parse(result.stdout);
   } catch (error) {
     throw new Error(
-      `failed to parse moon task for ${target}: ${error.message}\n` +
+      `failed to parse moon task for ${target}: ${formatError(error)}\n` +
         result.stdout.slice(0, 1000),
     );
   }
@@ -162,6 +170,15 @@ function assertTaskRunInCI(task, expected) {
   }
 }
 
+function assertCleanMutex(tasks, target) {
+  const expected = CLEAN_MUTEX_REQUIREMENTS.get(target);
+  if (!expected) {
+    return;
+  }
+
+  assertTaskOption(tasks, target, "mutex", expected);
+}
+
 function directDeps(tasks, target) {
   const task = tasks.get(target);
   assertTask(tasks, target);
@@ -193,6 +210,10 @@ function reaches(tasks, start, target) {
 function cleanTargetFor(buildTarget) {
   const [project] = buildTarget.split(":");
   return `${project}:clean-dist`;
+}
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 if (isDirectRun(import.meta.url)) {

--- a/scripts/check-release-graph.mjs
+++ b/scripts/check-release-graph.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+
+import {
+  forwardedArgs,
+  isDirectRun,
+  runCapture,
+} from "./dev-process.mjs";
+import { PUBLIC_PACKAGE_BUILD_TARGETS } from "./release-manifest.mjs";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const PUBLIC_AGGREGATE_TARGET = "release:build-public-packages";
+const LEGACY_GLOBAL_CLEAN_TARGET = "release:clean-public-package-dist";
+const RELEASE_UI_CLEAN_REQUIREMENTS = new Map([
+  ["console:build-release", ["api:clean-dist"]],
+  ["login-ui:build-release", ["api:clean-dist", "components:clean-dist"]],
+]);
+const RELEASE_ENTRYPOINT_TARGETS = [
+  "release:pack",
+  "release:snapshot",
+  "release:publish",
+];
+
+export async function main(args = forwardedArgs()) {
+  if (args.includes("--help")) {
+    console.log("usage: node scripts/check-release-graph.mjs");
+    return;
+  }
+
+  if (args.length > 0) {
+    throw new Error(`unknown arguments: ${args.join(" ")}`);
+  }
+
+  const publicGraph = await readTaskGraph(PUBLIC_AGGREGATE_TARGET);
+  const publicTasks = indexTasks(publicGraph);
+
+  assertTaskOption(publicTasks, PUBLIC_AGGREGATE_TARGET, "runInCI", false);
+
+  const aggregateDeps = directDeps(publicTasks, PUBLIC_AGGREGATE_TARGET);
+  if (aggregateDeps.has(LEGACY_GLOBAL_CLEAN_TARGET)) {
+    throw new Error(
+      `${PUBLIC_AGGREGATE_TARGET} must not list ${LEGACY_GLOBAL_CLEAN_TARGET} ` +
+        "as a sibling dep; each release build must clean its own dist instead.",
+    );
+  }
+
+  for (const target of PUBLIC_PACKAGE_BUILD_TARGETS) {
+    assertTask(publicTasks, target);
+    const cleanTarget = cleanTargetFor(target);
+    assertTaskOption(publicTasks, cleanTarget, "runInCI", false);
+
+    if (!aggregateDeps.has(target)) {
+      throw new Error(
+        `${PUBLIC_AGGREGATE_TARGET} is missing manifest build target ${target}`,
+      );
+    }
+
+    if (!reaches(publicTasks, target, cleanTarget)) {
+      throw new Error(`${target} does not depend on ${cleanTarget}`);
+    }
+  }
+
+  for (const [target, cleanTargets] of RELEASE_UI_CLEAN_REQUIREMENTS) {
+    const graph = await readTaskGraph(target);
+    const tasks = indexTasks(graph);
+    assertTask(tasks, target);
+
+    for (const cleanTarget of cleanTargets) {
+      assertTaskOption(tasks, cleanTarget, "runInCI", false);
+
+      if (!reaches(tasks, target, cleanTarget)) {
+        throw new Error(`${target} does not depend on ${cleanTarget}`);
+      }
+    }
+  }
+
+  for (const target of RELEASE_ENTRYPOINT_TARGETS) {
+    const task = await readTask(target);
+    const deps = new Set((task.deps ?? []).map((dep) => dep.target));
+    assertTaskRunInCI(task, false);
+
+    if (!deps.has(PUBLIC_AGGREGATE_TARGET)) {
+      throw new Error(`${target} must depend on ${PUBLIC_AGGREGATE_TARGET}`);
+    }
+    if (deps.has("console:build")) {
+      throw new Error(`${target} must use console:build-release, not console:build`);
+    }
+    for (const uiTarget of RELEASE_UI_CLEAN_REQUIREMENTS.keys()) {
+      if (!deps.has(uiTarget)) {
+        throw new Error(`${target} must depend on ${uiTarget}`);
+      }
+    }
+  }
+
+  console.log(
+    "release graph ok: every public package release build cleans its own " +
+      `dist, and ${RELEASE_UI_CLEAN_REQUIREMENTS.size} release UI builds ` +
+      "depend on the package release chain they consume",
+  );
+}
+
+async function readTaskGraph(target) {
+  const result = await runCapture("moon", ["task-graph", target, "--json"], {
+    cwd: repoRoot,
+  });
+
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(
+      `failed to parse moon task graph for ${target}: ${error.message}\n` +
+        result.stdout.slice(0, 1000),
+    );
+  }
+}
+
+async function readTask(target) {
+  const result = await runCapture("moon", ["task", target, "--json"], {
+    cwd: repoRoot,
+  });
+
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(
+      `failed to parse moon task for ${target}: ${error.message}\n` +
+        result.stdout.slice(0, 1000),
+    );
+  }
+}
+
+function indexTasks(graph) {
+  const tasks = new Map();
+  for (const task of Object.values(graph.data ?? {})) {
+    tasks.set(task.target, task);
+  }
+  return tasks;
+}
+
+function assertTask(tasks, target) {
+  if (!tasks.has(target)) {
+    throw new Error(`moon graph is missing ${target}`);
+  }
+}
+
+function assertTaskOption(tasks, target, option, expected) {
+  assertTask(tasks, target);
+  const task = tasks.get(target);
+
+  if (task.options?.[option] !== expected) {
+    throw new Error(
+      `${target} must set options.${option} to ${String(expected)}`,
+    );
+  }
+}
+
+function assertTaskRunInCI(task, expected) {
+  if (task.options?.runInCI !== expected) {
+    throw new Error(
+      `${task.target} must set options.runInCI to ${String(expected)}`,
+    );
+  }
+}
+
+function directDeps(tasks, target) {
+  const task = tasks.get(target);
+  assertTask(tasks, target);
+  return new Set((task.deps ?? []).map((dep) => dep.target));
+}
+
+function reaches(tasks, start, target) {
+  const pending = [start];
+  const seen = new Set();
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || seen.has(current)) {
+      continue;
+    }
+    if (current === target) {
+      return true;
+    }
+
+    seen.add(current);
+    for (const dep of directDeps(tasks, current)) {
+      pending.push(dep);
+    }
+  }
+
+  return false;
+}
+
+function cleanTargetFor(buildTarget) {
+  const [project] = buildTarget.split(":");
+  return `${project}:clean-dist`;
+}
+
+if (isDirectRun(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/release-clean.mjs
+++ b/scripts/release-clean.mjs
@@ -11,6 +11,8 @@ const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 export async function main(args = forwardedArgs()) {
   const command = args[0];
   switch (command) {
+    case "local-dist":
+      return await cleanLocalDistArtifacts();
     case "public-package-dist":
       return await cleanPublicPackageDistArtifacts();
     default:
@@ -26,12 +28,16 @@ export async function cleanPublicPackageDistArtifacts(root = repoRoot) {
   );
 }
 
+export async function cleanLocalDistArtifacts(root = process.cwd()) {
+  await rm(join(root, "dist"), { recursive: true, force: true });
+}
+
 function usage(error) {
   if (error) {
     console.error(error);
     console.error("");
   }
-  console.log("usage: node scripts/release-clean.mjs public-package-dist");
+  console.log("usage: node scripts/release-clean.mjs <local-dist|public-package-dist>");
   process.exit(error ? 1 : 0);
 }
 

--- a/tools/release/moon.yml
+++ b/tools/release/moon.yml
@@ -39,9 +39,9 @@ tasks:
       cache: false
       runDepsInParallel: false
       runFromWorkspaceRoot: true
-      # Excluded from `moon ci`: release package builds rewrite dist output
-      # after each package-local clean-dist task removes stale files. The
-      # check-graph guard verifies those edges before packaging runs.
+      # Excluded from `moon ci`: release package builds remove stale files and
+      # rewrite dist output inside their build-release tasks. The check-graph
+      # guard verifies those scripts and mutexes before packaging runs.
       runInCI: false
 
   version:

--- a/tools/release/moon.yml
+++ b/tools/release/moon.yml
@@ -11,45 +11,17 @@ tasks:
       runFromWorkspaceRoot: true
       runInCI: true
 
-  clean-public-package-dist:
-    command: "node scripts/release-clean.mjs public-package-dist"
-    deps:
-      # Deletes every public package's dist/ — the same directories these dev
-      # builds write. Within one moon invocation (e.g. release:snapshot, whose
-      # graph also contains dev builds via console:build and cli:test),
-      # `runDepsInParallel: false` on the parent only orders its direct dep
-      # targets, not their subtrees, so without these edges the clean races a
-      # concurrent dev build or cache hydration of the same dist (ENOTEMPTY).
-      # All of these are cache hits by the time the release chain runs.
-      # cli:test is in the release graph too (cli:build-release depends on
-      # it) and drives the built oclif CLI from apps/cli/dist while running.
-      - "cli:build"
-      - "cli:test"
-      - "api:build"
-      - "config:build"
-      - "components:build"
-      - "sdk-core:build"
-      - "sdk-next:build"
-      - "sdk-nuxt:build"
-      - "sdk-react:build"
-      - "sdk-vue:build"
-      - "sdk-angular:build"
-      - "sdk-solid:build"
-      - "sdk-svelte:build"
-      - "sdk-qwik:build"
+  check-graph:
+    command: "node scripts/check-release-graph.mjs"
     options:
       cache: false
       runFromWorkspaceRoot: true
-      # Must never run inside the `moon ci` build/test graph, where consumer
-      # tasks are importing those directories concurrently; the
-      # release:snapshot workflow step invokes it afterwards (with CI unset),
-      # strictly serialized.
       runInCI: false
 
   build-public-packages:
     command: "node -e 0"
     deps:
-      - "release:clean-public-package-dist"
+      - "release:check-graph"
       - "cli:build-release"
       - "api:build-release"
       - "config:build-release"
@@ -67,11 +39,9 @@ tasks:
       cache: false
       runDepsInParallel: false
       runFromWorkspaceRoot: true
-      # Excluded from `moon ci`: release builds rewrite the same dists that
-      # dev builds produce and consumer tasks read (typechecks, the built-CLI
-      # tests, demo bundles), so running them concurrently with the build/test
-      # graph wipes dists mid-consumption. The release:snapshot step in
-      # .github/workflows/ci.yml builds them afterwards, serially.
+      # Excluded from `moon ci`: release package builds rewrite dist output
+      # after each package-local clean-dist task removes stale files. The
+      # check-graph guard verifies those edges before packaging runs.
       runInCI: false
 
   version:
@@ -84,7 +54,7 @@ tasks:
     command: "node scripts/release.mjs pack"
     deps:
       - "release:build-public-packages"
-      - "console:build"
+      - "console:build-release"
       - "login-ui:build-release"
     outputs:
       - "/dist/release/**/*"
@@ -99,7 +69,7 @@ tasks:
     deps:
       - "server:test"
       - "release:build-public-packages"
-      - "console:build"
+      - "console:build-release"
       - "login-ui:build-release"
     outputs:
       - "/dist/release/**/*"
@@ -113,7 +83,7 @@ tasks:
     command: "node scripts/release.mjs publish"
     deps:
       - "release:build-public-packages"
-      - "console:build"
+      - "console:build-release"
       - "login-ui:build-release"
     options:
       cache: false


### PR DESCRIPTION
## Summary
- Fold package-local `dist/` cleanup into each public package `build-release` task so Moon holds any required mutex across cleanup and rebuild
- Keep release builds upstream of their normal build/test readers before cleanup, avoiding the missing-`dist` window that a separate clean task left open
- Update release orchestration to use the `console:build-release`/`login-ui:build-release` paths and extend the graph guard to verify cleanup scripts, mutexes, and package release-chain dependencies

## Testing
- `moon run release:check-graph`
- `git diff --check`

## Release notes / changeset
- No changeset: build/release graph wiring only; no published package API or runtime behavior change.

## Notes
- Full `moon run release:build-public-packages` was not run locally because this checkout is missing executable build tools such as `tsx` and `tsdown`; CI should exercise the package builds with a complete install.