### PR TITLE
Prevent release build races in package graphs

### DIFF
--- a/apps/cli/moon.yml
+++ b/apps/cli/moon.yml
@@ -55,6 +55,10 @@ tasks:
       - "dist/**/*"
     options:
       cache: false
+      # cli:test exercises the normal dev build and its workspace package
+      # readers. Finish it before release deps start cleaning/rebuilding the
+      # public package dist directories.
+      runDepsInParallel: false
       # Release builds remove stale package output and rebuild dist after
       # cli:test has finished using the dev build. They stay out of `moon ci`;
       # release:snapshot invokes them in the later release step instead.

--- a/packages/api/moon.yml
+++ b/packages/api/moon.yml
@@ -35,7 +35,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "generate"
     outputs:
       - "dist/**/*"

--- a/packages/components/moon.yml
+++ b/packages/components/moon.yml
@@ -37,7 +37,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
       - "design-tokens:build"
       - "shared-component-styles:build"

--- a/packages/config/moon.yml
+++ b/packages/config/moon.yml
@@ -28,7 +28,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
     outputs:
       - "dist/**/*"

--- a/packages/sdk-angular/moon.yml
+++ b/packages/sdk-angular/moon.yml
@@ -36,7 +36,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"

--- a/packages/sdk-core/moon.yml
+++ b/packages/sdk-core/moon.yml
@@ -26,7 +26,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
     outputs:
       - "dist/**/*"

--- a/packages/sdk-next/moon.yml
+++ b/packages/sdk-next/moon.yml
@@ -36,7 +36,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"

--- a/packages/sdk-nuxt/moon.yml
+++ b/packages/sdk-nuxt/moon.yml
@@ -38,7 +38,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"

--- a/packages/sdk-qwik/moon.yml
+++ b/packages/sdk-qwik/moon.yml
@@ -36,7 +36,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"

--- a/packages/sdk-react/moon.yml
+++ b/packages/sdk-react/moon.yml
@@ -36,7 +36,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"

--- a/packages/sdk-solid/moon.yml
+++ b/packages/sdk-solid/moon.yml
@@ -36,7 +36,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"

--- a/packages/sdk-svelte/moon.yml
+++ b/packages/sdk-svelte/moon.yml
@@ -36,7 +36,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"

--- a/packages/sdk-vue/moon.yml
+++ b/packages/sdk-vue/moon.yml
@@ -36,7 +36,6 @@ tasks:
       node ../../scripts/release-clean.mjs local-dist
       corepack pnpm run build
     deps:
-      - "build"
       - "api:build-release"
       - "components:build-release"
       - "sdk-core:build-release"

--- a/scripts/check-release-graph.mjs
+++ b/scripts/check-release-graph.mjs
@@ -58,16 +58,12 @@ export async function main(args = forwardedArgs()) {
     assertTaskOption(publicTasks, target, "runInCI", false);
     assertReleaseBuildCleans(publicTasks, target);
     assertBuildMutex(publicTasks, target);
+    assertSelfBuildNotInReleaseGraph(publicTasks, target);
 
     if (!aggregateDeps.has(target)) {
       throw new Error(
         `${PUBLIC_AGGREGATE_TARGET} is missing manifest build target ${target}`,
       );
-    }
-
-    const readerTarget = readerTargetFor(target);
-    if (!reaches(publicTasks, target, readerTarget)) {
-      throw new Error(`${target} does not depend on ${readerTarget}`);
     }
   }
 
@@ -106,8 +102,9 @@ export async function main(args = forwardedArgs()) {
   }
 
   console.log(
-    "release graph ok: every public package release build cleans and rebuilds " +
-      `dist atomically, and ${RELEASE_UI_BUILD_REQUIREMENTS.size} release UI ` +
+    "release graph ok: public package release builds clean and rebuild dist " +
+      "without self-build readers, and " +
+      `${RELEASE_UI_BUILD_REQUIREMENTS.size} release UI ` +
       "builds depend on the package release chain they consume",
   );
 }
@@ -184,6 +181,24 @@ function assertBuildMutex(tasks, target) {
   assertTaskOption(tasks, target, "mutex", expected);
 }
 
+function assertSelfBuildNotInReleaseGraph(tasks, target) {
+  if (target === "cli:build-release") {
+    assertTaskOption(tasks, target, "runDepsInParallel", false);
+    if (!reaches(tasks, target, "cli:test")) {
+      throw new Error("cli:build-release must depend on cli:test");
+    }
+    return;
+  }
+
+  const buildTarget = normalBuildTargetFor(target);
+  if (reaches(tasks, target, buildTarget)) {
+    throw new Error(
+      `${target} must not depend on ${buildTarget}; release builds clean and ` +
+        "rebuild their own dist, and normal build readers can race that cleanup.",
+    );
+  }
+}
+
 function assertReleaseBuildCleans(tasks, target) {
   assertTask(tasks, target);
   const task = tasks.get(target);
@@ -222,9 +237,9 @@ function reaches(tasks, start, target) {
   return false;
 }
 
-function readerTargetFor(buildTarget) {
+function normalBuildTargetFor(buildTarget) {
   const [project] = buildTarget.split(":");
-  return project === "cli" ? "cli:test" : `${project}:build`;
+  return `${project}:build`;
 }
 
 function formatError(error) {


### PR DESCRIPTION
## Summary
- Remove self-build reader dependencies from release build graphs so cleanup and rebuild steps do not race normal package builds
- Require `cli:build-release` to wait for `cli:test` and serialize its dependency execution
- Update the release graph check to enforce the new release/build separation

## Testing
- Not run (not requested)