### PR TITLE
chore: add release provenance smoke changeset

### DIFF
--- a/.changeset/release-provenance-smoke.md
+++ b/.changeset/release-provenance-smoke.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/cli": patch
+---
+
+Verify public npm provenance after repository publication.


### PR DESCRIPTION
## Summary

- Add a dedicated patch changeset to exercise the public npm release train after the repository is opened.
- Use `@zitadel/cli` as the changeset entry point so the fixed public package group is patch-bumped together.

## Validation

- `git diff --check`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec changeset status --since FETCH_HEAD`

## Release notes / changeset

- Real changeset added: `.changeset/release-provenance-smoke.md`
- Changesets reports a patch bump for the fixed public package group: `@zitadel/cli`, `@zitadel/server`, server platform packages, `@zitadel/api`, `@zitadel/config`, `@zitadel/components`, and all public SDK packages.

## Notes

- Keep this PR as a draft until after the repository is public and npm Trusted Publishing is configured for the public `@zitadel/*` packages.
- This intentionally creates a real publish candidate because dry-run releases set `NPM_CONFIG_PROVENANCE=false` and cannot prove npm provenance.