### PR TITLE
ci: allow release publish task in Actions

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -148,9 +148,10 @@ jobs:
           if [ -n "$RECOVER_VERSION" ]; then
             args+=(--recover-version "$RECOVER_VERSION")
           fi
-          # Dry runs do not publish, so provenance stays off here. Real
-          # publishes keep the GitHub Actions environment intact for OIDC.
-          moon run "${args[@]}"
+          # Release tasks are excluded from `moon ci`, but this workflow invokes
+          # them explicitly. Unset only CI so Moon keeps the task in the action
+          # pipeline while preserving the GitHub Actions/OIDC environment.
+          env -u CI moon run "${args[@]}"
         env:
           BASE_SHA: ${{ github.event.before || 'HEAD^' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,9 +165,10 @@ jobs:
           if [ -n "$RECOVER_VERSION" ]; then
             args+=(-- --recover-version "$RECOVER_VERSION")
           fi
-          # Keep the GitHub Actions environment intact: npm trusted publishing
-          # and provenance use it to exchange the workflow OIDC token.
-          moon run "${args[@]}"
+          # Release tasks are excluded from `moon ci`, but this workflow invokes
+          # them explicitly. Unset only CI so Moon keeps the task in the action
+          # pipeline while preserving the GitHub Actions/OIDC environment.
+          env -u CI moon run "${args[@]}"
         env:
           BASE_SHA: ${{ github.event.before || 'HEAD^' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Unset only `CI` around the explicit `moon run release:publish` calls in `release-publish.yml`.
- Keep the GitHub Actions environment intact so npm trusted publishing / provenance can still use OIDC.
- Add comments documenting why the workflow differs from normal `moon ci` behavior.

## Validation

- `env CI=true GITHUB_ACTIONS=true bash -lc 'args=(release:check-graph); env -u CI moon run "${args[@]}"'`
- `moon run release:check-graph`
- `git diff --check`

## Release notes / changeset

No changeset required — no shipped behavior changed.

## Notes

Root cause: the release Moon targets are marked `runInCI: false` so they are excluded from `moon ci`, but the publish workflow invokes `release:publish` explicitly inside GitHub Actions. With `CI=true`, Moon filtered the task out before running the release script, producing `No tasks found. Unable to execute action pipeline. For targets release:publish.`