### PR TITLE
test: isolate release GitHub env assertion

### DIFF
--- a/apps/cli/tests/unit/scripts/release-github.test.ts
+++ b/apps/cli/tests/unit/scripts/release-github.test.ts
@@ -329,6 +329,10 @@ ${GENERATED_BLOCK_END}`,
     await expect(
       upsertProductGithubRelease({
         metadata: metadata(),
+        env: {
+          GITHUB_REPOSITORY: "zitadel/nextgen",
+          GITHUB_SHA: "abc123",
+        },
         fetchImpl: async () => jsonResponse(500, {}),
         log: () => undefined,
       }),


### PR DESCRIPTION
## Summary

- Make the GitHub Release env-missing unit test pass an explicit env without `GITHUB_TOKEN`.
- Prevent the test from inheriting the real release workflow's ambient GitHub env when `release:publish` runs `cli:test`.

## Validation

- `env GITHUB_TOKEN=token GITHUB_REPOSITORY=zitadel/nextgen GITHUB_SHA=abc123 node --input-type=module -e "const m=await import('./scripts/release-github.mjs'); try { await m.upsertProductGithubRelease({ metadata:{version:'0.1.0-alpha.9',tag:'v0.1.0-alpha.9',commit:'abc123def456',shortCommit:'abc123d',imageTags:[],packages:[]}, env:{GITHUB_REPOSITORY:'zitadel/nextgen',GITHUB_SHA:'abc123'}, fetchImpl: async()=>({ok:false,status:500,statusText:'OK',text:async()=>'{ }',json:async()=>({})}) }); console.log('unexpected success'); } catch (error) { console.log(error.message); }"`
- `git diff --check`

Not run: targeted `corepack pnpm --filter @zitadel/cli run test -- tests/unit/scripts/release-github.test.ts -t "fails clearly"` because this worktree has no `node_modules`; `vitest` is not installed locally.

## Release notes / changeset

No changeset required — no shipped behavior changed.

## Notes

Root cause: the test called `upsertProductGithubRelease` without an explicit `env`, so it fell back to `process.env`. In the manual release publish job, `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and `GITHUB_SHA` are present, which made the code proceed to the mocked GitHub lookup instead of failing on the missing token.