### PR TITLE
ci: fail manual release no-ops

### DIFF
--- a/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
+++ b/apps/cli/tests/unit/scripts/check-changesets-status.test.ts
@@ -63,6 +63,10 @@ type ReleaseAutomationModule = {
 type ReleaseModule = {
   assertNoUnrecordedPendingChangesets: (repoRoot: string) => Promise<void>;
   releasePublishEnv: (env?: NodeJS.ProcessEnv) => NodeJS.ProcessEnv;
+  shouldFailManualPublishSkip: (
+    options: { dryRun?: boolean; recoverVersion?: string },
+    env?: NodeJS.ProcessEnv,
+  ) => boolean;
 };
 
 type CheckChangesetStatus = {
@@ -507,6 +511,29 @@ describe("release-automation", () => {
 });
 
 describe("release publish guard", () => {
+  it("fails manual non-dry publish skips instead of silently succeeding", async () => {
+    const { shouldFailManualPublishSkip } = await loadReleaseModule();
+    const workflowDispatchEnv = { GITHUB_EVENT_NAME: "workflow_dispatch" } as NodeJS.ProcessEnv;
+
+    expect(shouldFailManualPublishSkip({ dryRun: false, recoverVersion: "" }, workflowDispatchEnv)).toBe(
+      true,
+    );
+    expect(shouldFailManualPublishSkip({ dryRun: true, recoverVersion: "" }, workflowDispatchEnv)).toBe(
+      false,
+    );
+    expect(
+      shouldFailManualPublishSkip(
+        { dryRun: false, recoverVersion: "0.1.0-alpha.14" },
+        workflowDispatchEnv,
+      ),
+    ).toBe(false);
+    expect(
+      shouldFailManualPublishSkip({ dryRun: false, recoverVersion: "" }, {
+        GITHUB_EVENT_NAME: "push",
+      } as NodeJS.ProcessEnv),
+    ).toBe(false);
+  });
+
   it("forces production telemetry while publishing npm packages", async () => {
     const { releasePublishEnv } = await loadReleaseModule();
     const originalBase = process.env.ZITADEL_RELEASE_TEST_BASE;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -110,7 +110,18 @@ async function commandPublish(options) {
       throw new Error(message);
     }
     if (!preflight.shouldRun) {
-      console.log(`release publish: skip - ${preflight.reason}`);
+      const message = `release publish: skip - ${preflight.reason}`;
+      if (shouldFailManualPublishSkip(options)) {
+        throw new Error(
+          [
+            message,
+            "manual release dispatch would not publish anything; " +
+              `pass recover_version=${release.version} to recover this checked-out version, ` +
+              "or run from a Changesets version package commit.",
+          ].join("\n"),
+        );
+      }
+      console.log(message);
       return;
     }
   }
@@ -200,6 +211,10 @@ export async function assertNoUnrecordedPendingChangesets(root = repoRoot) {
 
 export function releasePublishEnv(overrides = {}) {
   return { ...process.env, ...overrides, ZITADEL_TELEMETRY_BUILD_CHANNEL: "production" };
+}
+
+export function shouldFailManualPublishSkip(options = {}, env = process.env) {
+  return env.GITHUB_EVENT_NAME === "workflow_dispatch" && !options.dryRun && !options.recoverVersion;
 }
 
 async function assertMainBranch(options, { allowDryRunBypass = true } = {}) {


### PR DESCRIPTION
## Summary

- Make a manual non-dry `release-publish` dispatch fail if the release preflight would skip publishing.
- Keep automatic push behavior unchanged: ordinary non-version commits can still skip, but a manually requested publish no longer succeeds as a green no-op.
- Include the checked-out package version in the error so operators know which `recover_version` to pass.

## Validation

- `node --check scripts/release.mjs`
- `node --input-type=module -e "const { shouldFailManualPublishSkip } = await import('./scripts/release.mjs'); const dispatch = { GITHUB_EVENT_NAME: 'workflow_dispatch' }; const push = { GITHUB_EVENT_NAME: 'push' }; console.log(JSON.stringify([shouldFailManualPublishSkip({ dryRun: false, recoverVersion: '' }, dispatch), shouldFailManualPublishSkip({ dryRun: true, recoverVersion: '' }, dispatch), shouldFailManualPublishSkip({ dryRun: false, recoverVersion: '0.1.0-alpha.14' }, dispatch), shouldFailManualPublishSkip({ dryRun: false, recoverVersion: '' }, push)]));"`
- `git diff --check`

Not run: targeted Vitest for `apps/cli/tests/unit/scripts/check-changesets-status.test.ts` because this worktree does not have `node_modules`; `vitest` is not installed locally.

## Release notes / changeset

No changeset required — no shipped behavior changed.

## Notes

Run `28942170044` checked out `main` at `9bf99e32` (`test: isolate release GitHub env assertion (#479)`), not a `build: version packages` commit, and `recover_version` was empty. The publish task therefore printed `release publish: skip - latest commit is not a Changesets version package commit` and exited successfully without publishing. To recover the current alpha manually, rerun the workflow with `dry_run=false` and `recover_version=0.1.0-alpha.14`.