### PR TITLE
ci: disable npm provenance on Depot release runner

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -96,8 +96,9 @@ Publishing uses **npm trusted publishing (OIDC)** — there is no `NPM_TOKEN`. O
 per public package, a maintainer adds a trusted publisher on npmjs.com (Settings →
 Trusted Publishing): provider GitHub Actions, repo `zitadel/nextgen`, workflow
 `release-publish.yml`. The package must exist on npm first (publish `0.0.x` by
-hand if needed). Real publishes set npm provenance on
-(`NPM_CONFIG_PROVENANCE=true`); dry runs leave it off because they do not publish.
+hand if needed). The release job runs on Depot, which npm treats as self-hosted;
+keep `NPM_CONFIG_PROVENANCE=false` until npm provenance is supported for that
+runner environment or the publish job moves to GitHub-hosted runners.
 
 Each public package must declare its license and ship a `LICENSE` file before its
 first publish — see [LICENSING.md](../LICENSING.md).

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -172,5 +172,8 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.before || 'HEAD^' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
+          # Depot runners are self-hosted from npm's provenance verifier's
+          # perspective. Keep trusted publishing via OIDC, but do not request
+          # npm provenance until the release job runs on GitHub-hosted runners.
+          NPM_CONFIG_PROVENANCE: "false"
           RECOVER_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.recover_version || '' }}


### PR DESCRIPTION
## Summary

- Set `NPM_CONFIG_PROVENANCE=false` for real `release-publish` npm publishes on Depot runners.
- Keep GitHub Actions OIDC/trusted publishing intact; only the npm provenance attestation request is disabled.
- Update the changesets release docs so they no longer say real publishes enable provenance.

## Validation

- `git diff --check`

Not run: full release publish. The failing workflow already reached `changeset publish`; npm rejected packages with `Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.`

## Release notes / changeset

No changeset required — no shipped behavior changed.

## Notes

Run `28943663115` failed during `changeset publish` because Depot runners are reported as self-hosted for npm provenance verification. After this merges, recover the attempted alpha publish with `release-publish` using `dry_run=false` and `recover_version=0.1.0-alpha.14`; Changesets should skip any versions that already made it to npm and publish the missing ones.