### PR TITLE
fix(login): render primary passkey action as a single button

### DIFF
--- a/.changeset/fix-duplicate-passkey-button.md
+++ b/.changeset/fix-duplicate-passkey-button.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/components": patch
+---
+
+Fix the default login template rendering two passkey buttons when the flow marks the passkey action as primary.

--- a/packages/components/src/orchestrator/liquid.spec.ts
+++ b/packages/components/src/orchestrator/liquid.spec.ts
@@ -289,7 +289,10 @@ describe("LiquidJS engine", () => {
     expect(result).not.toContain("forgot-password-href");
     expect(result).toContain('label="Sign in"');
     expect(result).not.toContain('label="Continue"');
-    expect(result.match(/data-testid="zitadel-action-passkey"/g)).toHaveLength(1);
+    const passkeyButtons =
+      result.match(/<zl-button[^>]*data-testid="zitadel-action-passkey"[^>]*>/g) ?? [];
+    expect(passkeyButtons).toHaveLength(1);
+    expect(passkeyButtons[0]).toContain('hierarchy="secondary"');
   });
 
   it("renders a primary passkey action as exactly one button (passkey-first flow)", () => {
@@ -311,9 +314,10 @@ describe("LiquidJS engine", () => {
       identity: null,
     };
     const result = engine.renderFileSync(TEMPLATE_NAMES.default, context);
-    const passkeyButtons = result.match(/data-testid="zitadel-action-passkey"/g);
+    const passkeyButtons =
+      result.match(/<zl-button[^>]*data-testid="zitadel-action-passkey"[^>]*>/g) ?? [];
     expect(passkeyButtons).toHaveLength(1);
-    expect(result).toContain('hierarchy="primary"');
+    expect(passkeyButtons[0]).toContain('hierarchy="primary"');
     expect(result).not.toContain('hierarchy="secondary"');
   });
 

--- a/packages/components/src/orchestrator/liquid.spec.ts
+++ b/packages/components/src/orchestrator/liquid.spec.ts
@@ -289,6 +289,32 @@ describe("LiquidJS engine", () => {
     expect(result).not.toContain("forgot-password-href");
     expect(result).toContain('label="Sign in"');
     expect(result).not.toContain('label="Continue"');
+    expect(result.match(/data-testid="zitadel-action-passkey"/g)).toHaveLength(1);
+  });
+
+  it("renders a primary passkey action as exactly one button (passkey-first flow)", () => {
+    const engine = createLiquidEngine({ locale: fullLocale });
+    const a = toArray({
+      passkey: { text_key: "identifier.action.passkey", primary: true },
+      register: { text_key: "identifier.action.register.link" },
+    });
+    const context = {
+      step: { name: "identifier", texts: { title_key: "identifier.title" } },
+      fields: [],
+      actions: a,
+      branding: {},
+      loading: false,
+      errors: [],
+      gates: {},
+      sso_providers: [],
+      messages: [],
+      identity: null,
+    };
+    const result = engine.renderFileSync(TEMPLATE_NAMES.default, context);
+    const passkeyButtons = result.match(/data-testid="zitadel-action-passkey"/g);
+    expect(passkeyButtons).toHaveLength(1);
+    expect(result).toContain('hierarchy="primary"');
+    expect(result).not.toContain('hierarchy="secondary"');
   });
 
   it("renders sign-in wrong credentials (6602:180268): inline password error, no form alert", () => {

--- a/packages/components/src/orchestrator/templates/default.liquid
+++ b/packages/components/src/orchestrator/templates/default.liquid
@@ -112,14 +112,16 @@
 
     {% assign passkey = actions | where: "name", "passkey" | first %}
     {% if passkey %}
-      <zl-button
-        hierarchy="secondary"
-        size="medium"
-        block
-        action="passkey"
-        data-testid="zitadel-action-passkey"
-        label="{{ passkey.text_key | t }}"
-      ></zl-button>
+      {% unless passkey.primary %}
+        <zl-button
+          hierarchy="secondary"
+          size="medium"
+          block
+          action="passkey"
+          data-testid="zitadel-action-passkey"
+          label="{{ passkey.text_key | t }}"
+        ></zl-button>
+      {% endunless %}
     {% endif %}
 
 


### PR DESCRIPTION
## Summary

- The default login template rendered a passkey action twice when a flow marked it `primary: true` (reported in passkey-first flow testing): the primary-action loop emitted it, and the dedicated passkey block at the bottom of the actions section emitted it again unconditionally.
- Guard the dedicated block with `{% unless passkey.primary %}` in `packages/components/src/orchestrator/templates/default.liquid`. A truthiness check (rather than `!= true`) mirrors the primary loop's own `{% if a.primary %}` test, so the two branches can never both fire regardless of how `primary` is encoded on the wire. Non-primary passkey actions render exactly as before.
- New spec: a primary passkey action renders exactly one `zitadel-action-passkey` button with `hierarchy="primary"` and no secondary button (fails with 2 matches before the fix). Extended the combined sign-in spec to pin the non-primary case at exactly one secondary button, guarding the other direction.

## Validation

- `npx vitest run src/orchestrator/liquid.spec.ts` in `packages/components` — 20/20 passing (includes the new + extended specs).

## Release notes / changeset

- Changeset: `.changeset/fix-duplicate-passkey-button.md` — Fix the default login template rendering two passkey buttons when the flow marks the passkey action as primary (`@zitadel/components`, patch).

## Notes

- Deliberately out of scope: action names carrying hidden semantics across the Go flow state machine (`routeOutcome` keying transitions by name), the validator, and this template. That coupling is why the template special-cases `'passkey'` by name at all; it's tracked separately in the session plan notes.