### PR TITLE
fix(api-mock): store and echo required project name per #462 spec

### DIFF
--- a/packages/api-mock/src/platform-handlers.ts
+++ b/packages/api-mock/src/platform-handlers.ts
@@ -141,6 +141,7 @@ function queryRecord(request: Request): Record<string, string> {
  */
 type ProjectRecord = {
   id: string;
+  name: string;
   projectSecret: string;
   previewSecret: string;
   previewOrigins: string[];
@@ -322,6 +323,7 @@ export function setupPlatformHandlers() {
       const createdAt = nowIso();
       const project: ProjectRecord = {
         id,
+        name: body.data.name,
         projectSecret: `sk_proj_${id.replaceAll("-", "")}_full`,
         previewSecret: `sk_proj_${id.replaceAll("-", "")}_preview`,
         previewOrigins: body.data.previewOrigins ?? [],
@@ -334,6 +336,7 @@ export function setupPlatformHandlers() {
       }
       const responseBody: CreateProject201 = {
         id: project.id,
+        name: project.name,
         projectSecret: project.projectSecret,
         previewSecret: project.previewSecret,
         previewOrigins: project.previewOrigins,
@@ -354,6 +357,7 @@ export function setupPlatformHandlers() {
       }
       const responseBody: GetProject200 = {
         id: project.id,
+        name: project.name,
         createdAt: project.createdAt,
         updatedAt: project.updatedAt,
       };

--- a/packages/api-mock/src/spec-conformance.spec.ts
+++ b/packages/api-mock/src/spec-conformance.spec.ts
@@ -168,13 +168,18 @@ describe("api-mock spec conformance — responses match orval-generated zod", ()
     const res = await fetch(`${BASE}/projects`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ previewOrigins: ["http://localhost:3000"], seedDefaults: false }),
+      body: JSON.stringify({
+        name: "conformance-app",
+        previewOrigins: ["http://localhost:3000"],
+        seedDefaults: false,
+      }),
     });
     expect(res.status).toBe(201);
     const body = (await res.json()) as Record<string, unknown>;
     // No CreateProjectResponse zod schema is emitted by orval. Validate
     // structurally against the fields create-project-response.yaml requires.
     expect(typeof body.id).toBe("string");
+    expect(body.name).toBe("conformance-app");
     expect(typeof body.projectSecret).toBe("string");
     expect(typeof body.previewSecret).toBe("string");
     expect(Array.isArray(body.previewOrigins)).toBe(true);
@@ -185,7 +190,7 @@ describe("api-mock spec conformance — responses match orval-generated zod", ()
     const create = await fetch(`${BASE}/projects`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ name: "conformance-app" }),
     });
     const { id } = (await create.json()) as { id: string };
     const res = await fetch(`${BASE}/projects/${id}`);


### PR DESCRIPTION
## Problem

#462 made `name` a required field on `POST /projects` in the OpenAPI spec, so the orval-regenerated zod (`CreateProjectBody`, `GetProjectResponse`, `CreateProject201`, `GetProject200` — untracked, rebuilt from the spec at build time) now requires `name` in both the request and the responses. The api-mock was not updated: `platform-handlers.ts` neither stored nor echoed `name`, so its POST handler 400s name-less bodies and `GET /projects/:id` responses fail `GetProjectResponse.parse`. Result: **`moon run api-mock:test` fails on a fresh checkout of main** with 2 spec-conformance failures. Main CI stayed green only because affected-detection didn't re-run `api-mock:test` on that push.

## Fix

- Add `name: string` to `ProjectRecord`, set it from `body.data.name` in the POST handler, and include it in the `CreateProject201` and `GetProject200` response bodies.
- Add `name` to the spec-conformance `POST /projects` fixtures and assert it round-trips (explicitly on the 201 body; via `GetProjectResponse.parse` — which now requires `name` — on the GET).

The hunks match #516's version of this fix verbatim, so the merge resolves cleanly whichever lands first. Landing it on main directly unbreaks the stacked PRs (#496/#499/#500/#502) when they merge main in, without waiting on #516.

No changeset: `@zitadel/api-mock` is private and is the only touched package.

## Verification

`moon run api-mock:test api-mock:typecheck api-mock:lint cli:test` — all 15 tasks green (cli: 103 files, 719 tests).

_Note: #462's squash also reverted #485's `SENTENCE_BY_PATH` narration entries in `apps/cli/src/commands/setup/index.ts`; that's cosmetic and already restored by #516, so it's intentionally not included here._