### PR TITLE
feat: require passkey auth method for passkey actions

### DIFF
--- a/internal/domain/flow_definition.go
+++ b/internal/domain/flow_definition.go
@@ -191,6 +191,11 @@ type FlowDefinitionAudience struct {
 // "x-auth-methods#password") rather than to a top-level user property.
 const authMethodPrefix = "x-auth-methods#"
 
+// authMethodPasskey is the `x-auth-methods` key the passkey and
+// passkey_register action kinds require to be enabled on the user
+// schema.
+const authMethodPasskey = "passkey"
+
 // Field carries the raw field name from a flow-definition step.
 type Field string
 

--- a/internal/domain/flow_definition_validator.go
+++ b/internal/domain/flow_definition_validator.go
@@ -42,6 +42,12 @@ func ValidateFlowDefinition(userSchema *jsonschema.Schema, flowDefinition FlowDe
 		return nil, err
 	}
 
+	// 3b. passkey / passkey_register actions require the passkey
+	// authentication method to be enabled on the user schema.
+	if err := validatePasskeyActionsEnabled(userSchema, flowDefinition.Steps); err != nil {
+		return nil, err
+	}
+
 	// 4. validate the graph structure: every step reachable from an initial step, no unreachable steps
 	pivotingTargets, err := validateGraph(flowDefinition)
 	if err != nil {
@@ -136,6 +142,32 @@ func resolveAllStepFields(schema *jsonschema.Schema, steps []FlowDefinitionStep)
 		out[step.Name] = resolved
 	}
 	return out, nil
+}
+
+// validatePasskeyActionsEnabled rejects a flow that declares a passkey
+// or passkey_register action while the user schema does not enable the
+// passkey authentication method under `x-auth-methods`. A passkey action
+// drives a WebAuthn ceremony that only makes sense once the tenant has
+// opted the method in, so the mismatch is caught at definition time
+// rather than surfacing as a runtime failure.
+func validatePasskeyActionsEnabled(schema *jsonschema.Schema, steps []FlowDefinitionStep) error {
+	authMethods, err := newSchemaReader(schema).AuthMethods()
+	if err != nil {
+		return ErrFlowDefinitionInvalid(fmt.Sprintf("read x-auth-methods: %v", err), nil)
+	}
+	for _, step := range steps {
+		for _, a := range step.Actions {
+			if a.Kind != FlowActionKindPasskey && a.Kind != FlowActionKindPasskeyRegister {
+				continue
+			}
+			if !authMethods.IsEnabled(authMethodPasskey) {
+				return ErrFlowDefinitionInvalid(fmt.Sprintf(
+					"step %q: action %q has kind %q but %q is not an enabled authentication method",
+					step.Name, a.Name, a.Kind, authMethodPasskey), nil)
+			}
+		}
+	}
+	return nil
 }
 
 // validateRequiredUserSchemaFields checks that all required fields in the

--- a/internal/domain/flow_definition_validator_test.go
+++ b/internal/domain/flow_definition_validator_test.go
@@ -81,6 +81,20 @@ var userSchemaIDAndPassword = []byte(`{
   }
 }`)
 
+var userSchemaPasskeyEnabled = []byte(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tenant.com/schemas/passkey-user.json",
+  "type": "object",
+  "required": ["email"],
+  "x-auth-methods": {
+    "password": { "enabled": true, "position": 0 },
+    "passkey":  { "enabled": true, "position": 1 }
+  },
+  "properties": {
+    "email": { "type": "string", "format": "email", "x-unique": "team" }
+  }
+}`)
+
 var userSchemaRequiredProps = []byte(`{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tenant.com/schemas/idpw-user.json",
@@ -1563,4 +1577,75 @@ func TestValidator_MissingRequiredUserSchemaFields(t *testing.T) {
 	_, err := domain.ValidateFlowDefinition(schema, def)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, domain.ErrFlowDefinitionInvalid(`required fields [first_name last_name] in user schema are missing in the flow definition steps`, nil))
+}
+
+// passkeyActionFlow builds a minimal login flow whose entry step offers a
+// single passkey-family action (kind) alongside the wiring the validator
+// requires (matching transition, terminal target).
+func passkeyActionFlow(actionName string, kind domain.FlowActionKind) domain.FlowDefinition {
+	return domain.FlowDefinition{
+		ProjectID: "p", Name: "f", SchemaVersion: "1",
+		UserSchema: "https://tenant.com/schemas/passkey-user.json",
+		Purposes:   map[domain.FlowDefinitionPurpose]string{domain.FlowDefinitionPurposeLogin: "identifier"},
+		Steps: []domain.FlowDefinitionStep{
+			{
+				Name: "identifier", Fields: []domain.Field{"email"},
+				Actions:     []domain.FlowStepAction{{Name: actionName, Kind: kind, Primary: true}},
+				Transitions: map[string]domain.FlowStepTransition{actionName: {Target: "done"}},
+			},
+			{Name: "done", Complete: gu.Ptr(domain.FlowStepCompleteRedirect)},
+		},
+	}
+}
+
+// TestValidator_PasskeyActionsRequireEnabledMethod rejects a flow that
+// declares a passkey or passkey_register action while the user schema
+// does not enable the passkey authentication method under
+// x-auth-methods. Catching it at definition time keeps a WebAuthn
+// ceremony from being offered against a schema that never opted in.
+func TestValidator_PasskeyActionsRequireEnabledMethod(t *testing.T) {
+	tests := []struct {
+		name       string
+		actionName string
+		kind       domain.FlowActionKind
+	}{
+		{"passkey", "passkey", domain.FlowActionKindPasskey},
+		{"passkey_register", "enroll", domain.FlowActionKindPasskeyRegister},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// password-only schema: passkey is not enabled.
+			schema := mustSchema(t, userSchemaIDAndPassword)
+			def := passkeyActionFlow(tt.actionName, tt.kind)
+			def.UserSchema = "https://tenant.com/schemas/idpw-user.json"
+
+			_, err := domain.ValidateFlowDefinition(schema, def)
+			require.Error(t, err)
+			assert.Contains(t, errorDetails(t, err), fmt.Sprintf(
+				`action %q has kind %q but "passkey" is not an enabled authentication method`, tt.actionName, tt.name))
+		})
+	}
+}
+
+// TestValidator_PasskeyActionsAcceptEnabledMethod is the positive
+// counterpart: the same actions validate cleanly once the user schema
+// enables passkey under x-auth-methods.
+func TestValidator_PasskeyActionsAcceptEnabledMethod(t *testing.T) {
+	tests := []struct {
+		name       string
+		actionName string
+		kind       domain.FlowActionKind
+	}{
+		{"passkey", "passkey", domain.FlowActionKindPasskey},
+		{"passkey_register", "enroll", domain.FlowActionKindPasskeyRegister},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := mustSchema(t, userSchemaPasskeyEnabled)
+			def := passkeyActionFlow(tt.actionName, tt.kind)
+
+			_, err := domain.ValidateFlowDefinition(schema, def)
+			require.NoError(t, err)
+		})
+	}
 }

--- a/packages/config/src/validate.test.ts
+++ b/packages/config/src/validate.test.ts
@@ -364,6 +364,25 @@ describe("schema-dependent rules", () => {
     );
   });
 
+  it("rejects passkey / passkey_register actions when passkey is not enabled", () => {
+    const disabled = structuredClone(schema);
+    (disabled["x-auth-methods"] as Record<string, { enabled: boolean }>).passkey.enabled = false;
+    const msgs = messages(validateFlowDefinition(flow(), disabled));
+    expect(msgs).toContain(
+      'step "identifier": action "passkey" has kind "passkey" but "passkey" is not an enabled authentication method',
+    );
+    expect(msgs).toContain(
+      'step "register": action "passkey_register" has kind "passkey_register" but "passkey" is not an enabled authentication method',
+    );
+  });
+
+  it("accepts passkey actions when passkey is enabled (default schema)", () => {
+    const msgs = messages(validateFlowDefinition(flow(), schema));
+    expect(msgs).not.toContain(
+      'step "identifier": action "passkey" has kind "passkey" but "passkey" is not an enabled authentication method',
+    );
+  });
+
   it("rejects on_success create_user without an upstream identifier", () => {
     // Minimal register-only flow: the create_user step collects a password
     // but no step on its path collects an identifier-challenge field.

--- a/packages/config/src/validate.ts
+++ b/packages/config/src/validate.ts
@@ -53,6 +53,7 @@ export const FLOW_VALIDATION_RULES = {
   "flip-table": { goRef: "validateFlipTableCoverage" },
   "schema/required-fields": { goRef: "validateRequiredUserSchemaFields" },
   "schema/fields-resolve": { goRef: "resolveAllStepFields" },
+  "schema/passkey-auth-method": { goRef: "validatePasskeyActionsEnabled" },
   "schema/on-success-manifest": { goRef: "validateOnSuccessManifests" },
   "warn/password-without-identifier": { goRef: null },
 } as const;
@@ -86,6 +87,9 @@ const BACK_ACTION_NAME = "back";
 
 /** Mirrors `authMethodPrefix` in flow_definition.go. */
 const AUTH_METHOD_PREFIX = "x-auth-methods#";
+
+/** Mirrors `authMethodPasskey` in flow_definition.go. */
+const AUTH_METHOD_PASSKEY = "passkey";
 
 /** Mirrors `ManifestForOnSuccess` in flow_on_success.go. */
 const ON_SUCCESS_MANIFESTS: Readonly<Record<string, readonly FieldChallenge[]>> = {
@@ -639,6 +643,24 @@ function validateAgainstSchema(def: FlowDef, schema: object): FlowValidationIssu
   }
   if (resolutionFailed) {
     return issues;
+  }
+
+  // Passkey action gate (validatePasskeyActionsEnabled): a passkey or
+  // passkey_register action requires the passkey auth method to be
+  // enabled on the user schema.
+  for (const step of def.steps) {
+    for (const action of step.actions) {
+      if (action.kind !== "passkey" && action.kind !== "passkey_register") continue;
+      if (!authMethodEnabled(raw, AUTH_METHOD_PASSKEY)) {
+        issues.push(
+          error(
+            "schema/passkey-auth-method",
+            `step ${q(step.name)}: action ${q(action.name)} has kind ${q(action.kind)} but ${q(AUTH_METHOD_PASSKEY)} is not an enabled authentication method`,
+            step.name,
+          ),
+        );
+      }
+    }
   }
 
   // on_success manifests (validateOnSuccessManifests): every kind the


### PR DESCRIPTION
## What

A flow that declares an action with `kind: passkey` or `kind: passkey_register` now fails validation unless the user schema enables the `passkey` authentication method under `x-auth-methods` (`x-auth-methods.passkey.enabled == true`).
