### PR TITLE
fix(api): align WithLogging with ADR 030

### DIFF
--- a/.changeset/align-with-logging.md
+++ b/.changeset/align-with-logging.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+Align request logging with ADR 030: expected 4xx responses log at `Warn` with `error_code` (parsed from the wire envelope only), 5xx at `Error`, and raw response bodies are no longer written to logs.

--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"time"
@@ -44,7 +45,7 @@ func WithLogging(next http.Handler) http.Handler {
 
 		lrw := &loggingResponseWriter{
 			ResponseWriter: w,
-			body:           bytes.NewBuffer(nil),
+			errorBody:      bytes.NewBuffer(nil),
 		}
 		next.ServeHTTP(lrw, r.WithContext(ctx))
 
@@ -53,15 +54,21 @@ func WithLogging(next http.Handler) http.Handler {
 		}
 
 		operationID, _ := GetOperationIDContext(ctx)
+		attrs := []any{
+			slog.Int("status_code", lrw.statusCode),
+			slog.Duration("duration", time.Since(start)),
+			slog.String("operation_id", operationID),
+		}
+		if code := extractWireErrorCode(lrw.errorBody.Bytes()); code != "" {
+			attrs = append(attrs, slog.String("error_code", code))
+		}
 
-		if lrw.statusCode >= 400 {
-			logger.Error("error while handling request",
-				slog.Int("status_code", lrw.statusCode),
-				slog.Duration("duration", time.Since(start)),
-				slog.String("response", lrw.body.String()),
-				slog.String("operation_id", operationID),
-			)
-		} else {
+		switch {
+		case lrw.statusCode >= http.StatusInternalServerError:
+			logger.Error("request failed", attrs...)
+		case lrw.statusCode >= http.StatusBadRequest:
+			logger.Warn("request rejected", attrs...)
+		default:
 			logger.Info("handled request",
 				slog.Int("status_code", lrw.statusCode),
 				slog.Duration("duration", time.Since(start)),
@@ -71,14 +78,32 @@ func WithLogging(next http.Handler) http.Handler {
 	})
 }
 
+// wireErrorCode is the minimal API error envelope shape for request logging.
+// Only the code field is extracted; the body is never logged (ADR 030).
+type wireErrorCode struct {
+	Code string `json:"code"`
+}
+
+func extractWireErrorCode(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var envelope wireErrorCode
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return ""
+	}
+	return envelope.Code
+}
+
 // ---------------------- LOGGING RESPONSE WRITER -----------------------------
 
 // loggingResponseWriter is a wrapper around an http.ResponseWriter which caches
-// the status-code. It also caches the body if the status-code is an error code.
+// the status-code. For error responses it buffers the body only so the wire
+// error code can be extracted for structured logs without logging the payload.
 type loggingResponseWriter struct {
 	http.ResponseWriter
 	statusCode int
-	body       *bytes.Buffer
+	errorBody  *bytes.Buffer
 }
 
 func (w *loggingResponseWriter) WriteHeader(code int) {
@@ -90,8 +115,8 @@ func (w *loggingResponseWriter) Write(b []byte) (int, error) {
 	switch {
 	case w.statusCode == 0:
 		w.statusCode = http.StatusOK
-	case w.statusCode >= 400:
-		w.body.Write(b)
+	case w.statusCode >= http.StatusBadRequest:
+		w.errorBody.Write(b)
 	}
 	return w.ResponseWriter.Write(b)
 }

--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -54,27 +54,32 @@ func WithLogging(next http.Handler) http.Handler {
 		}
 
 		operationID, _ := GetOperationIDContext(ctx)
+		duration := time.Since(start)
+
+		if lrw.statusCode < http.StatusBadRequest {
+			logger.Info("handled request",
+				slog.Int("status_code", lrw.statusCode),
+				slog.Duration("duration", duration),
+				slog.String("operation_id", operationID),
+			)
+			return
+		}
+
+		// Only buffer+parse error responses (≥400). Success bodies are never
+		// buffered, so JSON decode cannot run on the hot 2xx path.
 		attrs := []any{
 			slog.Int("status_code", lrw.statusCode),
-			slog.Duration("duration", time.Since(start)),
+			slog.Duration("duration", duration),
 			slog.String("operation_id", operationID),
 		}
 		if code := extractWireErrorCode(lrw.errorBody.Bytes()); code != "" {
 			attrs = append(attrs, slog.String("error_code", code))
 		}
-
-		switch {
-		case lrw.statusCode >= http.StatusInternalServerError:
+		if lrw.statusCode >= http.StatusInternalServerError {
 			logger.Error("request failed", attrs...)
-		case lrw.statusCode >= http.StatusBadRequest:
-			logger.Warn("request rejected", attrs...)
-		default:
-			logger.Info("handled request",
-				slog.Int("status_code", lrw.statusCode),
-				slog.Duration("duration", time.Since(start)),
-				slog.String("operation_id", operationID),
-			)
+			return
 		}
+		logger.Warn("request rejected", attrs...)
 	})
 }
 

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -1,0 +1,123 @@
+package middleware_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/api/middleware"
+	"github.com/zitadel/nextgen/internal/instrumentation/zlog"
+)
+
+type recordHandler struct {
+	records []slog.Record
+}
+
+func (h *recordHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *recordHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
+
+func (h *recordHandler) WithGroup(name string) slog.Handler { return h }
+
+func attrString(t *testing.T, r slog.Record, key string) (string, bool) {
+	t.Helper()
+	var value string
+	var found bool
+	r.Attrs(func(attr slog.Attr) bool {
+		if attr.Key == key {
+			value = attr.Value.String()
+			found = true
+			return false
+		}
+		return true
+	})
+	return value, found
+}
+
+func TestWithLogging_clientErrorLogsWarnWithoutBody(t *testing.T) {
+	var handler recordHandler
+	logger := slog.New(&handler)
+	ctx := zlog.WithLoggingContext(context.Background(), logger)
+
+	mw := middleware.WithLogging(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"code":"user.not_found","message":"not found"}`))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/users/1", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	var rejected *slog.Record
+	for i := range handler.records {
+		if handler.records[i].Message == "request rejected" {
+			rejected = &handler.records[i]
+			break
+		}
+	}
+	require.NotNil(t, rejected)
+	assert.Equal(t, slog.LevelWarn, rejected.Level)
+	code, ok := attrString(t, *rejected, "error_code")
+	require.True(t, ok)
+	assert.Equal(t, "user.not_found", code)
+	_, hasResponse := attrString(t, *rejected, "response")
+	assert.False(t, hasResponse)
+}
+
+func TestWithLogging_serverErrorLogsError(t *testing.T) {
+	var handler recordHandler
+	logger := slog.New(&handler)
+	ctx := zlog.WithLoggingContext(context.Background(), logger)
+
+	mw := middleware.WithLogging(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"code":"internal","message":"oops"}`))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/boom", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	var failed *slog.Record
+	for i := range handler.records {
+		if handler.records[i].Message == "request failed" {
+			failed = &handler.records[i]
+			break
+		}
+	}
+	require.NotNil(t, failed)
+	assert.Equal(t, slog.LevelError, failed.Level)
+}
+
+func TestWithLogging_successLogsInfo(t *testing.T) {
+	var handler recordHandler
+	logger := slog.New(&handler)
+	ctx := zlog.WithLoggingContext(context.Background(), logger)
+
+	mw := middleware.WithLogging(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/ok", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	var handled *slog.Record
+	for i := range handler.records {
+		if handler.records[i].Message == "handled request" {
+			handled = &handler.records[i]
+			break
+		}
+	}
+	require.NotNil(t, handled)
+	assert.Equal(t, slog.LevelInfo, handled.Level)
+}

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -105,6 +105,7 @@ func TestWithLogging_successLogsInfo(t *testing.T) {
 
 	mw := middleware.WithLogging(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"payload":"should-not-be-parsed"}`))
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/ok", nil).WithContext(ctx)
@@ -120,4 +121,6 @@ func TestWithLogging_successLogsInfo(t *testing.T) {
 	}
 	require.NotNil(t, handled)
 	assert.Equal(t, slog.LevelInfo, handled.Level)
+	_, hasErrorCode := attrString(t, *handled, "error_code")
+	assert.False(t, hasErrorCode)
 }


### PR DESCRIPTION
## Summary

Aligns request logging middleware with [ADR 030](docs/adrs/030-error-model-mapping-and-reporting.md) expected-client-error policy:

- **4xx** responses log at `Warn` (`request rejected`) instead of `Error`
- **5xx** responses log at `Error` (`request failed`)
- Stops logging the raw serialized `response` body (removes the main API-leak amplification path in middleware)
- Extracts only the wire `code` field into structured `error_code` for diagnostics

## Validation

- `go test ./internal/api/middleware/... -count=1`
- `go test ./internal/api/... -count=1`

## Release notes / changeset

Changeset: `.changeset/align-with-logging.md` — `@zitadel/server` patch: ADR 030 request logging alignment (4xx/5xx severity, `error_code` only, no raw bodies).

## Notes

- Largely independent of the errreport foundation (PR #521); can merge in either order.
- Does not plumb domain errors via context yet — `error_code` is parsed from the JSON envelope when present. Non-JSON error bodies omit `error_code`.
- API leak remediation at handler call sites remains a separate follow-up.

Made with [Cursor](https://cursor.com)