### PR TITLE
fix: close out the alpha.16 release-test findings

### DIFF
--- a/.changeset/plan-apply-change-enumeration.md
+++ b/.changeset/plan-apply-change-enumeration.md
@@ -1,0 +1,14 @@
+---
+"@zitadel/cli": patch
+---
+
+`plan --json` and `apply --json` now enumerate what they touch: a
+`data.changes` array with one `{kind, action, file, id?, previous_id?}`
+row per resource (action ∈ create/update/revision/delete). Plan rows
+preview the pending sync; apply rows report what happened, carrying the
+resulting platform ids (created ids, newly published revision ids), so
+agents can verify an edit did what they intended without re-applying.
+`apply` also gains `next_actions`/`next_commands` ("changes are live" +
+a versioned `plan` follow-up), and `schemas list` emits `created_at` in
+snake_case like every other envelope field. Counters and
+`files_updated` (local write-backs only) are unchanged.

--- a/.changeset/stable-credential-field-hooks.md
+++ b/.changeset/stable-credential-field-hooks.md
@@ -1,0 +1,11 @@
+---
+"@zitadel/components": patch
+---
+
+Automation hooks for auth-method credential fields are now method-named,
+matching what the docs have always promised: a flow field named
+`x-auth-methods#password` renders `data-testid="zitadel-field-password"`
+and `zitadel-input-password` instead of leaking the raw field name into
+the hooks. The `name` attribute (the wire/form key) is unchanged.
+Scripts that targeted the raw `zitadel-field-x-auth-methods#password`
+form must switch to the documented method-named hooks.

--- a/apps/cli/SKILLS.md
+++ b/apps/cli/SKILLS.md
@@ -46,6 +46,11 @@ Each invocation prints one JSON object:
 - On failure: `code` (e.g. `E_VALIDATION`, `E_NETWORK`, `E_NOT_FOUND`,
   `E_CONFLICT`) and `message`.
 - `next_commands`: the suggested follow-ups. Prefer these over free-text hints.
+- `plan` and `apply` also emit `data.changes`: one row per touched resource
+  (`{kind, action, file, id?, previous_id?}`, action ∈ create/update/revision/
+  delete). Plan rows preview; apply rows report, with the resulting platform
+  ids. Use it to verify an edit did what you intended — `apply`'s
+  `files_updated` lists only local write-backs, not platform changes.
 - `E_LOCAL_SERVER_NOT_RUNNING`: start the local runtime with
   `npx @zitadel/cli@alpha start`, then retry with `--server local`.
 - `E_NOT_FOUND`: an HTTP 404 from the target server. With the platform's
@@ -165,7 +170,11 @@ Use host hooks such as `zitadel-field-email`, `zitadel-field-password`, and
 `zitadel-action-submit` when targeting the Lit atoms. Use native shadow-control
 hooks such as `zitadel-input-email`, `zitadel-input-password`, and
 `zitadel-action-submit-button` when filling or clicking the underlying input or
-button. For sign-out, open the user menu button if needed, then pierce to
+button. Hooks stay method-named even when the flow engine names a credential
+field `x-auth-methods#<method>`; only the `name` attribute carries that raw
+form key. Enter inside a field submits the step's primary action, but only for
+key events that carry `key: "Enter"` — drivers whose synthesized key events
+omit it (some CDP wrappers) should click `zitadel-action-submit` instead. For sign-out, open the user menu button if needed, then pierce to
 `.signout-btn`; Playwright-style locators may use `zitadel-logout .signout-btn`.
 The canonical component hook list lives in `packages/components/README.md`.
 

--- a/apps/cli/src/commands/apply.ts
+++ b/apps/cli/src/commands/apply.ts
@@ -8,12 +8,14 @@ import { environmentSchema } from "../lib/environment";
 import {
   buildSyncPlan,
   collectPlanWarnings,
+  enumeratePlanResources,
   makeSyncers,
   renderPlan,
   runSyncLoop,
   summarizePlan,
 } from "../lib/sync";
 import { readZitadelSecret } from "../lib/project";
+import { publicCliCommand } from "../lib/public-cli";
 
 /**
  * `zitadel apply` — validate and upload repo config to the platform.
@@ -54,9 +56,26 @@ export default class Apply extends BaseCommand {
 
     if (!dryRun) {
       consola.start("Syncing schemas and flows to Zitadel");
-      const { filesUpdated } = await runSyncLoop(cwd, syncers);
+      const { filesUpdated, applied } = await runSyncLoop(cwd, syncers);
       consola.success("Sync complete");
-      return this.emit({ status: "ok", data: { synced: true, files_updated: filesUpdated } });
+      return this.emit({
+        status: "ok",
+        data: {
+          synced: true,
+          // Platform resources this run touched (with resulting ids);
+          // `files_updated` stays the local write-backs only.
+          changes: applied,
+          files_updated: filesUpdated,
+          next_actions:
+            applied.length === 0
+              ? ["Everything is already in sync — no changes were applied."]
+              : [
+                  "Changes are live — reload your app to see them.",
+                  "Re-run plan to confirm local config and platform are in sync.",
+                ],
+          next_commands: [publicCliCommand("plan", this.meta.cliVersion)],
+        },
+      });
     }
 
     consola.start("Building plan (dry run)");
@@ -77,7 +96,11 @@ export default class Apply extends BaseCommand {
     );
     return this.emit({
       status: "ok",
-      data: { ...summary, warnings: collectPlanWarnings(plan) },
+      data: {
+        ...summary,
+        changes: enumeratePlanResources(plan),
+        warnings: collectPlanWarnings(plan),
+      },
       pretty: renderPlan(plan, isTTY),
     });
   }

--- a/apps/cli/src/commands/plan.ts
+++ b/apps/cli/src/commands/plan.ts
@@ -8,6 +8,7 @@ import { environmentSchema } from "../lib/environment";
 import {
   buildSyncPlan,
   collectPlanWarnings,
+  enumeratePlanResources,
   makeSyncers,
   renderPlan,
   summarizePlan,
@@ -69,7 +70,11 @@ export default class Plan extends BaseCommand {
     );
     return this.emit({
       status: "ok",
-      data: { ...summary, warnings: collectPlanWarnings(plan) },
+      data: {
+        ...summary,
+        changes: enumeratePlanResources(plan),
+        warnings: collectPlanWarnings(plan),
+      },
       pretty: renderPlan(plan, isTTY),
     });
   }

--- a/apps/cli/src/commands/schemas/list.ts
+++ b/apps/cli/src/commands/schemas/list.ts
@@ -52,6 +52,10 @@ export default class SchemasList extends BaseCommand {
       object_type: objectType,
     });
 
+    // Envelope rows are snake_case like every other command's data; the
+    // orval model's `createdAt` is not spread verbatim.
+    const revisionRows = revisions.map((r) => ({ id: r.id, created_at: r.createdAt }));
+
     if (revisions.length === 0) {
       const message = `No revisions found for objectType "${objectType}".`;
       consola.warn(message);
@@ -68,7 +72,7 @@ export default class SchemasList extends BaseCommand {
         status: "ok",
         data: {
           object_type: objectType,
-          revisions,
+          revisions: revisionRows,
           count: revisions.length,
         },
         pretty: renderTable(objectType, revisions),
@@ -86,7 +90,7 @@ export default class SchemasList extends BaseCommand {
       cancel("No revision selected.");
       return this.emit({
         status: "ok",
-        data: { object_type: objectType, revisions, count: revisions.length },
+        data: { object_type: objectType, revisions: revisionRows, count: revisions.length },
         pretty: "",
       });
     }
@@ -102,7 +106,7 @@ export default class SchemasList extends BaseCommand {
       status: "ok",
       data: {
         object_type: objectType,
-        revisions,
+        revisions: revisionRows,
         selected: { id: picked, body },
         count: revisions.length,
       },

--- a/apps/cli/src/lib/sync/index.ts
+++ b/apps/cli/src/lib/sync/index.ts
@@ -24,4 +24,10 @@ export {
   runSyncLoop,
   writeBackResource,
 } from "./loop";
-export { collectPlanWarnings, renderPlan, summarizePlan } from "./plan-renderer";
+export {
+  collectPlanWarnings,
+  enumeratePlanResources,
+  renderPlan,
+  summarizePlan,
+  type PlanResourceChange,
+} from "./plan-renderer";

--- a/apps/cli/src/lib/sync/loop.ts
+++ b/apps/cli/src/lib/sync/loop.ts
@@ -7,6 +7,7 @@ import { consola } from "consola";
 import { FLOWS_DIR } from "../flows";
 import { stableStringify } from "../json";
 import { validatePlannedFlows } from "./flow-validation.js";
+import type { PlanResourceChange } from "./plan-renderer.js";
 import { readState, removeFromState, updateState } from "./state.js";
 import type { ResourceEntry, ResourceSyncer, SyncAction } from "./types.js";
 
@@ -185,7 +186,7 @@ export async function buildSyncPlan(
   return actions;
 }
 
-/** Result of {@link runSyncLoop}: the local files the loop rewrote. */
+/** Result of {@link runSyncLoop}: what changed on the platform and locally. */
 export type SyncLoopResult = {
   /**
    * Project-relative paths of files updated from the server's canonical
@@ -193,6 +194,13 @@ export type SyncLoopResult = {
    * local rewrite is never silent.
    */
   filesUpdated: string[];
+  /**
+   * The platform resources this run touched, in execution order. Unlike a
+   * plan-time enumeration, `id` carries the resulting platform id (the
+   * created id, the newly published revision id, or the id updated or
+   * deleted). Feeds the `apply` `--json` `changes` array.
+   */
+  applied: PlanResourceChange[];
 };
 
 /**
@@ -223,6 +231,7 @@ export async function runSyncLoop(
     }
   }
   const filesUpdated: string[] = [];
+  const applied: PlanResourceChange[] = [];
   // Revisions published by this run: superseded id → new id. Update actions
   // carrying a `repin` patch their `user_schema` from here.
   const repinned = new Map<string, string>();
@@ -264,6 +273,7 @@ export async function runSyncLoop(
         consola.info(
           `Created a new ${action.syncer.kind} on Zitadel from ${action.path} (id ${id})`,
         );
+        applied.push({ kind: action.syncer.kind, action: "create", file: action.path, id });
         break;
       }
       case "revise": {
@@ -287,6 +297,13 @@ export async function runSyncLoop(
             consola.info(`Re-pinned user_schema in ${flowPath} to ${id}`);
           }
         }
+        applied.push({
+          kind: action.syncer.kind,
+          action: "revision",
+          file: action.path,
+          id,
+          previous_id: action.previousId,
+        });
         break;
       }
       case "update": {
@@ -312,6 +329,7 @@ export async function runSyncLoop(
           hash: await writeBack(action, canonical, fallbackHash),
         });
         consola.info(`Updated the ${action.syncer.kind} on Zitadel from ${action.path}`);
+        applied.push({ kind: action.syncer.kind, action: "update", file: action.path, id: action.id });
         break;
       }
       case "delete": {
@@ -320,6 +338,7 @@ export async function runSyncLoop(
         consola.info(
           `Deleted the ${action.syncer.kind} on Zitadel because ${action.path} was removed locally`,
         );
+        applied.push({ kind: action.syncer.kind, action: "delete", file: action.path, id: action.id });
         break;
       }
       case "skip": {
@@ -340,7 +359,7 @@ export async function runSyncLoop(
     }
   }
 
-  return { filesUpdated: [...new Set(filesUpdated)] };
+  return { filesUpdated: [...new Set(filesUpdated)], applied };
 }
 
 /**

--- a/apps/cli/src/lib/sync/plan-renderer.ts
+++ b/apps/cli/src/lib/sync/plan-renderer.ts
@@ -38,6 +38,57 @@ export function collectPlanWarnings(
 }
 
 /**
+ * One entry of the `changes` array in the `plan` / `apply` `--json`
+ * payloads: which resource an action touches and how. `action` speaks the
+ * envelope's public vocabulary (`revision`, matching the `revisions`
+ * counter, not the internal `revise`). `id` is the platform id an
+ * update/delete targets; `previous_id` is the revision being superseded.
+ * The file path is the resource identity, mirroring {@link renderPlan}.
+ */
+export type PlanResourceChange = {
+  kind: ResourceSyncer["kind"];
+  action: "create" | "update" | "revision" | "delete";
+  file: string;
+  id?: string;
+  previous_id?: string;
+};
+
+/**
+ * Enumerate the non-`skip` actions of a {@link buildSyncPlan} result as
+ * envelope-ready {@link PlanResourceChange} rows. Pure; the structural
+ * counterpart of {@link summarizePlan} — counts and rows always agree.
+ */
+export function enumeratePlanResources(
+  actions: ReadonlyArray<SyncAction>,
+): PlanResourceChange[] {
+  const out: PlanResourceChange[] = [];
+  for (const action of actions) {
+    switch (action.kind) {
+      case "create":
+        out.push({ kind: action.syncer.kind, action: "create", file: action.path });
+        break;
+      case "update":
+        out.push({ kind: action.syncer.kind, action: "update", file: action.path, id: action.id });
+        break;
+      case "revise":
+        out.push({
+          kind: action.syncer.kind,
+          action: "revision",
+          file: action.path,
+          previous_id: action.previousId,
+        });
+        break;
+      case "delete":
+        out.push({ kind: action.syncer.kind, action: "delete", file: action.path, id: action.id });
+        break;
+      case "skip":
+        break;
+    }
+  }
+  return out;
+}
+
+/**
  * Render a {@link buildSyncPlan} result as a human-readable Terraform-style
  * plan. TTY-aware: colors and bold are emitted only when `tty` is true.
  * Returns the empty-state message when every action is `skip`.

--- a/apps/cli/tests/unit/commands/apply.test.ts
+++ b/apps/cli/tests/unit/commands/apply.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -85,5 +86,121 @@ describe("apply command pre-flight", () => {
     expect(json.status).toBe("error");
     expect(json.code).toBe("E_VALIDATION");
     expect(json.message).toContain("Missing environment variables");
+  });
+});
+
+const VALID_USER_SCHEMA = {
+  kind: "user-schema",
+  metaSchema: "https://nextgen.com/api/schemas/user-schema.json",
+  "x-auth-methods": { password: { enabled: true, position: 0 } },
+  properties: { email: { type: "string" } },
+};
+
+// VALID_FLOW deliberately references an env var for the pre-flight test
+// above; the sync test needs a flow that passes validation as-is.
+const SYNCABLE_FLOW = {
+  name: "default",
+  status: "active",
+  user_schema:
+    "https://raw.githubusercontent.com/zitadel/nextgen/refs/heads/main/api/openapi/endpoints/schemas/human-user.yaml",
+  purposes: { login: "identifier" },
+  steps: [
+    {
+      name: "identifier",
+      fields: [],
+      actions: [{ name: "submit", kind: "submit", primary: true }],
+      transitions: { submit: { target: "done" } },
+    },
+    { name: "done", complete: "show" },
+  ],
+};
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    const server = servers.pop();
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }
+});
+
+/**
+ * Minimal platform stub for one sync run: mints ids for schema and flow
+ * creates, echoes the submitted flow back as its canonical body (so no
+ * local write-back is needed), and 404s the schema canonical fetch (the
+ * syncer degrades to no write-back by design).
+ */
+async function startPlatformStub(): Promise<string> {
+  const server = createServer(async (req, res) => {
+    const path = new URL(req.url ?? "/", "http://localhost").pathname;
+    if (req.method === "POST" && path === "/schemas") {
+      res
+        .writeHead(201, { "content-type": "application/json" })
+        .end(JSON.stringify({ id: "sch_test_1" }));
+      return;
+    }
+    if (req.method === "POST" && path === "/flow_definitions") {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(chunk as Buffer);
+      }
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+        flow_definition: object;
+      };
+      res
+        .writeHead(201, { "content-type": "application/json" })
+        .end(JSON.stringify({ id: "flow_test_1", flow_definition: body.flow_definition }));
+      return;
+    }
+    res
+      .writeHead(404, { "content-type": "application/json" })
+      .end(JSON.stringify({ code: "not_found", message: "not found" }));
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "localhost", () => resolve()));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("platform stub did not expose a TCP address");
+  }
+  return `http://localhost:${String(address.port)}`;
+}
+
+describe("apply command sync", () => {
+  it("enumerates the applied resources with their platform ids", async () => {
+    const cwd = await makeCwd({ "default.json": SYNCABLE_FLOW });
+    await writeFile(join(cwd, ".zitadel/schemas/user.json"), JSON.stringify(VALID_USER_SCHEMA));
+    const server = await startPlatformStub();
+
+    const res = await runCliForTest(["apply", "--cwd", cwd, "--json", "--server", server]);
+
+    expect(res.exitCode).toBe(0);
+    const json = parseJson(res.stdout) as {
+      status: string;
+      data: {
+        synced: boolean;
+        changes: Array<Record<string, unknown>>;
+        files_updated: string[];
+        next_actions: string[];
+        next_commands: string[];
+      };
+    };
+    expect(json.status).toBe("ok");
+    expect(json.data.synced).toBe(true);
+    // `changes` names what happened on the platform, with resulting ids —
+    // `files_updated` stays local write-backs only (none here: the stub
+    // echoes the flow verbatim and the schema fetch degrades).
+    expect(json.data.changes).toEqual([
+      { kind: "schema", action: "create", file: ".zitadel/schemas/user.json", id: "sch_test_1" },
+      { kind: "flow", action: "create", file: ".zitadel/flows/default.json", id: "flow_test_1" },
+    ]);
+    expect(json.data.files_updated).toEqual([]);
+    expect(json.data.next_actions).toEqual([
+      "Changes are live — reload your app to see them.",
+      "Re-run plan to confirm local config and platform are in sync.",
+    ]);
+    expect(json.data.next_commands).toHaveLength(1);
+    expect(json.data.next_commands[0]).toMatch(/^npx @zitadel\/cli@\S+ plan$/);
   });
 });

--- a/apps/cli/tests/unit/commands/plan.test.ts
+++ b/apps/cli/tests/unit/commands/plan.test.ts
@@ -95,13 +95,19 @@ describe("plan command", () => {
       };
     };
     expect(json.status).toBe("ok");
-    // The user schema and the default flow are both new → two creates.
+    // The user schema and the default flow are both new → two creates,
+    // enumerated per resource in `changes` so agents can verify what a
+    // plan will touch without applying.
     expect(json.data).toEqual({
       creates: 2,
       updates: 0,
       revisions: 0,
       deletes: 0,
       total: 2,
+      changes: [
+        { kind: "schema", action: "create", file: ".zitadel/schemas/user.json" },
+        { kind: "flow", action: "create", file: ".zitadel/flows/default.json" },
+      ],
       warnings: [],
     });
   });

--- a/apps/cli/tests/unit/commands/schemas-list.test.ts
+++ b/apps/cli/tests/unit/commands/schemas-list.test.ts
@@ -103,14 +103,18 @@ describe("schemas list", () => {
       status: string;
       data: {
         object_type: string;
-        revisions: Array<{ id: string; createdAt: string }>;
+        revisions: Array<{ id: string; created_at: string }>;
         count: number;
       };
     };
     expect(json.status).toBe("ok");
     expect(json.data.count).toBe(2);
-    expect(json.data.revisions[0].id).toBe("sch_02");
-    expect(json.data.revisions[1].id).toBe("sch_01");
+    // Envelope rows are snake_case like the rest of the data contract,
+    // even though the server response is camelCase.
+    expect(json.data.revisions).toEqual([
+      { id: "sch_02", created_at: "2026-07-02T00:00:00Z" },
+      { id: "sch_01", created_at: "2026-06-01T00:00:00Z" },
+    ]);
   });
 
   it("URL-encodes URL-shaped schema ids when fetching a revision", async () => {

--- a/apps/cli/tests/unit/lib/sync/plan-renderer.test.ts
+++ b/apps/cli/tests/unit/lib/sync/plan-renderer.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import { normalizeFlowBody, normalizeSchemaBody } from "@zitadel/config/normalize";
 
-import { renderPlan, summarizePlan } from "../../../../src/lib/sync/plan-renderer";
+import {
+  enumeratePlanResources,
+  renderPlan,
+  summarizePlan,
+} from "../../../../src/lib/sync/plan-renderer";
 import type { ResourceSyncer, SyncAction } from "../../../../src/lib/sync/types";
 
 function makeSyncer(
@@ -68,6 +72,63 @@ describe("summarizePlan", () => {
       deletes: 0,
       total: 0,
     });
+  });
+});
+
+describe("enumeratePlanResources", () => {
+  it("maps every non-skip action to an envelope row, in plan order", () => {
+    const actions: SyncAction[] = [
+      { kind: "create", path: ".zitadel/schemas/user.json", syncer: schema, content: {}, hash: "h" },
+      {
+        kind: "update",
+        path: ".zitadel/flows/login.json",
+        syncer: flow,
+        id: "flow_1",
+        content: {},
+        hash: "h",
+        oldContent: null,
+      },
+      {
+        kind: "revise",
+        path: ".zitadel/schemas/user.json",
+        syncer: schema,
+        content: {},
+        hash: "h",
+        previousId: "sch_1",
+        oldContent: null,
+        affectedPaths: [".zitadel/flows/login.json"],
+      },
+      { kind: "delete", path: ".zitadel/flows/old.json", syncer: flow, id: "flow_0", oldContent: null },
+      { kind: "skip", path: ".zitadel/schemas/other.json", reason: "no-change" },
+    ];
+
+    // `revise` speaks the envelope's public vocabulary: `revision`,
+    // matching the `revisions` counter.
+    expect(enumeratePlanResources(actions)).toEqual([
+      { kind: "schema", action: "create", file: ".zitadel/schemas/user.json" },
+      { kind: "flow", action: "update", file: ".zitadel/flows/login.json", id: "flow_1" },
+      {
+        kind: "schema",
+        action: "revision",
+        file: ".zitadel/schemas/user.json",
+        previous_id: "sch_1",
+      },
+      { kind: "flow", action: "delete", file: ".zitadel/flows/old.json", id: "flow_0" },
+    ]);
+  });
+
+  it("agrees with summarizePlan on what counts", () => {
+    const actions: SyncAction[] = [
+      { kind: "create", path: "a", syncer: schema, content: {}, hash: "h" },
+      { kind: "skip", path: "b", reason: "immutable" },
+      { kind: "delete", path: "c", syncer: flow, id: "1", oldContent: null },
+    ];
+    expect(enumeratePlanResources(actions)).toHaveLength(summarizePlan(actions).total);
+  });
+
+  it("returns an empty array for an empty or skip-only plan", () => {
+    expect(enumeratePlanResources([])).toEqual([]);
+    expect(enumeratePlanResources([{ kind: "skip", path: "a", reason: "no-change" }])).toEqual([]);
   });
 });
 

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -11,6 +11,38 @@ import (
 	"github.com/zitadel/nextgen/internal/storage/database"
 )
 
+// Step error text keys the state machine emits when an auth-attempt
+// proof is rejected. Every engine-emitted step error must be a
+// localizable `error.*` catalog key or a reserved outcome token:
+// /login localizes only `error.*`-prefixed step errors and treats
+// outcome tokens as routing, so anything else renders verbatim (see
+// `localiseFlowErrorKeys` in
+// packages/components/src/orchestrator/liquid.ts). New emission sites
+// add a const here; [FlowStepErrorAllowed] and its contract test keep
+// the set honest.
+const (
+	// FlowStepErrorInvalidCredentials reports a rejected password
+	// proof. The client routes it inline to the password field
+	// (fieldErrorKeys in liquid.ts).
+	FlowStepErrorInvalidCredentials = "error.invalid_credentials"
+	// FlowStepErrorPasskeyInvalid reports a rejected passkey assertion.
+	FlowStepErrorPasskeyInvalid = "error.passkey_invalid"
+	// FlowStepErrorPasskeyRegistrationInvalid reports a rejected
+	// passkey registration attestation.
+	FlowStepErrorPasskeyRegistrationInvalid = "error.passkey_registration_invalid"
+)
+
+// FlowStepErrorAllowed reports whether a step error value honors the
+// client contract: a localizable `error.*` text key or a reserved
+// outcome token (reservedOutcomes in flow_definition_validator.go).
+func FlowStepErrorAllowed(key string) bool {
+	if strings.HasPrefix(key, "error.") {
+		return true
+	}
+	_, ok := reservedOutcomes[key]
+	return ok
+}
+
 // FlowStateMachine drives a flow definition forward in response to
 // client submissions. The handler owns cookie I/O; the state machine
 // never touches cookies.
@@ -632,9 +664,7 @@ func (r *FlowStateMachineRuntime) dispatchChallenges(pc *processCtx, resolved Fl
 				Plain:     value,
 			})
 			if errors.Is(err, ErrAuthAttemptProofRejected(nil)) {
-				// Catalog key the client routes inline to the password
-				// field (fieldErrorKeys in liquid.ts).
-				msg := "error.invalid_credentials"
+				msg := FlowStepErrorInvalidCredentials
 				return flowDispatchResult{StepError: &msg}, nil
 			}
 			if err != nil {
@@ -746,7 +776,7 @@ func (r *FlowStateMachineRuntime) processPasskey(pc *processCtx, resolved FlowRe
 			})
 			if errors.Is(err, ErrAuthAttemptProofRejected(nil)) {
 				state.ClearPendingChallenge()
-				msg := "error.passkey_registration_invalid"
+				msg := FlowStepErrorPasskeyRegistrationInvalid
 				rendered := r.buildStep(pc.state, pc.currentStep, resolved, &msg, nil, nil)
 				state.IssuedAt = r.now()
 				return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil
@@ -779,7 +809,7 @@ func (r *FlowStateMachineRuntime) processPasskey(pc *processCtx, resolved FlowRe
 			})
 			if errors.Is(err, ErrAuthAttemptProofRejected(nil)) {
 				state.ClearPendingChallenge()
-				msg := "error.passkey_invalid"
+				msg := FlowStepErrorPasskeyInvalid
 				rendered := r.buildStep(pc.state, pc.currentStep, resolved, &msg, nil, nil)
 				state.IssuedAt = r.now()
 				return passkeyPhaseResult{handled: true, halt: &FlowStepResult{State: state, Step: rendered}}, nil

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -2728,6 +2728,7 @@ func TestFlowStepErrorContract(t *testing.T) {
 		domain.FlowFieldChallengePasskey,
 		domain.FlowFieldChallengeMagicLink,
 		domain.FlowFieldChallengeSSO,
+		domain.FlowFieldChallengeOTP,
 	}
 	for _, challenge := range challenges {
 		for _, outcome := range domain.ImplicitOutcomesForChallenge(challenge) {

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -428,7 +428,7 @@ func TestFlowStateMachine_Process_LoginInvalidPassword(t *testing.T) {
 	require.NotNil(t, result.Step)
 	require.Equal(t, "credentials", result.Step.Name)
 	require.NotNil(t, result.Step.Error)
-	assert.Equal(t, "error.invalid_credentials", *result.Step.Error)
+	assert.Equal(t, domain.FlowStepErrorInvalidCredentials, *result.Step.Error)
 }
 
 func TestFlowStateMachine_Process_FieldValidationErrorKeepsStep(t *testing.T) {
@@ -706,7 +706,7 @@ func TestFlowStateMachine_Process_PasskeyProofRejectedKeepsStep(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, rejected.Step.Error)
-	assert.Equal(t, "error.passkey_invalid", *rejected.Step.Error)
+	assert.Equal(t, domain.FlowStepErrorPasskeyInvalid, *rejected.Step.Error)
 	assert.Nil(t, rejected.State.PendingChallenge)
 	assert.Equal(t, "authenticate", rejected.State.CurrentStep)
 }
@@ -893,7 +893,7 @@ func TestFlowStateMachine_Process_PasskeyAfterRejectionRebindsIdentifier(t *test
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "error.passkey_invalid", gu.Value(rejected.Step.Error))
+	assert.Equal(t, domain.FlowStepErrorPasskeyInvalid, gu.Value(rejected.Step.Error))
 	assert.Nil(t, rejected.State.PendingChallenge, "rejection clears PendingChallenge")
 
 	// Attempt 2, issue leg: the user re-types user2's email (passkey-only)
@@ -1990,7 +1990,7 @@ func TestFlowStateMachine_Process_PasskeyRegisterRejectedKeepsStep(t *testing.T)
 	})
 	require.NoError(t, err)
 	require.NotNil(t, rejected.Step.Error)
-	assert.Equal(t, "error.passkey_registration_invalid", *rejected.Step.Error)
+	assert.Equal(t, domain.FlowStepErrorPasskeyRegistrationInvalid, *rejected.Step.Error)
 	assert.Nil(t, rejected.State.PendingChallenge)
 	assert.Equal(t, "register", rejected.State.CurrentStep)
 }
@@ -2701,4 +2701,63 @@ func TestFlowStateMachine_Back_DropsPendingChallenge(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "step1", afterBack.Step.Name)
 	assert.Nil(t, afterBack.State.PendingChallenge, "back must drop the pending challenge")
+}
+
+// TestFlowStepErrorContract sweeps every value the engine can emit as
+// `step.Error` and pins the client contract: a localizable `error.*`
+// text key or a reserved outcome token. The scenario tests above prove
+// each value is emitted where expected; this gate is what fails when a
+// new emission value (a step-error const, an implicit outcome, a
+// validation rule) breaks the dialect /login localizes.
+func TestFlowStepErrorContract(t *testing.T) {
+	t.Parallel()
+
+	stepErrorConsts := []string{
+		domain.FlowStepErrorInvalidCredentials,
+		domain.FlowStepErrorPasskeyInvalid,
+		domain.FlowStepErrorPasskeyRegistrationInvalid,
+	}
+	for _, key := range stepErrorConsts {
+		assert.True(t, domain.FlowStepErrorAllowed(key), "step-error const %q must honor the contract", key)
+	}
+
+	challenges := []domain.FlowFieldChallenge{
+		domain.FlowFieldChallengeNone,
+		domain.FlowFieldChallengeIdentifier,
+		domain.FlowFieldChallengePassword,
+		domain.FlowFieldChallengePasskey,
+		domain.FlowFieldChallengeMagicLink,
+		domain.FlowFieldChallengeSSO,
+	}
+	for _, challenge := range challenges {
+		for _, outcome := range domain.ImplicitOutcomesForChallenge(challenge) {
+			// Unwired transitions surface the outcome token verbatim as
+			// step.Error, so every implicit outcome must stay reserved.
+			assert.True(t, domain.FlowStepErrorAllowed(outcome),
+				"implicit outcome %q of challenge %q must be a reserved token", outcome, challenge)
+		}
+	}
+	assert.True(t, domain.FlowStepErrorAllowed(domain.FlowImplicitOutcomeUserNotFound))
+	assert.True(t, domain.FlowStepErrorAllowed(domain.FlowImplicitOutcomeUserAlreadyExists))
+
+	rules := []domain.FlowFieldValidationRule{
+		domain.FlowFieldValidationRuleRequired,
+		domain.FlowFieldValidationRuleFormat,
+		domain.FlowFieldValidationRuleMinLength,
+		domain.FlowFieldValidationRuleMaxLength,
+		domain.FlowFieldValidationRuleUnknown,
+	}
+	// Field names are tenant-controlled and used verbatim in the key —
+	// the credential shape is the adversarial case.
+	for _, field := range []string{"email", "x-auth-methods#password"} {
+		for _, rule := range rules {
+			key := domain.FlowFieldValidationError{Field: field, Rule: rule}.TextKey()
+			assert.True(t, domain.FlowStepErrorAllowed(key),
+				"validation key %q (field %q, rule %q) must honor the contract", key, field, rule)
+		}
+	}
+
+	for _, key := range []string{"auth_attempt.password_invalid", "password_invalid", ""} {
+		assert.False(t, domain.FlowStepErrorAllowed(key), "%q must not pass the contract", key)
+	}
 }

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -177,7 +177,10 @@ Automation can use the stable host and native shadow-root hooks that the default
 template emits. Host atoms expose hooks such as `zitadel-field-email`,
 `zitadel-field-password`, and `zitadel-action-submit`; their native shadow
 controls expose hooks such as `zitadel-input-email`, `zitadel-input-password`,
-and `zitadel-action-submit-button`.
+and `zitadel-action-submit-button`. Hooks are method-named even when the flow
+engine names a credential field `x-auth-methods#<method>` — the `name`
+attribute keeps that raw form key, only the `data-testid` hooks are normalised
+(`hookName` in `src/internal/hook-name.ts`).
 
 A tenant Liquid template can already be supplied through the branding
 payload's `liquid_template` field; a dedicated declarative `template`

--- a/packages/components/src/atoms/zl-field.browser.spec.ts
+++ b/packages/components/src/atoms/zl-field.browser.spec.ts
@@ -118,6 +118,17 @@ describe("<zl-field> form participation (chromium)", () => {
     expect(submitted).toBe(0);
   });
 
+  it("normalises the auth-method credential name in the input testid", async () => {
+    const { field } = mount(
+      `<form><zl-field name="x-auth-methods#password" type="password" data-testid="zitadel-field-password"></zl-field></form>`,
+    );
+    await field.updateComplete;
+    const input = field.shadowRoot?.querySelector("input") as HTMLInputElement;
+    // The hook is method-named; the form key stays raw.
+    expect(input.getAttribute("data-testid")).toBe("zitadel-input-password");
+    expect(input.getAttribute("name")).toBe("x-auth-methods#password");
+  });
+
   it("delegates focus from the host to the inner input", async () => {
     const { field } = mount(`<form><zl-field name="email"></zl-field></form>`);
     await field.updateComplete;

--- a/packages/components/src/atoms/zl-field.ts
+++ b/packages/components/src/atoms/zl-field.ts
@@ -9,6 +9,7 @@ import fieldHost from "@zitadel/shared-component-styles/lit/text-field-host.css?
 import fieldSurface from "@zitadel/shared-component-styles/text-field.css?inline";
 
 import { emit } from "../internal/emit.js";
+import { hookName } from "../internal/hook-name.js";
 import { nextUid } from "../internal/unique-id.js";
 import type { AtomManifest } from "../manifest.js";
 import { baseHostStyles, surfaceStyles } from "../styles/index.js";
@@ -329,8 +330,10 @@ export class ZlField extends LitElement {
   private nativeInputTestId(): string | undefined {
     if (this.name) {
       // Field host hooks use zitadel-field-*; native hooks can be name-first
-      // without colliding with the host, unlike action buttons.
-      return `zitadel-input-${this.name}`;
+      // without colliding with the host, unlike action buttons. The hook
+      // token is normalised (x-auth-methods#password → password) while
+      // `name` stays the raw form key.
+      return `zitadel-input-${hookName(this.name)}`;
     }
     if (this.testId) {
       return `${this.testId}-input`;

--- a/packages/components/src/internal/hook-name.spec.ts
+++ b/packages/components/src/internal/hook-name.spec.ts
@@ -12,15 +12,23 @@ describe("hookName", () => {
     expect(hookName("givenName")).toBe("givenName");
   });
 
-  it("uses the after-hash token verbatim, without case changes", () => {
+  it("uses the after-prefix token verbatim, without case changes", () => {
     expect(hookName("x-auth-methods#magicLink")).toBe("magicLink");
   });
 
-  it("returns names with a trailing hash unchanged", () => {
-    expect(hookName("broken#")).toBe("broken#");
+  it("keeps hashes in tenant-authored property names", () => {
+    // Only the reserved prefix is dialect; any other `#` is part of the
+    // (arbitrary, tenant-authored) property name.
+    expect(hookName("a#b#c")).toBe("a#b#c");
+    expect(hookName("room#number")).toBe("room#number");
   });
 
-  it("takes the last hash segment when several appear", () => {
-    expect(hookName("a#b#c")).toBe("c");
+  it("returns a bare or degenerate prefix unchanged", () => {
+    expect(hookName("x-auth-methods#")).toBe("x-auth-methods#");
+    expect(hookName("x-auth-methods")).toBe("x-auth-methods");
+  });
+
+  it("strips only the leading prefix, keeping later hashes", () => {
+    expect(hookName("x-auth-methods#weird#method")).toBe("weird#method");
   });
 });

--- a/packages/components/src/internal/hook-name.spec.ts
+++ b/packages/components/src/internal/hook-name.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { hookName } from "./hook-name.js";
+
+describe("hookName", () => {
+  it("strips the auth-method credential prefix", () => {
+    expect(hookName("x-auth-methods#password")).toBe("password");
+  });
+
+  it("keeps plain field names unchanged", () => {
+    expect(hookName("email")).toBe("email");
+    expect(hookName("givenName")).toBe("givenName");
+  });
+
+  it("uses the after-hash token verbatim, without case changes", () => {
+    expect(hookName("x-auth-methods#magicLink")).toBe("magicLink");
+  });
+
+  it("returns names with a trailing hash unchanged", () => {
+    expect(hookName("broken#")).toBe("broken#");
+  });
+
+  it("takes the last hash segment when several appear", () => {
+    expect(hookName("a#b#c")).toBe("c");
+  });
+});

--- a/packages/components/src/internal/hook-name.ts
+++ b/packages/components/src/internal/hook-name.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalises a flow field name into its automation-hook token.
+ *
+ * Auth-method credential fields arrive from the flow engine as
+ * `x-auth-methods#<method>` (e.g. `x-auth-methods#password`), but the
+ * documented `data-testid` hooks are method-named
+ * (`zitadel-field-password`, `zitadel-input-password` — see
+ * packages/components/README.md and apps/cli/SKILLS.md). This helper
+ * feeds both hook construction sites: the bundled template's `testid`
+ * Liquid filter and `<zl-field>`'s native-input testid.
+ *
+ * Only the hook is normalised — the field's `name` attribute stays the
+ * raw wire/form key. The after-`#` token is used verbatim (no case or
+ * spacing changes). Testids are hooks, not identity: a step containing
+ * both `x-auth-methods#password` and a schema field literally named
+ * `password` would collide, which is theoretical and unhandled by
+ * design.
+ */
+export function hookName(field: string): string {
+  const hash = field.lastIndexOf("#");
+  if (hash === -1 || hash === field.length - 1) {
+    return field;
+  }
+  return field.slice(hash + 1);
+}

--- a/packages/components/src/internal/hook-name.ts
+++ b/packages/components/src/internal/hook-name.ts
@@ -1,4 +1,12 @@
 /**
+ * Reserved auth-method credential prefix of flow field names. Mirrors
+ * `AUTH_METHOD_PREFIX` in `@zitadel/config` (`src/validate.ts`), which
+ * owns the wire dialect; components has no dependency on that package,
+ * so the literal is repeated here.
+ */
+const AUTH_METHOD_PREFIX = "x-auth-methods#";
+
+/**
  * Normalises a flow field name into its automation-hook token.
  *
  * Auth-method credential fields arrive from the flow engine as
@@ -9,17 +17,15 @@
  * feeds both hook construction sites: the bundled template's `testid`
  * Liquid filter and `<zl-field>`'s native-input testid.
  *
- * Only the hook is normalised — the field's `name` attribute stays the
- * raw wire/form key. The after-`#` token is used verbatim (no case or
- * spacing changes). Testids are hooks, not identity: a step containing
- * both `x-auth-methods#password` and a schema field literally named
- * `password` would collide, which is theoretical and unhandled by
- * design.
+ * Only the reserved credential prefix is stripped — user-schema
+ * property names are tenant-authored arbitrary strings, so a `#`
+ * anywhere else is part of the name and stays in the hook. The
+ * after-prefix token is used verbatim (no case or spacing changes),
+ * and the field's `name` attribute always keeps the raw wire/form key.
  */
 export function hookName(field: string): string {
-  const hash = field.lastIndexOf("#");
-  if (hash === -1 || hash === field.length - 1) {
-    return field;
+  if (field.startsWith(AUTH_METHOD_PREFIX) && field.length > AUTH_METHOD_PREFIX.length) {
+    return field.slice(AUTH_METHOD_PREFIX.length);
   }
-  return field.slice(hash + 1);
+  return field;
 }

--- a/packages/components/src/orchestrator/liquid.spec.ts
+++ b/packages/components/src/orchestrator/liquid.spec.ts
@@ -137,6 +137,36 @@ describe("LiquidJS engine", () => {
     expect(result).toContain(mandatoryGatesMarkerComment);
   });
 
+  it("normalises auth-method credential names in testids but not in name", () => {
+    // The real flow engine names the credential field
+    // `x-auth-methods#password`; the documented hook is method-named.
+    const engine = createLiquidEngine({ locale });
+    const f = toArray({
+      "x-auth-methods#password": {
+        type: "password",
+        text_key: "password.field.password",
+        required: true,
+      },
+    });
+    const a = toArray({ submit: { text_key: "submit.continue", primary: true } });
+    const context = {
+      step: { name: "password", type: "password", texts: { title_key: "password.title" } },
+      fields: f,
+      actions: a,
+      branding: {},
+      loading: false,
+      errors: [],
+      gates: {},
+      sso_providers: [],
+      messages: [],
+      identity: null,
+    };
+    const result = engine.renderFileSync(TEMPLATE_NAMES.default, context);
+    expect(result).toContain('data-testid="zitadel-field-password"');
+    expect(result).not.toContain('data-testid="zitadel-field-x-auth-methods#password"');
+    expect(result).toContain('name="x-auth-methods#password"');
+  });
+
   it("renders step title from locale via default template", () => {
     const engine = createLiquidEngine({ locale });
     const a = toArray({ submit: { text_key: "submit.continue", primary: true } });

--- a/packages/components/src/orchestrator/liquid.ts
+++ b/packages/components/src/orchestrator/liquid.ts
@@ -17,6 +17,7 @@ import { Liquid } from "liquidjs";
 
 import type { FlowError } from "./template-context.js";
 import type { Locale } from "./locales/en.js";
+import { hookName } from "../internal/hook-name.js";
 import { mandatoryGatesMarkerComment } from "./mandatory-gates.js";
 import defaultTemplate from "./templates/default.liquid";
 
@@ -138,6 +139,14 @@ export function createLiquidEngine(options: CreateLiquidOptions): Liquid {
     }
     return "";
   });
+
+  /**
+   * Automation-hook token for a field name: strips the
+   * `x-auth-methods#` credential prefix so testids stay method-named
+   * (`zitadel-field-password`), while the `name` attribute keeps the
+   * raw wire key. See hookName for the contract.
+   */
+  engine.registerFilter("testid", (fieldName: unknown) => hookName(stringify(fieldName)));
 
   /** True when the error should render as `<zl-alert>`, not on a field. */
   engine.registerFilter("formLevelError", (err: unknown) => {

--- a/packages/components/src/orchestrator/templates/default.liquid
+++ b/packages/components/src/orchestrator/templates/default.liquid
@@ -31,7 +31,7 @@
       {% when 'checkbox' %}
         <zl-checkbox
           name="{{ f.name }}"
-          data-testid="zitadel-field-{{ f.name }}"
+          data-testid="zitadel-field-{{ f.name | testid }}"
           label="{{ f.text_key | t }}"
           value="true"
           {% if f.value %}checked{% endif %}
@@ -40,7 +40,7 @@
       {% when 'select' %}
         <zl-select
           name="{{ f.name }}"
-          data-testid="zitadel-field-{{ f.name }}"
+          data-testid="zitadel-field-{{ f.name | testid }}"
           label="{{ f.text_key | t }}"
           value="{{ f.value }}"
           options='{{ f.validation.enum | selectOptions | json }}'
@@ -58,7 +58,7 @@
         {% endif %}
         <zl-field
           name="{{ f.name }}"
-          data-testid="zitadel-field-{{ f.name }}"
+          data-testid="zitadel-field-{{ f.name | testid }}"
           label="{{ f.text_key | t }}"
           type="{{ f.type }}"
           value="{{ f.value }}"

--- a/packages/components/src/orchestrator/zitadel-login.browser.spec.ts
+++ b/packages/components/src/orchestrator/zitadel-login.browser.spec.ts
@@ -271,6 +271,52 @@ describe("<zitadel-login> form + focus (chromium)", () => {
     expect(body.fields).toEqual({ email: "alice@acme.com", password: "hunter2" });
   });
 
+  it("submits the step's primary action on Enter inside a field", async () => {
+    // Covers the orchestrator half of Enter-to-submit: `<zl-field>`
+    // forwards Enter to `form.requestSubmit()` (zl-field.browser.spec),
+    // and `handleFormSubmit` falls back to the first primary action
+    // because Enter provides no submitter.
+    const element = await mount();
+    const root = element.shadowRoot!;
+    await fillNativeField(root, "email", "alice@acme.com");
+    await fillNativeField(root, "password", "hunter2");
+
+    const emailField = root.querySelector('[data-testid="zitadel-field-email"]') as
+      | (HTMLElement & { updateComplete: Promise<unknown> })
+      | null;
+    if (!emailField) {
+      throw new Error("Expected email field host hook to render");
+    }
+    await emailField.updateComplete;
+    const input = emailField.shadowRoot?.querySelector("input");
+    if (!input) {
+      throw new Error("Expected native input inside the email field");
+    }
+    input.focus();
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      }),
+    );
+
+    await waitFor(() => {
+      const title = element.shadowRoot?.querySelector(".zl-card-title");
+      return title?.textContent?.includes("Sign in faster") ? title : null;
+    });
+    // Exactly one step submission (calls[0] is the flow create), carrying
+    // the primary action and the typed values.
+    expect(stub.calls).toHaveLength(2);
+    const enterBody = JSON.parse(String(stub.calls[1]?.init?.body ?? "{}")) as {
+      action?: string;
+      fields?: Record<string, string>;
+    };
+    expect(enterBody.action).toBe("submit");
+    expect(enterBody.fields).toEqual({ email: "alice@acme.com", password: "hunter2" });
+  });
+
   it("does not submit stale values after a field is cleared", async () => {
     const element = await mount();
     const root = element.shadowRoot!;


### PR DESCRIPTION
## Summary

Closes out the P0/P1 findings from the senior-tester pass over released `v0.1.0-alpha.16` (password-first Next.js golden journey, agent + human lens). Scope reconciled against main before implementation:

- **S1 — `test(domain)`: step.error dialect gate.** #525 fixed the `auth_attempt.*` leak by rewriting three inline literals; nothing prevented the next one. The literals are now named consts, scenario assertions reference them, and `TestFlowStepErrorContract` sweeps every known emission value (consts, implicit outcomes per challenge, field-validation keys including the credential-shaped field name) against the exported `FlowStepErrorAllowed` predicate — a new non-`error.*`, non-reserved step error fails CI instead of rendering verbatim in /login. No behavior change.
- **S2 — `fix(components)`: method-named credential hooks.** `x-auth-methods#password` leaked verbatim into `data-testid` hooks, breaking the documented `zitadel-field-password` / `zitadel-input-password` contract (the e2e password locator survived only via its label fallback). A shared `hookName` helper now normalises the hook token at both construction sites (new `testid` Liquid filter in the bundled template; `zl-field`'s native-input testid). The `name` attribute — the wire/form key — is untouched.
- **S3 — components tests/docs: Enter-to-submit.** The release-test finding "Enter does not submit" was **withdrawn as a driver artifact**: the embedded-browser CDP key event carried an empty `key` field, so `zl-field`'s `event.key === "Enter"` guard correctly ignored it; a well-formed Enter triggers `form.requestSubmit()` → primary action, as documented since #319. Residue landed here: the previously untested orchestrator half (`handleFormSubmit` → `findPrimaryAction`) now has a browser spec, and SKILLS.md tells agent drivers whose synthesized key events omit `key` to click `zitadel-action-submit` instead.
- **S4 — `feat(cli)`: plan/apply envelopes enumerate changes.** `plan --json` gave only counters; `apply --json` gave `{synced, files_updated}` where `files_updated` means *local write-backs* — a successful upload read as a no-op. Both now emit `data.changes` (`{kind, action, file, id?, previous_id?}` per resource; apply rows carry the resulting platform ids captured in `runSyncLoop`), apply gains `next_actions`/`next_commands`, and `schemas list` emits snake_case `created_at`. Counters, `files_updated`, and telemetry dimensions unchanged.

Out of scope by maintainer decision: the bare-`npx` `latest` dist-tag stub (alpha is shared via `@alpha`).

## Validation

- `go build ./...` and `go test ./internal/domain/ -count=1` — green (includes the new contract sweep).
- `packages/components`: `pnpm run test` (264 unit) and `pnpm run test:browser` (39, chromium) — green; the two new specs verified present by name (`normalises the auth-method credential name in the input testid`, `submits the step's primary action on Enter inside a field`).
- `apps/cli`: `npx vitest run` — 104 files / 763 tests green, including the new success-path `apply` test against a `node:http` platform stub (first one — apply previously had no success-path coverage), the `enumeratePlanResources` matrix, and the SKILLS.md contract tests over the edited doc.
- `npx tsc --noEmit` in both `apps/cli` and `packages/components` — clean.
- `moon run workspace:journey` (cross-framework register/logout/login e2e) — full matrix passed in 8m41s ("customer local setup journey matrix passed"; every framework's journey green, exit 0).

## Release notes / changeset

- Changeset: `.changeset/stable-credential-field-hooks.md` — `@zitadel/components` patch: credential-field automation hooks are method-named; scripts targeting the raw `zitadel-field-x-auth-methods#password` form must adjust.
- Changeset: `.changeset/plan-apply-change-enumeration.md` — `@zitadel/cli` patch: `plan`/`apply` `--json` enumerate per-resource changes with resulting ids; `apply` gains next steps; `schemas list` emits `created_at`.
- S1 alone would be "No changeset required — no shipped behavior changed" (tests + const refactor).

## Notes

- The full release-test report (what alpha.16 verifiably fixed, remaining P2s: password policy hint despite `validation.min_length` in the payload, no show-password toggle, password step not naming the account, `E_FRAMEWORK_NOT_DETECTED` hint self-duplication, `files_written` duplicates, scaffold's `next@16.2.4` DoS advisory, default DOB collection, "Create Next App" page titles) lives in the session log; P2s are deliberately not in this PR.
- S1 non-goals, noted for follow-up: runtime normalization in `buildStep`; rejection mappings for MagicLink/SSO/OTP (no dispatch case exists yet); unifying the two reserved-outcome definitions (`reservedOutcomes` in the validator vs the resolver consts) — the contract test now at least fails if they drift apart on emitted values.
- The server-side API casing inconsistency behind the `schemas list` fix (flow endpoints emit `created_at`, schema-list emits `createdAt`) is an OpenAPI-surface follow-up, deliberately not touched here.
- e2e note: `fieldControl(page, "password", …)` in cli-journey-e2e now matches via its primary `getByTestId` branch instead of the label fallback — no spec changes needed.
