### PR TITLE
fix: address alpha.16 community feedback on labels, README, and error copy

### DIFF
--- a/.changeset/alpha16-feedback-fixes.md
+++ b/.changeset/alpha16-feedback-fixes.md
@@ -1,0 +1,26 @@
+---
+"@zitadel/components": patch
+"@zitadel/config": patch
+"@zitadel/cli": patch
+"@zitadel/server": patch
+---
+
+Fixes from alpha.16 community feedback:
+
+- Custom schema fields now render a readable label. A property with no
+  catalog entry (e.g. `department`, `dateOfBirth`) falls back to a
+  humanised name ("Department", "Date of birth") on the form instead of
+  leaking the raw `<step>.field.<name>` text key. A catalogued key still
+  wins, so localised labels are unaffected.
+- The scaffolded `.zitadel/flows/README.md` no longer contains the
+  "Presets" section twice.
+- The `warn/default-flow-swap` plan warning now leads with the impact in
+  plain language: the new flow becomes the default for its purposes, and
+  every page that does not explicitly set `flow-name` on
+  `<zitadel-login>` will start rendering it — scope it via `audience`
+  or pin `flow-name` to opt out.
+- The flip-table validation error (login/register entry step missing its
+  `user_not_found`/`user_already_exists` transition) now explains who
+  gets stuck where: someone without an account would be stuck at
+  sign-in instead of being routed to registration, and vice versa. Plan,
+  apply, and the server report the same wording.

--- a/apps/cli/src/lib/sync/flow-validation.ts
+++ b/apps/cli/src/lib/sync/flow-validation.ts
@@ -151,10 +151,16 @@ function defaultSwapWarning(
   return {
     rule: "warn/default-flow-swap",
     message:
-      `applying this new active flow makes it the newest unscoped definition — ` +
-      `clients that do not pin a flow-name will get it as the default for ${purposes.join(", ")}. ` +
-      `Scope it via "audience" or set flow-name in the widget if that is not intended.`,
+      `once applied, this flow becomes the new default for ${humanList(purposes)}: ` +
+      `pages that do not explicitly set flow-name on <zitadel-login> will start rendering it. ` +
+      `If that is not intended, scope it with "audience" or set flow-name on the pages that should use it.`,
   };
+}
+
+/** ["login", "register"] → "login and register" (Oxford-free prose list). */
+function humanList(items: readonly string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  return `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
 }
 
 /**

--- a/apps/cli/tests/unit/lib/sync/loop.test.ts
+++ b/apps/cli/tests/unit/lib/sync/loop.test.ts
@@ -1254,7 +1254,9 @@ describe("plan-time flow validation", () => {
       expect(created?.kind).toBe("create");
       if (created?.kind === "create") {
         expect(created.warnings?.map((w) => w.rule)).toContain("warn/default-flow-swap");
-        expect(created.warnings?.at(-1)?.message).toContain("newest unscoped definition");
+        expect(created.warnings?.at(-1)?.message).toContain(
+          "becomes the new default for login and register",
+        );
       }
       expect(actions.find((a) => a.path === FLOW_PATH)?.kind).toBe("skip");
     } finally {

--- a/internal/domain/flow_definition_validator.go
+++ b/internal/domain/flow_definition_validator.go
@@ -474,8 +474,8 @@ func validateFlipTableCoverage(def FlowDefinition) error {
 			}
 			if _, ok := entry.Transitions[outcome]; !ok {
 				return ErrFlowDefinitionInvalid(fmt.Sprintf(
-					"step %q: entry step for purpose %q must wire %q transition because %q is also a purpose",
-					entry.Name, purpose, outcome, targetPurpose), nil)
+					"step %q: entry step for purpose %q must wire %q transition because %q is also a purpose: without it, %s",
+					entry.Name, purpose, outcome, targetPurpose, flipOutcomeImpacts[outcome]), nil)
 			}
 		}
 	}
@@ -491,6 +491,15 @@ var purposeFlipTargets = map[FlowDefinitionPurpose]map[string]FlowDefinitionPurp
 	FlowDefinitionPurposeRegister: {
 		FlowImplicitOutcomeUserAlreadyExists: FlowDefinitionPurposeLogin,
 	},
+}
+
+// flipOutcomeImpacts spells out, per implicit outcome, who gets stuck
+// where when the entry step leaves it unwired — the flip-table violation
+// explains the user impact, not just the graph rule. Mirrored verbatim
+// in packages/config/src/validate.ts (drift-audited there).
+var flipOutcomeImpacts = map[string]string{
+	FlowImplicitOutcomeUserNotFound:      "someone without an account gets stuck at sign-in instead of being routed to registration",
+	FlowImplicitOutcomeUserAlreadyExists: "someone who already has an account gets stuck at registration instead of being routed to sign-in",
 }
 
 // validateOnSuccessManifests verifies that every kind in each step's

--- a/packages/components/src/orchestrator/liquid.spec.ts
+++ b/packages/components/src/orchestrator/liquid.spec.ts
@@ -104,6 +104,16 @@ describe("LiquidJS engine", () => {
     expect(result).toBe("Team");
   });
 
+  it("splits on the last .field. for step names that contain the marker", () => {
+    // Step names are tenant-chosen: "signup.field.v2" is a legal step
+    // name, and the property name always follows the final ".field.".
+    const engine = createLiquidEngine({ locale });
+    const result = engine.parseAndRenderSync("{{ key | t }}", {
+      key: "signup.field.v2.field.department",
+    });
+    expect(result).toBe("Department");
+  });
+
   it("field sub-keys (placeholder/help) do not take the humanised fallback", () => {
     // `.placeholder`/`.help` resolve through their own filters, which stay
     // empty on a miss; `| t` keeps returning the raw key for them.

--- a/packages/components/src/orchestrator/liquid.spec.ts
+++ b/packages/components/src/orchestrator/liquid.spec.ts
@@ -78,6 +78,42 @@ describe("LiquidJS engine", () => {
     expect(fullLocale["action.back"]).toBe("Back");
   });
 
+  it("the | t filter humanises uncatalogued field-label keys", () => {
+    // Custom schema properties (`department`, `dateOfBirth`) produce
+    // `<step>.field.<name>` label keys no catalog can enumerate — the
+    // form must not render the raw key.
+    const engine = createLiquidEngine({ locale });
+    expect(
+      engine.parseAndRenderSync("{{ key | t }}", { key: "register.field.department" }),
+    ).toBe("Department");
+    expect(
+      engine.parseAndRenderSync("{{ key | t }}", { key: "register.field.dateOfBirth" }),
+    ).toBe("Date of birth");
+    expect(
+      engine.parseAndRenderSync("{{ key | t }}", { key: "register.field.emergency_contact" }),
+    ).toBe("Emergency contact");
+  });
+
+  it("a catalogued field-label key wins over the humanised fallback", () => {
+    const engine = createLiquidEngine({
+      locale: { ...locale, "register.field.department": "Team" },
+    });
+    const result = engine.parseAndRenderSync("{{ key | t }}", {
+      key: "register.field.department",
+    });
+    expect(result).toBe("Team");
+  });
+
+  it("field sub-keys (placeholder/help) do not take the humanised fallback", () => {
+    // `.placeholder`/`.help` resolve through their own filters, which stay
+    // empty on a miss; `| t` keeps returning the raw key for them.
+    const engine = createLiquidEngine({ locale });
+    const result = engine.parseAndRenderSync("{{ key | t }}", {
+      key: "register.field.department.placeholder",
+    });
+    expect(result).toBe("register.field.department.placeholder");
+  });
+
   it("fieldPlaceholder resolves sibling keys", () => {
     const engine = createLiquidEngine({ locale });
     const result = engine.parseAndRenderSync(

--- a/packages/components/src/orchestrator/liquid.ts
+++ b/packages/components/src/orchestrator/liquid.ts
@@ -191,7 +191,9 @@ function injectedKeyFallback(locale: Locale, key: string): string | undefined {
  */
 function fieldLabelFallback(key: string): string | undefined {
   const marker = ".field.";
-  const index = key.indexOf(marker);
+  // Last occurrence: step names are tenant-chosen and may themselves
+  // contain ".field."; the property name always follows the final marker.
+  const index = key.lastIndexOf(marker);
   if (index === -1) return undefined;
   const field = key.slice(index + marker.length);
   if (field === "" || field.includes(".")) return undefined;

--- a/packages/components/src/orchestrator/liquid.ts
+++ b/packages/components/src/orchestrator/liquid.ts
@@ -82,7 +82,10 @@ export function createLiquidEngine(options: CreateLiquidOptions): Liquid {
     function tFilter(this: { context: unknown }, key: unknown, ...args: unknown[]) {
       const lookupKey = stringify(key);
       const template =
-        options.locale[lookupKey] ?? injectedKeyFallback(options.locale, lookupKey) ?? lookupKey;
+        options.locale[lookupKey] ??
+        injectedKeyFallback(options.locale, lookupKey) ??
+        fieldLabelFallback(lookupKey) ??
+        lookupKey;
       return interpolate(template, args.map(stringify));
     },
   );
@@ -175,6 +178,24 @@ function injectedKeyFallback(locale: Locale, key: string): string | undefined {
     if (key.endsWith(suffix)) return locale[fallback];
   }
   return undefined;
+}
+
+/**
+ * Fallback for field-label keys (`<step>.field.<name>` — see
+ * `FlowField.TextKey` in `internal/domain/flow_field_resolver.go`). Both
+ * halves are tenant-chosen (step names and schema property names), so no
+ * catalog can enumerate the keys; a miss renders a humanised property name
+ * ("dateOfBirth" → "Date of birth") instead of leaking the raw key into the
+ * form. Sub-keys like `.placeholder`/`.help` are excluded — they resolve
+ * through their own filters, which stay empty on a miss.
+ */
+function fieldLabelFallback(key: string): string | undefined {
+  const marker = ".field.";
+  const index = key.indexOf(marker);
+  if (index === -1) return undefined;
+  const field = key.slice(index + marker.length);
+  if (field === "" || field.includes(".")) return undefined;
+  return capitaliseFirst(humaniseFieldName(field));
 }
 
 export type FlowErrorKeyContext = {

--- a/packages/config/defaults/README-flows.md
+++ b/packages/config/defaults/README-flows.md
@@ -76,14 +76,6 @@ enters login on a fields-less passkey step with an email → password
 fallback path. The preset only decides the starting point — edit
 anything here afterwards.
 
-## Presets
-
-`zitadel setup` scaffolds this folder from a preset (`--preset
-password-first` or `--preset passkey-first`). The passkey-first flow
-enters login on a fields-less passkey step with an email → password
-fallback path. The preset only decides the starting point — edit
-anything here afterwards.
-
 ## Schema revisions
 
 Editing a schema publishes a new immutable revision. When you `apply` a

--- a/packages/config/src/readmes.test.ts
+++ b/packages/config/src/readmes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { flowsReadmeContent, schemasReadmeContent } from "./readmes";
+
+// Regression guard for the scaffolded README content: a bad merge once
+// shipped `.zitadel/flows/README.md` with its "## Presets" section
+// duplicated verbatim, and nothing caught it because the files are read
+// straight from disk.
+describe.each([
+  ["flows", flowsReadmeContent],
+  ["schemas", schemasReadmeContent],
+])("%s README content", (_name, content) => {
+  it("is non-empty markdown with a top-level heading", () => {
+    expect(content()).toMatch(/^# /);
+  });
+
+  it("has no duplicated section headings", () => {
+    const headings = content()
+      .split("\n")
+      .filter((line) => line.startsWith("## "));
+    expect(headings).toEqual([...new Set(headings)]);
+  });
+});

--- a/packages/config/src/validate.test.ts
+++ b/packages/config/src/validate.test.ts
@@ -290,7 +290,7 @@ describe("graph / cycles / flip-table", () => {
     delete step(def, "identifier").transitions.user_not_found;
     const issues = validateFlowDefinition(def, schema);
     expect(messages(issues)).toContain(
-      'step "identifier": entry step for purpose "login" must wire "user_not_found" transition because "register" is also a purpose',
+      'step "identifier": entry step for purpose "login" must wire "user_not_found" transition because "register" is also a purpose: without it, someone without an account gets stuck at sign-in instead of being routed to registration',
     );
     expect(issues.find((i) => i.rule === "flip-table")).toBeDefined();
   });
@@ -299,7 +299,7 @@ describe("graph / cycles / flip-table", () => {
     const def = flow();
     delete step(def, "register").transitions.user_already_exists;
     expect(messages(validateFlowDefinition(def))).toContain(
-      'step "register": entry step for purpose "register" must wire "user_already_exists" transition because "login" is also a purpose',
+      'step "register": entry step for purpose "register" must wire "user_already_exists" transition because "login" is also a purpose: without it, someone who already has an account gets stuck at registration instead of being routed to sign-in',
     );
   });
 });
@@ -555,6 +555,13 @@ describe("drift audit (Go validator)", () => {
     // The passkey-action rule's message must stay verbatim-identical.
     expect(source).toContain(
       'offers passkey but "passkey" is not an enabled authentication method',
+    );
+    // The flip-table impact suffixes must stay verbatim-identical.
+    expect(source).toContain(
+      "someone without an account gets stuck at sign-in instead of being routed to registration",
+    );
+    expect(source).toContain(
+      "someone who already has an account gets stuck at registration instead of being routed to sign-in",
     );
     // purposeFlipTargets: login→user_not_found→register, register→user_already_exists→login.
     expect(source).toContain("FlowDefinitionPurposeLogin: {");

--- a/packages/config/src/validate.ts
+++ b/packages/config/src/validate.ts
@@ -79,6 +79,14 @@ export const PURPOSE_FLIP_TARGETS: Readonly<Record<string, Readonly<Record<strin
   register: { user_already_exists: "login" },
 };
 
+/** Mirrors `flipOutcomeImpacts` in flow_definition_validator.go (verbatim). */
+const FLIP_OUTCOME_IMPACTS: Readonly<Record<string, string>> = {
+  user_not_found:
+    "someone without an account gets stuck at sign-in instead of being routed to registration",
+  user_already_exists:
+    "someone who already has an account gets stuck at registration instead of being routed to sign-in",
+};
+
 /** Action kinds a flow author may declare; `back` is engine-injected. */
 const DECLARABLE_ACTION_KINDS = new Set(["submit", "passkey", "passkey_register", "navigate"]);
 
@@ -511,7 +519,7 @@ function validateFlipTableCoverage(def: FlowDef): FlowValidationIssue[] {
         issues.push(
           error(
             "flip-table",
-            `step ${q(entry.name)}: entry step for purpose ${q(purpose)} must wire ${q(outcome)} transition because ${q(targetPurpose)} is also a purpose`,
+            `step ${q(entry.name)}: entry step for purpose ${q(purpose)} must wire ${q(outcome)} transition because ${q(targetPurpose)} is also a purpose: without it, ${FLIP_OUTCOME_IMPACTS[outcome]}`,
             entry.name,
           ),
         );


### PR DESCRIPTION
## Summary

Fixes the four remaining items from Elina's alpha.16 feedback, closing out the schemas+flows bundle we point the community at:

- **Custom schema fields get a readable display label.** The engine emits `<step>.field.<name>` text keys; both halves are tenant-chosen, so no locale catalog can enumerate them, and the widget's `| t` filter fell back to the raw key (`register.field.department` on the form). It now falls back to a humanised property name (`department` → "Department", `dateOfBirth` → "Date of birth"). Catalogued keys still win, so existing localised labels are unaffected; `.placeholder`/`.help` sub-keys keep resolving through their own filters (empty on a miss).
- **`.zitadel/flows/README.md` no longer contains the "## Presets" section twice.** The duplication was in the source of truth (`packages/config/defaults/README-flows.md`), not the generator. A new test guards both scaffolded READMEs against duplicated section headings.
- **`warn/default-flow-swap` speaks plainly.** Was: "applying this new active flow makes it the newest unscoped definition — clients that do not pin a flow-name…". Now: "once applied, this flow becomes the new default for login and register: pages that do not explicitly set flow-name on `<zitadel-login>` will start rendering it…"
- **The flip-table validation error explains the user impact.** Appended to the existing message: "…without it, someone without an account gets stuck at sign-in instead of being routed to registration" (mirror-image wording for `user_already_exists`). Changed in the Go validator and mirrored verbatim in the plan-time TS port per the drift contract; the drift audit now pins both impact literals against the Go source. Append-only, so substring assertions in dependent suites stayed valid.

## Validation

- `go test ./internal/domain/` — pass
- `pnpm vitest run` in `packages/config` (88), `packages/components` (298), `packages/api-mock` (40) — pass
- `pnpm vitest run tests/unit tests/integration/setup-next.test.ts` in `apps/cli` (747) — pass
- `tsc --noEmit` in config/components/cli, `oxlint` in config, `go vet` + `gofmt -l` on `internal/domain` — clean

## Release notes / changeset

- Changeset: `.changeset/alpha16-feedback-fixes.md` — alpha.16 feedback fixes (`@zitadel/components`, `@zitadel/config`, `@zitadel/cli`, `@zitadel/server`)

## Notes

- The api-mock "POST /projects" conformance failure seen locally during this work was **not** a repo bug: generated orval output is gitignored and the worktree carried a stale artifact predating #462 (`name` missing from the generated `CreateProjectBody` zod). `pnpm generate` in `packages/api` resolves it; CI always regenerates via moon. No repo change was needed.
- The flip-table wording change is deliberately append-only so that anyone matching on the old message prefix (docs, scripts) keeps working.