### PR TITLE
ci: rename kanban workflow to "Add new issues and PRs to kanban project"

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,4 +1,4 @@
-name: Add new issues to product management project
+name: Add new issues and PRs to kanban project
 
 on:
   issues:


### PR DESCRIPTION
## Summary
- Renames the existing kanban workflow from "Add new issues to product management project" to "Add new issues and PRs to kanban project" to align naming across the org.
- No functional changes; still calls the shared `zitadel/.github/.github/workflows/kanban.yml` workflow with explicit secrets.

## Test plan
- [ ] N/A (name-only change)

---
_Generated by [Claude Code](https://claude.ai/code/session_016BkqGdRZ2gKTdkpYxmj2iD)_