### PR TITLE
test: de-flake TestSetUserPassword parallel-subtest shared-user race

### DIFF
--- a/internal/api/integration_test/user_test.go
+++ b/internal/api/integration_test/user_test.go
@@ -199,28 +199,34 @@ func TestSetUserPassword(t *testing.T) {
 	project, err := harness.EnsureProjectService(t).Create(t.Context(), helpers.ProjectName(), nil, true)
 	require.NoError(t, err)
 
-	user, err := harness.EnsureUserService(t).CreateUser(t.Context(), service.CreateUserInput{
-		ProjectID: project.ID,
-		User:      harness.TestData.Generator.GenerateUser(t, "testsetuserpassword@example.com"),
-	})
-	require.NoError(t, err)
-	userID := user["id"].(string)
-	userEmail := user["email"].(string)
-
-	params := api.SetUserPasswordParams{
-		ProjectID: api.ProjectID(project.ID),
-		UserID:    api.UserID(userID),
-	}
-
 	client, err := helpers.NewApiClient(harness.EnsureTestServer(t).URL)
 	require.NoError(t, err)
 	client.SetToken(project.ProjectSecret)
+
+	// Each subtest gets its own user: the subtests run in parallel and the
+	// password upsert is last-writer-wins on (project_id, user_id), so with a
+	// shared user a sibling's SetUserPassword can land between this subtest's
+	// write and its proof check and reject the proof.
+	createUser := func(t *testing.T, email string) (api.SetUserPasswordParams, string) {
+		t.Helper()
+		user, err := harness.EnsureUserService(t).CreateUser(t.Context(), service.CreateUserInput{
+			ProjectID: project.ID,
+			User:      harness.TestData.Generator.GenerateUser(t, email),
+		})
+		require.NoError(t, err)
+		return api.SetUserPasswordParams{
+			ProjectID: api.ProjectID(project.ID),
+			UserID:    api.UserID(user["id"].(string)),
+		}, user["email"].(string)
+	}
 
 	t.Run("ok", func(t *testing.T) {
 		t.Parallel()
 
 		t.Run("create initial password", func(t *testing.T) {
 			t.Parallel()
+
+			params, userEmail := createUser(t, "testsetuserpassword.initial@example.com")
 
 			const password = "fake-password"
 			request := &api.SetUserPasswordRequest{
@@ -241,6 +247,8 @@ func TestSetUserPassword(t *testing.T) {
 
 		t.Run("update password", func(t *testing.T) {
 			t.Parallel()
+
+			params, userEmail := createUser(t, "testsetuserpassword.update@example.com")
 
 			const originalPassword = "fake-password"
 			request := &api.SetUserPasswordRequest{


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why. -->

- `TestSetUserPassword/ok/create_initial_password` flaked on CI with "The proof was rejected" right after a successful `SetUserPassword` (seen on PR #563 full-pr run 29837069740). Root cause: the two `ok` subtests run with `t.Parallel()` but shared one user, and the password write is a last-writer-wins upsert on `(project_id, user_id)` — so `update password`'s second write (`new-password`) could land between `create initial password`'s write and its session proof check, which then read the wrong hash. The race also runs the other way (`create initial password` re-writing `fake-password` can break both of `update password`'s final assertions); CI just happened to catch this side.
- Fix: each subtest now creates its own user via a small `createUser` helper (`testsetuserpassword.initial@` / `.update@example.com`), so the parallel subtests write disjoint rows and the failure mechanism is structurally gone. Test semantics are unchanged: the service-level `CreateUser` fixture never stores a password credential (only the flow handler does), so "create initial password" still exercises the insert arm of the upsert and "update password" the overwrite arm.
- Not a product bug: `UserService.ApplyActions` commits before the handler returns 204, and the proof check reads the hash through a fresh read-committed pool query with no cache — there is no visibility gap in the set→check path. Diagnosis is by writer-elimination: given a 204, a rejected proof requires a different stored hash, and the sibling subtest is the only other writer to that row in the whole suite (the user lives in a project created fresh inside this test).

## Validation

<!-- List exact commands run. If validation was not run, say so explicitly. -->

- `go vet -tags postgres_integration ./internal/api/integration_test/` — ok
- `GOMAXPROCS=2 ZITADEL_TEST_POSTGRES_URL=… go test -tags postgres_integration ./internal/api/integration_test -run 'TestSetUserPassword$' -count=300` — ok (80s, embedded postgres)
- `GOMAXPROCS=3 ZITADEL_TEST_POSTGRES_URL=… go test -tags postgres_integration ./internal/api/integration_test -count=60 -parallel 32` — ok (full package under contention; also shows no email/fixture collisions elsewhere)
- The pre-fix flake resisted local reproduction (~450 iterations green under the same amplification): the harness hashes with real bcrypt cost 10 (~60–100ms), so the victim's proof-read normally beats the poisoning write by a full hash-duration; closing that window takes the scheduler starvation of a loaded 4-vCPU CI runner, not an idle many-core machine.

## Release notes / changeset

- No changeset required — no shipped behavior changed.

## Notes

- The `error/user not found` subtest was already self-contained and is untouched.