### PR TITLE
fix(api): normalize ogen decode errors to req.invalid

### DIFF
--- a/.changeset/normalize-ogen-decode-errors.md
+++ b/.changeset/normalize-ogen-decode-errors.md
@@ -2,4 +2,4 @@
 "@zitadel/server": patch
 ---
 
-Normalize ogen decode/validation failures to the stable `req.invalid` domain message, and name the offending field in flow `Fields` JSON decode errors without echoing `json.Unmarshal` parser text (ADR 030).
+Normalize ogen decode/validation failures to the stable `req.invalid` domain message, and name the offending field on flow `Fields` value decode errors without echoing `json.Unmarshal` parser text (ADR 030).

--- a/.changeset/normalize-ogen-decode-errors.md
+++ b/.changeset/normalize-ogen-decode-errors.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+Normalize ogen decode/validation failures to the stable `req.invalid` domain message, and name the offending field in flow `Fields` JSON decode errors without echoing `json.Unmarshal` parser text (ADR 030).

--- a/internal/api/error_handler.go
+++ b/internal/api/error_handler.go
@@ -99,9 +99,9 @@ func OgenErrorHandler(_ context.Context, w http.ResponseWriter, _ *http.Request,
 
 	case isDecodeError(err):
 		status = http.StatusBadRequest
-		d := domainErrorDetails(domain.ErrRequestInvalid())
-		d.Message = err.Error()
-		details = d
+		// Use the stable domain message — do not echo ogen/framework
+		// decode text into the client envelope (ADR 030).
+		details = domainErrorDetails(domain.ErrRequestInvalid())
 
 	default:
 		resp := errorResponse(err)

--- a/internal/api/error_handler_test.go
+++ b/internal/api/error_handler_test.go
@@ -81,7 +81,10 @@ func TestOgenErrorHandlerNonCredentialCookieDecodeStays400(t *testing.T) {
 	srv.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
-	require.Contains(t, rec.Body.String(), `"code":"req.invalid"`)
+	require.JSONEq(t,
+		`{"code":"req.invalid","message":"The request is invalid and fails base validation (missing required fields, wrong types, failed regex, etc.). Check the details for more information."}`,
+		rec.Body.String(),
+	)
 }
 
 func TestOgenErrorHandlerSecurityErrorNormalizedMessage(t *testing.T) {

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -97,7 +97,9 @@ func (h *Handler) SubmitFlowStep(ctx context.Context, req *api.FlowSubmitRequest
 	if fields, ok := req.Fields.Get(); ok {
 		decoded, err := decodeFlowFields(fields)
 		if err != nil {
-			return errorResponseWithStatusCode(http.StatusBadRequest, domain.ErrRequestInvalid()), nil
+			// Name the offending field only — do not surface json.Unmarshal text (ADR 030).
+			return errorResponseWithStatusCode(http.StatusBadRequest,
+				domain.ErrRequestInvalid().WithMessage(err.Error())), nil
 		}
 		submitReq.Fields = decoded
 	}
@@ -448,7 +450,7 @@ func decodeFlowFields(raw map[string]jx.Raw) (map[string]any, error) {
 	for k, v := range raw {
 		var decoded any
 		if err := json.Unmarshal(v, &decoded); err != nil {
-			return nil, fmt.Errorf("decode field %q: %w", k, err)
+			return nil, fmt.Errorf("invalid JSON for field %q", k)
 		}
 		out[k] = decoded
 	}

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -97,9 +98,10 @@ func (h *Handler) SubmitFlowStep(ctx context.Context, req *api.FlowSubmitRequest
 	if fields, ok := req.Fields.Get(); ok {
 		decoded, err := decodeFlowFields(fields)
 		if err != nil {
-			// Name the offending field only — do not surface json.Unmarshal text (ADR 030).
+			// Safe client message; Parent keeps a log-safe wrapper that still Unwraps
+			// to the json.Unmarshal cause for diagnostics (ADR 030).
 			return errorResponseWithStatusCode(http.StatusBadRequest,
-				domain.ErrRequestInvalid().WithMessage(err.Error())), nil
+				domain.ErrRequestInvalid().WithMessage(err.Error()).WithParent(err)), nil
 		}
 		submitReq.Fields = decoded
 	}
@@ -445,12 +447,36 @@ func toFlowStepComplete(c domain.FlowStepComplete) api.FlowStepComplete {
 	return api.FlowStepCompleteShow
 }
 
+// flowFieldDecodeError is a log-safe wrapper around a Fields JSON decode failure.
+// Error() names only the field for clients; Unwrap preserves the json.Unmarshal
+// cause for errors.Is/As. LogValue omits the cause string (it can embed payload
+// fragments / PII).
+type flowFieldDecodeError struct {
+	field string
+	err   error
+}
+
+func (e *flowFieldDecodeError) Error() string {
+	return fmt.Sprintf("invalid JSON for field %q", e.field)
+}
+
+func (e *flowFieldDecodeError) Unwrap() error {
+	return e.err
+}
+
+func (e *flowFieldDecodeError) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("kind", "json_decode"),
+		slog.String("field", e.field),
+	)
+}
+
 func decodeFlowFields(raw map[string]jx.Raw) (map[string]any, error) {
 	out := make(map[string]any, len(raw))
 	for k, v := range raw {
 		var decoded any
 		if err := json.Unmarshal(v, &decoded); err != nil {
-			return nil, fmt.Errorf("invalid JSON for field %q", k)
+			return nil, &flowFieldDecodeError{field: k, err: err}
 		}
 		out[k] = decoded
 	}

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -447,17 +447,19 @@ func toFlowStepComplete(c domain.FlowStepComplete) api.FlowStepComplete {
 	return api.FlowStepCompleteShow
 }
 
-// flowFieldDecodeError is a log-safe wrapper around a Fields JSON decode failure.
-// Error() names only the field for clients; Unwrap preserves the json.Unmarshal
-// cause for errors.Is/As. LogValue omits the cause string (it can embed payload
-// fragments / PII).
+// flowFieldDecodeError is a log-safe wrapper around a Fields value decode failure.
+// By the time decodeFlowFields runs, ogen has already syntax-validated the JSON;
+// failures here are typically values encoding/json cannot represent as Go any
+// (for example numbers outside float64). Error() names only the field for clients;
+// Unwrap preserves the json.Unmarshal cause for errors.Is/As. LogValue omits the
+// cause string (it can embed payload fragments / PII).
 type flowFieldDecodeError struct {
 	field string
 	err   error
 }
 
 func (e *flowFieldDecodeError) Error() string {
-	return fmt.Sprintf("invalid JSON for field %q", e.field)
+	return fmt.Sprintf("invalid value for field %q", e.field)
 }
 
 func (e *flowFieldDecodeError) Unwrap() error {
@@ -466,7 +468,7 @@ func (e *flowFieldDecodeError) Unwrap() error {
 
 func (e *flowFieldDecodeError) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("kind", "json_decode"),
+		slog.String("kind", "field_value"),
 		slog.String("field", e.field),
 	)
 }

--- a/internal/api/flow_error_test.go
+++ b/internal/api/flow_error_test.go
@@ -1,14 +1,66 @@
 package api
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"testing"
 
+	"github.com/go-faster/jx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/nextgen/internal/domain"
 )
+
+func TestDecodeFlowFields_sanitizedCause(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeFlowFields(map[string]jx.Raw{
+		"email": jx.Raw(`{"secret":`),
+	})
+	require.Error(t, err)
+	assert.Equal(t, `invalid JSON for field "email"`, err.Error())
+
+	var syntax *json.SyntaxError
+	require.ErrorAs(t, err, &syntax, "Unwrap must preserve the json.Unmarshal cause")
+
+	var decodeErr *flowFieldDecodeError
+	require.ErrorAs(t, err, &decodeErr)
+	logVal := decodeErr.LogValue()
+	require.Equal(t, slog.KindGroup, logVal.Kind())
+	attrs := logVal.Group()
+	got := make(map[string]string, len(attrs))
+	for _, a := range attrs {
+		got[a.Key] = a.Value.String()
+	}
+	assert.Equal(t, map[string]string{
+		"kind":  "json_decode",
+		"field": "email",
+	}, got)
+	assert.NotContains(t, fmt.Sprint(attrs), "secret")
+}
+
+func TestSubmitFlowFieldsDecode_attachesLogSafeParent(t *testing.T) {
+	t.Parallel()
+
+	cause := &flowFieldDecodeError{
+		field: "phone",
+		err:   errors.New(`invalid character '{' looking for beginning of object key string in {"password":"hunter2"}`),
+	}
+	dom := domain.ErrRequestInvalid().WithMessage(cause.Error()).WithParent(cause)
+	assert.Equal(t, `invalid JSON for field "phone"`, dom.Message)
+	assert.Equal(t, cause, dom.Parent)
+
+	// Parent LogValue must not surface the unmarshal / payload fragment.
+	parentLV, ok := dom.Parent.(slog.LogValuer)
+	require.True(t, ok)
+	for _, a := range parentLV.LogValue().Group() {
+		assert.NotContains(t, a.Value.String(), "hunter2")
+		assert.NotContains(t, a.Value.String(), "password")
+	}
+}
 
 func TestMapFlowErrorStatus_usesFlowSentinels(t *testing.T) {
 	t.Parallel()

--- a/internal/api/flow_error_test.go
+++ b/internal/api/flow_error_test.go
@@ -21,7 +21,7 @@ func TestDecodeFlowFields_sanitizedCause(t *testing.T) {
 		"email": jx.Raw(`{"secret":`),
 	})
 	require.Error(t, err)
-	assert.Equal(t, `invalid JSON for field "email"`, err.Error())
+	assert.Equal(t, `invalid value for field "email"`, err.Error())
 
 	var syntax *json.SyntaxError
 	require.ErrorAs(t, err, &syntax, "Unwrap must preserve the json.Unmarshal cause")
@@ -36,10 +36,29 @@ func TestDecodeFlowFields_sanitizedCause(t *testing.T) {
 		got[a.Key] = a.Value.String()
 	}
 	assert.Equal(t, map[string]string{
-		"kind":  "json_decode",
+		"kind":  "field_value",
 		"field": "email",
 	}, got)
 	assert.NotContains(t, fmt.Sprint(attrs), "secret")
+}
+
+func TestDecodeFlowFields_outOfRangeNumber(t *testing.T) {
+	t.Parallel()
+
+	// ogen RawAppend accepts 1e1000 as syntactically valid JSON; encoding/json
+	// cannot represent it as float64, so decodeFlowFields must fail with a
+	// field-value message (not "invalid JSON").
+	_, err := decodeFlowFields(map[string]jx.Raw{
+		"score": jx.Raw(`1e1000`),
+	})
+	require.Error(t, err)
+	assert.Equal(t, `invalid value for field "score"`, err.Error())
+	assert.NotContains(t, err.Error(), "JSON")
+
+	var decodeErr *flowFieldDecodeError
+	require.ErrorAs(t, err, &decodeErr)
+	assert.Equal(t, "score", decodeErr.field)
+	require.Error(t, decodeErr.err)
 }
 
 func TestSubmitFlowFieldsDecode_attachesLogSafeParent(t *testing.T) {
@@ -50,7 +69,7 @@ func TestSubmitFlowFieldsDecode_attachesLogSafeParent(t *testing.T) {
 		err:   errors.New(`invalid character '{' looking for beginning of object key string in {"password":"hunter2"}`),
 	}
 	dom := domain.ErrRequestInvalid().WithMessage(cause.Error()).WithParent(cause)
-	assert.Equal(t, `invalid JSON for field "phone"`, dom.Message)
+	assert.Equal(t, `invalid value for field "phone"`, dom.Message)
 	assert.Equal(t, cause, dom.Parent)
 
 	// Parent LogValue must not surface the unmarshal / payload fragment.


### PR DESCRIPTION
## Summary

- Normalize `OgenErrorHandler` decode/validation failures to the stable `req.invalid` domain message instead of echoing raw ogen `err.Error()` text (ADR 030).
- Include the Copilot follow-up for [#583](https://github.com/zitadel/nextgen/pull/583): name only the offending field on malformed flow `Fields` JSON (`invalid JSON for field "…"`), without wrapping `json.Unmarshal` parser text.

## Note

#583 auto-merged before Copilot’s review comment was addressed. The DX fix had been pushed to `flow-error` and replied on the review thread, but that commit was not in the merge. It is included here so the review is closed out on `main`.

## Validation

- `go test ./internal/api/ -count=1 -run 'TestOgenErrorHandler|TestSubmitFlow'`

## Release notes / changeset

Changeset: `.changeset/normalize-ogen-decode-errors.md` — `@zitadel/server` patch: normalize ogen decode messages and keep safe field names on flow `Fields` decode errors.

## Notes

- Remaining ADR 030 follow-ups: #48 (storage), contract hardening (status map dedup, selective `details`, schema sensitivity).

Made with [Cursor](https://cursor.com)