### PR TITLE
fix(api): ADR 030 contract hardening for #585

### DIFF
--- a/.changeset/issue-585-contract-hardening.md
+++ b/.changeset/issue-585-contract-hardening.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+Add structured `details.field` on flow `Fields` value decode errors; centralize error status mapping and document API `details` producer contract (ADR 030 / #585).

--- a/docs/adrs/030-error-model-mapping-and-reporting.md
+++ b/docs/adrs/030-error-model-mapping-and-reporting.md
@@ -313,7 +313,7 @@ This keeps both the value and its hash out of logs without losing debuggability:
 Policy:
 
 1. **Default-sensitive: do not log user/schema attribute payloads or raw request/response bodies.** Log the structured domain error (`code` + safe `message` + a few named, safe attributes), never the serialized body. This removes the blob problem at the source.
-2. **Declare sensitivity in the schema, enforce at the boundary.** Sensitivity is a property of the JSON Schema (`writeOnly`, `format: password`, or an `x-zitadel-sensitive` extension), consulted by the attribute-handling code — not guessed by the generic slog layer.
+2. **Declare sensitivity in the schema, enforce at the boundary.** Sensitivity is a property of the JSON Schema (`writeOnly`, `format: password`, or an `x-sensitive` extension — the implemented name in this repo; see [`user-property.yaml`](../../api/openapi/endpoints/schemas/user-property.yaml)), consulted by the attribute-handling code — not guessed by the generic slog layer.
 3. **Keep static key masking as defense-in-depth** for fixed-name credential attributes that appear in structured args.
 4. **URLs are safe-to-log by construction, not by redaction.** Path and query params are already logged everywhere downstream (proxies, load balancers, access logs, browser history, `Referer`), so the rule is the inverse of redaction: **no secret or PII may be carried in a path or query parameter** — those belong in headers or the request body. Logging keeps the URL and omits only the body.
 

--- a/docs/design/api/error-details-producers.md
+++ b/docs/design/api/error-details-producers.md
@@ -1,0 +1,47 @@
+# API error `details` producers
+
+> **Status:** Active
+> **Related:** [ADR 030](../../adrs/030-error-model-mapping-and-reporting.md), [#585](https://github.com/zitadel/nextgen/issues/585)
+
+## Contract
+
+`domain.Error.Details` is client-facing. Setting `Details` **is** exposing it — there is no per-code allow-list. Producers must attach only **client-actionable, non-sensitive** data (ADR 030 Decision 4 + 6).
+
+### Allowed
+
+- Field paths and constraint names
+- Schema / validation issue summaries without user attribute values
+- Conflict keys safe for the caller (for example purpose names on flow-definition updates)
+
+### Forbidden
+
+- Passwords, OTPs, tokens, API keys, private keys
+- Raw SQL, driver errors, storage row payloads
+- Email, phone, or other identifiers unless the endpoint is explicitly self-scoped and the field is the subject of the error
+
+`Parent` and `Origin` stay log-only; `domain.Error.LogValue` omits `Details` by default.
+
+## Wire shape
+
+The API nests producer payloads under `details.details` (legacy shape). Use [`marshalErrorDetails`](../../../internal/api/error_handler.go) or typed helpers — do not hand-build divergent encodings unless JSON marshalling cannot represent the type (for example ISO-8601 durations on session TTL).
+
+## Reference producers
+
+### Session TTL — `SessionInvalidTTLDetails`
+
+[`internal/domain/session.go`](../../../internal/domain/session.go) attaches `{ttl,max_ttl}` as ISO-8601 durations. Encoded by [`marshalSessionInvalidTTLDetails`](../../../internal/api/session.go).
+
+### Request field validation — `RequestInvalidFieldDetails`
+
+Flow `Fields` value decode failures attach `{field}` only (no parser text, no payload fragments). See [`SubmitFlowStep`](../../../internal/api/flow.go) and [`flowFieldDecodeError`](../../../internal/api/flow.go).
+
+## Inventory (fix / defer)
+
+| Location | Shape | Status |
+|----------|-------|--------|
+| `session.go` `SessionInvalidTTLDetails` | typed struct | Reference |
+| `flow.go` flow field decode | `RequestInvalidFieldDetails` | Reference |
+| `flow_definition_errors.go` / flowdef handlers | string validation messages | Kept — already on wire in integration tests |
+| `authz.go` write-miss handlers | opaque string on wrong codes | **Deferred** — intentional authz opacity |
+| `domain/user.go`, `service/user.go` | was string `WithDetails` | **Fixed** — moved to `Message` |
+| `service/auth_attempt.go` unsupported proof | was string `WithDetails` | **Fixed** — moved to `Message` |

--- a/docs/design/api/error-details-producers.md
+++ b/docs/design/api/error-details-producers.md
@@ -23,13 +23,13 @@
 
 ## Wire shape
 
-The API nests producer payloads under `details.details` (legacy shape). Use [`marshalErrorDetails`](../../../internal/api/error_handler.go) or typed helpers — do not hand-build divergent encodings unless JSON marshalling cannot represent the type (for example ISO-8601 durations on session TTL).
+The API nests producer payloads under `details.details` (legacy shape). Use [`marshalErrorDetails`](../../../internal/api/error_handler.go) for generic encoding; typed detail structs carry their own JSON rules (for example [`isoduration.Duration`](../../../internal/isoduration/duration.go) for ISO-8601 durations).
 
 ## Reference producers
 
 ### Session TTL — `SessionInvalidTTLDetails`
 
-[`internal/domain/session.go`](../../../internal/domain/session.go) attaches `{ttl,max_ttl}` as ISO-8601 durations. Encoded by [`marshalSessionInvalidTTLDetails`](../../../internal/api/session.go).
+[`internal/domain/session.go`](../../../internal/domain/session.go) attaches `{ttl,max_ttl}` as [`isoduration.Duration`](../../../internal/isoduration/duration.go) values. Generic `json.Marshal` emits ISO-8601 strings on the wire (same format as exchange request `ttl`).
 
 ### Request field validation — `RequestInvalidFieldDetails`
 

--- a/docs/design/flowengine/user-schema.md
+++ b/docs/design/flowengine/user-schema.md
@@ -13,7 +13,7 @@ What matters here is the contract: which schema annotations exist, how the flow 
 |---|---|---|---|
 | `x-identifier: true` | Field | Flow Engine | Field used for user resolution in the identifier step |
 | `x-mfa: "sms"` | Field | Policy Engine | Field can be used for OTP delivery |
-| `x-sensitive: true` | Field | Flow Engine | Value redacted in audit events |
+| `x-sensitive: true` | Field | Flow Engine / API producers | Value redacted in audit events; must not appear in API `message`/`details` when handling user attributes |
 | `x-editable: true` | Field | Flow Engine | Field appears in profiling / self-service flows |
 | `x-unique: "project"` | Field | Flow Engine | Server validates uniqueness on form submit (per-project scope) |
 | `x-claim: "claims.email"` | Field | Flow Engine | Maps to SSO/OIDC claim for auto-population |

--- a/docs/runbooks/api-path-query-sensitivity-audit.md
+++ b/docs/runbooks/api-path-query-sensitivity-audit.md
@@ -1,0 +1,44 @@
+# API path and query sensitivity audit
+
+> **Status:** Checklist (2026-07-22)
+> **Related:** [ADR 030 §6](../adrs/030-error-model-mapping-and-reporting.md), [#585](https://github.com/zitadel/nextgen/issues/585)
+
+## Rule
+
+URLs are **safe-to-log by construction**: path and query parameters may appear in proxies, access logs, browser history, and `Referer`. **No secret or PII may be carried in path or query** — those belong in headers or the request body.
+
+This runbook records pass / find / defer per public surface. Fixes that change OpenAPI contracts are tracked separately.
+
+## Checklist
+
+| Surface | Parameter | Kind | Verdict | Notes |
+|---------|-----------|------|---------|-------|
+| Resource CRUD (`/projects/{id}`, `/users/{id}`, …) | `{project_id}`, `{user_id}`, … | path | **Pass** | Opaque domain IDs, not direct PII |
+| `GET /sessions` | `user_id` | query | **Find** | User identifier in query string; acceptable for admin filtering today — document only; body-based filter would be breaking |
+| `GET /sessions` | `state`, `project_id`, pagination | query | **Pass** | Enum / opaque IDs |
+| OAuth `GET /oauth/authorize` | `client_id`, `redirect_uri`, `scope`, … | query | **Pass** | OIDC/OAuth public client metadata |
+| OAuth `GET /oauth/authorize` | `login_hint` | query | **Find** | May carry email/login identifier (OIDC spec); defer code change |
+| OAuth `GET /oauth/authorize` | `id_token_hint` | query | **Find** | May carry token material (OIDC spec); defer code change |
+| OAuth `GET /oauth/end-session` | `id_token_hint`, `post_logout_redirect_uri` | query | **Find** | Spec-driven; defer |
+| Flow submit `POST /flow/{id}/submit` | `_zflow` | cookie | **Pass** | Encrypted state handle, not user PII |
+| Session cookie routes | session token | cookie/header | **Pass** | Credential in cookie/header, not URL |
+| Schema / flow-definition filters | `purpose`, pagination | query | **Pass** | Non-sensitive enums and tokens |
+
+## Schema sensitivity (`x-sensitive`)
+
+- **Canonical extension:** `x-sensitive` on user schema properties ([`user-property.yaml`](../../api/openapi/endpoints/schemas/user-property.yaml)).
+- **Helper:** [`domain.IsSensitiveProperty`](../../internal/domain/schema_sensitive.go) for future producers.
+- **API errors:** Producers must not embed values of `x-sensitive: true` fields in `message` or `details` (see [error-details-producers.md](../design/api/error-details-producers.md)).
+
+## Verification
+
+```sh
+# Re-run when OpenAPI routes change:
+rg 'in: query' api/openapi/endpoints -l
+rg 'in: path' api/openapi/endpoints -l
+```
+
+## Deferred follow-ups
+
+- `login_hint` / `id_token_hint` on authorize — product/OIDC compatibility review before moving off query string.
+- `GET /sessions?user_id=` — consider POST filter body in a future API revision if query logging is a concern.

--- a/internal/api/auth_attempt.go
+++ b/internal/api/auth_attempt.go
@@ -256,7 +256,3 @@ func authAttemptStateToAPI(attempt *domain.AuthAttempt) api.AuthAttemptResponseS
 	}
 	return api.AuthAttemptResponseStateInProgress
 }
-
-func authAttemptErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	return domainErrorResponse(err)
-}

--- a/internal/api/auth_attempt.go
+++ b/internal/api/auth_attempt.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"encoding/base64"
-	"net/http"
 
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
@@ -259,19 +258,5 @@ func authAttemptStateToAPI(attempt *domain.AuthAttempt) api.AuthAttemptResponseS
 }
 
 func authAttemptErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	switch err.Code {
-	case domain.ErrAuthAttemptNotFound().Code:
-		return errorResponseWithStatusCode(http.StatusNotFound, err)
-	case domain.ErrAuthAttemptInvalidRequest().Code,
-		domain.ErrAuthAttemptInvalidProof().Code:
-		return errorResponseWithStatusCode(http.StatusBadRequest, err)
-	case domain.ErrAuthAttemptInvalidState().Code,
-		domain.ErrAuthAttemptAlreadyCompleted().Code,
-		domain.ErrAuthAttemptNotCompleted().Code,
-		domain.ErrAuthAttemptStaleChallenge().Code,
-		domain.ErrAuthAttemptProofRejected(nil).Code:
-		return errorResponseWithStatusCode(http.StatusConflict, err)
-	default:
-		return internalErrorResponse(err)
-	}
+	return domainErrorResponse(err)
 }

--- a/internal/api/error_handler.go
+++ b/internal/api/error_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/ogen-go/ogen/ogenerrors"
@@ -56,28 +55,7 @@ func errorResponse(err error) *api.ErrorDetailsStatusCode {
 	if !errors.As(err, &e) {
 		return internalErrorResponse(err)
 	}
-	switch {
-	case strings.HasPrefix(e.Code, domain.PrefixAuthAttempt.ErrorCodePrefix("")):
-		return authAttemptErrorResponse(e)
-	case strings.HasPrefix(e.Code, domain.PrefixFlow.ErrorCodePrefix("")):
-		return flowErrorResponse(e)
-	case strings.HasPrefix(e.Code, domain.PrefixFlowDefinition.ErrorCodePrefix("")):
-		return flowDefinitionErrorResponse(e)
-	case strings.HasPrefix(e.Code, domain.PrefixSession.ErrorCodePrefix("")):
-		return sessionErrorResponse(e)
-	case strings.HasPrefix(e.Code, domain.PrefixJSONSchema.ErrorCodePrefix("")):
-		return schemaErrorResponse(e)
-	case strings.HasPrefix(e.Code, domain.PrefixUser.ErrorCodePrefix("")):
-		return userErrorResponse(e)
-	case strings.HasPrefix(e.Code, domain.PrefixTeam.ErrorCodePrefix("")):
-		return teamErrorResponse(e)
-	case strings.HasPrefix(e.Code, domain.PrefixProject.ErrorCodePrefix("")):
-		return projectErrorResponse(e)
-	case e.Code == domain.ErrNotImplemented().Code:
-		return errorResponseWithStatusCode(http.StatusNotImplemented, e)
-	default:
-		return internalErrorResponse(err)
-	}
+	return domainErrorResponse(e)
 }
 
 // errorResponse is a convenience helper for the common case where the caller

--- a/internal/api/error_handler.go
+++ b/internal/api/error_handler.go
@@ -30,15 +30,26 @@ func domainErrorDetails(err error) api.ErrorDetails {
 		Message: domErr.Message,
 	}
 
-	if domErr.Details != nil {
-		if j, err := json.Marshal(domErr.Details); err == nil {
-			errDetails.Details = api.NewOptErrorDetailsDetails(api.ErrorDetailsDetails{
-				"details": j,
-			})
-		}
+	if details, ok := marshalErrorDetails(domErr.Details); ok {
+		errDetails.Details = details
 	}
 
 	return errDetails
+}
+
+// marshalErrorDetails encodes producer-attached Details for the wire envelope.
+// The legacy shape nests the payload under details.details (ADR 030).
+func marshalErrorDetails(details any) (api.OptErrorDetailsDetails, bool) {
+	if details == nil {
+		return api.OptErrorDetailsDetails{}, false
+	}
+	b, err := json.Marshal(details)
+	if err != nil {
+		return api.OptErrorDetailsDetails{}, false
+	}
+	return api.NewOptErrorDetailsDetails(api.ErrorDetailsDetails{
+		"details": b,
+	}), true
 }
 func errorResponse(err error) *api.ErrorDetailsStatusCode {
 	var e domain.Error

--- a/internal/api/error_handler_test.go
+++ b/internal/api/error_handler_test.go
@@ -112,3 +112,14 @@ func TestDomainErrorDetailsOmitsDiagnostics(t *testing.T) {
 	require.Equal(t, "An unexpected error occurred.", details.Message)
 	require.False(t, details.Details.Set, "parent/location diagnostics must not be serialized")
 }
+
+func TestDomainErrorDetails_structuredFieldDetails(t *testing.T) {
+	t.Parallel()
+
+	details := domainErrorDetails(domain.ErrRequestInvalid().WithDetails(domain.RequestInvalidFieldDetails{
+		Field: "score",
+	}))
+
+	require.True(t, details.Details.Set)
+	require.JSONEq(t, `{"field":"score"}`, string(details.Details.Value["details"]))
+}

--- a/internal/api/error_handler_test.go
+++ b/internal/api/error_handler_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/isoduration"
 )
 
 // newErrorHandlerTestServer builds the generated server around a zero-value
@@ -122,4 +124,16 @@ func TestDomainErrorDetails_structuredFieldDetails(t *testing.T) {
 
 	require.True(t, details.Details.Set)
 	require.JSONEq(t, `{"field":"score"}`, string(details.Details.Value["details"]))
+}
+
+func TestDomainErrorDetails_sessionInvalidTTLOmitsNanoseconds(t *testing.T) {
+	t.Parallel()
+
+	details := domainErrorDetails(domain.ErrSessionInvalidTTL().WithDetails(domain.SessionInvalidTTLDetails{
+		TTL:    isoduration.From(0),
+		MaxTTL: isoduration.From(24 * time.Hour),
+	}))
+
+	require.True(t, details.Details.Set)
+	require.JSONEq(t, `{"ttl":"PT0S","max_ttl":"P1D"}`, string(details.Details.Value["details"]))
 }

--- a/internal/api/error_status.go
+++ b/internal/api/error_status.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"net/http"
+
+	api "github.com/zitadel/nextgen/api/generated"
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+// codeHTTPStatus is the explicit domain error code → HTTP status manifest for
+// resource mappers in internal/api. Auth/opaque overrides (for example flow
+// cookie failures → 401 while flow.not_found → 404) are encoded here, not
+// inferred from suffixes (ADR 030).
+var codeHTTPStatus = map[string]int{
+	// User
+	domain.ErrUserInvalid().Code:          http.StatusBadRequest,
+	domain.ErrUserNotFound().Code:         http.StatusNotFound,
+	domain.ErrUserAlreadyExists().Code:    http.StatusConflict,
+	domain.ErrUserPermissionDenied().Code: http.StatusForbidden,
+
+	// Project
+	domain.ErrProjectNotFound().Code:         http.StatusNotFound,
+	domain.ErrProjectPermissionDenied().Code: http.StatusForbidden,
+	domain.ErrProjectNameInvalid().Code:      http.StatusBadRequest,
+
+	// Team
+	domain.ErrTeamNotFound().Code:         http.StatusNotFound,
+	domain.ErrTeamProjectNotFound().Code:  http.StatusNotFound,
+	domain.ErrTeamPermissionDenied().Code: http.StatusForbidden,
+
+	// JSON Schema
+	domain.ErrJSONSchemaNotFound().Code:         http.StatusNotFound,
+	domain.ErrJSONSchemaAlreadyExists().Code:    http.StatusConflict,
+	domain.ErrJSONSchemaInvalid().Code:          http.StatusBadRequest,
+	domain.ErrJSONSchemaPermissionDenied().Code: http.StatusForbidden,
+
+	// Session
+	domain.ErrSessionNotFound().Code:            http.StatusNotFound,
+	domain.ErrSessionTokenCreationFailed().Code: http.StatusInternalServerError,
+	domain.ErrSessionExchangeConflict().Code:    http.StatusBadRequest,
+	domain.ErrSessionInvalidHandoffToken().Code: http.StatusBadRequest,
+	domain.ErrSessionTokenInvalid().Code:        http.StatusUnauthorized,
+	domain.ErrNotImplemented().Code:             http.StatusNotImplemented,
+	domain.ErrSessionInvalidTTL().Code:          http.StatusBadRequest,
+
+	// Auth attempt
+	domain.ErrAuthAttemptNotFound().Code:         http.StatusNotFound,
+	domain.ErrAuthAttemptInvalidRequest().Code:   http.StatusBadRequest,
+	domain.ErrAuthAttemptInvalidProof().Code:     http.StatusBadRequest,
+	domain.ErrAuthAttemptInvalidState().Code:     http.StatusConflict,
+	domain.ErrAuthAttemptAlreadyCompleted().Code: http.StatusConflict,
+	domain.ErrAuthAttemptNotCompleted().Code:     http.StatusConflict,
+	domain.ErrAuthAttemptStaleChallenge().Code:   http.StatusConflict,
+	domain.ErrAuthAttemptProofRejected(nil).Code: http.StatusConflict,
+
+	// Flow runtime
+	domain.ErrFlowCookieInvalid().Code:   http.StatusUnauthorized,
+	domain.ErrFlowCookieExpired().Code:   http.StatusUnauthorized,
+	domain.ErrFlowNotFound().Code:        http.StatusNotFound,
+	domain.ErrFlowCompleted().Code:       http.StatusGone,
+	domain.ErrFlowSessionConflict().Code: http.StatusConflict,
+	domain.ErrFlowInvalidAction().Code:   http.StatusBadRequest,
+	domain.ErrFlowUnsupported().Code:     http.StatusBadRequest,
+	domain.ErrFlowInvalidPurpose().Code:  http.StatusBadRequest,
+
+	// Flow definition
+	domain.ErrFlowDefinitionNotFound().Code:          http.StatusNotFound,
+	domain.ErrFlowDefinitionPurposeMismatch().Code:   http.StatusBadRequest,
+	domain.ErrMissingFlowDefinitionID().Code:         http.StatusBadRequest,
+	domain.ErrMissingProjectID().Code:                http.StatusBadRequest,
+	domain.ErrFlowDefinitionInvalid(nil, nil).Code:   http.StatusBadRequest,
+	domain.ErrFlowDefinitionAlreadyExists().Code:     http.StatusConflict,
+	domain.ErrFlowDefinitionUpdateConflict(nil).Code: http.StatusConflict,
+	domain.ErrFlowDefinitionPermissionDenied().Code:  http.StatusForbidden,
+}
+
+func statusForDomainCode(code string) (int, bool) {
+	status, ok := codeHTTPStatus[code]
+	return status, ok
+}
+
+func domainErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
+	if status, ok := statusForDomainCode(err.Code); ok {
+		return errorResponseWithStatusCode(status, err)
+	}
+	return internalErrorResponse(err)
+}

--- a/internal/api/error_status_test.go
+++ b/internal/api/error_status_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+func TestStatusForDomainCode_manifest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        domain.Error
+		wantStatus int
+	}{
+		// User
+		{name: "user.invalid", err: domain.ErrUserInvalid(), wantStatus: http.StatusBadRequest},
+		{name: "user.not_found", err: domain.ErrUserNotFound(), wantStatus: http.StatusNotFound},
+		{name: "user.already_exists", err: domain.ErrUserAlreadyExists(), wantStatus: http.StatusConflict},
+		{name: "user.permission_denied", err: domain.ErrUserPermissionDenied(), wantStatus: http.StatusForbidden},
+
+		// Project
+		{name: "project.not_found", err: domain.ErrProjectNotFound(), wantStatus: http.StatusNotFound},
+		{name: "project.permission_denied", err: domain.ErrProjectPermissionDenied(), wantStatus: http.StatusForbidden},
+		{name: "project.name_invalid", err: domain.ErrProjectNameInvalid(), wantStatus: http.StatusBadRequest},
+
+		// Team
+		{name: "team.team_not_found", err: domain.ErrTeamNotFound(), wantStatus: http.StatusNotFound},
+		{name: "team.project_not_found", err: domain.ErrTeamProjectNotFound(), wantStatus: http.StatusNotFound},
+		{name: "team.permission_denied", err: domain.ErrTeamPermissionDenied(), wantStatus: http.StatusForbidden},
+
+		// Schema
+		{name: "sch.not_found", err: domain.ErrJSONSchemaNotFound(), wantStatus: http.StatusNotFound},
+		{name: "sch.already_exists", err: domain.ErrJSONSchemaAlreadyExists(), wantStatus: http.StatusConflict},
+		{name: "sch.invalid_request", err: domain.ErrJSONSchemaInvalid(), wantStatus: http.StatusBadRequest},
+		{name: "sch.permission_denied", err: domain.ErrJSONSchemaPermissionDenied(), wantStatus: http.StatusForbidden},
+
+		// Session
+		{name: "sess.not_found", err: domain.ErrSessionNotFound(), wantStatus: http.StatusNotFound},
+		{name: "sess.token_creation_failed", err: domain.ErrSessionTokenCreationFailed(), wantStatus: http.StatusInternalServerError},
+		{name: "sess.exchange_conflict", err: domain.ErrSessionExchangeConflict(), wantStatus: http.StatusBadRequest},
+		{name: "sess.invalid_handoff_token", err: domain.ErrSessionInvalidHandoffToken(), wantStatus: http.StatusBadRequest},
+		{name: "sess.token_invalid", err: domain.ErrSessionTokenInvalid(), wantStatus: http.StatusUnauthorized},
+		{name: "not_implemented", err: domain.ErrNotImplemented(), wantStatus: http.StatusNotImplemented},
+		{name: "sess.invalid_ttl", err: domain.ErrSessionInvalidTTL(), wantStatus: http.StatusBadRequest},
+
+		// Auth attempt
+		{name: "att.not_found", err: domain.ErrAuthAttemptNotFound(), wantStatus: http.StatusNotFound},
+		{name: "att.invalid_request", err: domain.ErrAuthAttemptInvalidRequest(), wantStatus: http.StatusBadRequest},
+		{name: "att.invalid_proof", err: domain.ErrAuthAttemptInvalidProof(), wantStatus: http.StatusBadRequest},
+		{name: "att.invalid_state", err: domain.ErrAuthAttemptInvalidState(), wantStatus: http.StatusConflict},
+		{name: "att.already_completed", err: domain.ErrAuthAttemptAlreadyCompleted(), wantStatus: http.StatusConflict},
+		{name: "att.not_completed", err: domain.ErrAuthAttemptNotCompleted(), wantStatus: http.StatusConflict},
+		{name: "att.stale_challenge", err: domain.ErrAuthAttemptStaleChallenge(), wantStatus: http.StatusConflict},
+		{name: "att.proof_rejected", err: domain.ErrAuthAttemptProofRejected(nil), wantStatus: http.StatusConflict},
+
+		// Flow runtime — auth/opaque overrides
+		{name: "flow.cookie_invalid", err: domain.ErrFlowCookieInvalid(), wantStatus: http.StatusUnauthorized},
+		{name: "flow.cookie_expired", err: domain.ErrFlowCookieExpired(), wantStatus: http.StatusUnauthorized},
+		{name: "flow.not_found", err: domain.ErrFlowNotFound(), wantStatus: http.StatusNotFound},
+		{name: "flow.completed", err: domain.ErrFlowCompleted(), wantStatus: http.StatusGone},
+		{name: "flow.session_conflict", err: domain.ErrFlowSessionConflict(), wantStatus: http.StatusConflict},
+		{name: "flow.invalid_action", err: domain.ErrFlowInvalidAction(), wantStatus: http.StatusBadRequest},
+		{name: "flow.unsupported", err: domain.ErrFlowUnsupported(), wantStatus: http.StatusBadRequest},
+		{name: "flow.invalid_purpose", err: domain.ErrFlowInvalidPurpose(), wantStatus: http.StatusBadRequest},
+
+		// Flow definition
+		{name: "flowdef.not_found", err: domain.ErrFlowDefinitionNotFound(), wantStatus: http.StatusNotFound},
+		{name: "flowdef.purpose_mismatch", err: domain.ErrFlowDefinitionPurposeMismatch(), wantStatus: http.StatusBadRequest},
+		{name: "flowdef.missing_id", err: domain.ErrMissingFlowDefinitionID(), wantStatus: http.StatusBadRequest},
+		{name: "flowdef.missing_project_id", err: domain.ErrMissingProjectID(), wantStatus: http.StatusBadRequest},
+		{name: "flowdef.invalid", err: domain.ErrFlowDefinitionInvalid(nil, nil), wantStatus: http.StatusBadRequest},
+		{name: "flowdef.already_exists", err: domain.ErrFlowDefinitionAlreadyExists(), wantStatus: http.StatusConflict},
+		{name: "flowdef.update_conflict", err: domain.ErrFlowDefinitionUpdateConflict(nil), wantStatus: http.StatusConflict},
+		{name: "flowdef.permission_denied", err: domain.ErrFlowDefinitionPermissionDenied(), wantStatus: http.StatusForbidden},
+	}
+
+	require.Len(t, tests, len(codeHTTPStatus), "every manifest entry must have a test case")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotStatus, ok := statusForDomainCode(tt.err.Code)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantStatus, gotStatus)
+
+			resp := domainErrorResponse(tt.err)
+			require.NotNil(t, resp)
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+		})
+	}
+}
+
+func TestDomainErrorResponse_unknownCodeIsInternal(t *testing.T) {
+	t.Parallel()
+
+	resp := domainErrorResponse(domain.Error{Code: "unknown.test", Message: "test"})
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, "unknown.test", string(resp.Response.Code))
+}

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -491,21 +491,6 @@ func jsonQuoted(s string) []byte {
 	return b
 }
 
-var (
-	codeFlowCookieInvalid   = domain.ErrFlowCookieInvalid().Code
-	codeFlowCookieExpired   = domain.ErrFlowCookieExpired().Code
-	codeFlowNotFound        = domain.ErrFlowNotFound().Code
-	codeFlowCompleted       = domain.ErrFlowCompleted().Code
-	codeFlowInvalidAction   = domain.ErrFlowInvalidAction().Code
-	codeFlowSessionConflict = domain.ErrFlowSessionConflict().Code
-	codeFlowUnsupported     = domain.ErrFlowUnsupported().Code
-	codeFlowInvalidPurpose  = domain.ErrFlowInvalidPurpose().Code
-)
-
-func flowErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	return domainErrorResponse(err)
-}
-
 // isCookieOrIDError matches any sentinel that means "this caller isn't
 // holding a valid flow handle for this path" — either the cookie was
 // missing/tampered/expired, or its embedded id doesn't match the path.
@@ -522,23 +507,23 @@ func mapFlowErrorStatus(err error) *api.ErrorDetailsStatusCode {
 		// err.Error() chain (ADR 030).
 		switch {
 		case errors.Is(err, domain.ErrFlowCookieInvalid()):
-			return flowErrorResponse(domain.ErrFlowCookieInvalid())
+			return domainErrorResponse(domain.ErrFlowCookieInvalid())
 		case errors.Is(err, domain.ErrFlowCookieExpired()):
-			return flowErrorResponse(domain.ErrFlowCookieExpired())
+			return domainErrorResponse(domain.ErrFlowCookieExpired())
 		case errors.Is(err, domain.ErrFlowNotFound()):
-			return flowErrorResponse(domain.ErrFlowNotFound())
+			return domainErrorResponse(domain.ErrFlowNotFound())
 		case errors.Is(err, domain.ErrFlowCompleted()):
-			return flowErrorResponse(domain.ErrFlowCompleted())
+			return domainErrorResponse(domain.ErrFlowCompleted())
 		case errors.Is(err, domain.ErrFlowInvalidAction()):
-			return flowErrorResponse(domain.ErrFlowInvalidAction())
+			return domainErrorResponse(domain.ErrFlowInvalidAction())
 		case errors.Is(err, domain.ErrFlowSessionConflict()):
-			return flowErrorResponse(domain.ErrFlowSessionConflict())
+			return domainErrorResponse(domain.ErrFlowSessionConflict())
 		case errors.Is(err, domain.ErrFlowUnsupported()):
-			return flowErrorResponse(domain.ErrFlowUnsupported())
+			return domainErrorResponse(domain.ErrFlowUnsupported())
 		case errors.Is(err, domain.ErrFlowInvalidPurpose()):
-			return flowErrorResponse(domain.ErrFlowInvalidPurpose())
+			return domainErrorResponse(domain.ErrFlowInvalidPurpose())
 		}
-		return flowErrorResponse(domErr)
+		return domainErrorResponse(domErr)
 	}
 	return errorResponse(err)
 }
@@ -571,36 +556,6 @@ func buildResolveHint(opt api.OptFlowHint) service.ResolveFlowHint {
 		out.UserSchemaID = &v
 	}
 	return out
-}
-
-var (
-	codeFlowDefinitionNotFound        = domain.ErrFlowDefinitionNotFound().Code
-	codeFlowDefinitionPurposeMismatch = domain.ErrFlowDefinitionPurposeMismatch().Code
-	codeFlowDefinitionInvalid         = domain.ErrFlowDefinitionInvalid(nil, nil).Code
-	codeMissingFlowDefinitionID       = domain.ErrMissingFlowDefinitionID().Code
-	codeMissingProjectID              = domain.ErrMissingProjectID().Code
-	codeFlowDefinitionAlreadyExists   = domain.ErrFlowDefinitionAlreadyExists().Code
-	codeFlowDefinitionUpdateConflict  = domain.ErrFlowDefinitionUpdateConflict(nil).Code
-	codeFlowDefinitionDenied          = domain.ErrFlowDefinitionPermissionDenied().Code
-)
-
-func flowDefinitionErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	switch err.Code {
-	case codeFlowDefinitionInvalid:
-		return flowDefinitionErrorResponseWithDetails(err, http.StatusBadRequest)
-	case codeFlowDefinitionAlreadyExists, codeFlowDefinitionUpdateConflict:
-		return flowDefinitionErrorResponseWithDetails(err, http.StatusConflict)
-	default:
-		return domainErrorResponse(err)
-	}
-}
-
-func flowDefinitionErrorResponseWithDetails(err domain.Error, statusCode int) *api.ErrorDetailsStatusCode {
-	return errorResponseWithStatusCode(statusCode, err)
-}
-
-func errorResponseWithDetails(err domain.Error, statusCode int) *api.ErrorDetailsStatusCode {
-	return errorResponseWithStatusCode(statusCode, err)
 }
 
 func parseURI(s string) (url.URL, error) {

--- a/internal/api/flow.go
+++ b/internal/api/flow.go
@@ -98,10 +98,11 @@ func (h *Handler) SubmitFlowStep(ctx context.Context, req *api.FlowSubmitRequest
 	if fields, ok := req.Fields.Get(); ok {
 		decoded, err := decodeFlowFields(fields)
 		if err != nil {
-			// Safe client message; Parent keeps a log-safe wrapper that still Unwraps
-			// to the json.Unmarshal cause for diagnostics (ADR 030).
-			return errorResponseWithStatusCode(http.StatusBadRequest,
-				domain.ErrRequestInvalid().WithMessage(err.Error()).WithParent(err)), nil
+			domErr := domain.ErrRequestInvalid().WithMessage(err.Error()).WithParent(err)
+			if decodeErr, ok := err.(*flowFieldDecodeError); ok {
+				domErr = domErr.WithDetails(domain.RequestInvalidFieldDetails{Field: decodeErr.field})
+			}
+			return errorResponseWithStatusCode(http.StatusBadRequest, domErr), nil
 		}
 		submitReq.Fields = decoded
 	}
@@ -502,20 +503,7 @@ var (
 )
 
 func flowErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	switch err.Code {
-	case codeFlowCookieInvalid, codeFlowCookieExpired:
-		return errorResponseWithStatusCode(http.StatusUnauthorized, err)
-	case codeFlowNotFound:
-		return errorResponseWithStatusCode(http.StatusNotFound, err)
-	case codeFlowCompleted:
-		return errorResponseWithStatusCode(http.StatusGone, err)
-	case codeFlowSessionConflict:
-		return errorResponseWithStatusCode(http.StatusConflict, err)
-	case codeFlowInvalidAction, codeFlowUnsupported, codeFlowInvalidPurpose:
-		return errorResponseWithStatusCode(http.StatusBadRequest, err)
-	default:
-		return internalErrorResponse(err)
-	}
+	return domainErrorResponse(err)
 }
 
 // isCookieOrIDError matches any sentinel that means "this caller isn't
@@ -598,40 +586,21 @@ var (
 
 func flowDefinitionErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
 	switch err.Code {
-	case codeFlowDefinitionNotFound:
-		return errorResponseWithStatusCode(http.StatusNotFound, err)
-	case codeFlowDefinitionPurposeMismatch,
-		codeMissingFlowDefinitionID,
-		codeMissingProjectID:
-		return errorResponseWithStatusCode(http.StatusBadRequest, err)
 	case codeFlowDefinitionInvalid:
-		return errorResponseWithDetails(err, http.StatusBadRequest)
+		return flowDefinitionErrorResponseWithDetails(err, http.StatusBadRequest)
 	case codeFlowDefinitionAlreadyExists, codeFlowDefinitionUpdateConflict:
-		return errorResponseWithDetails(err, http.StatusConflict)
-	case codeFlowDefinitionDenied:
-		return errorResponseWithStatusCode(http.StatusForbidden, err)
+		return flowDefinitionErrorResponseWithDetails(err, http.StatusConflict)
 	default:
-		return internalErrorResponse(err)
+		return domainErrorResponse(err)
 	}
 }
 
+func flowDefinitionErrorResponseWithDetails(err domain.Error, statusCode int) *api.ErrorDetailsStatusCode {
+	return errorResponseWithStatusCode(statusCode, err)
+}
+
 func errorResponseWithDetails(err domain.Error, statusCode int) *api.ErrorDetailsStatusCode {
-	errResp := errorResponseWithStatusCode(statusCode, err)
-	if err.Details == nil {
-		return errResp
-	}
-	if details, ok := err.Details.(string); ok {
-		b, marshalErr := json.Marshal(details)
-		if marshalErr == nil {
-			errResp.Response.Details = api.OptErrorDetailsDetails{
-				Value: api.ErrorDetailsDetails{
-					"details": b,
-				},
-				Set: true,
-			}
-		}
-	}
-	return errResp
+	return errorResponseWithStatusCode(statusCode, err)
 }
 
 func parseURI(s string) (url.URL, error) {

--- a/internal/api/ogenx/iso8601_duration.go
+++ b/internal/api/ogenx/iso8601_duration.go
@@ -1,109 +1,20 @@
 package ogenx
 
 import (
-	"fmt"
-	"regexp"
-	"strconv"
 	"time"
 
-	"github.com/go-faster/jx"
+	"github.com/zitadel/nextgen/internal/isoduration"
 )
 
-var iso8601Duration = regexp.MustCompile(`^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$`)
-
 // ISODuration is an ogen-compatible JSON type for ISO-8601 durations.
-type ISODuration time.Duration
+type ISODuration = isoduration.Duration
 
-func (d ISODuration) Encode(e *jx.Encoder) {
-	e.Str(formatISODuration(time.Duration(d)))
-}
-
-func (d *ISODuration) Decode(dec *jx.Decoder) error {
-	if d == nil {
-		return fmt.Errorf("unable to decode ISODuration to nil")
-	}
-	raw, err := dec.Str()
-	if err != nil {
-		return err
-	}
-	parsed, err := ParseISODuration(raw)
-	if err != nil {
-		return err
-	}
-	*d = ISODuration(parsed)
-	return nil
-}
-
+// ParseISODuration parses raw and returns a time.Duration for callers that
+// still use the standard library duration type.
 func ParseISODuration(raw string) (time.Duration, error) {
-	m := iso8601Duration.FindStringSubmatch(raw)
-	if m == nil {
-		return 0, fmt.Errorf("must be an ISO-8601 duration like PT3H")
+	d, err := isoduration.Parse(raw)
+	if err != nil {
+		return 0, err
 	}
-	if m[1] == "" && m[2] == "" && m[3] == "" && m[4] == "" {
-		return 0, fmt.Errorf("duration must include at least one unit")
-	}
-	total := time.Duration(0)
-	if m[1] != "" {
-		days, err := strconv.ParseInt(m[1], 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid day component")
-		}
-		total += time.Duration(days) * 24 * time.Hour
-	}
-	if m[2] != "" {
-		hours, err := strconv.ParseInt(m[2], 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid hour component")
-		}
-		total += time.Duration(hours) * time.Hour
-	}
-	if m[3] != "" {
-		minutes, err := strconv.ParseInt(m[3], 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid minute component")
-		}
-		total += time.Duration(minutes) * time.Minute
-	}
-	if m[4] != "" {
-		seconds, err := strconv.ParseFloat(m[4], 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid second component")
-		}
-		total += time.Duration(seconds * float64(time.Second))
-	}
-	return total, nil
-}
-
-func formatISODuration(d time.Duration) string {
-	if d < 0 {
-		return "PT0S"
-	}
-	if d == 0 {
-		return "PT0S"
-	}
-	seconds := d / time.Second
-	days := seconds / (24 * 3600)
-	seconds -= days * 24 * 3600
-	hours := seconds / 3600
-	seconds -= hours * 3600
-	minutes := seconds / 60
-	seconds -= minutes * 60
-
-	out := "P"
-	if days > 0 {
-		out += fmt.Sprintf("%dD", days)
-	}
-	if hours > 0 || minutes > 0 || seconds > 0 {
-		out += "T"
-		if hours > 0 {
-			out += fmt.Sprintf("%dH", hours)
-		}
-		if minutes > 0 {
-			out += fmt.Sprintf("%dM", minutes)
-		}
-		if seconds > 0 {
-			out += fmt.Sprintf("%dS", seconds)
-		}
-	}
-	return out
+	return d.Std(), nil
 }

--- a/internal/api/ogenx/iso8601_duration_test.go
+++ b/internal/api/ogenx/iso8601_duration_test.go
@@ -1,4 +1,4 @@
-package ogenx
+package ogenx_test
 
 import (
 	"testing"
@@ -6,42 +6,30 @@ import (
 
 	"github.com/go-faster/jx"
 	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/api/ogenx"
 )
 
 func TestParseISODuration(t *testing.T) {
-	for _, tt := range []struct {
-		name    string
-		raw     string
-		want    time.Duration
-		wantErr bool
-	}{
-		{name: "hours", raw: "PT3H", want: 3 * time.Hour},
-		{name: "minutes", raw: "PT45M", want: 45 * time.Minute},
-		{name: "composite", raw: "P1DT2H3M4S", want: 24*time.Hour + 2*time.Hour + 3*time.Minute + 4*time.Second},
-		{name: "invalid", raw: "3h", wantErr: true},
-		{name: "empty payload", raw: "P", wantErr: true},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseISODuration(tt.raw)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
-		})
-	}
+	t.Parallel()
+
+	got, err := ogenx.ParseISODuration("PT3H")
+	require.NoError(t, err)
+	require.Equal(t, 3*time.Hour, got)
 }
 
 func TestISODurationDecode(t *testing.T) {
-	var d ISODuration
+	t.Parallel()
+
+	var d ogenx.ISODuration
 	dec := jx.DecodeStr(`"PT2H"`)
 	require.NoError(t, d.Decode(dec))
-	require.EqualValues(t, 2*time.Hour, d)
+	require.Equal(t, 2*time.Hour, d.Std())
 }
 
 func TestISODurationEncode(t *testing.T) {
-	var d = ISODuration(2 * time.Hour)
+	t.Parallel()
+
+	d := ogenx.ISODuration(time.Duration(2 * time.Hour))
 	encoder := jx.GetEncoder()
 	defer jx.PutEncoder(encoder)
 

--- a/internal/api/project.go
+++ b/internal/api/project.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"errors"
-	"net/http"
 
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
@@ -48,14 +47,5 @@ func (h *Handler) GetProject(ctx context.Context, params api.GetProjectParams) (
 // ------------------ Errors ---------------
 
 func projectErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	switch err.Code {
-	case domain.ErrProjectNotFound().Code:
-		return errorResponseWithStatusCode(http.StatusNotFound, err)
-	case domain.ErrProjectPermissionDenied().Code:
-		return errorResponseWithStatusCode(http.StatusForbidden, err)
-	case domain.ErrProjectNameInvalid().Code:
-		return errorResponseWithStatusCode(http.StatusBadRequest, err)
-	default:
-		return internalErrorResponse(err)
-	}
+	return domainErrorResponse(err)
 }

--- a/internal/api/project.go
+++ b/internal/api/project.go
@@ -43,9 +43,3 @@ func (h *Handler) GetProject(ctx context.Context, params api.GetProjectParams) (
 		UpdatedAt: project.UpdatedAt,
 	}, nil
 }
-
-// ------------------ Errors ---------------
-
-func projectErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	return domainErrorResponse(err)
-}

--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"errors"
-	"net/http"
 
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
@@ -98,18 +97,7 @@ func (h *Handler) ListSchemas(ctx context.Context, params api.ListSchemasParams)
 // ------------------ Errors ---------------
 
 func schemaErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	switch err.Code {
-	case domain.ErrJSONSchemaNotFound().Code:
-		return errorResponseWithStatusCode(http.StatusNotFound, err)
-	case domain.ErrJSONSchemaAlreadyExists().Code:
-		return errorResponseWithStatusCode(http.StatusConflict, err)
-	case domain.ErrJSONSchemaInvalid().Code:
-		return errorResponseWithStatusCode(http.StatusBadRequest, err)
-	case domain.ErrJSONSchemaPermissionDenied().Code:
-		return errorResponseWithStatusCode(http.StatusForbidden, err)
-	default:
-		return internalErrorResponse(err)
-	}
+	return domainErrorResponse(err)
 }
 
 var unknownSchemaKindError = errors.New("unknown kind of schema")

--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -94,10 +94,4 @@ func (h *Handler) ListSchemas(ctx context.Context, params api.ListSchemasParams)
 	return &resp, nil
 }
 
-// ------------------ Errors ---------------
-
-func schemaErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	return domainErrorResponse(err)
-}
-
 var unknownSchemaKindError = errors.New("unknown kind of schema")

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -281,50 +281,41 @@ func sessionCookie(token string, maxAge int) string {
 }
 
 func sessionErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	switch err.Code {
-	case domain.ErrSessionNotFound().Code:
-		return errorResponseWithStatusCode(http.StatusNotFound, err)
-	case domain.ErrSessionTokenCreationFailed().Code:
-		return errorResponseWithStatusCode(http.StatusInternalServerError, err)
-	case domain.ErrSessionExchangeConflict().Code,
-		domain.ErrSessionInvalidHandoffToken().Code:
-		return errorResponseWithStatusCode(http.StatusBadRequest, err)
-	case domain.ErrSessionTokenInvalid().Code:
-		return errorResponseWithStatusCode(http.StatusUnauthorized, err)
-	case domain.ErrNotImplemented().Code:
-		return errorResponseWithStatusCode(http.StatusNotImplemented, err)
-	case domain.ErrSessionInvalidTTL().Code:
-		apiErr := &api.ErrorDetailsStatusCode{
-			StatusCode: http.StatusBadRequest,
-		}
-
-		details, ok := err.Details.(domain.SessionInvalidTTLDetails)
-		if !ok {
-			apiErr.Response = domainErrorDetails(err)
-			return apiErr
-		}
-
-		encoder := jx.GetEncoder()
-		defer jx.PutEncoder(encoder)
-
-		encoder.ObjStart()
-		encoder.Field("ttl", ogenx.ISODuration(details.TTL).Encode)
-		encoder.Field("max_ttl", ogenx.ISODuration(details.MaxTTL).Encode)
-		encoder.ObjEnd()
-
-		apiErr.Response = api.ErrorDetails{
-			Code:    api.ErrorCode(err.Code),
-			Message: err.Message,
-			Details: api.OptErrorDetailsDetails{
-				Set: true,
-				Value: api.ErrorDetailsDetails{
-					"details": jx.Raw(encoder.Bytes()),
-				},
-			},
-		}
-		return apiErr
-	default:
-		return internalErrorResponse(err)
-
+	if err.Code == domain.ErrSessionInvalidTTL().Code {
+		return sessionInvalidTTLResponse(err)
 	}
+	return domainErrorResponse(err)
+}
+
+func sessionInvalidTTLResponse(err domain.Error) *api.ErrorDetailsStatusCode {
+	apiErr := &api.ErrorDetailsStatusCode{
+		StatusCode: http.StatusBadRequest,
+	}
+
+	ttlDetails, ok := err.Details.(domain.SessionInvalidTTLDetails)
+	if !ok {
+		apiErr.Response = domainErrorDetails(err)
+		return apiErr
+	}
+
+	apiErr.Response = api.ErrorDetails{
+		Code:    api.ErrorCode(err.Code),
+		Message: err.Message,
+		Details: marshalSessionInvalidTTLDetails(ttlDetails),
+	}
+	return apiErr
+}
+
+func marshalSessionInvalidTTLDetails(details domain.SessionInvalidTTLDetails) api.OptErrorDetailsDetails {
+	encoder := jx.GetEncoder()
+	defer jx.PutEncoder(encoder)
+
+	encoder.ObjStart()
+	encoder.Field("ttl", ogenx.ISODuration(details.TTL).Encode)
+	encoder.Field("max_ttl", ogenx.ISODuration(details.MaxTTL).Encode)
+	encoder.ObjEnd()
+
+	return api.NewOptErrorDetailsDetails(api.ErrorDetailsDetails{
+		"details": jx.Raw(encoder.Bytes()),
+	})
 }

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -277,7 +277,3 @@ func deleteSessionCookie() string {
 func sessionCookie(token string, maxAge int) string {
 	return fmt.Sprintf("%s=%s; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=%d", sessionCookieName, token, maxAge)
 }
-
-func sessionErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	return domainErrorResponse(err)
-}

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/go-faster/jx"
 	"github.com/muhlemmer/gu"
 	api "github.com/zitadel/nextgen/api/generated"
-	"github.com/zitadel/nextgen/internal/api/ogenx"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
 )
@@ -281,41 +279,5 @@ func sessionCookie(token string, maxAge int) string {
 }
 
 func sessionErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	if err.Code == domain.ErrSessionInvalidTTL().Code {
-		return sessionInvalidTTLResponse(err)
-	}
 	return domainErrorResponse(err)
-}
-
-func sessionInvalidTTLResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	apiErr := &api.ErrorDetailsStatusCode{
-		StatusCode: http.StatusBadRequest,
-	}
-
-	ttlDetails, ok := err.Details.(domain.SessionInvalidTTLDetails)
-	if !ok {
-		apiErr.Response = domainErrorDetails(err)
-		return apiErr
-	}
-
-	apiErr.Response = api.ErrorDetails{
-		Code:    api.ErrorCode(err.Code),
-		Message: err.Message,
-		Details: marshalSessionInvalidTTLDetails(ttlDetails),
-	}
-	return apiErr
-}
-
-func marshalSessionInvalidTTLDetails(details domain.SessionInvalidTTLDetails) api.OptErrorDetailsDetails {
-	encoder := jx.GetEncoder()
-	defer jx.PutEncoder(encoder)
-
-	encoder.ObjStart()
-	encoder.Field("ttl", ogenx.ISODuration(details.TTL).Encode)
-	encoder.Field("max_ttl", ogenx.ISODuration(details.MaxTTL).Encode)
-	encoder.ObjEnd()
-
-	return api.NewOptErrorDetailsDetails(api.ErrorDetailsDetails{
-		"details": jx.Raw(encoder.Bytes()),
-	})
 }

--- a/internal/api/team.go
+++ b/internal/api/team.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	api "github.com/zitadel/nextgen/api/generated"
-	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
 )
 
@@ -35,10 +34,4 @@ func (h *Handler) GetTeam(ctx context.Context, params api.GetTeamParams) (api.Ge
 		CreatedAt: team.CreatedAt,
 		UpdatedAt: team.UpdatedAt,
 	}, nil
-}
-
-// ------------------ Errors ---------------
-
-func teamErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	return domainErrorResponse(err)
 }

--- a/internal/api/team.go
+++ b/internal/api/team.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"net/http"
 
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
@@ -41,14 +40,5 @@ func (h *Handler) GetTeam(ctx context.Context, params api.GetTeamParams) (api.Ge
 // ------------------ Errors ---------------
 
 func teamErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	switch err.Code {
-	case domain.ErrTeamNotFound().Code:
-		return errorResponseWithStatusCode(http.StatusNotFound, err)
-	case domain.ErrTeamProjectNotFound().Code:
-		return errorResponseWithStatusCode(http.StatusNotFound, err)
-	case domain.ErrTeamPermissionDenied().Code:
-		return errorResponseWithStatusCode(http.StatusForbidden, err)
-	default:
-		return internalErrorResponse(err)
-	}
+	return domainErrorResponse(err)
 }

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"net/http"
 
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
@@ -136,16 +135,5 @@ func (h *Handler) GetMyUser(ctx context.Context) (api.GetMyUserRes, error) {
 // ------------------ Errors ---------------
 
 func userErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	switch err.Code {
-	case domain.ErrUserInvalid().Code:
-		return errorResponseWithStatusCode(http.StatusBadRequest, err)
-	case domain.ErrUserNotFound().Code:
-		return errorResponseWithStatusCode(http.StatusNotFound, err)
-	case domain.ErrUserAlreadyExists().Code:
-		return errorResponseWithStatusCode(http.StatusConflict, err)
-	case domain.ErrUserPermissionDenied().Code:
-		return errorResponseWithStatusCode(http.StatusForbidden, err)
-	default:
-		return internalErrorResponse(err)
-	}
+	return domainErrorResponse(err)
 }

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -131,9 +131,3 @@ func (h *Handler) GetMyUser(ctx context.Context) (api.GetMyUserRes, error) {
 	}
 	return user, nil
 }
-
-// ------------------ Errors ---------------
-
-func userErrorResponse(err domain.Error) *api.ErrorDetailsStatusCode {
-	return domainErrorResponse(err)
-}

--- a/internal/domain/error.go
+++ b/internal/domain/error.go
@@ -120,3 +120,8 @@ func ErrInternal(err error) Error {
 func ErrRequestInvalid() Error {
 	return newError("req.invalid", "The request is invalid and fails base validation (missing required fields, wrong types, failed regex, etc.). Check the details for more information.", nil, nil)
 }
+
+// RequestInvalidFieldDetails names a request field that failed validation.
+type RequestInvalidFieldDetails struct {
+	Field string `json:"field"`
+}

--- a/internal/domain/schema_sensitive.go
+++ b/internal/domain/schema_sensitive.go
@@ -1,0 +1,18 @@
+package domain
+
+// IsSensitiveProperty reports whether a JSON Schema property is marked sensitive.
+// The canonical extension in this repo is x-sensitive (see user-property.yaml).
+func IsSensitiveProperty(propertySchema map[string]any) bool {
+	if propertySchema == nil {
+		return false
+	}
+	if v, ok := propertySchema["x-sensitive"]; ok {
+		switch t := v.(type) {
+		case bool:
+			return t
+		case float64:
+			return t != 0
+		}
+	}
+	return false
+}

--- a/internal/domain/schema_sensitive_test.go
+++ b/internal/domain/schema_sensitive_test.go
@@ -1,0 +1,17 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+func TestIsSensitiveProperty(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, domain.IsSensitiveProperty(nil))
+	assert.False(t, domain.IsSensitiveProperty(map[string]any{}))
+	assert.False(t, domain.IsSensitiveProperty(map[string]any{"x-sensitive": false}))
+	assert.True(t, domain.IsSensitiveProperty(map[string]any{"x-sensitive": true}))
+}

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/muhlemmer/gu"
+	"github.com/zitadel/nextgen/internal/isoduration"
 	"github.com/zitadel/nextgen/internal/storage/database"
 )
 
@@ -38,14 +39,14 @@ func ErrSessionInvalidTTL() Error {
 }
 
 type SessionInvalidTTLDetails struct {
-	TTL    time.Duration `json:"ttl"`
-	MaxTTL time.Duration `json:"max_ttl"`
+	TTL    isoduration.Duration `json:"ttl"`
+	MaxTTL isoduration.Duration `json:"max_ttl"`
 }
 
 func sessionInvalidTTLErr(requested, maxTTL time.Duration) Error {
 	return ErrSessionInvalidTTL().WithDetails(SessionInvalidTTLDetails{
-		TTL:    requested,
-		MaxTTL: maxTTL,
+		TTL:    isoduration.From(requested),
+		MaxTTL: isoduration.From(maxTTL),
 	})
 }
 

--- a/internal/domain/session_ttl_test.go
+++ b/internal/domain/session_ttl_test.go
@@ -1,7 +1,6 @@
 package domain_test
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -65,14 +64,8 @@ func assertSessionInvalidTTLDetails(t *testing.T, err error, wantTTL, wantMax ti
 	t.Helper()
 	var domErr domain.Error
 	require.ErrorAs(t, err, &domErr)
-	require.NotNil(t, domErr.Details)
-	b, err := json.Marshal(domErr.Details)
-	require.NoError(t, err)
-	var got struct {
-		TTL    time.Duration `json:"ttl"`
-		MaxTTL time.Duration `json:"max_ttl"`
-	}
-	require.NoError(t, json.Unmarshal(b, &got))
-	assert.Equal(t, wantTTL, got.TTL)
-	assert.Equal(t, wantMax, got.MaxTTL)
+	details, ok := domErr.Details.(domain.SessionInvalidTTLDetails)
+	require.True(t, ok)
+	assert.Equal(t, wantTTL, details.TTL.Std())
+	assert.Equal(t, wantMax, details.MaxTTL.Std())
 }

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -222,8 +222,9 @@ func NewCreateUser(projectID string, teamID *string, id string, schemabs []byte,
 func SchemaFromUserMap(user map[string]any) (string, error) {
 	schemaURL, ok := maputil.Get[string](user, "$schema")
 	if !ok {
-		return "", ErrUserInvalid().
-			WithDetails("No $schema provided for the user. A schema must be provided when creating a new user. Against this schema, the user will be validated")
+		return "", ErrUserInvalid().WithMessage(
+			"No $schema provided for the user. A schema must be provided when creating a new user. Against this schema, the user will be validated",
+		)
 	}
 	return schemaURL, nil
 }

--- a/internal/isoduration/duration.go
+++ b/internal/isoduration/duration.go
@@ -1,0 +1,141 @@
+package isoduration
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/go-faster/jx"
+)
+
+var iso8601Duration = regexp.MustCompile(`^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$`)
+
+// Duration is an ISO-8601 duration for JSON APIs (for example PT3H, P1D).
+type Duration time.Duration
+
+// From converts a standard library duration to an ISO-serializable duration.
+func From(d time.Duration) Duration {
+	return Duration(d)
+}
+
+// Std returns the underlying time.Duration for domain calculations.
+func (d Duration) Std() time.Duration {
+	return time.Duration(d)
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Format(d.Std()))
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var raw string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	parsed, err := Parse(raw)
+	if err != nil {
+		return err
+	}
+	*d = parsed
+	return nil
+}
+
+// Encode implements ogen/jx JSON encoding for request and response bodies.
+func (d Duration) Encode(e *jx.Encoder) {
+	e.Str(Format(d.Std()))
+}
+
+// Decode implements ogen/jx JSON decoding for request and response bodies.
+func (d *Duration) Decode(dec *jx.Decoder) error {
+	if d == nil {
+		return fmt.Errorf("unable to decode Duration to nil")
+	}
+	raw, err := dec.Str()
+	if err != nil {
+		return err
+	}
+	parsed, err := Parse(raw)
+	if err != nil {
+		return err
+	}
+	*d = parsed
+	return nil
+}
+
+// Parse parses an ISO-8601 duration string into a Duration.
+func Parse(raw string) (Duration, error) {
+	m := iso8601Duration.FindStringSubmatch(raw)
+	if m == nil {
+		return 0, fmt.Errorf("must be an ISO-8601 duration like PT3H")
+	}
+	if m[1] == "" && m[2] == "" && m[3] == "" && m[4] == "" {
+		return 0, fmt.Errorf("duration must include at least one unit")
+	}
+	total := time.Duration(0)
+	if m[1] != "" {
+		days, err := strconv.ParseInt(m[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid day component")
+		}
+		total += time.Duration(days) * 24 * time.Hour
+	}
+	if m[2] != "" {
+		hours, err := strconv.ParseInt(m[2], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid hour component")
+		}
+		total += time.Duration(hours) * time.Hour
+	}
+	if m[3] != "" {
+		minutes, err := strconv.ParseInt(m[3], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid minute component")
+		}
+		total += time.Duration(minutes) * time.Minute
+	}
+	if m[4] != "" {
+		seconds, err := strconv.ParseFloat(m[4], 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid second component")
+		}
+		total += time.Duration(seconds * float64(time.Second))
+	}
+	return Duration(total), nil
+}
+
+// Format renders d as an ISO-8601 duration string.
+func Format(d time.Duration) string {
+	if d < 0 {
+		return "PT0S"
+	}
+	if d == 0 {
+		return "PT0S"
+	}
+	seconds := d / time.Second
+	days := seconds / (24 * 3600)
+	seconds -= days * 24 * 3600
+	hours := seconds / 3600
+	seconds -= hours * 3600
+	minutes := seconds / 60
+	seconds -= minutes * 60
+
+	out := "P"
+	if days > 0 {
+		out += fmt.Sprintf("%dD", days)
+	}
+	if hours > 0 || minutes > 0 || seconds > 0 {
+		out += "T"
+		if hours > 0 {
+			out += fmt.Sprintf("%dH", hours)
+		}
+		if minutes > 0 {
+			out += fmt.Sprintf("%dM", minutes)
+		}
+		if seconds > 0 {
+			out += fmt.Sprintf("%dS", seconds)
+		}
+	}
+	return out
+}

--- a/internal/isoduration/duration_test.go
+++ b/internal/isoduration/duration_test.go
@@ -1,0 +1,68 @@
+package isoduration_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-faster/jx"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/isoduration"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "hours", raw: "PT3H", want: 3 * time.Hour},
+		{name: "minutes", raw: "PT45M", want: 45 * time.Minute},
+		{name: "composite", raw: "P1DT2H3M4S", want: 24*time.Hour + 2*time.Hour + 3*time.Minute + 4*time.Second},
+		{name: "invalid", raw: "3h", wantErr: true},
+		{name: "empty payload", raw: "P", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := isoduration.Parse(tt.raw)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got.Std())
+		})
+	}
+}
+
+func TestFormat(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "PT2H", isoduration.Format(2*time.Hour))
+	require.Equal(t, "PT0S", isoduration.Format(0))
+	require.Equal(t, "P1D", isoduration.Format(24*time.Hour))
+}
+
+func TestDurationMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	b, err := json.Marshal(isoduration.From(2 * time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, `"PT2H"`, string(b))
+}
+
+func TestDurationDecodeEncode(t *testing.T) {
+	t.Parallel()
+
+	var d isoduration.Duration
+	dec := jx.DecodeStr(`"PT2H"`)
+	require.NoError(t, d.Decode(dec))
+	require.Equal(t, 2*time.Hour, d.Std())
+
+	encoder := jx.GetEncoder()
+	defer jx.PutEncoder(encoder)
+	d.Encode(encoder)
+	require.Equal(t, `"PT2H"`, encoder.String())
+}

--- a/internal/service/auth_attempt.go
+++ b/internal/service/auth_attempt.go
@@ -491,7 +491,7 @@ func (s *authAttemptService) verify(ctx context.Context, attempt *domain.AuthAtt
 		return passkeyChallenge, attempt.SetPasskeyFactor(verification), nil
 
 	default:
-		return nil, nil, domain.ErrAuthAttemptInvalidRequest().WithDetails("unsupported proof type")
+		return nil, nil, domain.ErrAuthAttemptInvalidRequest().WithMessage("unsupported proof type")
 	}
 }
 

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -233,7 +233,7 @@ func (o *CreateUserAction) Prepare(ctx context.Context, db database.QueryExecuto
 	schemaEntity, err := o.schemaRepo.GetByID(ctx, db, o.ProjectID, schemaURL)
 	if err != nil {
 		if _, ok := errors.AsType[*database.NoRowFoundError](err); ok {
-			return domain.ErrUserInvalid().WithDetails("$schema is not known to the system. First create a schema, then create users.")
+			return domain.ErrUserInvalid().WithMessage("$schema is not known to the system. First create a schema, then create users.")
 		}
 		return domain.ErrInternal(err).WithMessage("failed to get schema from database")
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #585](https://github.com/zitadel/nextgen/issues/585) contract hardening across three areas:

1. **Status map dedup** — single `codeHTTPStatus` manifest in `internal/api/error_status.go`; all domain errors route through `domainErrorResponse`.
2. **Selective details** — shared `marshalErrorDetails`; structured `RequestInvalidFieldDetails` for flow field decode; string blobs moved to `Message` where appropriate.
3. **Schema sensitivity docs** — path/query audit runbook and `x-sensitive` cross-links.

Follow-up cleanup in this PR:
- Session TTL details use `internal/isoduration.Duration` (ISO wire encoding at the type, not per-handler).
- Removed thin `*_errorResponse` wrappers that only delegated to `domainErrorResponse`; `errorResponse` now calls the manifest directly.

## Validation

- `go test ./internal/isoduration/ ./internal/api/ ./internal/domain/` — pass

## Release notes / changeset

Changeset included (`.changeset/issue-585-contract-hardening.md`) — API error envelope behavior change for consumers parsing details.

## Notes

- Authz opaque `WithDetails("project does not exist")` intentionally deferred.
- Legacy `details.details` nesting preserved in `marshalErrorDetails`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acf6b6fd-2b35-4033-8ca0-1e395f67e055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acf6b6fd-2b35-4033-8ca0-1e395f67e055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

