### PR TITLE
build: cross-compile and pack release artifacts concurrently

### DIFF
--- a/apps/cli/tests/unit/scripts/dev-process.test.ts
+++ b/apps/cli/tests/unit/scripts/dev-process.test.ts
@@ -83,4 +83,16 @@ describe("mapWithConcurrency", () => {
       mapWithConcurrency(["a", "b"], 16, async (item, index) => `${item}${index}`),
     ).resolves.toEqual(["a0", "b1"]);
   });
+
+  it("rejects limits that are not positive integers instead of silently no-oping", async () => {
+    const { mapWithConcurrency } = await loadModule();
+
+    // A NaN limit previously produced zero worker lanes: the call returned
+    // an all-undefined result array without running any work.
+    for (const limit of [Number.NaN, 0, -1, 2.5, Number.POSITIVE_INFINITY]) {
+      await expect(mapWithConcurrency(["a"], limit, async (item) => item)).rejects.toThrow(
+        "positive integer limit",
+      );
+    }
+  });
 });

--- a/apps/cli/tests/unit/scripts/dev-process.test.ts
+++ b/apps/cli/tests/unit/scripts/dev-process.test.ts
@@ -5,6 +5,11 @@ import { describe, expect, it } from "vitest";
 
 type DevProcessModule = {
   isDirectRun: (moduleUrl: string, argv?: string[]) => boolean;
+  mapWithConcurrency: <T, R>(
+    items: T[],
+    limit: number,
+    worker: (item: T, index: number) => Promise<R>,
+  ) => Promise<R[]>;
 };
 
 async function loadModule(): Promise<DevProcessModule> {
@@ -28,5 +33,54 @@ describe("dev-process helpers", () => {
 
     expect(isDirectRun(moduleUrl, [process.execPath])).toBe(false);
     expect(isDirectRun(moduleUrl, [process.execPath, "scripts/doctor.mjs"])).toBe(false);
+  });
+});
+
+describe("mapWithConcurrency", () => {
+  it("preserves input order in results and never exceeds the limit", async () => {
+    const { mapWithConcurrency } = await loadModule();
+
+    let inFlight = 0;
+    let peak = 0;
+    const results = await mapWithConcurrency([5, 4, 3, 2, 1], 2, async (item) => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      // Later items finish faster to prove results are ordered by input,
+      // not by completion.
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, item * 4));
+      inFlight -= 1;
+      return item * 10;
+    });
+
+    expect(results).toEqual([50, 40, 30, 20, 10]);
+    expect(peak).toBe(2);
+  });
+
+  it("stops starting new work after a failure and rethrows the first error", async () => {
+    const { mapWithConcurrency } = await loadModule();
+
+    const started: number[] = [];
+    await expect(
+      mapWithConcurrency([0, 1, 2, 3, 4, 5], 2, async (item) => {
+        started.push(item);
+        if (item === 1) {
+          throw new Error(`boom on ${item}`);
+        }
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 10));
+        return item;
+      }),
+    ).rejects.toThrow("boom on 1");
+
+    // Lanes finish their in-flight item but pull nothing new once failed.
+    expect(started.length).toBeLessThan(6);
+  });
+
+  it("handles empty input and limits larger than the input", async () => {
+    const { mapWithConcurrency } = await loadModule();
+
+    await expect(mapWithConcurrency([], 4, async () => "x")).resolves.toEqual([]);
+    await expect(
+      mapWithConcurrency(["a", "b"], 16, async (item, index) => `${item}${index}`),
+    ).resolves.toEqual(["a0", "b1"]);
   });
 });

--- a/scripts/dev-process.mjs
+++ b/scripts/dev-process.mjs
@@ -90,6 +90,42 @@ export function formatCommand(command, args = []) {
   return [command, ...args].map(shellQuote).join(" ");
 }
 
+// Maps items through an async worker with at most `limit` in flight,
+// preserving input order in the results. After a failure no new work starts,
+// but in-flight workers are awaited (their child processes cannot be
+// abandoned safely); the first error is rethrown once all lanes settle.
+export async function mapWithConcurrency(items, limit, worker) {
+  const entries = [...items];
+  const results = new Array(entries.length);
+  const errors = [];
+  const width = Math.max(1, Math.min(limit, entries.length));
+  let next = 0;
+  let failed = false;
+
+  await Promise.all(
+    Array.from({ length: width }, async () => {
+      while (!failed) {
+        const index = next;
+        next += 1;
+        if (index >= entries.length) {
+          return;
+        }
+        try {
+          results[index] = await worker(entries[index], index);
+        } catch (error) {
+          errors.push(error);
+          failed = true;
+        }
+      }
+    }),
+  );
+
+  if (errors.length > 0) {
+    throw errors[0];
+  }
+  return results;
+}
+
 export function forwardedArgs(args = process.argv.slice(2)) {
   return args[0] === "--" ? args.slice(1) : args;
 }

--- a/scripts/dev-process.mjs
+++ b/scripts/dev-process.mjs
@@ -95,10 +95,16 @@ export function formatCommand(command, args = []) {
 // but in-flight workers are awaited (their child processes cannot be
 // abandoned safely); the first error is rethrown once all lanes settle.
 export async function mapWithConcurrency(items, limit, worker) {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error(`mapWithConcurrency requires a positive integer limit, got ${limit}`);
+  }
   const entries = [...items];
+  if (entries.length === 0) {
+    return [];
+  }
   const results = new Array(entries.length);
   const errors = [];
-  const width = Math.max(1, Math.min(limit, entries.length));
+  const width = Math.min(limit, entries.length);
   let next = 0;
   let failed = false;
 

--- a/scripts/release-artifacts.mjs
+++ b/scripts/release-artifacts.mjs
@@ -5,7 +5,7 @@ import { chmod, copyFile, mkdir, readFile, readdir, rm, stat, writeFile } from "
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { run, runCapture } from "./dev-process.mjs";
+import { mapWithConcurrency, run, runCapture } from "./dev-process.mjs";
 import {
   PUBLIC_PACKAGE_DIRS,
   PUBLIC_RELEASE_PACKAGES,
@@ -93,7 +93,9 @@ export async function buildServerBinaries(options = {}) {
   const runFn = options.run ?? run;
   const baseEnv = { ...process.env, ...(options.env ?? {}) };
 
-  for (const platform of platforms) {
+  // The per-platform builds are independent and the Go build cache is safe
+  // under concurrency, so cross-compile all platforms at once.
+  await mapWithConcurrency(platforms, platforms.length, async (platform) => {
     const dir = platformDir(outDir, platform);
     const output = join(dir, binaryName(platform.goos));
     await mkdir(dir, { recursive: true });
@@ -123,7 +125,7 @@ export async function buildServerBinaries(options = {}) {
         },
       },
     );
-  }
+  });
 
   return { outDir, platforms, version, gitInfo: info };
 }
@@ -227,7 +229,10 @@ export async function packPublicPackages(options = {}) {
   await rm(tarballsDir, { recursive: true, force: true });
   await mkdir(tarballsDir, { recursive: true });
 
-  for (const dir of PUBLIC_PACKAGE_DIRS) {
+  // Packs are independent (distinct package dirs, distinct tarball names in a
+  // shared destination); cap concurrency so the cli prepack rebuild and the
+  // larger packages do not stampede the runner.
+  await mapWithConcurrency(PUBLIC_PACKAGE_DIRS, 8, async (dir) => {
     const manifest = await readPackageManifest(repoRoot, join(dir, "package.json"));
     await assertPublishDirectoryReady({ repoRoot, dir, manifest });
     // `pnpm pack` runs the package's `prepack`, which for @zitadel/cli rebuilds
@@ -242,7 +247,7 @@ export async function packPublicPackages(options = {}) {
       cwd: repoRoot,
       env,
     });
-  }
+  });
 
   return tarballsDir;
 }


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why. -->

- `buildServerBinaries` compiled the 5 server platforms strictly in sequence and `packPublicPackages` packed the 19 public packages one by one. Both loops are independent per item, so they now run through a new `mapWithConcurrency` helper in `scripts/dev-process.mjs` (order-preserving results, no new work started after a failure, in-flight children awaited).
- All 5 `go build`s run at once — the Go build cache is concurrency-safe; the win comes from overlapping the serial link phases. Measured locally with a cold cache: 1m56 → 1m33 (~20%); warm-cache runs (the CI norm with the restored setup-go cache) save proportionally more.
- `pnpm pack` runs with concurrency 8 into the shared tarballs dir (distinct filenames; the `@zitadel/cli` prepack rebuild keeps its production telemetry-channel stamp).
- This shortens the release-artifact build step every full PR pays (and the publish/build job), independent of the pipeline rework in #487 — which merges over this cleanly since it doesn't touch these function bodies.

## Validation

<!-- List exact commands run. If validation was not run, say so explicitly. -->

- `moon run release:pack` then `node apps/cli-journey-e2e/scripts/verify-tarballs.mjs dist/release/<v>/npm` — 19 installable tarballs verified
- Cold-cache timing A/B via direct `buildServerBinaries` invocation (`go clean -cache` before each): sequential 1m55.9s, parallel 1m32.8s
- `vitest run tests/unit/scripts/dev-process.test.ts tests/unit/scripts/release-artifacts.test.ts` — 12 tests green (new coverage: order preservation, concurrency cap, fail-fast semantics, empty input)
- `moon run cli:lint` — clean

## Release notes / changeset

- No changeset required — no shipped behavior changed (release build scripts and tests only; no publishable package source is touched).

## Notes

- Failure semantics are deliberately "finish in-flight, start nothing new": spawned `go`/`pnpm` children cannot be abandoned safely, so a failing platform/package surfaces after the current lane items settle, with the first error rethrown.
- Log lines from concurrent packs interleave; Moon already interleaves parallel task output, so this matches the existing CI log shape.