### PR TITLE
refactor: source container max-widths from Figma

### DIFF
--- a/packages/design-tokens/scripts/build.ts
+++ b/packages/design-tokens/scripts/build.ts
@@ -1,8 +1,8 @@
 /**
  * Builds the public token surfaces of `@zitadel/design-tokens` from:
  *   - `src/legacy.tokens.json` — frozen legacy `--zl-color-*` surface
- *   - `src/generated/figma.tokens.json` — resolved shadcn semantic colours
- *   - `src/overrides.ts` — typography, motion, focus, breakpoints, containers
+ *   - `src/generated/figma.tokens.json` — resolved shadcn colours + container scale
+ *   - `src/overrides.ts` — fonts, motion, focus, breakpoints, gray primitives
  *
  * Emits four files into `src/generated/`:
  *
@@ -68,6 +68,8 @@ interface ShadcnTokensFile {
   text: Record<string, unknown>;
   fontFamily: Record<string, string>;
   fontWeight: Record<string, number>;
+  /** Figma's `container/*` max-width scale in px (`sm`=384 … `7xl`=1280). */
+  container: Record<string, Px>;
   typography: Record<string, Record<string, unknown>>;
 }
 
@@ -214,10 +216,10 @@ function build(): BuildResult {
     push(cssVarName("breakpoint", name), value, ["breakpoint", name]);
   }
 
-  // ---- overrides: container max-widths ----
-  for (const [name, value] of Object.entries(overrides.container)) {
-    push(cssVarName("container", kebab(name)), value, ["container", name]);
-  }
+  // ---- container max-widths: Zitadel semantic roles mapped onto Figma's `container/*` scale ----
+  // Figma owns the pixel values; build owns which scale step each role uses.
+  push(cssVarName("container", "auth-card"), pxToRem(containerStep("sm")), ["container", "authCard"]);
+  push(cssVarName("container", "page"), pxToRem(containerStep("7xl")), ["container", "page"]);
 
   // ---- layout: grid columns / gutter / margin (columns unitless, spacing in rem) ----
   for (const [name, value] of Object.entries(figma.layout ?? {})) {
@@ -244,6 +246,15 @@ function setDeep(target: Record<string, unknown>, path: string[], value: string)
     cursor = cursor[key] as Record<string, unknown>;
   }
   cursor[path[path.length - 1] ?? ""] = value;
+}
+
+/** Read a step from Figma's container scale, failing loud if the designer dropped it. */
+function containerStep(name: string): Px {
+  const px = shadcn.container?.[name];
+  if (typeof px !== "number") {
+    throw new Error(`figma.tokens.json is missing container.${name} — cannot emit the container max-width surface`);
+  }
+  return px;
 }
 
 function resolveFocusColor(): Hex {
@@ -362,9 +373,6 @@ function emitShadcn(shadcnColorVars: string[]): string {
 
 function toCamel(s: string): string {
   return s.replace(/[-_/](.)/g, (_, ch) => ch.toUpperCase());
-}
-function kebab(s: string): string {
-  return s.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 }
 function sortedNumeric<V>(record: Record<string, V>): Array<[string, V]> {
   return Object.entries(record).sort(([a], [b]) => Number(a) - Number(b));

--- a/packages/design-tokens/scripts/sync-from-export.ts
+++ b/packages/design-tokens/scripts/sync-from-export.ts
@@ -23,7 +23,7 @@
  *   - any other multi-mode collection is treated as viewport typography
  *     (its leaves become `typography.<mode>.<name>`);
  *   - single-mode collections contribute primitives, surfaced by group name
- *     (`radius`, `text`, `font`, `font-weight`).
+ *     (`radius`, `text`, `font`, `font-weight`, `container`).
  */
 import { access, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
@@ -253,6 +253,8 @@ export interface SyncedTokens {
   text: Record<string, unknown>;
   fontFamily: Record<string, unknown>;
   fontWeight: Record<string, unknown>;
+  /** Figma's `container/*` max-width scale (px). `build.ts` maps semantic roles onto these steps. */
+  container: Record<string, unknown>;
   typography: Record<string, Record<string, unknown>>;
 }
 
@@ -329,6 +331,7 @@ export function syncTokens(files: Array<{ name: string; data: unknown }>): Synce
     text: buildGroup("text", singleMode, registry),
     fontFamily: buildGroup("font", singleMode, registry),
     fontWeight: buildGroup("font-weight", singleMode, registry),
+    container: buildGroup("container", singleMode, registry),
     typography,
   };
 }

--- a/packages/design-tokens/src/generated/figma.tokens.json
+++ b/packages/design-tokens/src/generated/figma.tokens.json
@@ -229,6 +229,21 @@
     "extrabold": 800,
     "black": 900
   },
+  "container": {
+    "3xs": 256,
+    "2xs": 288,
+    "xs": 320,
+    "sm": 384,
+    "md": 448,
+    "lg": 512,
+    "xl": 576,
+    "2xl": 672,
+    "3xl": 768,
+    "4xl": 896,
+    "5xl": 1024,
+    "6xl": 1152,
+    "7xl": 1280
+  },
   "typography": {
     "desktop": {
       "headingXl": {

--- a/packages/design-tokens/src/overrides.ts
+++ b/packages/design-tokens/src/overrides.ts
@@ -5,7 +5,9 @@
  * surface as the Figma-sourced tokens, namespaced under `--zl-*` so they're
  * indistinguishable to consumers. Anything authored here is a deliberate
  * decision documented inline; if a value belongs to the design system it
- * should be added to Figma and pulled via sync instead.
+ * should be added to Figma and pulled via sync instead. Each entry stays here
+ * only until Figma publishes its equivalent — then delete it and let the sync
+ * surface it (as `container` already does).
  *
  * Mode handling (current PR):
  *   - The default surface is dark mode, applied at `:root` and mirrored on
@@ -31,7 +33,6 @@ export interface DesignTokenOverrides {
   motion: MotionTokens;
   focus: FocusTokens;
   breakpoint: BreakpointTokens;
-  container: ContainerTokens;
 }
 
 export interface ColorPrimitiveTokens {
@@ -98,13 +99,6 @@ export interface BreakpointTokens {
   "4xl": string;
 }
 
-export interface ContainerTokens {
-  /** Auth card max-width per the Figma spec (24rem = 384px). */
-  authCard: string;
-  /** Page shell upper bound used when an auth page also renders marketing chrome. */
-  page: string;
-}
-
 export const overrides: DesignTokenOverrides = {
   colorPrimitive: {
     gray: {
@@ -155,9 +149,5 @@ export const overrides: DesignTokenOverrides = {
     "2xl": "96rem",
     "3xl": "120rem",
     "4xl": "160rem",
-  },
-  container: {
-    authCard: "24rem",
-    page: "80rem",
   },
 };


### PR DESCRIPTION
## Summary
- Surface Figma's `container/*` max-width scale through `sync-from-export.ts` (added to `figma.tokens.json`).
- Map the `authCard`/`page` semantic roles onto that scale in `build.ts` (`authCard → container.sm` = 384/24rem, `page → container.7xl` = 1280/80rem), with a fail-loud guard if Figma ever drops a step.
- Drop the duplicate hand-authored `container` block (and `ContainerTokens` type) from `overrides.ts` — Figma is now the single source for container widths.

First step of consolidating design-token sources onto Figma. `container` is the one category Figma already publishes at matching values, so it moves with zero output change. The remaining hand-authored tokens (breakpoints `xs`/`3xl`/`4xl`, motion, focus, brand gray ramp) stay in `overrides.ts`/legacy until Figma publishes them or the legacy migration lands.

## Validation
- `moon run design-tokens:generate` → `tokens.css`, `tokens.ts`, `tailwind.css`, `shadcn.css` are **byte-identical** to `main` (empty diff); only `figma.tokens.json` gains the container block.
- `moon run design-tokens:typecheck design-tokens:test` → pass (7/7), including the public token-surface snapshot.

## Release notes / changeset
No changeset required — no shipped behavior changed (no-op refactor; generated output byte-identical).

## Notes
- The container scale is surfaced in full (`3xs`–`7xl`) in `figma.tokens.json` to mirror Figma; `build.ts` currently consumes only `sm` and `7xl`.