### PR TITLE
fix(api): require `project.write` for queryProjects

### DIFF
--- a/.changeset/project-query-authz-amendments.md
+++ b/.changeset/project-query-authz-amendments.md
@@ -1,0 +1,8 @@
+---
+"@zitadel/server": patch
+---
+
+`queryProjects` now requires the `project.write` scope. Its contract still
+declared `project.read`, the browser-plane preview secret's scope, which must
+not gate an operator read — aligning it with the project management access
+model from ADR 037.

--- a/.changeset/project-query-authz-amendments.md
+++ b/.changeset/project-query-authz-amendments.md
@@ -5,4 +5,4 @@
 `queryProjects` now requires the `project.write` scope. Its contract still
 declared `project.read`, the browser-plane preview secret's scope, which must
 not gate an operator read — aligning it with the project management access
-model from ADR 037.
+model from ADR 036.

--- a/api/generated/oas_security_gen.go
+++ b/api/generated/oas_security_gen.go
@@ -154,7 +154,7 @@ var oauth2ScopesOAuth2 = map[string][]string{
 		"project.write",
 	},
 	QueryProjectsOperation: []string{
-		"project.read",
+		"project.write",
 	},
 	RevokeSessionOperation: []string{
 		"session.delete",

--- a/api/openapi/endpoints/projects/query/methods.yaml
+++ b/api/openapi/endpoints/projects/query/methods.yaml
@@ -3,9 +3,12 @@ post:
   summary: Query projects
   tags:
     - Projects
-  security: 
+  security:
     - oauth2:
-        - project.read
+        # project.write, not project.read: project.read is carried by the
+        # browser-plane preview secret, so it cannot gate an operator read
+        # until ADR 036 splits the credential planes into distinct schemes.
+        - project.write
   requestBody:
     description: Request to query projects.
     required: true

--- a/internal/api/authz_internal_test.go
+++ b/internal/api/authz_internal_test.go
@@ -64,6 +64,9 @@ func TestResourceAccessScopes(t *testing.T) {
 		{"team.read cannot write", teamAccess, opWrite, "team.read", false},
 
 		{"project.read does not read project management state", projectAccess, opRead, "project.read", false},
+		// queryProjects has no project parameter of its own and binds to the
+		// token's project like getProject: only project.write reaches it.
+		{"project.write reaches queryProjects (opRead)", projectAccess, opRead, "project.write", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/integration_test/authz_test.go
+++ b/internal/api/integration_test/authz_test.go
@@ -254,6 +254,51 @@ func TestManagementAuthz(t *testing.T) {
 			require.NoError(t, err)
 			assertAuthzStatus(t, resp, 403, "proj.permission_denied")
 		})
+
+		// queryProjects has no handler yet; until then it always
+		// answers ht.ErrNotImplemented regardless of caller, so there is no authz
+		// signal to probe. #410 implements the handler and un-skips this.
+		t.Run("query projects", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("bound to the token's project", func(t *testing.T) {
+				t.Parallel()
+				// todo (grvijayan)
+				t.Skip("queryProjects handler not yet implemented")
+
+				// queryProjects is scoped to the caller's bound project: each secret sees
+				// exactly its own project and never one it isn't bound to (foreign, bound to
+				// other, must not see victim).
+				resp, err := foreign.QueryProjects(t.Context(), &api.QueryProjectsRequest{})
+				require.NoError(t, err)
+				listResp, ok := resp.(*api.QueryProjectsResponse)
+				require.True(t, ok, helpers.MustMarshal(t, resp))
+				require.Len(t, listResp.Projects, 1, "the foreign secret sees only its own project")
+				assert.Equal(t, other.ID, listResp.Projects[0].ID, "the foreign secret sees exactly its own project (other)")
+
+				// a client with the own secret sees its own project.
+				ownClient, err := helpers.NewApiClient(harness.EnsureTestServer(t).URL)
+				require.NoError(t, err)
+				harness.SetProjectSecretOnApiClient(t, ownClient, victim)
+
+				ownResp, err := ownClient.QueryProjects(t.Context(), &api.QueryProjectsRequest{})
+				require.NoError(t, err)
+				ownListResp, ok := ownResp.(*api.QueryProjectsResponse)
+				require.True(t, ok, helpers.MustMarshal(t, ownResp))
+				require.Len(t, ownListResp.Projects, 1, "the own secret sees only its own project")
+				assert.Equal(t, victim.ID, ownListResp.Projects[0].ID, "the own secret sees exactly its own project (victim)")
+			})
+
+			t.Run("preview secret rejected", func(t *testing.T) {
+				t.Parallel()
+				// todo (grvijayan)
+				t.Skip("queryProjects handler not yet implemented")
+
+				resp, err := preview.QueryProjects(t.Context(), &api.QueryProjectsRequest{})
+				require.NoError(t, err)
+				assertAuthzStatus(t, resp, 403, "proj.permission_denied")
+			})
+		})
 	})
 }
 

--- a/internal/service/project.go
+++ b/internal/service/project.go
@@ -198,6 +198,12 @@ func (s *projectService) Update(ctx context.Context, id, name string) (*domain.P
 
 // ListProjectsRequest is the input for listing projects.
 type ListProjectsRequest struct {
+	// ProjectID, if set, restricts results to that single project.
+	// It is set based on the scope of the caller.
+	// If it's bound to a single project, the ProjectID should be set by the handler.
+	// Left empty, the list spans all projects: the handler need not pass a ProjectID
+	// if the caller has broader access (e.g., system-level read access).
+	ProjectID string
 	Limit     int
 	PageToken string
 	Sorting   *Sorting // optional; defaults to createdAt asc
@@ -211,7 +217,10 @@ type ListProjectsResponse struct {
 }
 
 func (s *projectService) List(ctx context.Context, req ListProjectsRequest) (*ListProjectsResponse, error) {
-	filters := make([]v2database.Filter[domain.ProjectField], 0, len(req.Filters))
+	filters := make([]v2database.Filter[domain.ProjectField], 0, len(req.Filters)+1)
+	if req.ProjectID != "" {
+		filters = append(filters, v2database.Equal(v2database.Col(domain.ProjectFieldID), req.ProjectID))
+	}
 	for _, f := range req.Filters {
 		filter, err := projectFilter(f)
 		if err != nil {

--- a/internal/service/project_test.go
+++ b/internal/service/project_test.go
@@ -410,6 +410,40 @@ func TestProjectService_List(t *testing.T) {
 			},
 		},
 		{
+			name:   "zero limit uses default, not storage's no-limit",
+			req:    service.ListProjectsRequest{Limit: 0},
+			result: &v2database.ListResult[*domain.Project]{},
+			checkOpts: func(t *testing.T, opts *v2database.ListOptions[domain.ProjectField]) {
+				assert.Equal(t, uint32(20), opts.Pagination.Limit)
+			},
+		},
+		{
+			name: "project id restricts results to that project",
+			req:  service.ListProjectsRequest{ProjectID: "proj_a"},
+			result: &v2database.ListResult[*domain.Project]{
+				Items: []*domain.Project{{ID: "proj_a"}},
+			},
+			checkOpts: func(t *testing.T, opts *v2database.ListOptions[domain.ProjectField]) {
+				assert.Equal(t, v2database.And(
+					v2database.Equal(v2database.Col(domain.ProjectFieldID), "proj_a"),
+				), opts.Filter)
+			},
+		},
+		{
+			name: "project id filter",
+			req: service.ListProjectsRequest{
+				ProjectID: "proj_a",
+				Filters:   []service.Filter{{Field: "createdAt", Operation: "equals", Value: createdAt.Format(time.RFC3339)}},
+			},
+			result: &v2database.ListResult[*domain.Project]{},
+			checkOpts: func(t *testing.T, opts *v2database.ListOptions[domain.ProjectField]) {
+				assert.Equal(t, v2database.And(
+					v2database.Equal(v2database.Col(domain.ProjectFieldID), "proj_a"),
+					v2database.Equal(v2database.Col(domain.ProjectFieldCreatedAt), createdAt),
+				), opts.Filter)
+			},
+		},
+		{
 			name: "sort by createdAt desc",
 			req: service.ListProjectsRequest{
 				Sorting: &service.Sorting{Field: "createdAt", Direction: "desc"},


### PR DESCRIPTION
## Summary

Amendments from PR #580's authorization model (#624):

- queryProjects declared `project.read`, the browser-plane preview secret's scope, which must not gate an operator read. Flip the contract to `project.write` and regenerate.
- `ProjectService.List` gains an opt-in `ProjectID` restriction so a project-bound caller sees only its own project; left empty the list spans all projects for a broader-scoped caller.
- Adds a scope-table test case in `authz_internal_test.go` pinning that queryProjects maps to `project.write`, plus a skipped integration probe in `integration_test/authz_test.go` for #410 to un-skip once the queryProjects handler exists. No docs changes.

## Validation
- `moon run server:generate` (OpenAPI regen; only the queryProjects scope changed)
- `go test ./...`
- `go test -v -tags postgres_integration -timeout=10m ./...`
- `go test -v -tags spanner_integration -timeout=10m ./...`

## Release notes / changeset
- Changeset: `.changeset/project-query-authz-amendments.md`

## Notes

Closes https://github.com/zitadel/nextgen/issues/624
