### PR TITLE
ci: use moon's built-in run summary and slim the failure reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
     # which inject DEPOT_CACHE_TOKEN independently of GitHub secret filtering.
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-24.04' || 'depot-ubuntu-24.04-16' }}
     timeout-minutes: 120
+    env:
+      # Moon marks failed tasks by color alone, so a failed `moon ci` can end at
+      # "Tasks: 1 failed" with no named target. The summary names them in plain
+      # text and replays each failed task's own output. Green runs pay only a
+      # pass/fail list; the replay section is empty when nothing failed.
+      MOON_SUMMARY: detailed
     steps:
       - uses: actions/checkout@v6
         with:

--- a/apps/cli/tests/unit/scripts/report-moon-failures.test.ts
+++ b/apps/cli/tests/unit/scripts/report-moon-failures.test.ts
@@ -1,16 +1,16 @@
-import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile, utimes } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-type Failure = { name: string; status: string; error: string };
+type Failure = { name: string; status: string; detail: string };
 
 type ReportMoonFailuresModule = {
   actionName: (action: unknown) => string;
+  actionDetail: (action: unknown) => string;
   normalizeFailures: (report: unknown) => Failure[];
   escapeAnnotation: (value: string) => string;
   escapeMarkdownTableCell: (value: string) => string;
-  formatFailureReport: (failures: Failure[]) => string;
   formatGithubAnnotations: (failures: Failure[]) => string[];
   formatStepSummary: (failures: Failure[]) => string;
   loadMoonReport: (options?: {
@@ -30,14 +30,20 @@ async function loadModule(): Promise<ReportMoonFailuresModule> {
   )) as ReportMoonFailuresModule;
 }
 
+// Shaped after a real moon 2.x report: the action-level `error` is the same
+// sentence for every failed task, and the exit code lives in the operations.
 function failedRunTaskReport() {
   return {
     actions: [
       {
         label: "RunTask(server:format)",
         status: "failed",
-        error: "Task process exited with a non-zero exit code",
+        error: "Task server:format failed to run.",
         node: { action: "run-task", params: { target: "server:format" } },
+        operations: [
+          { meta: { type: "hash-generation", hash: "abc123" }, status: "passed" },
+          { meta: { type: "task-execution", command: "gofmt -l", exitCode: 1 }, status: "failed" },
+        ],
       },
       {
         label: "RunTask(server:test)",
@@ -67,6 +73,21 @@ describe("report-moon-failures", () => {
     expect(actionName({ label: "SetupToolchain" })).toBe("SetupToolchain");
   });
 
+  it("prefers the task exit code over moon's boilerplate error", async () => {
+    const { actionDetail } = await loadModule();
+    expect(
+      actionDetail({
+        error: "Task server:format failed to run.",
+        operations: [{ meta: { type: "task-execution", exitCode: 127 } }],
+      }),
+    ).toBe("exit 127");
+    // Setup and sync actions run no task, so their error message is all there is.
+    expect(actionDetail({ error: "  Failed to install go 1.24.  " })).toBe(
+      "Failed to install go 1.24.",
+    );
+    expect(actionDetail({ operations: [{ meta: { type: "hash-generation" } }] })).toBe("");
+  });
+
   it("normalizes failed, invalid, and timed-out actions only", async () => {
     const { normalizeFailures } = await loadModule();
     expect(
@@ -80,30 +101,28 @@ describe("report-moon-failures", () => {
         ],
       }),
     ).toEqual([
-      { name: "a:lint", status: "failed", error: "" },
-      { name: "a:test", status: "invalid", error: "" },
-      { name: "a:build", status: "timed-out", error: "" },
+      { name: "a:lint", status: "failed", detail: "" },
+      { name: "a:test", status: "invalid", detail: "" },
+      { name: "a:build", status: "timed-out", detail: "" },
     ]);
   });
 
-  it("formats a plain-text failure block and GHA annotations", async () => {
-    const { normalizeFailures, formatFailureReport, formatGithubAnnotations } = await loadModule();
-    const failures = normalizeFailures(failedRunTaskReport());
-    const text = formatFailureReport(failures);
-    expect(text).toContain("Failed moon tasks (1):");
-    expect(text).toContain("- server:format (failed)");
-    expect(text).toContain("error: Task process exited with a non-zero exit code");
-    expect(formatGithubAnnotations(failures)).toEqual([
-      "::error title=Moon task failed::server:format: Task process exited with a non-zero exit code",
+  it("annotates failures with the target, status, and exit code", async () => {
+    const { normalizeFailures, formatGithubAnnotations } = await loadModule();
+    expect(formatGithubAnnotations(normalizeFailures(failedRunTaskReport()))).toEqual([
+      "::error title=Moon task failed::server:format failed (exit 1)",
     ]);
+    expect(
+      formatGithubAnnotations([{ name: "a:build", status: "timed-out", detail: "" }]),
+    ).toEqual(["::error title=Moon task failed::a:build timed-out"]);
   });
 
   it("escapes workflow-command special characters in annotations", async () => {
     const { escapeAnnotation, formatGithubAnnotations } = await loadModule();
     expect(escapeAnnotation("100%\r\nok")).toBe("100%25%0D%0Aok");
     expect(
-      formatGithubAnnotations([{ name: "a:test", status: "failed", error: "done 50%\nok" }]),
-    ).toEqual(["::error title=Moon task failed::a:test: done 50%25%0Aok"]);
+      formatGithubAnnotations([{ name: "a:test", status: "failed", detail: "done 50%\nok" }]),
+    ).toEqual(["::error title=Moon task failed::a:test failed (done 50%25%0Aok)"]);
   });
 
   it("escapes markdown table cells and collapses newlines", async () => {
@@ -111,7 +130,7 @@ describe("report-moon-failures", () => {
     expect(escapeMarkdownTableCell("a|b\\c")).toBe("a\\|b\\\\c");
     expect(escapeMarkdownTableCell("line1\nline2")).toBe("line1 / line2");
     const summary = formatStepSummary([
-      { name: "server:format", status: "failed", error: "path\\with|pipe\nand more" },
+      { name: "server:format", status: "failed", detail: "path\\with|pipe\nand more" },
     ]);
     expect(summary).toContain("path\\\\with\\|pipe / and more");
   });
@@ -133,7 +152,22 @@ describe("report-moon-failures", () => {
 
     const summary = await readFile(summaryPath, "utf8");
     expect(summary).toContain("## Failed Moon tasks");
-    expect(summary).toContain("`server:format`");
+    expect(summary).toContain("| `server:format` | failed | exit 1 |");
+  });
+
+  // A job that runs `moon ci` and then `moon run` leaves both reports behind;
+  // reading the stale one reports the wrong step's failures.
+  it("reads the newest report when both exist", async () => {
+    const { loadMoonReport } = await loadModule();
+    const cacheDir = await mkdtemp(join(tmpdir(), "moon-failures-newest-"));
+    await writeFile(join(cacheDir, "ciReport.json"), JSON.stringify({ actions: [] }));
+    await writeFile(join(cacheDir, "runReport.json"), JSON.stringify(failedRunTaskReport()));
+
+    const stale = new Date(Date.now() - 60_000);
+    await utimes(join(cacheDir, "ciReport.json"), stale, stale);
+
+    const loaded = await loadMoonReport({ cacheDir });
+    expect(loaded?.path).toBe(join(cacheDir, "runReport.json"));
   });
 
   it("no-ops cleanly when no report exists", async () => {

--- a/scripts/report-moon-failures.mjs
+++ b/scripts/report-moon-failures.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-import { appendFile, readFile } from "node:fs/promises";
+import { appendFile, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { forwardedArgs, isDirectRun } from "./dev-process.mjs";
 
 const FAILURE_STATUSES = new Set(["failed", "invalid", "timed-out"]);
+const REPORT_FILE_NAMES = ["ciReport.json", "runReport.json"];
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const defaultCacheDir = join(repoRoot, ".moon", "cache");
 
@@ -17,7 +18,18 @@ export function actionName(action) {
   return typeof action?.label === "string" && action.label ? action.label : "unknown";
 }
 
-export function actionError(action) {
+/**
+ * A failed task's `error` is always the same sentence ("Task <target> failed to
+ * run."), so the exit code from its task-execution operation is the only detail
+ * worth carrying: 127 reads as a missing binary, 1 as a check that rejected the
+ * tree. Setup and sync actions run no task and do put a real message in `error`.
+ */
+export function actionDetail(action) {
+  const operations = Array.isArray(action?.operations) ? action.operations : [];
+  const execution = operations.find((operation) => operation?.meta?.type === "task-execution");
+  if (typeof execution?.meta?.exitCode === "number") {
+    return `exit ${execution.meta.exitCode}`;
+  }
   return typeof action?.error === "string" ? action.error.trim() : "";
 }
 
@@ -28,7 +40,7 @@ export function normalizeFailures(report) {
     .map((action) => ({
       name: actionName(action),
       status: action.status,
-      error: actionError(action),
+      detail: actionDetail(action),
     }));
 }
 
@@ -45,35 +57,26 @@ export function escapeMarkdownTableCell(value) {
     .replace(/\|/g, "\\|");
 }
 
-export function formatFailureReport(failures) {
-  const lines = [`Failed moon tasks (${failures.length}):`];
-  for (const failure of failures) {
-    lines.push(`- ${failure.name} (${failure.status})`);
-    if (failure.error) {
-      lines.push(`  error: ${failure.error}`);
-    }
-  }
-  return `${lines.join("\n")}\n`;
-}
-
 export function formatGithubAnnotations(failures) {
   return failures.map((failure) => {
-    const detail = failure.error ? `${failure.name}: ${failure.error}` : failure.name;
-    return `::error title=Moon task failed::${escapeAnnotation(detail)}`;
+    const summary = failure.detail
+      ? `${failure.name} ${failure.status} (${failure.detail})`
+      : `${failure.name} ${failure.status}`;
+    return `::error title=Moon task failed::${escapeAnnotation(summary)}`;
   });
 }
 
 export function formatStepSummary(failures) {
   const rows = failures.map((failure) => {
-    const error = failure.error ? escapeMarkdownTableCell(failure.error) : "";
-    return `| \`${failure.name}\` | ${failure.status} | ${error} |`;
+    const detail = failure.detail ? escapeMarkdownTableCell(failure.detail) : "";
+    return `| \`${failure.name}\` | ${failure.status} | ${detail} |`;
   });
   return [
     "## Failed Moon tasks",
     "",
     `Moon reported **${failures.length}** failed action${failures.length === 1 ? "" : "s"}.`,
     "",
-    "| Task | Status | Error |",
+    "| Task | Status | Detail |",
     "| --- | --- | --- |",
     ...rows,
     "",
@@ -86,12 +89,16 @@ export async function loadMoonReport(options = {}) {
     return { report: JSON.parse(raw), path: options.reportPath };
   }
 
+  // `moon ci` writes ciReport.json and `moon run` writes runReport.json into the
+  // same cache dir, so a job that does both leaves two reports behind. Read the
+  // newest: preferring a fixed name reports the earlier step's failures.
   const cacheDir = options.cacheDir ?? defaultCacheDir;
-  for (const fileName of ["ciReport.json", "runReport.json"]) {
+  const candidates = [];
+  for (const fileName of REPORT_FILE_NAMES) {
     const candidate = join(cacheDir, fileName);
     try {
-      const raw = await readFile(candidate, "utf8");
-      return { report: JSON.parse(raw), path: candidate };
+      const stats = await stat(candidate);
+      candidates.push({ path: candidate, modifiedAt: stats.mtimeMs });
     } catch (error) {
       if (error && typeof error === "object" && error.code === "ENOENT") {
         continue;
@@ -99,7 +106,13 @@ export async function loadMoonReport(options = {}) {
       throw error;
     }
   }
-  return null;
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  candidates.sort((left, right) => right.modifiedAt - left.modifiedAt);
+  const newest = candidates[0].path;
+  return { report: JSON.parse(await readFile(newest, "utf8")), path: newest };
 }
 
 export async function reportMoonFailures(options = {}) {
@@ -115,7 +128,8 @@ export async function reportMoonFailures(options = {}) {
     return { failedCount: 0, skipped: false, path: loaded.path };
   }
 
-  process.stdout.write(formatFailureReport(failures));
+  // No plain-text block here: MOON_SUMMARY (set on the CI job) already prints a
+  // named pass/fail list and replays failed task output into the same log.
   for (const annotation of formatGithubAnnotations(failures)) {
     console.log(annotation);
   }
@@ -170,7 +184,9 @@ function parseArgs(argv) {
 function printUsage() {
   console.log(`Usage: node scripts/report-moon-failures.mjs [--report <path>] [--cache-dir <dir>]
 
-Reads moon's ciReport.json (or runReport.json) and prints failed tasks for CI logs.
+Reads moon's newest report (ciReport.json / runReport.json) and turns failed
+actions into GitHub Actions error annotations plus a job-summary table, so a
+failure is visible on the run page without opening the job log.
 Always exits 0 so a missing report cannot replace the moon step's exit code.
 `);
 }


### PR DESCRIPTION
## Summary

Follow-up to #656, which diagnosed the right problem: `moon ci` marks failed tasks by **color
alone**, so a GHA run can end at `Tasks: 1 failed` with no named target. Two things came out of
reviewing that PR.

**1. Moon already ships the plain-text half of the fix.** `MOON_SUMMARY=detailed` ends the run
with a named pass/fail list and replays each failed task's own output. Verified against moon
2.3.3:

```
 SUMMARY

pass SyncWorkspace
fail RunTask(proj:bad) (25ms, 15509ac9)
fail RunTask(proj:missing-bin) (25ms, 779e0680)

 REVIEW

proj:missing-bin
bash: definitely-not-a-real-binary: command not found
```

Set at job level on `full-pr`, so the multi-target `moon run` steps get it too. Green runs pay
only the pass/fail list — the replay section is empty when nothing failed.

**2. The reporter script stays, slimmer.** With the summary on, the log names failures — but only
once you open the failed job. `::error` annotations and the job-summary table render on the run
page with zero clicks, which the log cannot do, and that is GHA-specific surfacing that belongs
in the Actions layer. (`moonrepo/run-report-action` is the upstream equivalent, but it posts a PR
comment: needs `pull-requests: write` against this workflow's `contents: read`, and does not
cover `merge_group` runs.) What goes is the part that now duplicates moon:

| Change | Why |
| --- | --- |
| Drop the plain-text failure block | A second, worse copy of moon's `SUMMARY` in the same log |
| Annotate with the exit code, not `error` | `action.error` is the constant `Task <target> failed to run.` for *every* failed task. `operations[].meta.exitCode` separates `127` (missing binary) from `1` (check rejected the tree) |
| Read the newest report, not always `ciReport.json` | A job that runs `moon ci` and then `moon run` leaves both reports behind; picking by filename reports the earlier step's failures |

Annotations now read `server:format failed (exit 1)` instead of
`server:format: Task server:format failed to run.`

## Validation

- `vitest run tests/unit/scripts/report-moon-failures.test.ts` — 9 passed, including new coverage
  for exit-code extraction, the setup/sync-action fallback (no execution operation, real message
  in `error`), and newest-report selection.
- Reporter run against a real moon 2.3.3 `ciReport.json` from a scratch workspace with two failing
  tasks: annotations came out as `proj:bad failed (exit 3)` and `proj:missing-bin failed
  (exit 127)`, with a matching job-summary table.
- Newest-report selection checked both directions on real files — touching either report makes it
  win.
- `MOON_SUMMARY=detailed moon ci` verified locally on moon 2.3.3 (output above). This PR's own
  `full-pr` run is the in-situ check.

## Release notes / changeset

No changeset required — no shipped behavior changed.

## Notes

- `apps/server/moon.yml`'s gofmt message from #656 is untouched; it stands on its own.
- If the annotations and job summary turn out not to earn their keep now that the log names
  failures, deleting the script and its test is a clean revert — the flag is the part that carries
  the fix.
