### PR TITLE
build: make @zitadel/testing installable from the consumer-journey registry

### DIFF
--- a/apps/cli-journey-e2e/AGENTS.md
+++ b/apps/cli-journey-e2e/AGENTS.md
@@ -34,6 +34,12 @@ generated app. It must not test the checked-in demo apps.
   `@zitadel/sdk-vue`, `@zitadel/sdk-angular`, `@zitadel/sdk-solid`,
   `@zitadel/sdk-svelte`, and `@zitadel/sdk-qwik`. Private support packages must
   stay out of the artifact set.
+- `JOURNEY_ONLY_PACKAGES` (`scripts/release-manifest.mjs`, currently
+  `@zitadel/testing`) are the deliberate exception: the journey packs and
+  publishes them into its temporary Verdaccio registry so a fresh app can
+  install them like a customer, but they must never enter the release
+  artifact set — `verify-tarballs.mjs` accepts them only behind
+  `--allow-journey-extras`, which release verification does not pass.
 - Keep the generated app on `localhost` for browser tests. WebAuthn rejects IP
   address relying-party IDs such as `127.0.0.1`.
 - Keep each framework suite Playwright-serial and one-worker. Framework suites

--- a/apps/cli-journey-e2e/scripts/local-registry.mjs
+++ b/apps/cli-journey-e2e/scripts/local-registry.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { cp, mkdir, open, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-import { PUBLIC_PACKAGE_DIRS } from "../../../scripts/release-manifest.mjs";
+import { JOURNEY_ONLY_PACKAGES, PUBLIC_PACKAGE_DIRS } from "../../../scripts/release-manifest.mjs";
 
 export const packageDirs = [...PUBLIC_PACKAGE_DIRS];
 
@@ -36,6 +36,7 @@ export async function prepareLocalRegistry(input) {
 
   await buildPackages(input.repoRoot, input.run, env, log, input.prebuiltTarballsDir);
   await packPackages(input.repoRoot, paths.tarballsDir, input.run, env, log, input.prebuiltTarballsDir);
+  await packJourneyOnlyPackages(input.repoRoot, paths.tarballsDir, input.run, env, log);
   await verifyTarballs(input.repoRoot, paths.tarballsDir, input.run, env);
   const startRegistry = input.startLocalRegistry ?? startLocalRegistry;
   const registry = await startRegistry({
@@ -82,10 +83,31 @@ export async function packPackages(repoRoot, tarballsDir, _run, _env, log = () =
   }
 }
 
+/**
+ * Journey-only packages never enter the release tarball set
+ * (dist/release/<version>/npm stays exactly PUBLIC_RELEASE_PACKAGES), so the
+ * journey builds and packs them itself — also when running from prebuilt
+ * release tarballs.
+ */
+export async function packJourneyOnlyPackages(repoRoot, tarballsDir, run, env, log = () => undefined) {
+  for (const pkg of JOURNEY_ONLY_PACKAGES) {
+    log(`packing journey-only package ${pkg.name}`);
+    if (pkg.buildTarget) {
+      await run("moon", ["run", pkg.buildTarget], { cwd: repoRoot, env });
+    }
+    await run(
+      "corepack",
+      ["pnpm", "--dir", pkg.dir, "pack", "--pack-destination", tarballsDir],
+      { cwd: repoRoot, env },
+    );
+  }
+}
+
 export async function verifyTarballs(repoRoot, tarballsDir, run, env) {
   await run("node", [
     "apps/cli-journey-e2e/scripts/verify-tarballs.mjs",
     tarballsDir,
+    "--allow-journey-extras",
   ], { cwd: repoRoot, env });
 }
 

--- a/apps/cli-journey-e2e/scripts/verify-tarballs.mjs
+++ b/apps/cli-journey-e2e/scripts/verify-tarballs.mjs
@@ -8,7 +8,7 @@ import { JOURNEY_ONLY_PACKAGES, PUBLIC_PACKAGE_DIRS } from "../../../scripts/rel
 const [tarballsDir, ...flags] = process.argv.slice(2);
 if (!tarballsDir || tarballsDir.startsWith("--")) {
   throw new Error(
-    "usage: node scripts/verify-tarballs.mjs <tarballs-dir> [--allow-journey-extras]",
+    "usage: node apps/cli-journey-e2e/scripts/verify-tarballs.mjs <tarballs-dir> [--allow-journey-extras]",
   );
 }
 const unknownFlags = flags.filter((flag) => flag !== "--allow-journey-extras");

--- a/apps/cli-journey-e2e/scripts/verify-tarballs.mjs
+++ b/apps/cli-journey-e2e/scripts/verify-tarballs.mjs
@@ -3,17 +3,31 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 
-import { PUBLIC_PACKAGE_DIRS } from "../../../scripts/release-manifest.mjs";
+import { JOURNEY_ONLY_PACKAGES, PUBLIC_PACKAGE_DIRS } from "../../../scripts/release-manifest.mjs";
 
-const tarballsDir = process.argv[2];
-if (!tarballsDir) {
-  throw new Error("usage: node scripts/verify-tarballs.mjs <tarballs-dir>");
+const [tarballsDir, ...flags] = process.argv.slice(2);
+if (!tarballsDir || tarballsDir.startsWith("--")) {
+  throw new Error(
+    "usage: node scripts/verify-tarballs.mjs <tarballs-dir> [--allow-journey-extras]",
+  );
 }
+const unknownFlags = flags.filter((flag) => flag !== "--allow-journey-extras");
+if (unknownFlags.length > 0) {
+  throw new Error(`unknown flags: ${unknownFlags.join(", ")}`);
+}
+// Journey registries carry the journey-only packages on top of the release
+// set; release artifact dirs are verified without the flag and must contain
+// exactly the public release packages.
+const allowJourneyExtras = flags.includes("--allow-journey-extras");
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../../..");
+const requiredPackageDirs = [
+  ...PUBLIC_PACKAGE_DIRS,
+  ...(allowJourneyExtras ? JOURNEY_ONLY_PACKAGES.map((pkg) => pkg.dir) : []),
+];
 const requiredPackageNames = new Set(
-  await Promise.all(PUBLIC_PACKAGE_DIRS.map(packageName)),
+  await Promise.all(requiredPackageDirs.map(packageName)),
 );
 const dependencyFields = [
   "dependencies",

--- a/apps/cli-journey-e2e/scripts/verify-tarballs.test.mjs
+++ b/apps/cli-journey-e2e/scripts/verify-tarballs.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, before, test } from "node:test";
+
+import {
+  JOURNEY_ONLY_PACKAGES,
+  PUBLIC_PACKAGE_DIRS,
+} from "../../../scripts/release-manifest.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../..");
+const script = join(here, "verify-tarballs.mjs");
+
+// The script resolves required package names from the repo manifests, so the
+// fixture tarballs must carry the real names. Fabricate one minimal valid
+// tarball per package: server platform packages additionally need their
+// executable bin to satisfy assertServerPlatformBinary.
+let fixtureRoot;
+let releaseSetDir;
+let journeySetDir;
+
+before(async () => {
+  fixtureRoot = await mkdtemp(join(tmpdir(), "verify-tarballs-test-"));
+  releaseSetDir = join(fixtureRoot, "release-set");
+  journeySetDir = join(fixtureRoot, "journey-set");
+  await mkdir(releaseSetDir, { recursive: true });
+
+  for (const dir of PUBLIC_PACKAGE_DIRS) {
+    await makeTarball(releaseSetDir, await packageName(dir));
+  }
+  // The journey set is the release set plus every journey-only package.
+  await cp(releaseSetDir, journeySetDir, { recursive: true });
+  for (const pkg of JOURNEY_ONLY_PACKAGES) {
+    await makeTarball(journeySetDir, await packageName(pkg.dir));
+  }
+});
+
+after(async () => {
+  await rm(fixtureRoot, { recursive: true, force: true });
+});
+
+test("release mode accepts exactly the public release set", () => {
+  const strict = runVerify(releaseSetDir);
+  assert.equal(strict.status, 0, strict.stderr);
+  assert.match(strict.stdout, /verified \d+ installable tarballs/);
+});
+
+test("release mode rejects journey-only tarballs as unexpected", () => {
+  const result = runVerify(journeySetDir);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unexpected package @zitadel\/testing/);
+});
+
+test("journey mode requires the journey-only packages on top of the release set", () => {
+  const withExtras = runVerify(journeySetDir, "--allow-journey-extras");
+  assert.equal(withExtras.status, 0, withExtras.stderr);
+
+  const missingExtras = runVerify(releaseSetDir, "--allow-journey-extras");
+  assert.notEqual(missingExtras.status, 0);
+  assert.match(missingExtras.stderr, /missing tarball for @zitadel\/testing/);
+});
+
+test("unknown flags are rejected", () => {
+  const result = runVerify(releaseSetDir, "--bogus");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unknown flags: --bogus/);
+});
+
+function runVerify(dir, ...flags) {
+  return spawnSync("node", [script, dir, ...flags], { encoding: "utf8" });
+}
+
+async function packageName(dir) {
+  const manifest = JSON.parse(await readFile(join(repoRoot, dir, "package.json"), "utf8"));
+  return manifest.name;
+}
+
+async function makeTarball(outDir, name) {
+  const safe = name.replace(/[@/]/g, "-").replace(/^-/, "");
+  const stage = join(fixtureRoot, "stage", safe);
+  const packageDir = join(stage, "package");
+  await mkdir(packageDir, { recursive: true });
+  const manifest = { name, version: "1.0.0" };
+  if (/^@zitadel\/server-(?:darwin|linux|win32)-/.test(name)) {
+    const bin = name.includes("win32") ? "bin/nextgen.exe" : "bin/nextgen";
+    manifest.bin = { nextgen: `./${bin}` };
+    await mkdir(join(packageDir, "bin"), { recursive: true });
+    await writeFile(join(packageDir, bin), "#!/bin/sh\n", { mode: 0o755 });
+  }
+  await writeFile(join(packageDir, "package.json"), JSON.stringify(manifest));
+  const tar = spawnSync("tar", ["-czf", join(outDir, `${safe}-1.0.0.tgz`), "-C", stage, "package"], {
+    encoding: "utf8",
+  });
+  assert.equal(tar.status, 0, tar.stderr);
+}

--- a/apps/cli/tests/unit/scripts/local-registry.test.ts
+++ b/apps/cli/tests/unit/scripts/local-registry.test.ts
@@ -128,9 +128,24 @@ describe("local registry helper", () => {
       args: ["run", "release:pack"],
       options: { cwd: repoRoot, env },
     });
+    // Journey-only packages are built and packed on top of the release set.
+    expect(runCalls).toContainEqual({
+      command: "moon",
+      args: ["run", "testing:build"],
+      options: { cwd: repoRoot, env },
+    });
+    expect(runCalls).toContainEqual({
+      command: "corepack",
+      args: ["pnpm", "--dir", "packages/testing", "pack", "--pack-destination", paths.tarballsDir],
+      options: { cwd: repoRoot, env },
+    });
     expect(runCalls).toContainEqual({
       command: "node",
-      args: ["apps/cli-journey-e2e/scripts/verify-tarballs.mjs", paths.tarballsDir],
+      args: [
+        "apps/cli-journey-e2e/scripts/verify-tarballs.mjs",
+        paths.tarballsDir,
+        "--allow-journey-extras",
+      ],
       options: { cwd: repoRoot, env },
     });
     expect(calls).toContainEqual({ type: "start-registry", port: 51_234 });
@@ -227,9 +242,26 @@ describe("local registry helper", () => {
       args: ["run", "release:pack"],
       options: { cwd: repoRoot, env },
     });
+    // Prebuilt release tarballs never carry journey-only packages (the
+    // release artifact set must stay exactly the public packages), so the
+    // journey still builds and packs those itself before verifying.
     expect(runCalls[0]).toEqual({
+      command: "moon",
+      args: ["run", "testing:build"],
+      options: { cwd: repoRoot, env },
+    });
+    expect(runCalls[1]).toEqual({
+      command: "corepack",
+      args: ["pnpm", "--dir", "packages/testing", "pack", "--pack-destination", paths.tarballsDir],
+      options: { cwd: repoRoot, env },
+    });
+    expect(runCalls[2]).toEqual({
       command: "node",
-      args: ["apps/cli-journey-e2e/scripts/verify-tarballs.mjs", paths.tarballsDir],
+      args: [
+        "apps/cli-journey-e2e/scripts/verify-tarballs.mjs",
+        paths.tarballsDir,
+        "--allow-journey-extras",
+      ],
       options: { cwd: repoRoot, env },
     });
     expect(await readFile(join(paths.tarballsDir, "zitadel-cli-0.1.0-alpha.5.tgz"), "utf8")).toBe(

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -21,6 +21,8 @@ through the registration UI, serialized per suite. This kit fills the middle:
 ## Quick start (Playwright)
 
 ```sh
+# once published to npm — today this resolves only inside this repo and the
+# consumer-journey registry (see the status note above)
 npm i -D @zitadel/testing @playwright/test
 ```
 
@@ -225,9 +227,13 @@ on top, in intended order:
    journey registry now carries the kit. Next: a consumer-journey lane that
    installs the kit from that registry against the published binary, proving
    the customer configuration in CI. Remaining after that: entries in the
-   release manifest and the changeset `fixed` train, the Windows decision
-   (deferred until the SQLite local default removes the embedded-Postgres
-   lifecycle), and the semver commitment.
+   release manifest and the changeset `fixed` train, the one-time npm
+   bootstrap for the new package name (first manual `npm publish --access
+   public` with an OTP, then configuring the GitHub Actions trusted
+   publisher on npmjs so CI's OIDC publishing takes over — same dance as
+   every previous package), the Windows decision (deferred until the SQLite
+   local default removes the embedded-Postgres lifecycle), and the semver
+   commitment.
 
 Parked until server support exists: passkey seeding (pre-registered WebAuthn
 credentials). Independent refactor: extract `apps/cli/src/lib/local-server`

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -5,9 +5,10 @@ Test-kit for **seeded ephemeral local Zitadel instances**: boot the real server
 project with the default login flow, and mint password users that can complete
 the real login journey immediately.
 
-> **Status: POC.** Private, in-repo only. The public API validates the
-> "auth in code" L2 shape; publishing to npm is a separate, deliberate step
-> (see [Future work](#future-work)).
+> **Status: pre-release.** Not yet published to npm. The package is consumed
+> in-repo and published to the consumer-journey's temporary registry so a
+> fresh app can install it the way a customer would; publishing to npm is a
+> separate, deliberate step (see [Roadmap](#roadmap)).
 
 ## Why
 
@@ -18,6 +19,13 @@ through the registration UI, serialized per suite. This kit fills the middle:
 **real server, programmatic seeding, parallel-safe per-test users.**
 
 ## Quick start (Playwright)
+
+```sh
+npm i -D @zitadel/testing @playwright/test
+```
+
+The kit drives the `zitadel` CLI, which resolves the published
+`@zitadel/server` platform binary on its own — no binary paths, no env vars.
 
 One instance per suite, seeded per test. `withZitadel()` generates the
 `webServer` entries that boot the instance and run your app against it — no
@@ -159,18 +167,27 @@ mutate project-wide state; revisit with warm-dir reuse if that need appears.
 - A crashed run can orphan a server: `zitadel stop --all` sweeps every
   CLI-managed runtime on the machine.
 
-## Known limitations (POC)
+## Developing in this repo
+
+Customer installs get the published server binary through `@zitadel/server`'s
+platform packages; the in-repo workspace carries no such binary, so the repo's
+own suites run `moon run server:build` and point the kit at the result via
+`ZITADEL_SERVER_BINARY` (the `withZitadel` option `zitadel.serverBinary` /
+`serverBinaryHint` exists for this). That source build also embeds no UIs, so
+the in-repo moon tasks set `NEXTGEN_SERVER_LOGIN_ENABLED=false` /
+`NEXTGEN_SERVER_CONSOLE_ENABLED=false` — the suites drive the app-embedded
+login, not the server-hosted `/ui/*`. Published binaries ship with both UIs
+embedded and need none of this.
+
+## Known limitations
 
 - `@zitadel/api`'s client stores auth in module-global state; avoid
   interleaving calls to *different* instances within one process. Separate
   processes (Playwright workers) are unaffected.
-- Requires the in-repo server binary (`moon run server:build`) via
-  `ZITADEL_SERVER_BINARY`; the npm platform packages carry no binary in-repo.
-  That build also embeds no UIs, so the in-repo moon tasks set
-  `NEXTGEN_SERVER_LOGIN_ENABLED=false` / `NEXTGEN_SERVER_CONSOLE_ENABLED=false`
-  — the suites drive the app-embedded login, not the server-hosted `/ui/*`.
-  Published binaries ship with both UIs embedded.
-- macOS/Linux only (the CLI's port preflight uses `lsof`).
+- macOS/Linux only for now. Not because of the port preflight (it degrades
+  gracefully where `lsof` is missing) — the untested surface on Windows is the
+  process-group stop and embedded-Postgres lifecycle. Revisit once the local
+  runtime's SQLite default removes the Postgres component.
 
 ## Roadmap
 
@@ -203,10 +220,14 @@ on top, in intended order:
    cookies + issuer + handoff verification through `sandbox.domain()`,
    registering the preview URL as an allowed origin post-deploy
    (`PATCH /projects`), and cleanup that survives failed runs.
-6. **Publishing.** Peer-dep story for `@zitadel/cli` and `@playwright/test`,
-   entries in the release manifest and the changeset `fixed` train, Windows
-   support (the CLI port preflight shells `lsof`), and the semver commitment
-   — after the API has survived a second in-repo consumer.
+6. **Publishing.** Progress: the API survived a second in-repo consumer, the
+   `@playwright/test` peer-dep story is settled (optional peer), and the
+   journey registry now carries the kit. Next: a consumer-journey lane that
+   installs the kit from that registry against the published binary, proving
+   the customer configuration in CI. Remaining after that: entries in the
+   release manifest and the changeset `fixed` train, the Windows decision
+   (deferred until the SQLite local default removes the embedded-Postgres
+   lifecycle), and the semver commitment.
 
 Parked until server support exists: passkey seeding (pre-registered WebAuthn
 credentials). Independent refactor: extract `apps/cli/src/lib/local-server`

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -12,7 +12,6 @@
     "url": "git+https://github.com/zitadel/nextgen.git",
     "directory": "packages/testing"
   },
-  "private": true,
   "type": "module",
   "files": [
     "dist"
@@ -45,6 +44,14 @@
     "@zitadel/api": "workspace:*",
     "@zitadel/cli": "workspace:*",
     "@zitadel/config": "workspace:*"
+  },
+  "peerDependencies": {
+    "@playwright/test": ">=1.60"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@playwright/test": "catalog:",

--- a/packages/testing/src/envelope.ts
+++ b/packages/testing/src/envelope.ts
@@ -5,6 +5,31 @@ export interface CliEnvelope<TData> {
   status: string;
   data: TData;
   warnings?: string[];
+  /** Error envelopes (`status: "error"`) carry remediation guidance. */
+  code?: string;
+  message?: string;
+  hint?: string;
+  next_commands?: string[];
+}
+
+/**
+ * Render an error envelope's remediation fields for humans — the CLI's
+ * `hint`/`next_commands` are the actionable part of a failure (e.g. "Reinstall
+ * @zitadel/cli so npm can install @zitadel/server"), so surface them instead
+ * of a raw stdout dump. Returns undefined when the envelope has no message.
+ */
+export function describeEnvelopeError(envelope: CliEnvelope<unknown>): string | undefined {
+  if (typeof envelope.message !== "string" || envelope.message.length === 0) {
+    return undefined;
+  }
+  const lines = [envelope.code ? `${envelope.code}: ${envelope.message}` : envelope.message];
+  if (envelope.hint) {
+    lines.push(`hint: ${envelope.hint}`);
+  }
+  if (envelope.next_commands && envelope.next_commands.length > 0) {
+    lines.push(`next: ${envelope.next_commands.join(" | ")}`);
+  }
+  return lines.join("\n");
 }
 
 export interface StartEnvelopeData {

--- a/packages/testing/src/lifecycle.ts
+++ b/packages/testing/src/lifecycle.ts
@@ -2,8 +2,13 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { runCli, tail } from "./cli";
-import { parseCliEnvelope, type CliEnvelope, type StartEnvelopeData } from "./envelope";
+import { runCli, tail, type RunCliResult } from "./cli";
+import {
+  describeEnvelopeError,
+  parseCliEnvelope,
+  type CliEnvelope,
+  type StartEnvelopeData,
+} from "./envelope";
 import { getFreePort } from "./ports";
 import type { LocalZitadelRuntime } from "./types";
 
@@ -56,8 +61,7 @@ export async function bootLocalServer(options: BootServerOptions = {}): Promise<
     // Keep the dir on failure: server.log inside it is the diagnostic.
     throw new Error(
       `zitadel start exited with code ${result.exitCode}.\n` +
-        `stdout: ${tail(result.stdout) || "(empty)"}\n` +
-        `stderr: ${tail(result.stderr) || "(empty)"}\n` +
+        `${failureDetail(result)}\n` +
         `state dir kept for inspection: ${dir}`,
     );
   }
@@ -71,8 +75,7 @@ export async function bootLocalServer(options: BootServerOptions = {}): Promise<
     if (stopResult.exitCode !== 0) {
       throw new Error(
         `zitadel stop exited with code ${stopResult.exitCode}.\n` +
-          `stdout: ${tail(stopResult.stdout) || "(empty)"}\n` +
-          `stderr: ${tail(stopResult.stderr) || "(empty)"}\n` +
+          `${failureDetail(stopResult)}\n` +
           `state dir kept for inspection: ${dir}`,
       );
     }
@@ -83,7 +86,8 @@ export async function bootLocalServer(options: BootServerOptions = {}): Promise<
     envelope = parseCliEnvelope<StartEnvelopeData>(result.stdout, "zitadel start");
     if (envelope.status !== "ok") {
       throw new Error(
-        `zitadel start reported status "${envelope.status}":\n${tail(result.stdout)}`,
+        `zitadel start reported status "${envelope.status}":\n` +
+          `${describeEnvelopeError(envelope) ?? tail(result.stdout)}`,
       );
     }
   } catch (error) {
@@ -142,4 +146,21 @@ export async function bootLocalServer(options: BootServerOptions = {}): Promise<
     },
     stop,
   };
+}
+
+/**
+ * A failed CLI run usually still prints an error envelope; its
+ * message/hint/next_commands beat raw output tails (e.g. a fresh install
+ * missing @zitadel/server gets "Reinstall @zitadel/cli" instead of a stack).
+ */
+function failureDetail(result: RunCliResult): string {
+  try {
+    const described = describeEnvelopeError(parseCliEnvelope<unknown>(result.stdout, "zitadel"));
+    if (described) {
+      return described;
+    }
+  } catch {
+    // stdout carried no envelope; fall back to the raw tails.
+  }
+  return `stdout: ${tail(result.stdout) || "(empty)"}\nstderr: ${tail(result.stderr) || "(empty)"}`;
 }

--- a/packages/testing/tests/unit/envelope.test.ts
+++ b/packages/testing/tests/unit/envelope.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { describeEnvelopeError, type CliEnvelope } from "../../src/envelope";
+import { bootLocalServer } from "../../src/lifecycle";
+import { fakeCliBin } from "./helpers/fake-cli";
+
+const errorEnvelope = (overrides: Partial<CliEnvelope<unknown>> = {}): CliEnvelope<unknown> => ({
+  status: "error",
+  code: "E_VALIDATION",
+  message: "Zitadel server npm package is not available",
+  hint: "Reinstall @zitadel/cli so npm can install @zitadel/server and its platform package.",
+  next_commands: ["npm install @zitadel/cli@alpha"],
+  data: undefined,
+  ...overrides,
+});
+
+describe("describeEnvelopeError", () => {
+  it("renders code, message, hint, and next commands", () => {
+    expect(describeEnvelopeError(errorEnvelope())).toBe(
+      [
+        "E_VALIDATION: Zitadel server npm package is not available",
+        "hint: Reinstall @zitadel/cli so npm can install @zitadel/server and its platform package.",
+        "next: npm install @zitadel/cli@alpha",
+      ].join("\n"),
+    );
+  });
+
+  it("omits absent fields and returns undefined without a message", () => {
+    expect(describeEnvelopeError(errorEnvelope({ code: undefined, hint: undefined }))).toBe(
+      "Zitadel server npm package is not available\nnext: npm install @zitadel/cli@alpha",
+    );
+    expect(describeEnvelopeError({ status: "ok", data: undefined })).toBeUndefined();
+  });
+});
+
+describe("bootLocalServer failure surfacing", () => {
+  it("surfaces the error envelope's hint and next commands over raw tails", async () => {
+    const fake = await fakeCliBin({
+      startExitCode: 1,
+      startStdout: JSON.stringify(errorEnvelope()),
+    });
+    await expect(bootLocalServer({ cliBin: fake.binPath, port: 18099 })).rejects.toThrow(
+      /hint: Reinstall @zitadel\/cli[\s\S]*next: npm install @zitadel\/cli@alpha/,
+    );
+  });
+});

--- a/scripts/release-manifest.mjs
+++ b/scripts/release-manifest.mjs
@@ -121,6 +121,20 @@ export const PUBLIC_RELEASE_PACKAGES = [
   },
 ];
 
+// Published only to the consumer journey's temporary Verdaccio registry so a
+// fresh app can install them the way a customer would. Deliberately NOT part
+// of PUBLIC_RELEASE_PACKAGES: never packed into release artifacts, never
+// promoted, and never published to npm (each entry must also stay in the
+// changesets ignore list, which skips both version and publish).
+export const JOURNEY_ONLY_PACKAGES = [
+  {
+    name: "@zitadel/testing",
+    dir: "packages/testing",
+    moonProject: "testing",
+    buildTarget: "testing:build",
+  },
+];
+
 export const PUBLIC_PACKAGE_DIRS = PUBLIC_RELEASE_PACKAGES.map((pkg) => pkg.dir);
 export const PUBLIC_PACKAGE_NAMES = PUBLIC_RELEASE_PACKAGES.map((pkg) => pkg.name);
 export const PUBLIC_PACKAGE_BUILD_TARGETS = PUBLIC_RELEASE_PACKAGES


### PR DESCRIPTION
## Summary

Phase 2 (customer-shaped runtime) step 1 of 2: make `@zitadel/testing` installable the way a customer would install it — from the consumer journey's temporary Verdaccio registry — without letting it anywhere near the release artifact set or npm.

- **`packages/testing` is no longer `private`.** `apps/cli-journey-e2e/scripts/publish-tarballs.mjs` (correctly) refuses private tarballs, and the journey registry is exactly where the kit now needs to be. Accidental npm publishing stays impossible twice over: npm publish runs via `changeset publish` and the kit is in the changesets `ignore` list (skips version **and** publish), and the release artifact set is the explicit `PUBLIC_RELEASE_PACKAGES` allowlist, which the kit is not part of. No release-tooling script derives publishability from the `private` flag (checked `scripts/*.mjs` + `tools/release`).
- **`JOURNEY_ONLY_PACKAGES`** (new export in `scripts/release-manifest.mjs`) makes the distinction first-class: packages the journey packs and publishes into its registry but that must never enter release artifacts. `prepareLocalRegistry` gains a `packJourneyOnlyPackages` step that builds (`moon run testing:build`) and packs the kit into the journey tarball dir — deliberately also on the `--tarballs-dir` prebuilt path, so `dist/release/<version>/npm` stays exactly the public release set.
- **`verify-tarballs.mjs` learns `--allow-journey-extras`**: with the flag (journey registries) the journey-only packages are required on top of the release set; without it (release verification in ci.yml stays flagless) they are rejected as unexpected. The existing checks (no private manifests, no unresolved `workspace:`/`catalog:` specs, semver versions, platform binary presence) apply to the kit tarball too.
- **`@playwright/test` becomes an optional peer dependency** (`>=1.60`, the tested floor) — the `./playwright` entry needs it, the core entry does not. Kept in devDependencies for the kit's own tests.
- **Kit polish for the customer path:** boot/stop failures now surface the CLI error envelope's `code`/`message`/`hint`/`next_commands` instead of raw stdout tails (a fresh install missing `@zitadel/server` now says "Reinstall @zitadel/cli …" with the exact command). README: install line + a note that the CLI resolves the published binary on its own; the in-repo `ZITADEL_SERVER_BINARY`/UI-flags wiring moved to a "Developing in this repo" section; the Windows limitation is re-justified accurately (the port preflight degrades gracefully without `lsof` — the untested surface is process-group stop and the embedded-Postgres lifecycle, revisit after the SQLite local default) and the roadmap's publishing item reflects actual progress.
- `apps/cli/tests/unit/scripts/local-registry.test.ts` updated to lock the new call contract (journey-extras pack runs in both fresh and prebuilt paths; verify gets the flag).
- `apps/cli-journey-e2e/AGENTS.md`: the "only public packages" rule now names the journey-only exception and its guard.

Step 2 (separate PR) adds the consumer-journey lane that installs the kit from this registry and runs a `withZitadel()` login suite against the published binary — the customer-configuration proof in CI.

## Validation

- Packed manifest checkpoint: `pnpm --dir packages/testing pack` → `workspace:*` deps rewrote to `0.1.0-alpha.17`, `catalog:` devDeps rewrote to concrete ranges — the tarball passes `verify-tarballs`' installability assertions.
- `verify-tarballs` mode matrix on a kit-only dir: flagless → `unexpected package @zitadel/testing`; with flag → kit accepted, missing release packages reported; unknown flag rejected.
- `moon run testing:test testing:lint testing:typecheck testing:build` — 50 unit tests incl. new `envelope.test.ts` (hint/next_commands surfacing through `bootLocalServer`).
- `moon run cli:test` — 802 tests incl. the updated local-registry contract tests.
- `moon run cli-journey-e2e:test cli-journey-e2e:lint` — green.
- `moon run cli-journey-e2e:e2e-local -- --framework next` — full journey green with the kit packed, verified, and published to Verdaccio alongside the release set.
- `moon run workspace:check -- --only release` — green (release graph + changesets-status validation over the touched manifest).

## Release notes / changeset

- No changeset required — `@zitadel/testing` is changeset-ignored and 0.0.0; no publishable package's shipped behavior changed (release scripts are repo tooling).

## Notes

- The `private: true` removal is the one deliberate risk decision; the two independent guards above are the mitigation, and `verify-tarballs` without the flag is the CI tripwire if a kit tarball ever appears in a release dir.
- Windows remains a documented non-goal until the SQLite local default removes the embedded-Postgres lifecycle (per the phase plan).
