### PR TITLE
fix: declare the demo login pages' fixed light surface on the widget

### DIFF
--- a/apps/demo-next/src/app/login/widget.tsx
+++ b/apps/demo-next/src/app/login/widget.tsx
@@ -7,7 +7,11 @@ const ZitadelLogin = dynamic(
     const { demoProject } = await import("@/zitadel");
     await import("@zitadel/components");
     return function ZitadelLoginElement() {
-      return <zitadel-login project={demoProject} post-sign-in-url="/admin" />;
+      // This page fixes its surface to light (see page.tsx), so declare it on
+      // the widget: the element-level `theme` outranks tenant branding (the
+      // dev mock pins dark), which is the documented contract for embedding
+      // into a page whose colour is not negotiable.
+      return <zitadel-login project={demoProject} theme="light" post-sign-in-url="/admin" />;
     };
   },
   { ssr: false },

--- a/apps/demo-next/src/custom-elements.d.ts
+++ b/apps/demo-next/src/custom-elements.d.ts
@@ -11,6 +11,7 @@ declare module "react" {
         "post-sign-in-url"?: string;
         purpose?: string;
         "flow-name"?: string;
+        theme?: "" | "light" | "dark" | "auto";
         lang?: string;
         locales?: Record<string, Locale>;
       };

--- a/apps/demo-nuxt/pages/login.vue
+++ b/apps/demo-nuxt/pages/login.vue
@@ -9,8 +9,13 @@
     "
   >
     <ClientOnly>
+      <!-- This page fixes its surface to light (the <main> background), so
+           declare it on the widget: the element-level `theme` outranks tenant
+           branding (the dev mock pins dark), which is the documented contract
+           for embedding into a page whose colour is not negotiable. -->
       <zitadel-login
         :project="project"
+        theme="light"
         post-sign-in-url="/admin"
       />
     </ClientOnly>


### PR DESCRIPTION
## Summary

Both demo login pages (`apps/demo-next/src/app/login/page.tsx`, `apps/demo-nuxt/pages/login.vue`) center the sign-in widget on a hardcoded light backdrop (`#f3f4f6`), while the dev mock's default tenant branding (`packages/api-mock/src/default-dev-branding.ts`) pins `theme: { mode: "dark" }`. Tenant branding outranks the widget's `auto` fallback, so the widget painted dark-mode values onto the light page — near-white title, field label, and primary-button surface were effectively invisible when running `moon run api-mock:start` + `moon run demo-next:dev`.

**Chosen fix: declare the fixed surface on the widget** — `theme="light"` on both demos' `<zitadel-login>`, with a comment explaining why. This is the honest demo behavior because it is the documented embedding contract for exactly this situation: the element-level `theme` exists (and outranks tenant branding) *because the embedding app knows its own surface better than the tenant's stored branding does*. The demo now actively demonstrates that precedence rule against a mock tenant that pins the opposite mode.

Rejected alternatives:
- A backdrop that follows the widget's `data-theme` would invert the ownership story ("the embedding app owns the page") and add adaptive plumbing to a demo meant to be minimal and copyable.
- Changing the mock's default branding would hide the element-over-branding precedence instead of demonstrating it, and other surfaces (Storybook presets, e2e) render against the current dark default.

`apps/demo-next/src/custom-elements.d.ts` (the hand-maintained JSX declaration) gains the `theme` attribute so the TSX typechecks.

## Validation

- `moon run demo-next:typecheck demo-next:lint demo-nuxt:typecheck demo-nuxt:lint` — all green.
- Visual (api-mock on `PORT=4000`, demo-next dev with `ZITADEL_URL=http://localhost:4000`, freshly built dist): under an emulated **dark** OS preference *and* the mock's dark tenant branding, the widget now resolves `data-theme="light"` — dark title/label text and a dark primary button on the light card, fully legible; under a light preference the rendering is identical (explicit theme is scheme-independent, as a fixed surface wants).

## Release notes / changeset

No changeset required — no shipped behavior changed (demo reference apps only; both are in the changesets `ignore` list).

## Notes

- Pre-existing issue; verified identical on `main` before the session-surface work (#686).
- Expected trivial conflict with #686: that PR replaces `custom-elements.d.ts` with a reference to the shipped `@zitadel/sdk-next/jsx` declarations (which already include `theme`). Whichever lands second resolves by taking #686's version of that file; the `widget.tsx`/`login.vue` changes are untouched by it.
- The admin pages have a milder cousin: the `<zitadel-logout>` avatar draws dark-mode tokens on a light page. On `main` the element has no `theme` property — #686 adds one, so pinning `theme="light"` on the demo logout widgets is a one-line follow-up once that merges.
