### PR TITLE
test: add session-mint and seed vocabulary to @zitadel/testing

### DIFF
--- a/apps/console/scripts/dev-real.mts
+++ b/apps/console/scripts/dev-real.mts
@@ -135,10 +135,15 @@ zitadel = await startLocalZitadel({
 const seeded: SeededUser[] = [];
 try {
   seeded.push(await zitadel.seedUser(DEV_USER));
-  for (const user of EXTRA_USERS) {
-    const { email, ...attributes } = user;
-    seeded.push(await zitadel.seedUser({ email, attributes }));
-  }
+  seeded.push(
+    ...(await zitadel.seedUsers(EXTRA_USERS.length, {
+      email: (index) => EXTRA_USERS[index]!.email,
+      attributes: (index) => {
+        const { email: _email, ...attributes } = EXTRA_USERS[index]!;
+        return attributes;
+      },
+    })),
+  );
 } catch (error) {
   console.error(`[console-dev-real] seeding failed: ${(error as Error).message}`);
   await shutdown(1);

--- a/apps/demo-next-e2e/src-real/authenticated.spec.ts
+++ b/apps/demo-next-e2e/src-real/authenticated.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@zitadel/testing/playwright";
+
+/**
+ * The session-mint promise: tests start past login. The fixture seeds a user,
+ * drives the real flow headlessly, and injects the session cookie — if any of
+ * that were fake, the middleware would bounce /admin straight to /login.
+ */
+test("an authenticatedPage starts on a protected route without visiting login", async ({
+  authenticatedPage,
+  zitadel,
+}) => {
+  const { page, user, session } = authenticatedPage;
+
+  await page.goto("/admin");
+  await expect(page).toHaveURL(/\/admin(?:[/?#]|$)/);
+  await expect(page.getByRole("heading", { name: "Admin" })).toBeVisible();
+  await expect(page.getByText(`Signed in as ${user.id}`)).toBeVisible();
+
+  // The same minted token drives session APIs headlessly — the value the
+  // future vitest surface builds on, proven without a browser in the loop.
+  // /sessions/me authenticates via the session cookie (the SDK middleware's
+  // own headless pattern), so send the token the way a cookie would carry it.
+  const me = await fetch(`${zitadel.handle.baseUrl}/sessions/me`, {
+    headers: { cookie: `__nextgen_session=${session.sessionToken}` },
+  });
+  expect(me.status).toBe(200);
+  expect(((await me.json()) as { user_id?: string }).user_id).toBe(user.id);
+});

--- a/apps/demo-next-e2e/src-real/registration.spec.ts
+++ b/apps/demo-next-e2e/src-real/registration.spec.ts
@@ -1,0 +1,93 @@
+import type { Locator, Page } from "@playwright/test";
+
+import { expect, test } from "@zitadel/testing/playwright";
+
+/**
+ * Registration through the real flow with a kit-minted unused identity:
+ * `seed.identity()` creates nothing, so the flow itself must create the user —
+ * verified through the API afterwards. Locators follow the journey suite's
+ * resilient pattern (testid first, role fallback) because registration spans
+ * more steps than login.
+ */
+test("a fresh identity registers through the real flow", async ({ page, seed, zitadel }) => {
+  const who = seed.identity();
+
+  await page.goto("/login");
+  await page.getByLabel(/email/i).fill(who.email);
+  // Submitting an unknown identifier routes into registration (the journey
+  // suite's proven entry) — there is no separate register button to hunt for.
+  await clickAction(page, /continue|sign in/i, ["submit"]);
+  await expect(
+    page.getByRole("heading", { name: /create|register|sign up|no-account/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  await fillIfVisible(page, /email/i, who.email);
+  await clickActionIfVisible(page, /continue.*password|password/i, ["submit"]);
+  await page.getByLabel(/password/i).first().fill(who.password);
+  await clickAction(page, /continue|sign up|create account|register/i, ["submit"]);
+  await skipPasskeyUpsellIfVisible(page);
+
+  await page.waitForURL(/\/admin(?:[/?#]|$)/, { timeout: 30_000 });
+
+  // The flow, not the kit, must have created the user (the project secret
+  // scopes the list; the response is a plain array of user documents).
+  const users = (await zitadel.api.listUsers({ limit: 100 })) as Array<{ email?: string }>;
+  const created = users.find((user) => user.email === who.email);
+  expect(created).toBeDefined();
+});
+
+async function skipPasskeyUpsellIfVisible(page: Page): Promise<void> {
+  const skip = page.getByRole("button", { name: /skip for now/i });
+  const outcome = await Promise.race([
+    skip.waitFor({ state: "visible", timeout: 30_000 }).then(() => "upsell" as const),
+    page
+      .waitForURL(/\/admin(?:[/?#]|$)/, { timeout: 30_000 })
+      .then(() => "done" as const),
+  ]);
+  if (outcome === "upsell") {
+    await skip.click();
+  }
+}
+
+async function clickAction(page: Page, name: RegExp, actionNames: string[]): Promise<void> {
+  const target = actionCandidates(page, name, actionNames).find(Boolean);
+  for (const candidate of actionCandidates(page, name, actionNames)) {
+    if (await candidate.first().isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await candidate.first().click();
+      return;
+    }
+  }
+  await (target as Locator).first().click();
+}
+
+async function clickActionIfVisible(
+  page: Page,
+  name: RegExp,
+  actionNames: string[],
+): Promise<void> {
+  for (const candidate of actionCandidates(page, name, actionNames)) {
+    if (await candidate.first().isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await candidate.first().click();
+      return;
+    }
+  }
+}
+
+function actionCandidates(page: Page, name: RegExp, actionNames: string[]): Locator[] {
+  return [
+    ...actionNames.flatMap((action) => [
+      page.getByTestId(`zitadel-action-${action}-button`),
+      page.getByTestId(`zitadel-action-${action}-link`),
+      page.locator(`zl-button[action="${action}"], [data-action="${action}"]`),
+    ]),
+    page.getByRole("button", { name }),
+    page.getByRole("link", { name }),
+  ];
+}
+
+async function fillIfVisible(page: Page, label: RegExp, value: string): Promise<void> {
+  const field = page.getByLabel(label).first();
+  if (await field.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await field.fill(value);
+  }
+}

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -75,6 +75,29 @@ apps; the console maps the same fields to `VITE_*`/`CONSOLE_*` names instead.
 The fixtures find the instance through `ZITADEL_TESTING_HANDSHAKE`, which
 `withZitadel()` points at its handshake file.
 
+### Start tests authenticated
+
+Most app tests don't want to re-test login. `authenticatedPage` seeds a user,
+drives the real login flow headlessly (the same Flow API the login UI renders),
+and injects the resulting session cookie into a dedicated browser context:
+
+```ts
+test("member sees the dashboard", async ({ authenticatedPage }) => {
+  const { page, user } = authenticatedPage;
+  await page.goto("/dashboard"); // already signed in as `user`
+});
+```
+
+Underneath sits `seed.session()`, whose `sessionToken` also drives session
+APIs without any browser — backend tests call the instance directly with the
+cookie header (`cookie: __nextgen_session=<sessionToken>`, the SDK
+middleware's own headless pattern). Scope: password flows (the shipped
+`password-first` presets). A flow step demanding anything beyond the user's
+email and password — a challenge, another factor — fails with the step name;
+log in through the UI for those. `seed.identity()` complements registration
+specs: an unused email+password that creates nothing, so the flow under test
+must create the user.
+
 The two in-repo consumers are `apps/demo-next-e2e/playwright.real.config.mts`
 and `apps/console-e2e/playwright.real.config.mts` — run them with
 `moon run demo-next-e2e:e2e-real` / `moon run console-e2e:e2e-real`.
@@ -112,6 +135,9 @@ z.handle;   // serializable: { baseUrl, projectId, projectSecret, schemaId, prev
 z.api;      // authenticated @zitadel/api client (bearer = projectSecret)
 z.appEnv;   // { ZITADEL_URL, NEXT_PUBLIC_ZITADEL_PROJECT_ID, ZITADEL_PROJECT_SECRET }
 await z.seedUser({ email?, password?, attributes? }); // → { id, email, password }
+await z.seedUsers(8, { email?, password?, attributes? }); // per-index templates
+z.identity(); // unused { email, password } — creates nothing
+await z.seedSession({ user? }); // → { user, sessionToken, expiresAt, cookie }
 await z.stop(); // stop server, reap embedded Postgres, remove owned temp dir
 ```
 
@@ -196,20 +222,19 @@ This package is deliberately the **local runtime core** — "Testcontainers for
 Zitadel" when the app under test and Playwright share one machine. The layers
 on top, in intended order:
 
-1. **Registration fixtures.** `zitadel.identity()` (mint an unused identity
-   *without* creating the user) plus a spec that drives the real registration
-   UI and verifies the created user through the API. Until then,
-   `cli-journey-e2e` keeps covering registration.
+1. **Registration fixtures.** Landed: `zitadel.identity()` plus the
+   demo-next-e2e registration spec driving the real registration UI and
+   verifying the created user through the API. `cli-journey-e2e` keeps the
+   packaged-product registration coverage.
 2. **Email/OTP capture.** `zitadel.email.waitForCode(address)` for
    verification flows. Blocked on a server-side story (dev SMTP sink or
    API-exposed codes); password-only flows don't hit this.
-3. **Session-mint seed-op.** The `withZitadel(config)` orchestration half of
-   this item has landed (Playwright-config adapter owning the boot
-   supervisor, handshake, app-env injection, and teardown; `AppEnvTemplate`
-   as the framework-neutral env mechanism with `nextAppEnv` as the first
-   preset). Remaining: a session-mint seed-op (authenticated session/token
-   for a seeded user) so backend tests can skip the browser and a vitest
-   surface earns its keep.
+3. **Vitest surface.** Landed from this item: `withZitadel(config)`
+   orchestration, `AppEnvTemplate`/`nextAppEnv`, and the session-mint seed-op
+   (`seed.session()` driving the real flow headlessly, `authenticatedPage` on
+   top). Remaining: a dedicated `@zitadel/testing/vitest` entry once a second
+   backend consumer exists — `sessionToken` already serves backend tests
+   directly.
 4. **Remote mode: ephemeral project on a persistent instance.** For app
    deployments that cannot reach a local process (preview environments).
    `bootstrapProject({ baseUrl })` + `connectZitadel(handle)` already compose

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -3,7 +3,8 @@ import { createZitadelClient } from "@zitadel/api/client";
 import { applyAppEnvTemplate, nextAppEnv } from "./app-env";
 import { bootstrapProject, type BootstrapProjectOptions } from "./bootstrap";
 import { bootLocalServer, type BootServerOptions } from "./lifecycle";
-import { seedUser } from "./seed";
+import { identity, seedUser, seedUsers } from "./seed";
+import { mintSession } from "./session";
 import type { ConnectedZitadel, InstanceHandle, LocalZitadel } from "./types";
 
 export type StartLocalZitadelOptions = BootServerOptions &
@@ -16,15 +17,26 @@ export type StartLocalZitadelOptions = BootServerOptions &
  */
 export function connectZitadel(handle: InstanceHandle): ConnectedZitadel {
   const api = createZitadelClient({ baseUrl: handle.baseUrl, token: handle.projectSecret });
-  return {
+  const context = { projectId: handle.projectId, schemaId: handle.schemaId };
+  const connected: ConnectedZitadel = {
     handle,
     api,
     // The Next-shaped convenience view; other frameworks apply their own
     // template to `handle` (see AppEnvTemplate).
     appEnv: applyAppEnvTemplate(nextAppEnv, handle),
-    seedUser: (input) =>
-      seedUser(api, { projectId: handle.projectId, schemaId: handle.schemaId }, input),
+    seedUser: (input) => seedUser(api, context, input),
+    seedUsers: (count, template) => seedUsers(api, context, count, template),
+    identity,
+    seedSession: async (input = {}) => {
+      const { user: existing, flowDefinitionName, origin, ...userInput } = input;
+      const user = existing ?? (await seedUser(api, context, userInput));
+      return mintSession(api, handle, context, user, {
+        flowDefinitionName,
+        origin: origin ?? handle.appOrigin,
+      });
+    },
   };
+  return connected;
 }
 
 /**
@@ -65,6 +77,7 @@ export async function startLocalZitadel(
     projectSecret: bootstrapped.projectSecret,
     schemaId: bootstrapped.schemaId,
     previewSecret: bootstrapped.previewSecret,
+    appOrigin: options.appOrigins?.[0],
   };
   return {
     ...connectZitadel(handle),
@@ -81,11 +94,17 @@ export type { BootstrapProjectOptions, BootstrappedProject } from "./bootstrap";
 export { readHandshakeSync, waitForHandshake, writeHandshake } from "./handshake";
 export { bootLocalServer } from "./lifecycle";
 export type { BootedServer, BootServerOptions } from "./lifecycle";
+export { SESSION_COOKIE_NAME } from "./session";
 export type {
   ConnectedZitadel,
+  Identity,
   InstanceHandle,
   LocalZitadel,
   LocalZitadelRuntime,
+  MintedSession,
   SeededUser,
+  SeedSessionInput,
   SeedUserInput,
+  SeedUsersTemplate,
+  SessionCookie,
 } from "./types";

--- a/packages/testing/src/playwright.ts
+++ b/packages/testing/src/playwright.ts
@@ -1,14 +1,41 @@
-import { test as base } from "@playwright/test";
+import { test as base, type Page } from "@playwright/test";
 
 import { readHandshakeSync } from "./handshake";
 import { connectZitadel } from "./index";
-import type { ConnectedZitadel, SeededUser, SeedUserInput } from "./types";
+import type {
+  ConnectedZitadel,
+  Identity,
+  MintedSession,
+  SeededUser,
+  SeedSessionInput,
+  SeedUserInput,
+  SeedUsersTemplate,
+} from "./types";
+
+export interface AuthenticatedPage {
+  /** A page in its own context, already carrying the session cookie. */
+  page: Page;
+  user: SeededUser;
+  session: MintedSession;
+}
 
 export interface ZitadelTestFixtures {
-  /** Per-test seeding; each call mints a unique user on the shared instance. */
+  /** Per-test seeding; each call mints unique data on the shared instance. */
   seed: {
     user(input?: SeedUserInput): Promise<SeededUser>;
+    users(count: number, template?: SeedUsersTemplate): Promise<SeededUser[]>;
+    /** Unused email+password for registration flows — creates nothing. */
+    identity(): Identity;
+    /** Seeded user + headless real-flow login; password flows only. */
+    session(input?: SeedSessionInput): Promise<MintedSession>;
   };
+  /**
+   * Start the test authenticated: a fresh user, a real session minted through
+   * the flow API, and the cookie injected into a dedicated browser context —
+   * the default `page` stays signed out for login-flow tests. Requires
+   * `use.baseURL` (every withZitadel consumer sets it).
+   */
+  authenticatedPage: AuthenticatedPage;
 }
 
 export interface ZitadelWorkerFixtures {
@@ -33,8 +60,30 @@ export const test = base.extend<ZitadelTestFixtures, ZitadelWorkerFixtures>({
     },
     { scope: "worker" },
   ],
-  seed: async ({ zitadel }, use) => {
-    await use({ user: (input) => zitadel.seedUser(input) });
+  seed: async ({ zitadel, baseURL }, use) => {
+    await use({
+      user: (input) => zitadel.seedUser(input),
+      users: (count, template) => zitadel.seedUsers(count, template),
+      identity: () => zitadel.identity(),
+      // The suite's baseURL is the app origin the project allowlists.
+      session: (input) => zitadel.seedSession({ origin: baseURL, ...input }),
+    });
+  },
+  authenticatedPage: async ({ browser, zitadel, baseURL }, use) => {
+    if (!baseURL) {
+      throw new Error(
+        "authenticatedPage requires `use.baseURL` so the session cookie can be " +
+          "scoped to the app under test.",
+      );
+    }
+    const session = await zitadel.seedSession({ origin: baseURL });
+    const context = await browser.newContext({ baseURL });
+    // `addCookies` takes either url or domain/path; url derives the rest.
+    const { path: _path, ...cookie } = session.cookie;
+    await context.addCookies([{ ...cookie, url: baseURL }]);
+    const page = await context.newPage();
+    await use({ page, user: session.user, session });
+    await context.close();
   },
 });
 
@@ -43,4 +92,13 @@ export { applyAppEnvTemplate, nextAppEnv } from "./app-env";
 export type { AppEnvTemplate } from "./app-env";
 export { withZitadel } from "./playwright-config";
 export type { WithZitadelOptions } from "./playwright-config";
-export type { ConnectedZitadel, InstanceHandle, SeededUser, SeedUserInput } from "./types";
+export type {
+  ConnectedZitadel,
+  Identity,
+  InstanceHandle,
+  MintedSession,
+  SeededUser,
+  SeedSessionInput,
+  SeedUserInput,
+  SeedUsersTemplate,
+} from "./types";

--- a/packages/testing/src/seed.ts
+++ b/packages/testing/src/seed.ts
@@ -3,11 +3,23 @@ import { randomUUID } from "node:crypto";
 import type { ZitadelClient } from "@zitadel/api/client";
 
 import { requireString } from "./bootstrap";
-import type { SeededUser, SeedUserInput } from "./types";
+import type { Identity, SeededUser, SeedUserInput, SeedUsersTemplate } from "./types";
 
 export interface SeedContext {
   projectId: string;
   schemaId: string;
+}
+
+/**
+ * A unique unused email + password. Nothing is created on the instance —
+ * this is the input for registration-flow specs, which must prove the flow
+ * creates the user.
+ */
+export function identity(): Identity {
+  return {
+    email: `e2e-${randomUUID().slice(0, 8)}@example.com`,
+    password: `Pw!${randomUUID()}`,
+  };
 }
 
 /**
@@ -23,8 +35,9 @@ export async function seedUser(
   context: SeedContext,
   input: SeedUserInput = {},
 ): Promise<SeededUser> {
-  const email = input.email ?? `e2e-${randomUUID().slice(0, 8)}@example.com`;
-  const password = input.password ?? `Pw!${randomUUID()}`;
+  const fresh = identity();
+  const email = input.email ?? fresh.email;
+  const password = input.password ?? fresh.password;
   // Reserved fields win over attributes: the returned SeededUser must never
   // disagree with what was actually created (a silently overridden email or
   // $schema would yield credentials that cannot log in).
@@ -43,4 +56,30 @@ export async function seedUser(
     { project_id: context.projectId },
   );
   return { id, email, password };
+}
+
+/**
+ * Seed `count` users sequentially. The template makes fixture data
+ * deterministic per index (stable emails/names keep screenshot diffs about
+ * code, not reshuffled data — the `console:dev-real` pattern); untemplated
+ * fields fall back to the unique defaults. Name-like attributes need a
+ * schema that declares them (`useCase: "consumer"` or wider).
+ */
+export async function seedUsers(
+  client: ZitadelClient,
+  context: SeedContext,
+  count: number,
+  template: SeedUsersTemplate = {},
+): Promise<SeededUser[]> {
+  const users: SeededUser[] = [];
+  for (let index = 0; index < count; index += 1) {
+    users.push(
+      await seedUser(client, context, {
+        email: template.email?.(index),
+        password: template.password?.(index),
+        attributes: template.attributes?.(index),
+      }),
+    );
+  }
+  return users;
 }

--- a/packages/testing/src/session.ts
+++ b/packages/testing/src/session.ts
@@ -120,7 +120,15 @@ async function flowFetch(
   if (!response.ok || !parsed) {
     const detail =
       parsed && typeof parsed === "object" ? ` — ${JSON.stringify(parsed)}` : "";
-    throw new Error(`seed.session: POST ${path} returned ${response.status}${detail}`);
+    // An origin-allowlist rejection without an Origin header is a
+    // configuration gap, not a flow problem — say how to close it. (No eager
+    // check: a project with an empty allowlist may accept originless calls.)
+    const hint =
+      !origin && /origin/i.test(detail)
+        ? "\nNo Origin header was sent: pass `origin` to seedSession() (the Playwright " +
+          "fixtures pass the suite's baseURL) or `appOrigins` to startLocalZitadel()."
+        : "";
+    throw new Error(`seed.session: POST ${path} returned ${response.status}${detail}${hint}`);
   }
   return parsed;
 }

--- a/packages/testing/src/session.ts
+++ b/packages/testing/src/session.ts
@@ -1,0 +1,164 @@
+import type { ZitadelClient } from "@zitadel/api/client";
+import type { CreateFlow201, CreateFlow201StepFieldsItem } from "@zitadel/api/generated/model";
+
+import type { SeedContext } from "./seed";
+import type { InstanceHandle, MintedSession, SeededUser } from "./types";
+
+/** Mirrors the server's session cookie (internal/api/session.go). */
+export const SESSION_COOKIE_NAME = "__nextgen_session";
+
+const MAX_FLOW_STEPS = 6;
+
+export interface MintSessionOptions {
+  /** Forwarded to `POST /flow`; the project's default flow when omitted. */
+  flowDefinitionName?: string;
+  /** Origin header for flow calls (the project's origin check enforces it). */
+  origin?: string;
+}
+
+/**
+ * Drive the real login flow headlessly for a seeded password user and
+ * exchange the terminal handoff for a session: exactly what `<zitadel-login>`
+ * does, minus the rendering. Supports flows whose steps only ask for the
+ * user's email and password (the shipped `password-first` presets); any step
+ * demanding more — a challenge, an unknown field — fails loudly by design.
+ *
+ * Flow calls use raw fetch instead of the typed client because the flow is
+ * stateless through the sealed `_zflow` cookie (internal/api/flow.go): every
+ * response re-seals the flow state into Set-Cookie, and submits are rejected
+ * without it. Browsers round-trip it implicitly; here a one-cookie jar does.
+ */
+export async function mintSession(
+  client: ZitadelClient,
+  handle: Pick<InstanceHandle, "baseUrl" | "projectSecret">,
+  context: SeedContext,
+  user: SeededUser,
+  options: MintSessionOptions = {},
+): Promise<MintedSession> {
+  const values: Record<string, string> = { email: user.email, password: user.password };
+  const jar = new FlowCookieJar();
+  const origin = options.origin;
+
+  let response = await flowFetch(handle, jar, origin, "/flow", {
+    project_id: context.projectId,
+    purpose: "login",
+    ...(options.flowDefinitionName ? { flow_definition_name: options.flowDefinitionName } : {}),
+  });
+
+  for (let hop = 0; hop < MAX_FLOW_STEPS; hop += 1) {
+    if (response.handoff_token) {
+      const exchanged = await client.exchangeHandoff(
+        { handoff_token: response.handoff_token },
+        { project_id: context.projectId },
+      );
+      return {
+        user,
+        sessionToken: exchanged.session_token,
+        expiresAt: exchanged.session.expires_at,
+        cookie: {
+          name: SESSION_COOKIE_NAME,
+          value: exchanged.session_token,
+          httpOnly: true,
+          secure: true,
+          sameSite: "Lax",
+          path: "/",
+        },
+      };
+    }
+    response = await flowFetch(handle, jar, origin, `/flow/${encodeURIComponent(response.id)}/submit`, {
+      session_token: response.session_token,
+      action: "submit",
+      fields: collectFields(response, values),
+    });
+  }
+
+  throw new Error(
+    `seed.session: flow did not complete within ${MAX_FLOW_STEPS} steps ` +
+      `(last step: ${describeStep(response)}).`,
+  );
+}
+
+/** One-cookie jar for the sealed `_zflow` flow-state cookie. */
+class FlowCookieJar {
+  private cookie: string | undefined;
+
+  absorb(response: Response): void {
+    for (const raw of response.headers.getSetCookie()) {
+      const [pair] = raw.split(";", 1);
+      if (pair?.startsWith("_zflow=")) {
+        this.cookie = pair;
+      }
+    }
+  }
+
+  header(): Record<string, string> {
+    return this.cookie ? { cookie: this.cookie } : {};
+  }
+}
+
+async function flowFetch(
+  handle: Pick<InstanceHandle, "baseUrl" | "projectSecret">,
+  jar: FlowCookieJar,
+  origin: string | undefined,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<CreateFlow201> {
+  const response = await fetch(`${handle.baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${handle.projectSecret}`,
+      // The project's origin allowlist applies to flow calls; send the app
+      // origin the way a browser request through the app would carry it.
+      ...(origin ? { origin } : {}),
+      ...jar.header(),
+    },
+    body: JSON.stringify(body),
+  });
+  jar.absorb(response);
+  const parsed = (await response.json().catch(() => undefined)) as CreateFlow201 | undefined;
+  if (!response.ok || !parsed) {
+    const detail =
+      parsed && typeof parsed === "object" ? ` — ${JSON.stringify(parsed)}` : "";
+    throw new Error(`seed.session: POST ${path} returned ${response.status}${detail}`);
+  }
+  return parsed;
+}
+
+/**
+ * Fill exactly the fields the current step declares — the orchestrator's
+ * convention — from the known email/password values. An unknown required
+ * field means this flow needs more than a password login can provide.
+ */
+function collectFields(response: CreateFlow201, values: Record<string, string>): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const field of response.step.fields ?? []) {
+    const value = values[fieldKey(field)];
+    if (value === undefined) {
+      throw new Error(
+        `seed.session supports password flows only; step ${describeStep(response)} ` +
+          `declares field "${field.name}", which the kit cannot fill. ` +
+          `Log in through the UI for flows with additional factors.`,
+      );
+    }
+    fields[field.name] = value;
+  }
+  return fields;
+}
+
+/**
+ * Steps name credential fields with schema pointers (e.g.
+ * `x-auth-methods#password`); match on the trailing segment so the value map
+ * stays the plain `{ email, password }` a caller thinks in.
+ */
+function fieldKey(field: CreateFlow201StepFieldsItem): string {
+  const name = field.name;
+  const tail = name.split(/[#/.]/).at(-1) ?? name;
+  return tail.toLowerCase();
+}
+
+function describeStep(response: CreateFlow201): string {
+  const name = response.step.name ?? "(unnamed)";
+  const declared = (response.step.fields ?? []).map((field) => field.name).join(", ");
+  return `"${name}"${declared ? ` [fields: ${declared}]` : ""}`;
+}

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -9,6 +9,12 @@ export interface InstanceHandle {
   projectId: string;
   projectSecret: string;
   /**
+   * First registered app origin. Flow submissions enforce the project's
+   * origin allowlist, so headless drivers (seedSession) send it as the
+   * Origin header the way a browser request through the app would.
+   */
+  appOrigin?: string;
+  /**
    * Server-assigned id of the seeded user schema. User documents must
    * reference it via their `$schema` field, so seeding needs it alongside the
    * project credential.
@@ -30,6 +36,49 @@ export interface SeededUser {
   password: string;
 }
 
+/** An unused identity: seeded nowhere, ready for registration-flow specs. */
+export interface Identity {
+  email: string;
+  password: string;
+}
+
+/** Injectable mirror of the server's session cookie (session.go). */
+export interface SessionCookie {
+  name: string;
+  value: string;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: "Lax";
+  path: string;
+}
+
+export interface MintedSession {
+  user: SeededUser;
+  /** Bearer for session management APIs (e.g. `GET /sessions/me`). */
+  sessionToken: string;
+  expiresAt: string;
+  cookie: SessionCookie;
+}
+
+export interface SeedSessionInput extends SeedUserInput {
+  /** Mint for an existing user instead of seeding a fresh one. */
+  user?: SeededUser;
+  /** Specific flow definition; the project default when omitted. */
+  flowDefinitionName?: string;
+  /**
+   * Origin header for the flow calls (must be on the project's allowlist).
+   * Defaults to the handle's registered app origin; the Playwright fixtures
+   * pass the suite's baseURL.
+   */
+  origin?: string;
+}
+
+export interface SeedUsersTemplate {
+  email?: (index: number) => string;
+  password?: (index: number) => string;
+  attributes?: (index: number) => Record<string, unknown>;
+}
+
 export interface ConnectedZitadel {
   handle: InstanceHandle;
   /** Authenticated platform API client (bearer = project secret). */
@@ -37,6 +86,16 @@ export interface ConnectedZitadel {
   /** Env vars an SDK-based app needs to talk to this instance/project. */
   appEnv: Record<string, string>;
   seedUser(input?: SeedUserInput): Promise<SeededUser>;
+  /** Batch-seed users; the template makes fixture data deterministic. */
+  seedUsers(count: number, template?: SeedUsersTemplate): Promise<SeededUser[]>;
+  /** A unique unused email+password — nothing is created on the instance. */
+  identity(): Identity;
+  /**
+   * Seed (or take) a user and drive the real login flow headlessly to a
+   * session: tests inject `cookie` to start authenticated, backend tests use
+   * `sessionToken` directly. Password flows only.
+   */
+  seedSession(input?: SeedSessionInput): Promise<MintedSession>;
 }
 
 export interface LocalZitadelRuntime {

--- a/packages/testing/tests/unit/seed.test.ts
+++ b/packages/testing/tests/unit/seed.test.ts
@@ -119,3 +119,40 @@ describe("seedUser via connectZitadel", () => {
     });
   });
 });
+
+describe("seed vocabulary", () => {
+  it("identity() mints unique unused credentials and touches no API", () => {
+    const zitadel = connectZitadel(handle);
+    const one = zitadel.identity();
+    const two = zitadel.identity();
+    expect(one.email).toMatch(/^e2e-[0-9a-f]{8}@example\.com$/);
+    expect(one.email).not.toBe(two.email);
+    expect(one.password).not.toBe(two.password);
+    // onUnhandledRequest: "error" would fail this test if anything was called.
+  });
+
+  it("seedUsers applies the per-index template and keeps unique defaults", async () => {
+    let nextId = 0;
+    server.use(
+      http.post(`${BASE}/users`, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        nextId += 1;
+        return HttpResponse.json({ id: `user_${nextId}`, echo: body }, { status: 201 });
+      }),
+    );
+    const zitadel = connectZitadel(handle);
+    const users = await zitadel.seedUsers(3, {
+      email: (index) => `fixture-${index}@example.com`,
+      attributes: (index) => ({ givenName: `User${index}` }),
+    });
+
+    expect(users.map((user) => user.id)).toEqual(["user_1", "user_2", "user_3"]);
+    expect(users.map((user) => user.email)).toEqual([
+      "fixture-0@example.com",
+      "fixture-1@example.com",
+      "fixture-2@example.com",
+    ]);
+    // Untemplated passwords stay unique per user.
+    expect(new Set(users.map((user) => user.password)).size).toBe(3);
+  });
+});

--- a/packages/testing/tests/unit/session.test.ts
+++ b/packages/testing/tests/unit/session.test.ts
@@ -1,0 +1,184 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { connectZitadel } from "../../src/index";
+import type { InstanceHandle } from "../../src/types";
+
+const BASE = "http://zitadel-testing.invalid";
+
+const handle: InstanceHandle = {
+  baseUrl: BASE,
+  projectId: "proj_1",
+  projectSecret: "secret_1",
+  schemaId: "sch_1",
+  appOrigin: "http://app.invalid:3002",
+};
+
+interface Captured {
+  flowStart?: Record<string, unknown>;
+  flowStartOrigin?: string | null;
+  submits: Array<Record<string, unknown>>;
+  submitCookies: Array<string | null>;
+  exchangeBody?: Record<string, unknown>;
+  exchangeProject?: string;
+}
+
+const captured: Captured = { submits: [], submitCookies: [] };
+
+const identifierStep = {
+  id: "flow_1",
+  session_token: "flow-token-1",
+  step: { name: "identifier", fields: [{ name: "email" }] },
+};
+const passwordStep = {
+  id: "flow_1",
+  session_token: "flow-token-2",
+  step: { name: "password", fields: [{ name: "x-auth-methods#password" }] },
+};
+const terminalStep = {
+  id: "flow_1",
+  session_token: "flow-token-3",
+  step: { name: "done", complete: "show" },
+  handoff_token: "handoff_1",
+};
+
+const userHandlers = [
+  http.post(`${BASE}/users`, () => HttpResponse.json({ id: "user_1" }, { status: 201 })),
+  http.put(`${BASE}/users/:userId/password`, () => new HttpResponse(null, { status: 204 })),
+];
+
+const server = setupServer(
+  ...userHandlers,
+  http.post(`${BASE}/flow`, async ({ request }) => {
+    captured.flowStart = (await request.json()) as Record<string, unknown>;
+    captured.flowStartOrigin = request.headers.get("origin");
+    return HttpResponse.json(identifierStep, {
+      status: 201,
+      headers: { "set-cookie": "_zflow=state-1; HttpOnly; Path=/" },
+    });
+  }),
+  http.post(`${BASE}/flow/:id/submit`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    captured.submits.push(body);
+    captured.submitCookies.push(request.headers.get("cookie"));
+    return HttpResponse.json(captured.submits.length === 1 ? passwordStep : terminalStep, {
+      headers: { "set-cookie": `_zflow=state-${captured.submits.length + 1}; HttpOnly; Path=/` },
+    });
+  }),
+  http.post(`${BASE}/sessions/exchange`, async ({ request }) => {
+    captured.exchangeBody = (await request.json()) as Record<string, unknown>;
+    captured.exchangeProject = new URL(request.url).searchParams.get("project_id") ?? "";
+    return HttpResponse.json({
+      session: { id: "sess_1", user_id: "user_1", expires_at: "2027-01-01T00:00:00Z" },
+      session_token: "session-token-1",
+    });
+  }),
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+  server.resetHandlers();
+  captured.submits = [];
+  captured.submitCookies = [];
+  delete captured.flowStart;
+  delete captured.flowStartOrigin;
+  delete captured.exchangeBody;
+  delete captured.exchangeProject;
+});
+afterAll(() => server.close());
+
+describe("seedSession", () => {
+  it("drives the two-step flow like the orchestrator and exchanges the handoff", async () => {
+    const zitadel = connectZitadel(handle);
+    const session = await zitadel.seedSession();
+
+    expect(captured.flowStart).toEqual({ project_id: "proj_1", purpose: "login" });
+    // Step 1: only the declared email field, threading the flow session token.
+    expect(captured.submits[0]).toEqual({
+      session_token: "flow-token-1",
+      action: "submit",
+      fields: { email: session.user.email },
+    });
+    // Step 2: the schema-pointer field name is matched on its tail segment.
+    expect(captured.submits[1]).toEqual({
+      session_token: "flow-token-2",
+      action: "submit",
+      fields: { "x-auth-methods#password": session.user.password },
+    });
+    expect(captured.exchangeBody).toEqual({ handoff_token: "handoff_1" });
+    expect(captured.exchangeProject).toBe("proj_1");
+    // The sealed flow-state cookie must round-trip and advance each hop.
+    // (msw's node interceptor appends its own virtual cookie store to the
+    // header, so assert containment, not equality — the real path has no
+    // auto-jar, which is why the kit carries its own.)
+    expect(captured.submitCookies[0]).toContain("_zflow=state-1");
+    expect(captured.submitCookies[1]).toContain("_zflow=state-2");
+    expect(captured.submitCookies[1]).not.toContain("_zflow=state-1");
+    // The project's origin allowlist applies to flow calls; the handle's
+    // registered app origin is the default.
+    expect(captured.flowStartOrigin).toBe("http://app.invalid:3002");
+
+    expect(session.sessionToken).toBe("session-token-1");
+    expect(session.expiresAt).toBe("2027-01-01T00:00:00Z");
+    expect(session.cookie).toEqual({
+      name: "__nextgen_session",
+      value: "session-token-1",
+      httpOnly: true,
+      secure: true,
+      sameSite: "Lax",
+      path: "/",
+    });
+  });
+
+  it("mints for an existing user without seeding and honors the flow name", async () => {
+    const zitadel = connectZitadel(handle);
+    const user = { id: "user_9", email: "kept@acme.com", password: "Fixed-pw-1" };
+    server.use(
+      http.post(`${BASE}/users`, () => {
+        throw new Error("must not seed when a user is provided");
+      }),
+    );
+
+    const session = await zitadel.seedSession({
+      user,
+      flowDefinitionName: "custom-login",
+      origin: "http://other.invalid",
+    });
+    expect(captured.flowStart).toEqual({
+      project_id: "proj_1",
+      purpose: "login",
+      flow_definition_name: "custom-login",
+    });
+    expect(captured.flowStartOrigin).toBe("http://other.invalid");
+    expect(session.user).toBe(user);
+    expect(captured.submits[0]).toMatchObject({ fields: { email: "kept@acme.com" } });
+  });
+
+  it("fails loudly on a step declaring fields it cannot fill", async () => {
+    server.use(
+      http.post(`${BASE}/flow`, () =>
+        HttpResponse.json(
+          {
+            id: "flow_1",
+            session_token: "t",
+            step: { name: "mfa-otp", fields: [{ name: "one_time_code" }] },
+          },
+          { status: 201 },
+        ),
+      ),
+    );
+    const zitadel = connectZitadel(handle);
+    await expect(zitadel.seedSession()).rejects.toThrow(
+      /password flows only.*"mfa-otp".*"one_time_code"/s,
+    );
+  });
+
+  it("caps the number of flow steps instead of looping", async () => {
+    server.use(
+      http.post(`${BASE}/flow/:id/submit`, () => HttpResponse.json(identifierStep)),
+    );
+    const zitadel = connectZitadel(handle);
+    await expect(zitadel.seedSession()).rejects.toThrow(/did not complete within 6 steps/);
+  });
+});

--- a/packages/testing/tests/unit/session.test.ts
+++ b/packages/testing/tests/unit/session.test.ts
@@ -174,6 +174,21 @@ describe("seedSession", () => {
     );
   });
 
+  it("explains a missing Origin when the allowlist rejects the call", async () => {
+    server.use(
+      http.post(`${BASE}/flow`, () =>
+        HttpResponse.json(
+          { code: "req.invalid", message: 'origin "x" is not allowed for this project' },
+          { status: 400 },
+        ),
+      ),
+    );
+    const zitadel = connectZitadel({ ...handle, appOrigin: undefined });
+    await expect(zitadel.seedSession()).rejects.toThrow(
+      /No Origin header was sent.*appOrigins/s,
+    );
+  });
+
   it("caps the number of flow steps instead of looping", async () => {
     server.use(
       http.post(`${BASE}/flow/:id/submit`, () => HttpResponse.json(identifierStep)),


### PR DESCRIPTION
## Summary

Phase 3 of the test-kit track: **tests start past login**. Adds `seed.session()` — a headless drive of the real login flow — with an `authenticatedPage` Playwright fixture on top, plus the small seed vocabulary (`seed.identity()`, `seed.users(n, template)`), all dogfooded in the demo real lane. No server or SDK changes.

- **`seed.session()`** (`packages/testing/src/session.ts`): starts the flow (`POST /flow`, same body as the orchestrator), submits each step's *declared* fields from `{ email, password }` (no hardcoded schema pointers — pointer names match on their tail segment), exchanges the terminal `handoff_token`, and returns `{ user, sessionToken, expiresAt, cookie }` with the cookie mirroring the server's attributes. Two things the real server taught the driver, now encoded and unit-tested: the flow is stateless through the sealed **`_zflow` cookie** (flow calls use raw fetch with a one-cookie jar, since browsers round-trip it implicitly and the typed client hides response headers), and flow submissions enforce the **project origin allowlist** (the driver sends the app origin; the handle now carries `appOrigin` from bootstrap as the default, and the Playwright fixtures pass the suite's `baseURL`).
- **`authenticatedPage` fixture**: seeds a user, mints a session, injects the cookie into a dedicated browser context (plain `page` stays signed out for login-flow tests). Scope is deliberate and documented: password flows only — a step demanding anything beyond email/password fails with the step name.
- **Seed vocabulary**: `seed.identity()` (unused email+password, creates nothing — registration specs must prove the flow creates the user) and `seed.users(n, template)` with per-index templates; `apps/console/scripts/dev-real.mts` refactored onto it (deletes its hand-rolled loop).
- **Dogfood specs** in `apps/demo-next-e2e/src-real/`: `authenticated.spec.ts` (straight to `/admin`, never sees `/login`, plus a headless `GET /sessions/me` with the cookie header — the SDK middleware's own pattern — proving the token serves backend tests) and `registration.spec.ts` (fresh identity through the real registration UI, user existence verified via the API).
- README: "Start tests authenticated" section, API block, roadmap items 1 and 3 updated to their landed state (remaining from item 3: a dedicated vitest entry once a second backend consumer exists).

## Validation

- `moon run testing:build testing:test testing:typecheck testing:lint` — 56 unit tests across 10 files (new: msw-backed flow walk asserting the submit bodies, the `_zflow` jar round-trip, the Origin header default and override, the unsupported-step guard, and the step cap; `seed.identity`/`seed.users` coverage).
- `moon run demo-next-e2e:e2e-real` — **4/4**: authenticated-page (3.5s incl. headless mint), registration (0.7s), both existing login specs, 2 workers on one shared instance.
- `moon run console:dev-real -- --seed-only` — boots and seeds 9 users through `seed.users`, graceful stop.
- `moon run console-e2e:e2e-real` — 3/3 consumer regression.

## Release notes / changeset

- No changeset required — `@zitadel/testing` is changeset-ignored (pre-publish); demo/console apps are ignored too.

## Notes

- The three real-server corrections the dogfood run surfaced (flow-state cookie, origin allowlist, `/sessions/me` cookie auth) are exactly the contracts a customer would have tripped on; they're now encoded in the driver, its unit tests, and the README's backend-test recipe.
- `seed.session()` composes with existing users (`{ user }`) and specific flows (`{ flowDefinitionName }`); remote-mode reuse comes free since it sits on `connectZitadel`.
- Next on the roadmap per the phase plan: project-per-worker isolation and the CDP passkey helper; OTP/email capture stays server-gated.
