### PR TITLE
test(console): gate add-user e2e reads on the rendered schema form

### DIFF
--- a/apps/console-e2e/src-real/add-user.spec.ts
+++ b/apps/console-e2e/src-real/add-user.spec.ts
@@ -39,6 +39,12 @@ async function openDrawer(page: Page, user: { email: string; password: string })
   await page.getByRole("button", { name: "Add", exact: true }).click();
   const drawer = page.getByRole("dialog", { name: "Add user" });
   await expect(drawer).toBeVisible();
+  // Two fetches gate the form: the drawer shows "Loading schemas…" until the
+  // list resolves, and fields mount only once the selected schema's definition
+  // arrives. Locator actions auto-wait through both, but one-shot reads
+  // (`renderedFields`) and raw key presses don't — so only hand tests a drawer
+  // whose form is actually on screen.
+  await expect(drawer.locator('input[data-slot="input"]').first()).toBeVisible();
   return drawer;
 }
 
@@ -279,6 +285,9 @@ test("can be completed with the keyboard alone", async ({ page, zitadel, seed })
   await page.getByRole("button", { name: "Add", exact: true }).press("Enter");
   const drawer = page.getByRole("dialog", { name: "Add user" });
   await expect(drawer).toBeVisible();
+  // Same readiness gate as `openDrawer`: a raw Tab loop never auto-waits, so
+  // the schema-driven form must be on screen before traversal starts.
+  await expect(drawer.locator('input[data-slot="input"]').first()).toBeVisible();
 
   const email = uniqueEmail("keyboard");
   for (const property of schema.required) {


### PR DESCRIPTION
## Summary

`ci` on unrelated PRs started tripping over `src-real/add-user.spec.ts › can be completed with the keyboard alone` (first seen on [PR #681's run](https://github.com/zitadel/nextgen/actions/runs/30742334570/job/91481840392)): `never reached target within 20 tabs; last focus: Close`. The same commit passed on the adjacent run five minutes later — a cold-start race, not a product regression.

Two fetches gate the drawer's form: the schema *list* (the combobox shows "Loading schemas…" until it resolves), then the selected schema's *definition*, which is what actually mounts the fields. Playwright locator actions auto-wait through both, so most of the file is immune — but the suite has two reads that get no auto-waiting, and each is a distinct race window:

- **Keyboard traversal** (the CI failure): raw `keyboard.press("Tab")` starts while the drawer still says "Loading schemas…". The failure snapshot in the `console-e2e-diagnostics` artifact shows the focus trap holding exactly two tab stops (Close, Cancel) at that moment, so the loop bounces between them 20 times in ~800 ms and throws.
- **`renderedFields()`** (reproduced locally while validating the fix): a one-shot `evaluateAll` in *renders exactly the properties the API's schema defines*. Its existing guard waits for the **picker** to resolve, but fields mount on the **definition** fetch — in that window the read returns `[]` against an expected `["email"]`.

The fix gives both the same precondition instead of per-call-site patches: `openDrawer` now returns only once the first schema-driven input (`input[data-slot="input"]`, the selector `renderedFields()` already uses) is visible, and the keyboard test — which opens the drawer via key press rather than `openDrawer` — gets the same one-line gate. This also un-vacuouses *marks only the properties the schema does not require*, whose `toHaveCount(0)` assertions could previously all pass before any field existed. `tabUntil` itself stays strict — a real reachability failure should still fail fast, not be retried into silence.

## Validation

- Reproduced CI's failure mode deterministically: with a temporary 2 s `page.route` delay on the schema fetches, the unguarded keyboard test fails with CI's exact error (`never reached target within 20 tabs; last focus: Close`); with the gate it passes under the same delay.
- The `renderedFields` race fired naturally on a local cold run (`Array [] !== ["email"]`, picker already showing `DefaultHumanUserSchema` in the failure snapshot) and no longer can: the one-shot read now runs strictly after the first field is visible, and the field set mounts in a single render.
- `moon run console-e2e:e2e-real` — full real-instance suite green locally (13/13).

## Release notes / changeset

Test-only; nothing a user installs changes. No changeset.

## Notes

- The flake shipped with #673 this morning and can hit any PR whose merge ref includes it; it is unrelated to the PRs it fails on (#681 was CLI-only).
