### PR TITLE
test(console): synchronize the add-user drawer field assertions

### DIFF
--- a/apps/console-e2e/src-real/add-user.spec.ts
+++ b/apps/console-e2e/src-real/add-user.spec.ts
@@ -75,10 +75,15 @@ test("renders exactly the properties the API's schema defines", async ({ page, z
   const schema = await projectSchema(zitadel);
   const drawer = await openDrawer(page, await seed.user());
 
-  await expect(drawer.getByRole("combobox", { name: "User Schema" })).not.toContainText(
-    "Select schema",
-  );
-  expect(await renderedFields(drawer)).toEqual(schema.properties);
+  // While schemas load the trigger is disabled and reads "Loading schemas…" —
+  // which also satisfies the placeholder check below, so wait for the
+  // resolved state positively first (fast machines hit the loading window).
+  const picker = drawer.getByRole("combobox", { name: "User Schema" });
+  await expect(picker).not.toHaveAttribute("aria-disabled", "true");
+  await expect(picker).not.toContainText("Select schema");
+  // The fields mount after the auto-selection resolves; `evaluateAll` never
+  // waits, so poll the exact set instead of reading it once.
+  await expect.poll(() => renderedFields(drawer)).toEqual(schema.properties);
   await expectNoErrorBoundary(page);
 });
 
@@ -90,6 +95,9 @@ test("marks only the properties the schema does not require", async ({ page, zit
     const field = drawer
       .locator('[data-slot="field"]')
       .filter({ has: page.locator(`input[name="${property}"]`) });
+    // Without this, a required property would pass vacuously (count 0) while
+    // the schema-driven fields are still mounting.
+    await expect(field).toBeVisible();
     await expect(field.getByText("Optional")).toHaveCount(schema.required.has(property) ? 0 : 1);
   }
 });


### PR DESCRIPTION
## Summary

Fixes the deterministic local failure of #673's Add-user drawer spec `renders exactly the properties the API's schema defines` (`apps/console-e2e/src-real/add-user.spec.ts:72`). On a fast machine it failed 3/3 — including on pristine main — with `renderedFields` returning `[]` where the schema defines `["email"]`; #673's own CI was green, which is what made it environment-shaped.

**Root cause (spec synchronization, not a component bug):** while schemas load, the picker trigger is disabled and reads **"Loading schemas…"** (`add-user-sheet.tsx:318,327`) — a state that *also satisfies* the spec's only guard, `not.toContainText("Select schema")`, since the placeholder never appears in it. On a fast machine the guard passes during the loading window and the very next line reads the field names with `evaluateAll`, which never auto-waits → zero inputs. The failure snapshot confirms it: at assertion time the drawer shows `combobox "User Schema" [disabled]` and no fields. Every sibling spec passes because it synchronizes implicitly through auto-waiting `fill`/`toBeVisible` calls.

**Fix:**
- Wait for the resolved state positively first (`aria-disabled` gone — the same gate the file's keyboard specs already use), keep the placeholder check, and replace the one-shot read with `expect.poll(() => renderedFields(drawer))` so the exact-set assertion waits for the mounted fields.
- One-line hardening in `marks only the properties the schema does not require`: assert the field is visible before counting its "Optional" marker — previously a required property (expected count 0) could pass vacuously while fields were still mounting.

## Validation

- `moon run console-e2e:e2e-real` — **13/13** twice in a row (the fixed spec at ~1.6s), on the machine where the failure reproduced 3/3 before the fix.
- Attribution runs that pinned the diagnosis: failure reproduced on pristine main @ `5253a1a4` with a clean tree, ruling out in-flight branches.

## Release notes / changeset

- No changeset — e2e suite only, no publishable package changes (`@zitadel/console-e2e` is changeset-ignored).

## Notes

- En route, one failed lane run was a port squat: an orphaned CLI-managed runtime from an earlier aborted run held the lane's fixed Zitadel port (8093). `node apps/cli/bin/run.js stop --all` reaps those — worth remembering when the lane dies at boot with "healthz is already used".
