### PR TITLE
feat: add a virtual-passkey helper to @zitadel/testing

### DIFF
--- a/.changeset/testing-virtual-passkey.md
+++ b/.changeset/testing-virtual-passkey.md
@@ -7,5 +7,6 @@ fixture to the test-kit: a CDP virtual authenticator (platform authenticator,
 discoverable credentials, automatic user presence) that lets tests complete
 real passkey registration and login ceremonies headlessly, plus
 `credentialCount()` for asserting credential reuse. Chromium projects only,
-and the app under test must be served on `localhost` — WebAuthn rejects IP
-relying-party IDs.
+and the app under test needs an origin WebAuthn accepts as a relying-party
+ID: HTTPS, or `http://localhost` for local tests — raw IP origins are
+invalid.

--- a/.changeset/testing-virtual-passkey.md
+++ b/.changeset/testing-virtual-passkey.md
@@ -1,0 +1,11 @@
+---
+"@zitadel/testing": minor
+---
+
+Add `enableVirtualPasskey(page)` and the on-demand `passkey` Playwright
+fixture to the test-kit: a CDP virtual authenticator (platform authenticator,
+discoverable credentials, automatic user presence) that lets tests complete
+real passkey registration and login ceremonies headlessly, plus
+`credentialCount()` for asserting credential reuse. Chromium projects only,
+and the app under test must be served on `localhost` — WebAuthn rejects IP
+relying-party IDs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -436,7 +436,7 @@ What these got wrong, from this repo's own history:
 
 | Shipped title | What it actually did | Should have been |
 | --- | --- | --- |
-| `feat: add withZitadel() Playwright orchestration to @zitadel/testing` (#680) | `@zitadel/testing` is journey-only and never published to npm | `test:` |
+| `feat: add withZitadel() Playwright orchestration to @zitadel/testing` (#680) | `@zitadel/testing` was journey-only and unpublished at the time (since #692 it ships on the release train, so kit API changes are `feat` today) | `test:` (then) |
 | `feat: add Figma export sync pipeline for design tokens` (#494) | A sync script and a workflow; nothing in a release | `build:` |
 | `chore: set argon2id as default password hashing algorithm` (#526) | Changed a shipped security default, with a `@zitadel/server` changeset | `feat:` |
 | `docs(config): improve schema README guidance` (#482) | Rewrote a README that `@zitadel/config` generates into the user's project | `feat(config):` |

--- a/apps/cli-journey-e2e/fixtures/testkit/zitadel-e2e/passkey.spec.ts
+++ b/apps/cli-journey-e2e/fixtures/testkit/zitadel-e2e/passkey.spec.ts
@@ -1,0 +1,45 @@
+/* oxlint-disable playwright/no-conditional-in-test -- the registration choice
+   only re-asks for the email on some flow configs; fill it when it renders. */
+import { expect, test } from "@zitadel/testing/playwright";
+
+/**
+ * Passkey round-trip with the kit's virtual authenticator: register a fresh
+ * identity with a passkey through the app-embedded flow, then sign back in
+ * with it. The whole trip stays on one page — the credential lives in the
+ * page-bound virtual authenticator, so signing out means clearing cookies,
+ * not opening a fresh context. Chromium only.
+ */
+test("a fresh identity registers and signs in with a passkey", async ({
+  page,
+  seed,
+  passkey,
+}) => {
+  const who = seed.identity();
+
+  await page.goto("/login");
+  await page.getByLabel(/email/i).fill(who.email);
+  await page
+    .getByRole("button", { name: /continue|sign in/i })
+    .first()
+    .click();
+  await expect(
+    page.getByRole("heading", { name: /create|register|sign up|no-account/i }),
+  ).toBeVisible({ timeout: 30_000 });
+  const emailAgain = page.getByLabel(/email/i).first();
+  if (await emailAgain.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await emailAgain.fill(who.email);
+  }
+  await page.getByRole("button", { name: /passkey/i }).first().click();
+  await page.waitForURL(/\/profile(?:[/?#]|$)/, { timeout: 30_000 });
+  await expect.poll(() => passkey.credentialCount()).toBe(1);
+
+  await page.context().clearCookies();
+  await page.goto("/login");
+  await expect(page.getByLabel(/email/i)).toBeVisible({ timeout: 30_000 });
+  await page.getByLabel(/email/i).fill(who.email);
+  await page.getByRole("button", { name: /passkey/i }).first().click();
+  await page.waitForURL(/\/profile(?:[/?#]|$)/, { timeout: 30_000 });
+
+  // Login reused the registered credential instead of minting another.
+  await expect.poll(() => passkey.credentialCount()).toBe(1);
+});

--- a/apps/cli-journey-e2e/moon.yml
+++ b/apps/cli-journey-e2e/moon.yml
@@ -4,6 +4,7 @@ layer: "automation"
 stack: "frontend"
 dependsOn:
   - "cli"
+  - "testing"
 
 tasks:
   lint:
@@ -21,6 +22,8 @@ tasks:
       ZITADEL_TELEMETRY: "0"
     deps:
       - "cli:build"
+      # The journey spec imports the kit's virtual-passkey helper.
+      - "testing:build"
     options:
       runInCI: false
 
@@ -30,6 +33,7 @@ tasks:
       ZITADEL_TELEMETRY: "0"
     deps:
       - "cli:build"
+      - "testing:build"
     options:
       runInCI: false
 

--- a/apps/cli-journey-e2e/package.json
+++ b/apps/cli-journey-e2e/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@playwright/test": "catalog:",
+    "@zitadel/testing": "workspace:*",
     "eslint-plugin-playwright": "catalog:"
   }
 }

--- a/apps/cli-journey-e2e/src/user-journey.spec.ts
+++ b/apps/cli-journey-e2e/src/user-journey.spec.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable playwright/expect-expect, playwright/no-conditional-in-test */
-import { expect, test, type CDPSession, type Locator, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { enableVirtualPasskey } from "@zitadel/testing/playwright";
 
 test.describe.configure({ mode: "serial" });
 test.setTimeout(60_000);
@@ -41,7 +42,7 @@ if (preset === "passkey-first") {
   test(`passkey-first preset: fallback registration, then one-tap passkey login in a fresh ${framework} app`, async ({
     page,
   }) => {
-    const authenticator = await enableVirtualAuthenticator(page);
+    const authenticator = await enableVirtualPasskey(page);
     const email = uniqueEmail("passkey-first");
 
     await gotoLogin(page);
@@ -58,7 +59,7 @@ if (preset === "passkey-first") {
     await registerWithPasskey(page, email);
     await expectSignedIn(page);
     await expectSessionCookie(page);
-    await expectVirtualCredentialCount(authenticator, 1);
+    await expect.poll(() => authenticator.credentialCount()).toBe(1);
 
     await logout(page);
 
@@ -73,7 +74,7 @@ if (preset === "passkey-first") {
     await clickAction(page, /continue with passkey|passkey/i, ["passkey"]);
     await expectSignedIn(page);
     await expectSessionCookie(page);
-    await expectVirtualCredentialCount(authenticator, 1);
+    await expect.poll(() => authenticator.credentialCount()).toBe(1);
   });
 }
 
@@ -81,7 +82,7 @@ if (preset === "password-first" && process.env.JOURNEY_ENABLE_PASSKEY !== "0") {
   test(`passkey-only registration, logout, and passkey login work in a fresh ${framework} app`, async ({
     page,
   }) => {
-    const authenticator = await enableVirtualAuthenticator(page);
+    const authenticator = await enableVirtualPasskey(page);
 
     const email = uniqueEmail("passkey");
 
@@ -89,13 +90,13 @@ if (preset === "password-first" && process.env.JOURNEY_ENABLE_PASSKEY !== "0") {
     await registerWithPasskey(page, email);
     await expectSignedIn(page);
     await expectSessionCookie(page);
-    await expectVirtualCredentialCount(authenticator, 1);
+    await expect.poll(() => authenticator.credentialCount()).toBe(1);
 
     await logout(page);
     await loginWithPasskey(page, email);
     await expectSignedIn(page);
     await expectSessionCookie(page);
-    await expectVirtualCredentialCount(authenticator, 1);
+    await expect.poll(() => authenticator.credentialCount()).toBe(1);
   });
 }
 
@@ -212,41 +213,6 @@ async function expectSessionCookie(page: Page): Promise<void> {
     (cookie) => cookie.name === "__nextgen_session",
   );
   expect(sessionCookie?.httpOnly).toBe(true);
-}
-
-type VirtualAuthenticator = {
-  client: CDPSession;
-  authenticatorId: string;
-};
-
-async function enableVirtualAuthenticator(page: Page): Promise<VirtualAuthenticator> {
-  const client = await page.context().newCDPSession(page);
-  await client.send("WebAuthn.enable");
-  const { authenticatorId } = await client.send("WebAuthn.addVirtualAuthenticator", {
-    options: {
-      protocol: "ctap2",
-      transport: "internal",
-      hasResidentKey: true,
-      hasUserVerification: true,
-      isUserVerified: true,
-      automaticPresenceSimulation: true,
-    },
-  });
-  return { client, authenticatorId };
-}
-
-async function expectVirtualCredentialCount(
-  authenticator: VirtualAuthenticator,
-  expected: number,
-): Promise<void> {
-  await expect
-    .poll(async () => {
-      const { credentials } = await authenticator.client.send("WebAuthn.getCredentials", {
-        authenticatorId: authenticator.authenticatorId,
-      });
-      return credentials.length;
-    })
-    .toBe(expected);
 }
 
 async function logout(page: Page): Promise<void> {

--- a/apps/cli/tests/unit/scripts/check-pr-title.test.ts
+++ b/apps/cli/tests/unit/scripts/check-pr-title.test.ts
@@ -95,6 +95,8 @@ describe("isNonShippingFile", () => {
     // The console and login UI ship inside the server container.
     "apps/console/src/routes/users.tsx",
     "apps/login-ui/src/app.ts",
+    // On the release train since #692 — customers install it from npm.
+    "packages/testing/src/passkey.ts",
   ])("treats %s as shipping", async (file) => {
     const { isNonShippingFile } = await load();
     expect(isNonShippingFile(file)).toBe(false);
@@ -114,7 +116,6 @@ describe("isNonShippingFile", () => {
     "apps/console-e2e/tests/users.spec.ts",
     "apps/demo-next/next-env.d.ts",
     "apps/storybook/main.ts",
-    "packages/testing/src/orchestration.ts",
     "packages/api-mock/src/handlers.ts",
     "packages/components/moon.yml",
     "internal/domain/user_test.go",
@@ -135,13 +136,12 @@ describe("isNonShippingFile", () => {
 });
 
 describe("checkPrTitle", () => {
-  it("fails feat when nothing in the diff reaches a user (#680)", async () => {
+  it("fails feat when nothing in the diff reaches a user", async () => {
     const { checkPrTitle } = await load();
     const report = checkPrTitle({
-      title: "feat: add withZitadel() Playwright orchestration to @zitadel/testing",
+      title: "feat: extend the api-mock flow fixtures",
       files: [
-        "packages/testing/src/orchestration.ts",
-        "packages/testing/tests/unit/orchestration.test.ts",
+        "packages/api-mock/src/handlers.ts",
         "apps/console-e2e/playwright.real.config.mts",
         "apps/demo-next/next-env.d.ts",
       ],
@@ -151,6 +151,21 @@ describe("checkPrTitle", () => {
     expect(report.ok).toBe(false);
     expect(report.errors.map((error) => error.code)).toContain("non-shipping-customer-type");
     expect(report.errors[0]?.message).toContain('Use "test:"');
+  });
+
+  it("allows feat for kit API changes now that @zitadel/testing ships (#692)", async () => {
+    const { checkPrTitle } = await load();
+    const report = checkPrTitle({
+      title: "feat: add a virtual-passkey helper to @zitadel/testing",
+      files: [
+        "packages/testing/src/passkey.ts",
+        "packages/testing/tests/unit/passkey.test.ts",
+        "apps/demo-next-e2e/src-real/passkey.spec.ts",
+      ],
+      config,
+    });
+
+    expect(report.ok).toBe(true);
   });
 
   it("fails feat on a build pipeline (#494)", async () => {
@@ -306,7 +321,7 @@ describe("checkPrTitle", () => {
 
 describe("suggestType", () => {
   it.each([
-    [["packages/testing/src/x.ts", "apps/console-e2e/a.spec.ts"], "test"],
+    [["packages/api-mock/src/x.ts", "apps/console-e2e/a.spec.ts"], "test"],
     [[".github/workflows/ci.yml"], "ci"],
     [["docs/adrs/030.md", "AGENTS.md"], "docs"],
     [["packages/design-tokens/scripts/build.ts", ".github/workflows/sync.yml"], "build"],
@@ -338,7 +353,7 @@ describe("renderStepSummary", () => {
   it("names the failure and the next action", async () => {
     const { checkPrTitle, renderStepSummary } = await load();
     const summary = renderStepSummary(
-      checkPrTitle({ title: "feat: add a harness", files: ["packages/testing/src/x.ts"], config }),
+      checkPrTitle({ title: "feat: add a harness", files: ["packages/api-mock/src/x.ts"], config }),
     );
 
     expect(summary).toContain("# PR title");

--- a/apps/demo-next-e2e/src-real/flow-actions.ts
+++ b/apps/demo-next-e2e/src-real/flow-actions.ts
@@ -1,0 +1,53 @@
+import type { Locator, Page } from "@playwright/test";
+
+/**
+ * Resilient widget interaction shared by the real-flow specs: prefer the
+ * orchestrator's stable action testids, fall back to roles — the journey
+ * suite's proven pattern for flows that span multiple steps.
+ */
+export async function clickAction(
+  page: Page,
+  name: RegExp,
+  actionNames: string[],
+): Promise<void> {
+  const target = actionCandidates(page, name, actionNames).find(Boolean);
+  for (const candidate of actionCandidates(page, name, actionNames)) {
+    if (await candidate.first().isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await candidate.first().click();
+      return;
+    }
+  }
+  await (target as Locator).first().click();
+}
+
+export async function clickActionIfVisible(
+  page: Page,
+  name: RegExp,
+  actionNames: string[],
+): Promise<void> {
+  for (const candidate of actionCandidates(page, name, actionNames)) {
+    if (await candidate.first().isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await candidate.first().click();
+      return;
+    }
+  }
+}
+
+function actionCandidates(page: Page, name: RegExp, actionNames: string[]): Locator[] {
+  return [
+    ...actionNames.flatMap((action) => [
+      page.getByTestId(`zitadel-action-${action}-button`),
+      page.getByTestId(`zitadel-action-${action}-link`),
+      page.locator(`zl-button[action="${action}"], [data-action="${action}"]`),
+    ]),
+    page.getByRole("button", { name }),
+    page.getByRole("link", { name }),
+  ];
+}
+
+export async function fillIfVisible(page: Page, label: RegExp, value: string): Promise<void> {
+  const field = page.getByLabel(label).first();
+  if (await field.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await field.fill(value);
+  }
+}

--- a/apps/demo-next-e2e/src-real/flow-actions.ts
+++ b/apps/demo-next-e2e/src-real/flow-actions.ts
@@ -10,14 +10,16 @@ export async function clickAction(
   name: RegExp,
   actionNames: string[],
 ): Promise<void> {
-  const target = actionCandidates(page, name, actionNames).find(Boolean);
-  for (const candidate of actionCandidates(page, name, actionNames)) {
+  const candidates = actionCandidates(page, name, actionNames);
+  for (const candidate of candidates) {
     if (await candidate.first().isVisible({ timeout: 1_000 }).catch(() => false)) {
       await candidate.first().click();
       return;
     }
   }
-  await (target as Locator).first().click();
+  // Nothing was visible within the probes: fall back to an auto-waiting click
+  // on the first (most specific) candidate.
+  await candidates[0].first().click();
 }
 
 export async function clickActionIfVisible(

--- a/apps/demo-next-e2e/src-real/passkey.spec.ts
+++ b/apps/demo-next-e2e/src-real/passkey.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@zitadel/testing/playwright";
+
+import { clickAction, fillIfVisible } from "./flow-actions";
+
+/**
+ * Passkey round-trip through the real flow with the kit's virtual
+ * authenticator: register a fresh identity with a passkey at the
+ * registration-choice step (the default password-first flow offers it), then
+ * sign back in with that passkey. The whole trip stays on one page — the
+ * credential lives in the page-bound virtual authenticator, so signing out
+ * means clearing cookies, not opening a fresh context.
+ */
+test("a fresh identity registers with a passkey and signs back in with it", async ({
+  page,
+  seed,
+  passkey,
+}) => {
+  const who = seed.identity();
+
+  await page.goto("/login");
+  await page.getByLabel(/email/i).fill(who.email);
+  await clickAction(page, /continue|sign in/i, ["submit"]);
+  await expect(
+    page.getByRole("heading", { name: /create|register|sign up|no-account/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  await fillIfVisible(page, /email/i, who.email);
+  await clickAction(page, /register.*passkey|passkey.*register|passkey_register/i, [
+    "passkey_register",
+  ]);
+  await page.waitForURL(/\/admin(?:[/?#]|$)/, { timeout: 30_000 });
+  await expect.poll(() => passkey.credentialCount()).toBe(1);
+
+  await page.context().clearCookies();
+  await page.goto("/login");
+  // The login surface re-hydrates after the navigation; wait for the field
+  // before driving it (the journey documents this race after redirects).
+  await expect(page.getByLabel(/email/i)).toBeVisible({ timeout: 30_000 });
+  await page.getByLabel(/email/i).fill(who.email);
+  await clickAction(page, /sign in with.*passkey|passkey/i, ["passkey"]);
+  await page.waitForURL(/\/admin(?:[/?#]|$)/, { timeout: 30_000 });
+
+  // Login must reuse the registered credential, not mint another.
+  await expect.poll(() => passkey.credentialCount()).toBe(1);
+});

--- a/apps/demo-next-e2e/src-real/registration.spec.ts
+++ b/apps/demo-next-e2e/src-real/registration.spec.ts
@@ -50,4 +50,3 @@ async function skipPasskeyUpsellIfVisible(page: Page): Promise<void> {
     await skip.click();
   }
 }
-

--- a/apps/demo-next-e2e/src-real/registration.spec.ts
+++ b/apps/demo-next-e2e/src-real/registration.spec.ts
@@ -1,6 +1,8 @@
-import type { Locator, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 import { expect, test } from "@zitadel/testing/playwright";
+
+import { clickAction, clickActionIfVisible, fillIfVisible } from "./flow-actions";
 
 /**
  * Registration through the real flow with a kit-minted unused identity:
@@ -49,45 +51,3 @@ async function skipPasskeyUpsellIfVisible(page: Page): Promise<void> {
   }
 }
 
-async function clickAction(page: Page, name: RegExp, actionNames: string[]): Promise<void> {
-  const target = actionCandidates(page, name, actionNames).find(Boolean);
-  for (const candidate of actionCandidates(page, name, actionNames)) {
-    if (await candidate.first().isVisible({ timeout: 1_000 }).catch(() => false)) {
-      await candidate.first().click();
-      return;
-    }
-  }
-  await (target as Locator).first().click();
-}
-
-async function clickActionIfVisible(
-  page: Page,
-  name: RegExp,
-  actionNames: string[],
-): Promise<void> {
-  for (const candidate of actionCandidates(page, name, actionNames)) {
-    if (await candidate.first().isVisible({ timeout: 1_000 }).catch(() => false)) {
-      await candidate.first().click();
-      return;
-    }
-  }
-}
-
-function actionCandidates(page: Page, name: RegExp, actionNames: string[]): Locator[] {
-  return [
-    ...actionNames.flatMap((action) => [
-      page.getByTestId(`zitadel-action-${action}-button`),
-      page.getByTestId(`zitadel-action-${action}-link`),
-      page.locator(`zl-button[action="${action}"], [data-action="${action}"]`),
-    ]),
-    page.getByRole("button", { name }),
-    page.getByRole("link", { name }),
-  ];
-}
-
-async function fillIfVisible(page: Page, label: RegExp, value: string): Promise<void> {
-  const field = page.getByLabel(label).first();
-  if (await field.isVisible({ timeout: 1_000 }).catch(() => false)) {
-    await field.fill(value);
-  }
-}

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -96,6 +96,30 @@ log in through the UI for those. `seed.identity()` complements registration
 specs: an unused email+password that creates nothing, so the flow under test
 must create the user.
 
+### Test passkey flows
+
+`enableVirtualPasskey(page)` — also available as the on-demand `passkey`
+fixture — attaches a CDP virtual authenticator to the page (a platform
+authenticator with discoverable credentials and automatic user presence), so
+the real registration and login ceremonies complete without an OS dialog:
+
+```ts
+test("registers and signs in with a passkey", async ({ page, seed, passkey }) => {
+  const who = seed.identity();
+  // drive /login → registration choice → "Register with passkey" …
+  await expect.poll(() => passkey.credentialCount()).toBe(1);
+});
+```
+
+Constraints, all inherent to WebAuthn/CDP: Chromium projects only (the CDP
+WebAuthn domain exists nowhere else); the authenticator is bound to the page,
+so register and sign back in on the same page (sign out by clearing cookies
+instead of opening a fresh context); and serve the app on `localhost`, never
+`127.0.0.1` — WebAuthn rejects IP relying-party IDs. The default
+`password-first` flow offers passkey registration at the registration-choice
+step; boot `preset: "passkey-first"` for one-tap discoverable-credential
+login flows.
+
 The two in-repo consumers are `apps/demo-next-e2e/playwright.real.config.mts`
 and `apps/console-e2e/playwright.real.config.mts` — run them with
 `moon run demo-next-e2e:e2e-real` / `moon run console-e2e:e2e-real`.
@@ -144,9 +168,10 @@ what the Playwright fixtures use, and what a future remote-instance mode would
 build on.
 
 From `@zitadel/testing/playwright`: the `test`/`expect` fixtures (`seed.user()`
-per test, `zitadel` per worker), plus `withZitadel(options)` returning
-`{ webServer }` for the config, and `nextAppEnv`/`applyAppEnvTemplate` for the
-env-template mechanism described above.
+per test, `zitadel` per worker, `passkey` on demand), plus `withZitadel(options)`
+returning `{ webServer }` for the config, `enableVirtualPasskey(page)` for
+non-fixture pages, and `nextAppEnv`/`applyAppEnvTemplate` for the env-template
+mechanism described above.
 
 ## How it works
 
@@ -251,6 +276,8 @@ on top, in intended order:
    local default removes the embedded-Postgres lifecycle) and the stability
    commitment when the train leaves alpha.
 
-Parked until server support exists: passkey seeding (pre-registered WebAuthn
-credentials). Independent refactor: extract `apps/cli/src/lib/local-server`
-into a shared package and swap the lifecycle shell-out for imports.
+Parked until server support exists: passkey *seeding* (pre-registered WebAuthn
+credentials) — UI-driven passkey ceremonies are covered today by
+`enableVirtualPasskey`. Independent refactor: extract
+`apps/cli/src/lib/local-server` into a shared package and swap the lifecycle
+shell-out for imports.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -114,8 +114,9 @@ test("registers and signs in with a passkey", async ({ page, seed, passkey }) =>
 Constraints, all inherent to WebAuthn/CDP: Chromium projects only (the CDP
 WebAuthn domain exists nowhere else); the authenticator is bound to the page,
 so register and sign back in on the same page (sign out by clearing cookies
-instead of opening a fresh context); and serve the app on `localhost`, never
-`127.0.0.1` — WebAuthn rejects IP relying-party IDs. The default
+instead of opening a fresh context); and serve the app on an origin WebAuthn
+accepts as a relying-party ID — HTTPS on a real domain, or `http://localhost`
+for local tests; raw IP origins like `127.0.0.1` are invalid. The default
 `password-first` flow offers passkey registration at the registration-choice
 step; boot `preset: "passkey-first"` for one-tap discoverable-credential
 login flows.

--- a/packages/testing/src/passkey.ts
+++ b/packages/testing/src/passkey.ts
@@ -61,11 +61,13 @@ export async function enableVirtualPasskey(page: Page): Promise<VirtualPasskey> 
     async dispose() {
       // Best-effort: the page (and with it the CDP target) may already be
       // gone when teardown runs after a failed test; never mask that failure.
+      // Detach even when the removal fails, so the session never outlives it.
       try {
         await client.send("WebAuthn.removeVirtualAuthenticator", { authenticatorId });
-        await client.detach();
       } catch {
         // ignore
+      } finally {
+        await client.detach().catch(() => undefined);
       }
     },
   };

--- a/packages/testing/src/passkey.ts
+++ b/packages/testing/src/passkey.ts
@@ -22,9 +22,10 @@ export interface VirtualPasskey {
  *
  * Chromium only: the CDP WebAuthn domain does not exist in WebKit or Firefox.
  * The authenticator is bound to this page — drive registration and the later
- * login from the same page, or the credential is gone. The app under test
- * must be served on `localhost` (not `127.0.0.1`): WebAuthn rejects IP
- * addresses as relying-party IDs.
+ * login from the same page, or the credential is gone. Serve the app under
+ * test on an origin WebAuthn accepts as a relying-party ID: HTTPS on a real
+ * domain, or `http://localhost` for local runs — raw IP origins such as
+ * `http://127.0.0.1` are invalid RP IDs.
  */
 export async function enableVirtualPasskey(page: Page): Promise<VirtualPasskey> {
   let client: CDPSession;
@@ -38,17 +39,24 @@ export async function enableVirtualPasskey(page: Page): Promise<VirtualPasskey> 
       { cause: error },
     );
   }
-  await client.send("WebAuthn.enable");
-  const { authenticatorId } = await client.send("WebAuthn.addVirtualAuthenticator", {
-    options: {
-      protocol: "ctap2",
-      transport: "internal",
-      hasResidentKey: true,
-      hasUserVerification: true,
-      isUserVerified: true,
-      automaticPresenceSimulation: true,
-    },
-  });
+  let authenticatorId: string;
+  try {
+    await client.send("WebAuthn.enable");
+    ({ authenticatorId } = await client.send("WebAuthn.addVirtualAuthenticator", {
+      options: {
+        protocol: "ctap2",
+        transport: "internal",
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true,
+      },
+    }));
+  } catch (error) {
+    // Don't leave a half-initialized CDP session attached behind a throw.
+    await client.detach().catch(() => undefined);
+    throw error;
+  }
 
   return {
     authenticatorId,

--- a/packages/testing/src/passkey.ts
+++ b/packages/testing/src/passkey.ts
@@ -1,0 +1,72 @@
+import type { CDPSession, Page } from "@playwright/test";
+
+/**
+ * A virtual WebAuthn authenticator attached to one page. Ceremonies started
+ * from that page (passkey registration, passkey login) complete automatically
+ * — no OS authenticator dialog, no touch.
+ */
+export interface VirtualPasskey {
+  /** CDP id of the virtual authenticator, for advanced raw-protocol use. */
+  authenticatorId: string;
+  /** Number of credentials the authenticator currently stores. */
+  credentialCount(): Promise<number>;
+  /** Remove the authenticator and detach the CDP session. */
+  dispose(): Promise<void>;
+}
+
+/**
+ * Attach a virtual passkey authenticator to the page via the Chrome DevTools
+ * Protocol. The options mirror a platform authenticator with discoverable
+ * credentials and automatic user presence — the profile the consumer journey
+ * has run in CI since passkey coverage became mandatory there.
+ *
+ * Chromium only: the CDP WebAuthn domain does not exist in WebKit or Firefox.
+ * The authenticator is bound to this page — drive registration and the later
+ * login from the same page, or the credential is gone. The app under test
+ * must be served on `localhost` (not `127.0.0.1`): WebAuthn rejects IP
+ * addresses as relying-party IDs.
+ */
+export async function enableVirtualPasskey(page: Page): Promise<VirtualPasskey> {
+  let client: CDPSession;
+  try {
+    client = await page.context().newCDPSession(page);
+  } catch (error) {
+    throw new Error(
+      "enableVirtualPasskey: could not open a CDP session — passkey testing " +
+        "needs Chromium's virtual authenticator, so run passkey specs in a " +
+        "Chromium project.",
+      { cause: error },
+    );
+  }
+  await client.send("WebAuthn.enable");
+  const { authenticatorId } = await client.send("WebAuthn.addVirtualAuthenticator", {
+    options: {
+      protocol: "ctap2",
+      transport: "internal",
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+      automaticPresenceSimulation: true,
+    },
+  });
+
+  return {
+    authenticatorId,
+    async credentialCount() {
+      const { credentials } = await client.send("WebAuthn.getCredentials", {
+        authenticatorId,
+      });
+      return credentials.length;
+    },
+    async dispose() {
+      // Best-effort: the page (and with it the CDP target) may already be
+      // gone when teardown runs after a failed test; never mask that failure.
+      try {
+        await client.send("WebAuthn.removeVirtualAuthenticator", { authenticatorId });
+        await client.detach();
+      } catch {
+        // ignore
+      }
+    },
+  };
+}

--- a/packages/testing/src/playwright.ts
+++ b/packages/testing/src/playwright.ts
@@ -2,6 +2,7 @@ import { test as base, type Page } from "@playwright/test";
 
 import { readHandshakeSync } from "./handshake";
 import { connectZitadel } from "./index";
+import { enableVirtualPasskey, type VirtualPasskey } from "./passkey";
 import type {
   ConnectedZitadel,
   Identity,
@@ -36,6 +37,12 @@ export interface ZitadelTestFixtures {
    * `use.baseURL` (every withZitadel consumer sets it).
    */
   authenticatedPage: AuthenticatedPage;
+  /**
+   * Virtual passkey authenticator attached to the default `page`, disposed on
+   * teardown. On-demand: tests that don't request it pay nothing. Chromium
+   * only — see `enableVirtualPasskey` for the constraints.
+   */
+  passkey: VirtualPasskey;
 }
 
 export interface ZitadelWorkerFixtures {
@@ -69,6 +76,11 @@ export const test = base.extend<ZitadelTestFixtures, ZitadelWorkerFixtures>({
       session: (input) => zitadel.seedSession({ origin: baseURL, ...input }),
     });
   },
+  passkey: async ({ page }, use) => {
+    const passkey = await enableVirtualPasskey(page);
+    await use(passkey);
+    await passkey.dispose();
+  },
   authenticatedPage: async ({ browser, zitadel, baseURL }, use) => {
     if (!baseURL) {
       throw new Error(
@@ -90,6 +102,8 @@ export const test = base.extend<ZitadelTestFixtures, ZitadelWorkerFixtures>({
 export { expect } from "@playwright/test";
 export { applyAppEnvTemplate, nextAppEnv } from "./app-env";
 export type { AppEnvTemplate } from "./app-env";
+export { enableVirtualPasskey } from "./passkey";
+export type { VirtualPasskey } from "./passkey";
 export { withZitadel } from "./playwright-config";
 export type { WithZitadelOptions } from "./playwright-config";
 export type {

--- a/packages/testing/tests/unit/passkey.test.ts
+++ b/packages/testing/tests/unit/passkey.test.ts
@@ -87,7 +87,7 @@ describe("enableVirtualPasskey", () => {
     expect(fake.detached).toBe(true);
   });
 
-  it("swallows teardown errors from an already-closed page", async () => {
+  it("swallows teardown errors and still detaches the session", async () => {
     const fake = fakeCdpPage({
       failSend: (method) =>
         method === "WebAuthn.removeVirtualAuthenticator"
@@ -97,6 +97,7 @@ describe("enableVirtualPasskey", () => {
     const passkey = await enableVirtualPasskey(fake.page);
 
     await expect(passkey.dispose()).resolves.toBeUndefined();
+    expect(fake.detached).toBe(true);
   });
 
   it("explains the Chromium requirement when no CDP session is available", async () => {

--- a/packages/testing/tests/unit/passkey.test.ts
+++ b/packages/testing/tests/unit/passkey.test.ts
@@ -1,0 +1,115 @@
+import type { Page } from "@playwright/test";
+import { describe, expect, it } from "vitest";
+
+import { enableVirtualPasskey } from "../../src/passkey";
+
+interface FakeCdp {
+  calls: Array<{ method: string; params?: unknown }>;
+  detached: boolean;
+  page: Page;
+  failSend?: (method: string) => Error | undefined;
+}
+
+function fakeCdpPage(overrides: Partial<Pick<FakeCdp, "failSend">> = {}): FakeCdp {
+  const fake: FakeCdp = {
+    calls: [],
+    detached: false,
+    failSend: overrides.failSend,
+    page: undefined as unknown as Page,
+  };
+  const client = {
+    async send(method: string, params?: unknown) {
+      const failure = fake.failSend?.(method);
+      if (failure) {
+        throw failure;
+      }
+      fake.calls.push({ method, params });
+      if (method === "WebAuthn.addVirtualAuthenticator") {
+        return { authenticatorId: "auth_1" };
+      }
+      if (method === "WebAuthn.getCredentials") {
+        return { credentials: [{ credentialId: "c1" }, { credentialId: "c2" }] };
+      }
+      return {};
+    },
+    async detach() {
+      fake.detached = true;
+    },
+  };
+  fake.page = {
+    context: () => ({ newCDPSession: async () => client }),
+  } as unknown as Page;
+  return fake;
+}
+
+describe("enableVirtualPasskey", () => {
+  it("adds the journey-proven authenticator profile and reads credentials", async () => {
+    const fake = fakeCdpPage();
+    const passkey = await enableVirtualPasskey(fake.page);
+
+    // The exact CDP sequence and options the consumer journey runs in CI:
+    // a platform authenticator with discoverable credentials and automatic
+    // user presence. Changing any flag changes which ceremonies complete.
+    expect(fake.calls).toEqual([
+      { method: "WebAuthn.enable", params: undefined },
+      {
+        method: "WebAuthn.addVirtualAuthenticator",
+        params: {
+          options: {
+            protocol: "ctap2",
+            transport: "internal",
+            hasResidentKey: true,
+            hasUserVerification: true,
+            isUserVerified: true,
+            automaticPresenceSimulation: true,
+          },
+        },
+      },
+    ]);
+    expect(passkey.authenticatorId).toBe("auth_1");
+
+    await expect(passkey.credentialCount()).resolves.toBe(2);
+    expect(fake.calls.at(-1)).toEqual({
+      method: "WebAuthn.getCredentials",
+      params: { authenticatorId: "auth_1" },
+    });
+  });
+
+  it("removes the authenticator and detaches on dispose", async () => {
+    const fake = fakeCdpPage();
+    const passkey = await enableVirtualPasskey(fake.page);
+
+    await passkey.dispose();
+    expect(fake.calls.at(-1)).toEqual({
+      method: "WebAuthn.removeVirtualAuthenticator",
+      params: { authenticatorId: "auth_1" },
+    });
+    expect(fake.detached).toBe(true);
+  });
+
+  it("swallows teardown errors from an already-closed page", async () => {
+    const fake = fakeCdpPage({
+      failSend: (method) =>
+        method === "WebAuthn.removeVirtualAuthenticator"
+          ? new Error("Target closed")
+          : undefined,
+    });
+    const passkey = await enableVirtualPasskey(fake.page);
+
+    await expect(passkey.dispose()).resolves.toBeUndefined();
+  });
+
+  it("explains the Chromium requirement when no CDP session is available", async () => {
+    const page = {
+      context: () => ({
+        newCDPSession: async () => {
+          throw new Error("CDP session is only available in Chromium");
+        },
+      }),
+    } as unknown as Page;
+
+    await expect(enableVirtualPasskey(page)).rejects.toThrow(
+      /Chromium's virtual authenticator/,
+    );
+  });
+});

--- a/packages/testing/tests/unit/passkey.test.ts
+++ b/packages/testing/tests/unit/passkey.test.ts
@@ -100,6 +100,16 @@ describe("enableVirtualPasskey", () => {
     expect(fake.detached).toBe(true);
   });
 
+  it("detaches the session when initialization fails after it opened", async () => {
+    const fake = fakeCdpPage({
+      failSend: (method) =>
+        method === "WebAuthn.enable" ? new Error("WebAuthn domain unavailable") : undefined,
+    });
+
+    await expect(enableVirtualPasskey(fake.page)).rejects.toThrow("WebAuthn domain unavailable");
+    expect(fake.detached).toBe(true);
+  });
+
   it("explains the Chromium requirement when no CDP session is available", async () => {
     const page = {
       context: () => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,6 +470,9 @@ importers:
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
+      '@zitadel/testing':
+        specifier: workspace:*
+        version: link:../../packages/testing
       eslint-plugin-playwright:
         specifier: 'catalog:'
         version: 2.10.2(eslint@10.2.1(jiti@2.7.0))

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -41,13 +41,14 @@ const NON_SHIPPING_TOP_LEVEL_DIRS = [
 ];
 
 // Workspaces that build or exercise the product without ever reaching a user:
-// harnesses, mocks, demos, and the docs site.
+// mocks, demos, and the docs site. (`packages/testing` left this list when it
+// joined the release train in #692 — the manifest-derived PUBLISHED_ROOTS
+// covers it now.)
 const NON_SHIPPING_WORKSPACES = [
   "apps/docs/",
   "apps/mock-zitadel/",
   "apps/storybook/",
   "packages/api-mock/",
-  "packages/testing/",
 ];
 
 // Repo-meta markdown, wherever it sits. Every other `.md` is treated as shipping
@@ -191,7 +192,6 @@ export function suggestType(files) {
         path.includes("/testdata/") ||
         /^apps\/[^/]*-e2e\//.test(path) ||
         /^apps\/demo-[^/]+\//.test(path) ||
-        path.startsWith("packages/testing/") ||
         path.startsWith("apps/mock-zitadel/") ||
         path.startsWith("packages/api-mock/"),
     )


### PR DESCRIPTION
## Summary

Phase 5 of the test-kit track: **passkey testing lands in `@zitadel/testing`.** The kit was password-only while passkeys are the product's flagship flow — a passkey-first customer couldn't test their real auth path with it. This PR extracts the consumer journey's CI-proven CDP virtual-authenticator into the kit as public API and dogfoods it in three consumers. New public surface on a published package, hence `feat:` and a `minor` changeset.

- **`enableVirtualPasskey(page)`** (`packages/testing/src/passkey.ts`) + on-demand **`passkey` fixture**: attaches a virtual platform authenticator via CDP (ctap2, internal transport, discoverable credentials, user verified, automatic presence — exactly the profile the journey has run in CI), so real passkey registration and login ceremonies complete headlessly. The returned handle exposes `credentialCount()` (assert credential reuse via `expect.poll`) and `dispose()` — teardown the journey's private version never had. Clear error on non-Chromium projects (no CDP WebAuthn domain elsewhere).
- **Demo dogfood** (`apps/demo-next-e2e/src-real/passkey.spec.ts`): full round-trip on the existing e2e-real instance — fresh identity registers with a passkey at the registration-choice step of the *default password-first flow* (no second preset boot needed), signs out by clearing cookies **on the same page** (the credential lives in the page-bound authenticator), signs back in with the passkey, credential count stays 1. Shared widget-interaction helpers extracted to `src-real/flow-actions.ts` (were private copies in `registration.spec.ts`).
- **Journey improvements** (the dogfooding ask):
  - The **testkit consumer fixture** gains `fixtures/testkit/zitadel-e2e/passkey.spec.ts` — the same round-trip against the generated app, importing `enableVirtualPasskey` from the **registry-installed** kit: the customer-configuration proof now covers passkeys.
  - The **product journey** (`user-journey.spec.ts`) drops its private `enableVirtualAuthenticator`/`expectVirtualCredentialCount` (~35 lines) for the kit import — the packaged-product journey now consumes the kit helper on every CI run, both presets. Wiring: `@zitadel/testing` devDep + moon `testing:build` deps on the e2e tasks (automation → tool, same layering as demo-next-e2e).
- **README**: "Test passkey flows" section with the three inherent constraints (Chromium-only; page-bound authenticator — same-page round-trip, sign out via cookie clearing; `localhost` not `127.0.0.1` — WebAuthn rejects IP RP IDs) and the preset guidance (default flow offers passkey at the choice step; `passkey-first` for one-tap). Roadmap: ceremonies covered; server-side passkey *seeding* stays parked.

## Validation

- `moon run testing:build testing:test testing:typecheck testing:lint` — 61 unit tests / 11 files (new suite locks the exact CDP call sequence and authenticator options, `credentialCount`, dispose semantics incl. closed-target tolerance, and the Chromium error).
- `moon run demo-next-e2e:e2e-real` — **5/5** (new passkey round-trip 3.2s; suite 25.1s, 2 workers, one instance).
- `env -u CI moon run cli-journey-e2e:e2e-testkit` — **2/2** consumer specs (passkey 1.7s) with the kit installed from the journey registry.
- `env -u CI node .../run-local.mjs --framework next` — **3/3** product journey (password + passkey-only) through the kit-imported helper.
- `env -u CI node .../run-local.mjs --framework next --preset passkey-first` — **2/2 (7.0s)** (fallback registration + one-tap discoverable login).
- `moon run console-e2e:e2e-real` — **12/13**: the one failure is #673's new "renders exactly the properties the API's schema defines" spec, which fails **identically on pristine main** on this machine (reproduced 3/3 incl. clean tree @ `5253a1a4`; green in #673's CI) — pre-existing, environment-shaped, and fixed by #695 (readiness gate in `openDrawer`), not caused by this branch. With a readiness wait the lane runs 13/13 here. Every consumer-regression spec relevant to the kit passes.
- `moon run cli-journey-e2e:lint cli-journey-e2e:test` — journey scripts unaffected.

## Release notes / changeset

- `.changeset/testing-virtual-passkey.md` (`minor` for `@zitadel/testing`) — ships with the next alpha on the train.

## Notes

- Scope lines held: `seed.session()` stays password-only (a passkey step still fails loudly with the step name); server-side passkey seeding stays parked until server support exists; no multi-instance `withZitadel` (not needed — the default flow covers registration-choice passkeys).
- Remaining roadmap after this: OTP/email capture (server-gated), vitest entry (second backend consumer), project-per-worker (API-level suites), SQLite flip checklist (#665).
