### PR TITLE
feat(console): delete a user, and drop UI the API cannot back

### DIFF
--- a/.changeset/console-delete-user.md
+++ b/.changeset/console-delete-user.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": minor
+---
+
+Delete a user from the console. The users list gains a Delete action that asks you to type DELETE to confirm, then permanently removes the user along with their sessions and grants.

--- a/.changeset/console-remove-unbacked-ui.md
+++ b/.changeset/console-remove-unbacked-ui.md
@@ -1,5 +1,0 @@
----
-"@zitadel/server": patch
----
-
-The console no longer offers navigation and controls that had nothing behind them. The Sessions link, which could not load because listing sessions is not implemented yet, is hidden along with an organisation switcher that listed placeholder organisations, four permanently disabled sidebar entries, and Search and Documentation buttons that did nothing when clicked.

--- a/.changeset/console-remove-unbacked-ui.md
+++ b/.changeset/console-remove-unbacked-ui.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+The console no longer offers navigation and controls that had nothing behind them. The Sessions link, which could not load because listing sessions is not implemented yet, is hidden along with an organisation switcher that listed placeholder organisations, four permanently disabled sidebar entries, and Search and Documentation buttons that did nothing when clicked.

--- a/apps/console-e2e/src-real/add-user.spec.ts
+++ b/apps/console-e2e/src-real/add-user.spec.ts
@@ -1,6 +1,8 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@zitadel/testing/playwright";
 
+import { expectNoErrorBoundary, signIn } from "./support";
+
 /**
  * End-to-end coverage for the Add user drawer (issue #633) against a real
  * instance, so the schema-driven form is exercised over the actual
@@ -20,18 +22,6 @@ test.describe.configure({ mode: "parallel" });
 // `queryProjects` is single-project (ADR 0004). D6 expects it back in a future
 // version, so the cases below are parked with the block, not deleted; restore
 // them alongside the block and the unit specs when both reasons clear.
-
-const ERROR_HEADINGS = ["Not authorized", "Something went wrong"];
-
-/** See `console-real.spec.ts` — the console's login screen (Console ADR 0003). */
-async function signIn(page: Page, user: { email: string; password: string }): Promise<void> {
-  await page.goto("/login");
-  await page.getByLabel("Work email").fill(user.email);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.getByLabel("Password").fill(user.password);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith("/login"));
-}
 
 /** Signs in, lands on /users and opens the drawer. */
 async function openDrawer(page: Page, user: { email: string; password: string }) {
@@ -369,8 +359,3 @@ test("Escape closes the open list first, then the drawer", async ({ page, seed }
   await expect(drawer).toBeHidden();
 });
 
-async function expectNoErrorBoundary(page: Page): Promise<void> {
-  for (const heading of ERROR_HEADINGS) {
-    await expect(page.getByText(heading, { exact: true })).toHaveCount(0);
-  }
-}

--- a/apps/console-e2e/src-real/add-user.spec.ts
+++ b/apps/console-e2e/src-real/add-user.spec.ts
@@ -14,10 +14,12 @@ import { expect, test } from "@zitadel/testing/playwright";
 
 test.describe.configure({ mode: "parallel" });
 
-// The Projects block is hidden until the backend can grant access — roles need
-// ADR 034's app-group catalog (epic #419) and `queryProjects` is single-project
-// (ADR 0004). Its cases below are parked with it, not deleted; restore them
-// alongside the block and the unit specs when the endpoints land.
+// The Projects block is out of the MVP: design removed the project selector
+// (design decisions log D6, 2026-07-31), and the backend could not grant access
+// regardless — roles need ADR 034's app-group catalog (epic #419) and
+// `queryProjects` is single-project (ADR 0004). D6 expects it back in a future
+// version, so the cases below are parked with the block, not deleted; restore
+// them alongside the block and the unit specs when both reasons clear.
 
 const ERROR_HEADINGS = ["Not authorized", "Something went wrong"];
 
@@ -75,10 +77,17 @@ test("renders exactly the properties the API's schema defines", async ({ page, z
   const schema = await projectSchema(zitadel);
   const drawer = await openDrawer(page, await seed.user());
 
-  await expect(drawer.getByRole("combobox", { name: "User Schema" })).not.toContainText(
-    "Select schema",
-  );
-  expect(await renderedFields(drawer)).toEqual(schema.properties);
+  // Both loading labels are excluded, not just the empty one: "Loading schemas…"
+  // is also `not "Select schema"`, so waiting on that alone let the assertion
+  // below run mid-fetch and compare against an empty field set.
+  const picker = drawer.getByRole("combobox", { name: "User Schema" });
+  await expect(picker).not.toContainText("Select schema");
+  await expect(picker).not.toContainText("Loading schemas");
+
+  // Polled rather than read once: `evaluateAll` takes a single snapshot and does
+  // not retry, so it can land between the schema resolving and its fields
+  // rendering.
+  await expect.poll(() => renderedFields(drawer)).toEqual(schema.properties);
   await expectNoErrorBoundary(page);
 });
 

--- a/apps/console-e2e/src-real/console-real.spec.ts
+++ b/apps/console-e2e/src-real/console-real.spec.ts
@@ -1,25 +1,8 @@
-import type { Page } from "@playwright/test";
 import { expect, test } from "@zitadel/testing/playwright";
 
-const ERROR_HEADINGS = ["Not authorized", "Something went wrong"];
+import { expectNoErrorBoundary, signIn } from "./support";
 
 test.describe.configure({ mode: "parallel" });
-
-/**
- * Completes the console's login screen (Console ADR 0003) with a seeded
- * user: the default-login flow's identifier step ("Work email" + "Sign in"),
- * then the password step ("Password" + "Sign in"). The widget exchanges the
- * handoff for the `__nextgen_session` cookie and performs a full-document
- * navigation away from /login.
- */
-async function signIn(page: Page, user: { email: string; password: string }): Promise<void> {
-  await page.goto("/login");
-  await page.getByLabel("Work email").fill(user.email);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.getByLabel("Password").fill(user.password);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith("/login"));
-}
 
 test("shows the bootstrapped project", async ({ page, zitadel, seed }) => {
   await signIn(page, await seed.user());
@@ -94,9 +77,3 @@ test("keeps the project credential out of browser requests and resources", async
   expect(leakedResources).toEqual([]);
   expect((await page.content()).includes(zitadel.handle.projectSecret)).toBe(false);
 });
-
-async function expectNoErrorBoundary(page: Page): Promise<void> {
-  for (const heading of ERROR_HEADINGS) {
-    await expect(page.getByText(heading, { exact: true })).toHaveCount(0);
-  }
-}

--- a/apps/console-e2e/src-real/delete-user.spec.ts
+++ b/apps/console-e2e/src-real/delete-user.spec.ts
@@ -1,0 +1,120 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@zitadel/testing/playwright";
+
+/**
+ * End-to-end coverage for the delete-user dialog (issue #632) against a real
+ * instance.
+ *
+ * The unit specs cover the confirmation gate and the error path with a stubbed
+ * API. What only a live backend proves is that `DELETE /users/{user_id}` is
+ * actually reached with the console's project scope, that the delete is a real
+ * one (the row does not come back on reload), and that the list the operator is
+ * left looking at reflects it.
+ */
+
+test.describe.configure({ mode: "parallel" });
+
+const ERROR_HEADINGS = ["Not authorized", "Something went wrong"];
+
+/** See `console-real.spec.ts` — the console's login screen (Console ADR 0003). */
+async function signIn(page: Page, user: { email: string; password: string }): Promise<void> {
+  await page.goto("/login");
+  await page.getByLabel("Work email").fill(user.email);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await page.getByLabel("Password").fill(user.password);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await page.waitForURL((url) => !url.pathname.endsWith("/login"));
+}
+
+/** Signs in as `actor` and lands on the users list. */
+async function openList(page: Page, actor: { email: string; password: string }): Promise<void> {
+  await signIn(page, actor);
+  await page.goto("/users");
+  await expect(page.getByRole("heading", { name: "Users", exact: true })).toBeVisible();
+}
+
+/** Opens the delete dialog from the row menu of `name`. */
+async function openDeleteDialog(page: Page, name: string) {
+  await page.getByRole("button", { name: `Actions for ${name}` }).click();
+  await page.getByRole("menuitem", { name: "Delete", exact: true }).click();
+  const dialog = page.getByRole("alertdialog", { name: `Delete ${name}?` });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+async function expectNoErrorBoundary(page: Page): Promise<void> {
+  for (const heading of ERROR_HEADINGS) {
+    await expect(page.getByText(heading, { exact: true })).toHaveCount(0);
+  }
+}
+
+test("deletes a user for real and drops it from the list", async ({ page, seed }) => {
+  // Two users: one to sign in as, one to delete. Deleting the signed-in user
+  // would end the session mid-test and prove something else entirely.
+  const actor = await seed.user();
+  const victim = await seed.user();
+  await openList(page, actor);
+
+  const dialog = await openDeleteDialog(page, victim.email);
+  await dialog.getByRole("textbox", { name: "Type DELETE to confirm" }).fill("DELETE");
+  await dialog.getByRole("button", { name: "Delete user", exact: true }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText(`${victim.email} deleted`)).toBeVisible();
+  await expect(page.getByRole("link", { name: victim.email })).toHaveCount(0);
+
+  // The delete is a hard delete server-side, so it must survive a reload — a row
+  // that reappears would mean the list was only optimistically updated.
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "Users", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: victim.email })).toHaveCount(0);
+  await expectNoErrorBoundary(page);
+});
+
+test("keeps the confirm action locked until DELETE is typed exactly", async ({ page, seed }) => {
+  const actor = await seed.user();
+  const victim = await seed.user();
+  await openList(page, actor);
+
+  const dialog = await openDeleteDialog(page, victim.email);
+  const confirm = dialog.getByRole("button", { name: "Delete user", exact: true });
+  const input = dialog.getByRole("textbox", { name: "Type DELETE to confirm" });
+
+  await expect(confirm).toBeDisabled();
+  await input.fill("delete");
+  await expect(confirm).toBeDisabled();
+  await input.fill("DELETE ");
+  await expect(confirm).toBeDisabled();
+  await input.fill("DELETE");
+  await expect(confirm).toBeEnabled();
+});
+
+test("cancelling leaves the user in place", async ({ page, seed }) => {
+  const actor = await seed.user();
+  const victim = await seed.user();
+  await openList(page, actor);
+
+  const dialog = await openDeleteDialog(page, victim.email);
+  await dialog.getByRole("textbox", { name: "Type DELETE to confirm" }).fill("DELETE");
+  await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(page.getByRole("link", { name: victim.email })).toBeVisible();
+
+  // Re-opening starts from a blank confirmation rather than the typed one.
+  const reopened = await openDeleteDialog(page, victim.email);
+  await expect(reopened.getByRole("textbox", { name: "Type DELETE to confirm" })).toHaveValue("");
+  await expect(reopened.getByRole("button", { name: "Delete user", exact: true })).toBeDisabled();
+});
+
+test("the row menu offers only actions the API can serve", async ({ page, seed }) => {
+  // Edit user (#693), Deactivate (#553) and Reset password were rendering as
+  // live controls with nothing behind them; they are out until they work.
+  const actor = await seed.user();
+  const victim = await seed.user();
+  await openList(page, actor);
+
+  await page.getByRole("button", { name: `Actions for ${victim.email}` }).click();
+  const menu = page.getByRole("menu", { name: `Actions for ${victim.email}` });
+  await expect(menu.getByRole("menuitem")).toHaveText(["View details", "Delete"]);
+});

--- a/apps/console-e2e/src-real/delete-user.spec.ts
+++ b/apps/console-e2e/src-real/delete-user.spec.ts
@@ -1,6 +1,8 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@zitadel/testing/playwright";
 
+import { expectNoErrorBoundary, signIn } from "./support";
+
 /**
  * End-to-end coverage for the delete-user dialog (issue #632) against a real
  * instance.
@@ -13,18 +15,6 @@ import { expect, test } from "@zitadel/testing/playwright";
  */
 
 test.describe.configure({ mode: "parallel" });
-
-const ERROR_HEADINGS = ["Not authorized", "Something went wrong"];
-
-/** See `console-real.spec.ts` — the console's login screen (Console ADR 0003). */
-async function signIn(page: Page, user: { email: string; password: string }): Promise<void> {
-  await page.goto("/login");
-  await page.getByLabel("Work email").fill(user.email);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.getByLabel("Password").fill(user.password);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith("/login"));
-}
 
 /** Signs in as `actor` and lands on the users list. */
 async function openList(page: Page, actor: { email: string; password: string }): Promise<void> {
@@ -42,11 +32,6 @@ async function openDeleteDialog(page: Page, name: string) {
   return dialog;
 }
 
-async function expectNoErrorBoundary(page: Page): Promise<void> {
-  for (const heading of ERROR_HEADINGS) {
-    await expect(page.getByText(heading, { exact: true })).toHaveCount(0);
-  }
-}
 
 test("deletes a user for real and drops it from the list", async ({ page, seed }) => {
   // Two users: one to sign in as, one to delete. Deleting the signed-in user

--- a/apps/console-e2e/src-real/support.ts
+++ b/apps/console-e2e/src-real/support.ts
@@ -1,0 +1,45 @@
+import type { Page } from "@playwright/test";
+import { expect } from "@zitadel/testing/playwright";
+
+/**
+ * Shared helpers for the real-instance console suites.
+ *
+ * `signIn` had been copied verbatim into all three spec files. It is the one
+ * step every real-instance test starts with, so a drift between copies would
+ * mean the suites were signing in differently while looking identical.
+ */
+
+/**
+ * Completes the console's login screen (Console ADR 0003) with a seeded
+ * user: the default-login flow's identifier step ("Work email" + "Sign in"),
+ * then the password step ("Password" + "Sign in"). The widget exchanges the
+ * handoff for the `__nextgen_session` cookie and performs a full-document
+ * navigation away from /login.
+ */
+export async function signIn(
+  page: Page,
+  user: { email: string; password: string },
+): Promise<void> {
+  await page.goto("/login");
+  await page.getByLabel("Work email").fill(user.email);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await page.getByLabel("Password").fill(user.password);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await page.waitForURL((url) => !url.pathname.endsWith("/login"));
+}
+
+/** Copy the route error boundaries render; none of it should appear on a pass. */
+const ERROR_HEADINGS = ["Not authorized", "Something went wrong"];
+
+/**
+ * Asserts no error boundary rendered.
+ *
+ * Worth its own check because a boundary replaces the screen entirely: without
+ * it, an assertion that some element is *absent* passes just as happily when the
+ * whole route failed to load.
+ */
+export async function expectNoErrorBoundary(page: Page): Promise<void> {
+  for (const heading of ERROR_HEADINGS) {
+    await expect(page.getByText(heading, { exact: true })).toHaveCount(0);
+  }
+}

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -26,6 +26,7 @@
     "radix-ui": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "sonner": "catalog:",
     "tailwind-merge": "catalog:",
     "tailwindcss": "catalog:",
     "tw-animate-css": "catalog:"

--- a/apps/console/src/components/add-user-sheet.spec.tsx
+++ b/apps/console/src/components/add-user-sheet.spec.tsx
@@ -80,9 +80,11 @@ async function openSheet() {
 }
 
 describe("add user sheet", () => {
-  // The Projects block is hidden until the backend can grant access (roles need
-  // ADR 034's app-group catalog, epic #419; `queryProjects` is single-project per
-  // ADR 0004). Its specs are parked with it rather than deleted — restore the
+  // The Projects block is out of the MVP: design removed the project selector
+  // (design decisions log D6, 2026-07-31), and the backend could not grant
+  // access regardless (roles need ADR 034's app-group catalog, epic #419;
+  // `queryProjects` is single-project per ADR 0004). D6 expects it back in a
+  // future version, so its specs are parked rather than deleted — restore the
   // block, this file's cases and `project-access.spec.tsx` together.
   it("builds the form from the selected schema's properties", async () => {
     // The whole point of the screen: controls come from the schema, not a

--- a/apps/console/src/components/add-user-sheet.tsx
+++ b/apps/console/src/components/add-user-sheet.tsx
@@ -1,4 +1,3 @@
-import { ApiError } from "@zitadel/api/runtime/fetch";
 import { AlertCircle, Loader2, UserRoundCog, X } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useId, useState } from "react";
 
@@ -27,7 +26,8 @@ import {
 } from "@/components/ui/sheet";
 
 import { api } from "../api/zitadel";
-// Parked until the backend can grant roles — see the block below.
+import { describeError } from "../lib/api-error";
+// Parked — design decisions log D6, plus no grant endpoints. See the block below.
 // import {
 //   ProjectAccess,
 //   type ProjectAccessRow,
@@ -75,8 +75,10 @@ const FOOTER = "flex-row items-center justify-end gap-3 bg-background px-6 py-4"
  * email, a `business` one also asks for names and a company.
  *
  * The design also specifies a "Projects (optional)" block granting the new user
- * project roles. That needs endpoints which do not exist yet (project list #405,
- * grants/roles #419), so it is deliberately omitted rather than mocked — see
+ * project roles. It is deliberately omitted rather than mocked: design removed
+ * the project selector from the MVP (design decisions log D6, 2026-07-31) and
+ * the grant endpoints do not exist (#419). D6 expects it back in a future
+ * version, so the block and its component are parked, not deleted — see
  * issue #633.
  */
 export function AddUserSheet({
@@ -253,13 +255,22 @@ function AddUserForm({
             />
           ))}
         </div>
-        {/* Projects block — hidden until the backend can actually grant access.
-            It needs a role catalogue (ADR 034's app-group catalog, epic #419)
-            and a multi-project scope; today `queryProjects` returns only the
-            caller's own project (ADR 0004) and `POST /users` accepts no grants,
-            so the block could select things it could never save. The component,
-            its unit spec and its e2e coverage are kept intact alongside this —
-            restore all four together when the endpoints land. */}
+        {/* Projects block — out of the MVP for two independent reasons, both of
+            which must clear before it returns.
+
+            Design removed the project selector (design decisions log D6,
+            2026-07-31) and expects it back in a future version; the log's
+            "project access" open question — how project ↔ team ↔ access relate
+            — is what has to settle first.
+
+            The backend could not honour it anyway: granting needs a role
+            catalogue (ADR 034's app-group catalog, epic #419) and a
+            multi-project scope, but `queryProjects` returns only the caller's
+            own project (ADR 0004) and `POST /users` accepts no grants, so the
+            block could select things it could never save.
+
+            The component, its unit spec and its e2e coverage are kept intact
+            alongside this — restore all four together. */}
         {/* <Separator />
         <ProjectAccess projects={projects} rows={access} onChange={setAccess} /> */}
         {error && (
@@ -380,34 +391,3 @@ function SchemaInput({
   );
 }
 
-/**
- * The message to show for a failed request.
- *
- * **The API owns this copy.** ADR 030 defines the error payload's `message` as
- * the human-facing string, so it is rendered verbatim rather than mapped to
- * console-authored text — the console has no design source for error strings and
- * no i18n layer, so re-writing them would only fork the wording per client.
- *
- * The message lives in the response *body* (`error-details.yaml`).
- * `ApiError.message` is a transport-level string (`POST /users returned 409`,
- * built in `runtime/fetch.ts`) and must never reach an operator, so the body is
- * read explicitly. `fallback` covers the case where there is no payload at all —
- * a network failure or a non-JSON response.
- *
- * Attributing a `409` to a specific input is deliberately not attempted:
- * `ErrUserAlreadyExists()` carries no details and ADR 030 records that `details`
- * is never populated today, so the response cannot say which value collided.
- * Guessing from the schema's `x-unique` markers would put console-authored copy
- * under a field the server never named.
- */
-function describeError(cause: unknown, fallback: string): string {
-  if (cause instanceof ApiError) {
-    const body = cause.body;
-    if (body && typeof body === "object") {
-      const message = (body as Record<string, unknown>).message;
-      if (typeof message === "string" && message.trim() !== "") return message;
-    }
-    return fallback;
-  }
-  return cause instanceof Error ? cause.message : fallback;
-}

--- a/apps/console/src/components/app-shell/AppShell.tsx
+++ b/apps/console/src/components/app-shell/AppShell.tsx
@@ -1,13 +1,6 @@
 import { Link, useMatchRoute } from "@tanstack/react-router";
-import {
-  BookOpen,
-  ChevronsUpDown,
-  LogOut,
-  Monitor,
-  Moon,
-  Search,
-  Sun,
-} from "lucide-react";
+// `BookOpen` / `Search` return with the parked footer items below.
+import { ChevronsUpDown, LogOut, Monitor, Moon, Sun } from "lucide-react";
 import { type KeyboardEvent, type ReactNode, useRef } from "react";
 
 import {
@@ -138,18 +131,27 @@ function AppSidebar({ user, onSignOut }: { user?: ShellUser; onSignOut?: () => v
 
       <SidebarFooter>
         <SidebarMenu className="gap-2">
-          <SidebarMenuItem>
-            <SidebarMenuButton tooltip="Search" className="font-serif">
-              <Search aria-hidden />
-              <span>Search</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <SidebarMenuButton tooltip="Documentation" className="font-serif">
-              <BookOpen aria-hidden />
-              <span>Documentation</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
+          {/* Search and Documentation are parked: both rendered as ordinary
+              enabled buttons with no handler, so clicking them did nothing at
+              all — the worst of the three states, since they looked live.
+
+              Search needs a cross-resource query endpoint; ADR 031's
+              `POST /{resource}/query` exists only for projects today, so there
+              is nothing to search across. Documentation needs a published URL
+              for the docs site to point at.
+
+              <SidebarMenuItem>
+                <SidebarMenuButton tooltip="Search" className="font-serif">
+                  <Search aria-hidden />
+                  <span>Search</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton tooltip="Documentation" className="font-serif">
+                  <BookOpen aria-hidden />
+                  <span>Documentation</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem> */}
           <UserMenuItem user={user} onSignOut={onSignOut} />
         </SidebarMenu>
       </SidebarFooter>

--- a/apps/console/src/components/app-shell/ContextSwitcher.tsx
+++ b/apps/console/src/components/app-shell/ContextSwitcher.tsx
@@ -1,4 +1,5 @@
-import { Box, Building2, ChevronsUpDown, type LucideIcon, Search } from "lucide-react";
+// `Building2` returns with the parked organisation switcher below.
+import { Box, ChevronsUpDown, type LucideIcon, Search } from "lucide-react";
 import { useEffect, useId, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -28,13 +29,6 @@ interface SwitcherOption {
   plan?: string;
 }
 
-const ORGS: SwitcherOption[] = [
-  { id: "acme", label: "Acme Inc", plan: "Free" },
-  { id: "clearwater", label: "Clearwater Labs", plan: "Pro" },
-  { id: "benimac", label: "Benimac LTD", plan: "Enterprise" },
-  { id: "horizons", label: "Horizons Studio", plan: "Pro" },
-];
-
 export function ContextSwitcher() {
   const projects = useProjects();
   // The console is bound to one project, and `queryProjects` is scope-pinned to
@@ -45,20 +39,28 @@ export function ContextSwitcher() {
 
   return (
     <div className="flex w-full min-w-0 flex-col gap-2 md:w-auto md:flex-row md:items-center">
-      <Switcher
-        icon={Building2}
-        label="Acme Inc"
-        shortLabel="Acme"
-        plan="Free"
-        options={ORGS}
-        ariaLabel="Switch organization"
-      />
-      <Switcher
-        icon={Box}
-        label={current?.label}
-        options={projects}
-        ariaLabel="Switch project"
-      />
+      {/* The organisation switcher is parked. It was four invented orgs —
+          "Acme Inc / Free", "Clearwater Labs / Pro", "Benimac LTD / Enterprise",
+          "Horizons Studio / Pro" — with a hardcoded current selection and a plan
+          badge naming a tier nothing sells yet. It sat at the top of every
+          screen, which made the whole console look like it was scoped to a real
+          organisation on a real plan.
+
+          Organisations are teams in this model, and there is no team list
+          endpoint: the API has `POST /teams` and `GET /teams/{team_id}` only, so
+          the current team cannot be resolved, let alone switched. Restore this
+          when `Team: List/Query` (#620) lands, and take the plan badge from
+          billing (#667) rather than a literal.
+
+          <Switcher
+            icon={Building2}
+            label={currentTeam?.label}
+            shortLabel={currentTeam?.shortLabel}
+            plan={currentTeam?.plan}
+            options={teams}
+            ariaLabel="Switch organization"
+          /> */}
+      <Switcher icon={Box} label={current?.label} options={projects} ariaLabel="Switch project" />
     </div>
   );
 }

--- a/apps/console/src/components/app-shell/app-shell.spec.tsx
+++ b/apps/console/src/components/app-shell/app-shell.spec.tsx
@@ -27,11 +27,22 @@ vi.mock("@/auth/session", async (importOriginal) => {
  * does not exist". Also covers the theme toggle writing `data-theme` and
  * persisting the preference.
  */
-const NAV_ORDER = ["Projects", "Users"];
-// Sessions is absent for a different reason than the other four: its screen was
-// built, but `GET /sessions` answers 501 (#699), so the link only ever reached
-// an error boundary. It returns with the endpoint.
-const NEVER_SHOWN = ["App groups", "Applications", "Analytics", "Activity Log", "Sessions"];
+// Users is the only surface with a design hand-off, so it is the only thing the
+// sidebar offers.
+const NAV_ORDER = ["Users"];
+// Absent for three different reasons, all of them deliberate:
+//   - the first four have no endpoint at all
+//   - Sessions was built, but `GET /sessions` answers 501 (#699)
+//   - Projects works and stays reachable at its URL; it has simply never been
+//     designed, so it is not advertised as a finished screen
+const NEVER_SHOWN = [
+  "App groups",
+  "Applications",
+  "Analytics",
+  "Activity Log",
+  "Sessions",
+  "Projects",
+];
 
 // A path pattern rather than an absolute URL: this spec imports the router
 // statically, so `api/zitadel.ts` evaluates its base URL before `vi.stubEnv`
@@ -53,7 +64,7 @@ function renderShell() {
 describe("app shell navigation", () => {
   it("lists only built screens, every one of them a link", async () => {
     renderShell();
-    await screen.findByRole("link", { name: /^Projects/ });
+    await screen.findByRole("link", { name: /^Users/ });
     const nav = within(screen.getByRole("navigation", { name: "Primary" }));
 
     const items = nav.getAllByRole("listitem");
@@ -67,7 +78,7 @@ describe("app shell navigation", () => {
 
   it("does not advertise screens that have no endpoint behind them", async () => {
     renderShell();
-    await screen.findByRole("link", { name: /^Projects/ });
+    await screen.findByRole("link", { name: /^Users/ });
     const nav = within(screen.getByRole("navigation", { name: "Primary" }));
 
     for (const label of NEVER_SHOWN) {
@@ -85,7 +96,7 @@ describe("theme toggle", () => {
 
   it("switches data-theme and persists the preference", async () => {
     renderShell();
-    await screen.findByRole("link", { name: /^Projects/ });
+    await screen.findByRole("link", { name: /^Users/ });
 
     await userEvent.click(screen.getByRole("radio", { name: "Light" }));
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");

--- a/apps/console/src/components/app-shell/app-shell.spec.tsx
+++ b/apps/console/src/components/app-shell/app-shell.spec.tsx
@@ -27,8 +27,11 @@ vi.mock("@/auth/session", async (importOriginal) => {
  * does not exist". Also covers the theme toggle writing `data-theme` and
  * persisting the preference.
  */
-const NAV_ORDER = ["Projects", "Users", "Sessions"];
-const NEVER_SHOWN = ["App groups", "Applications", "Analytics", "Activity Log"];
+const NAV_ORDER = ["Projects", "Users"];
+// Sessions is absent for a different reason than the other four: its screen was
+// built, but `GET /sessions` answers 501 (#699), so the link only ever reached
+// an error boundary. It returns with the endpoint.
+const NEVER_SHOWN = ["App groups", "Applications", "Analytics", "Activity Log", "Sessions"];
 
 // A path pattern rather than an absolute URL: this spec imports the router
 // statically, so `api/zitadel.ts` evaluates its base URL before `vi.stubEnv`

--- a/apps/console/src/components/app-shell/app-shell.spec.tsx
+++ b/apps/console/src/components/app-shell/app-shell.spec.tsx
@@ -18,23 +18,17 @@ vi.mock("@/auth/session", async (importOriginal) => {
 
 
 /**
- * The sidebar reproduces the Figma `Sidebar 08.` mock: a flat list of 7 items.
- * Built screens come from `staticData.nav` on the route tree (Console ADR 0001)
- * and render as links; the remaining design-only entries (screens not built yet)
- * come from `DESIGN_ONLY_NAV` and render as non-navigable items so the sidebar
- * matches the design pixel-for-pixel. Also covers the theme toggle writing
- * `data-theme` + persisting the preference.
+ * The sidebar lists only screens that exist. Entries come from `staticData.nav`
+ * on the route tree (Console ADR 0001) and every one is a link.
+ *
+ * It used to render the Figma mock's full 7 items, with the 4 unbuilt ones as
+ * `aria-disabled` rows. That is what this spec now guards against: a disabled
+ * row advertises a feature and reads as "you cannot do this" rather than "this
+ * does not exist". Also covers the theme toggle writing `data-theme` and
+ * persisting the preference.
  */
-const NAV_ORDER = [
-  "Projects",
-  "Users",
-  "App groups",
-  "Applications",
-  "Analytics",
-  "Sessions",
-  "Activity Log",
-];
-const BUILT_ITEMS = ["Projects", "Users", "Sessions"];
+const NAV_ORDER = ["Projects", "Users", "Sessions"];
+const NEVER_SHOWN = ["App groups", "Applications", "Analytics", "Activity Log"];
 
 // A path pattern rather than an absolute URL: this spec imports the router
 // statically, so `api/zitadel.ts` evaluates its base URL before `vi.stubEnv`
@@ -54,7 +48,7 @@ function renderShell() {
 }
 
 describe("app shell navigation", () => {
-  it("renders the 7 design items in order, linking only the built screens", async () => {
+  it("lists only built screens, every one of them a link", async () => {
     renderShell();
     await screen.findByRole("link", { name: /^Projects/ });
     const nav = within(screen.getByRole("navigation", { name: "Primary" }));
@@ -62,16 +56,19 @@ describe("app shell navigation", () => {
     const items = nav.getAllByRole("listitem");
     expect(items.map((li) => li.textContent?.trim())).toEqual(NAV_ORDER);
 
-    for (const label of BUILT_ITEMS) {
-      expect(nav.getByRole("link", { name: new RegExp(`^${label}`) })).toBeInTheDocument();
-    }
-    // Built rows are links; design-only rows are focusable buttons marked
-    // aria-disabled (the logo is a separate Home link outside the list).
+    // Every row navigates somewhere (the logo is a separate Home link outside
+    // the list), so there is no row that looks like a destination but is not.
     const linkedRows = items.filter((li) => within(li).queryByRole("link"));
-    expect(linkedRows).toHaveLength(BUILT_ITEMS.length);
-    const designOnly = NAV_ORDER.filter((label) => !BUILT_ITEMS.includes(label));
-    for (const label of designOnly) {
-      expect(nav.getByRole("button", { name: label })).toHaveAttribute("aria-disabled", "true");
+    expect(linkedRows).toHaveLength(NAV_ORDER.length);
+  });
+
+  it("does not advertise screens that have no endpoint behind them", async () => {
+    renderShell();
+    await screen.findByRole("link", { name: /^Projects/ });
+    const nav = within(screen.getByRole("navigation", { name: "Primary" }));
+
+    for (const label of NEVER_SHOWN) {
+      expect(nav.queryByText(label)).not.toBeInTheDocument();
     }
   });
 });

--- a/apps/console/src/components/delete-user-dialog.spec.tsx
+++ b/apps/console/src/components/delete-user-dialog.spec.tsx
@@ -1,0 +1,178 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// The `_authed` layout guards every screen behind `GET /sessions/me`
+// (Console ADR 0003); mock the auth module so routes render as signed in.
+vi.mock("@/auth/session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/auth/session")>();
+  const { makeTestSession } = await import("@/auth/session.fixture");
+  return { ...actual, fetchSession: vi.fn(async () => makeTestSession()) };
+});
+
+vi.stubEnv("VITE_CONSOLE_API_BASE", "http://localhost/api");
+// The build-time override `getConsoleProjectId()` prefers (Console ADR 0004 §5),
+// so the scoping assertion below has a known value to check rather than the
+// empty string runtime discovery would leave it at under test.
+vi.stubEnv("VITE_CONSOLE_PROJECT_ID", "proj_console");
+
+const USERS_URL = "http://localhost/api/users";
+const USER = { id: "user_1", givenName: "Maya", familyName: "Patel", email: "maya@acme.com" };
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => {
+  server.close();
+  vi.unstubAllEnvs();
+});
+
+/**
+ * Opens the dialog the way an operator does — through the list row's menu —
+ * rather than rendering the component in isolation, so the wiring between the
+ * menu item and the dialog is covered too (the menu closing on select would
+ * otherwise tear the dialog down before it renders).
+ */
+async function openDialog() {
+  const [{ RouterProvider, createMemoryHistory }, { createAppRouter }] = await Promise.all([
+    import("@tanstack/react-router"),
+    import("../router"),
+  ]);
+  const router = createAppRouter({
+    history: createMemoryHistory({ initialEntries: ["/users"] }),
+  });
+  render(<RouterProvider router={router} />);
+  await userEvent.click(await screen.findByRole("button", { name: "Actions for Maya Patel" }));
+  await userEvent.click(await screen.findByRole("menuitem", { name: "Delete" }));
+  return router;
+}
+
+describe("delete user dialog", () => {
+  it("offers only actions that reach the API", async () => {
+    // The menu used to list Edit user, Reset password and Deactivate, none of
+    // which had an endpoint behind them. A menu of dead controls is worse than
+    // a short menu — it reads as a feature that is broken rather than absent.
+    server.use(http.get(USERS_URL, () => HttpResponse.json([USER])));
+    const [{ RouterProvider, createMemoryHistory }, { createAppRouter }] = await Promise.all([
+      import("@tanstack/react-router"),
+      import("../router"),
+    ]);
+    render(
+      <RouterProvider
+        router={createAppRouter({ history: createMemoryHistory({ initialEntries: ["/users"] }) })}
+      />,
+    );
+    await userEvent.click(await screen.findByRole("button", { name: "Actions for Maya Patel" }));
+
+    expect(await screen.findByRole("menuitem", { name: "View details" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Delete" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Edit user" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Reset password" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Deactivate" })).not.toBeInTheDocument();
+  });
+
+  it("names the user in the heading and keeps Delete locked until DELETE is typed", async () => {
+    server.use(http.get(USERS_URL, () => HttpResponse.json([USER])));
+    await openDialog();
+
+    expect(await screen.findByRole("heading", { name: "Delete Maya Patel?" })).toBeInTheDocument();
+    const confirm = screen.getByRole("button", { name: "Delete user" });
+    expect(confirm).toBeDisabled();
+
+    // A near-miss must not unlock it: the confirmation is the only thing
+    // standing between a click and an irreversible delete.
+    await userEvent.type(screen.getByLabelText("Type DELETE to confirm"), "DELET");
+    expect(confirm).toBeDisabled();
+  });
+
+  it("does not accept the confirmation in the wrong case", async () => {
+    server.use(http.get(USERS_URL, () => HttpResponse.json([USER])));
+    await openDialog();
+
+    await userEvent.type(screen.getByLabelText("Type DELETE to confirm"), "delete");
+    expect(screen.getByRole("button", { name: "Delete user" })).toBeDisabled();
+  });
+
+  it("deletes the user, scoped to the console project, and reports success", async () => {
+    let deleted: URL | undefined;
+    server.use(
+      http.get(USERS_URL, () => HttpResponse.json(deleted ? [] : [USER])),
+      http.delete(`${USERS_URL}/:userId`, ({ request, params }) => {
+        deleted = new URL(request.url);
+        expect(params.userId).toBe("user_1");
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    await openDialog();
+
+    await userEvent.type(screen.getByLabelText("Type DELETE to confirm"), "DELETE");
+    await userEvent.click(screen.getByRole("button", { name: "Delete user" }));
+
+    // The delete must carry the project scope: `DELETE /users/{user_id}` takes
+    // `project_id`, and without it the request is not the one the operator
+    // thinks they are making.
+    await waitFor(() => expect(deleted).toBeDefined());
+    expect(deleted?.searchParams.get("project_id")).toBe("proj_console");
+
+    // Success is confirmed to the operator (design decisions log D2) and the
+    // row is gone from the invalidated list.
+    expect(await screen.findByText("Maya Patel deleted")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole("link", { name: "Maya Patel" })).not.toBeInTheDocument(),
+    );
+  });
+
+  it("cancels without deleting, even with the confirmation typed", async () => {
+    // Regression: the Radix Cancel primitive renders a bare `<button>`, which
+    // inside a `<form>` defaults to `type="submit"` — so Cancel submitted the
+    // form and deleted the user. Caught by the real-instance e2e, pinned here.
+    let deleteCalls = 0;
+    server.use(
+      http.get(USERS_URL, () => HttpResponse.json([USER])),
+      http.delete(`${USERS_URL}/:userId`, () => {
+        deleteCalls += 1;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    await openDialog();
+
+    await userEvent.type(screen.getByLabelText("Type DELETE to confirm"), "DELETE");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument(),
+    );
+    expect(deleteCalls).toBe(0);
+    // Reachable again after dismissal. This also pins the second bug the e2e
+    // found: opening the dialog from inside the row menu left the menu open
+    // underneath, and its `aria-hidden` on the rest of the page outlived the
+    // dialog — so the list was invisible to assistive tech after cancelling.
+    expect(screen.getByRole("link", { name: "Maya Patel" })).toBeInTheDocument();
+  });
+
+  it("keeps the dialog open and shows the server's message when the delete fails", async () => {
+    server.use(
+      http.get(USERS_URL, () => HttpResponse.json([USER])),
+      http.delete(`${USERS_URL}/:userId`, () =>
+        HttpResponse.json({ message: "User not found." }, { status: 404 }),
+      ),
+    );
+    await openDialog();
+
+    await userEvent.type(screen.getByLabelText("Type DELETE to confirm"), "DELETE");
+    await userEvent.click(screen.getByRole("button", { name: "Delete user" }));
+
+    // ADR 030 makes the payload's `message` the human-facing string, so it is
+    // shown verbatim rather than replaced with console-authored copy.
+    expect(await screen.findByText("User not found.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Delete Maya Patel?" })).toBeInTheDocument();
+    // Recoverable: the operator can retry without re-typing. (The list itself is
+    // outside the modal's a11y tree while it is open, so it is not asserted on
+    // here — the success case covers the row going away.)
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Delete user" })).toBeEnabled(),
+    );
+  });
+});

--- a/apps/console/src/components/delete-user-dialog.tsx
+++ b/apps/console/src/components/delete-user-dialog.tsx
@@ -1,0 +1,223 @@
+import { AlertCircle, Loader2, TriangleAlert } from "lucide-react";
+import { type ReactNode, useId, useState } from "react";
+import { toast } from "sonner";
+
+import { Alert, AlertTitle } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import { api } from "../api/zitadel";
+import { describeError } from "../lib/api-error";
+import { getConsoleProjectId } from "../runtime/runtime";
+
+/**
+ * The word the operator has to type before the action unlocks. Compared
+ * case-sensitively: the design (`656:49130`) renders it uppercase, and a
+ * confirmation step that accepts "delete" is not the barrier it appears to be.
+ */
+const CONFIRM_WORD = "DELETE";
+
+// Long utility strings live as named constants so Tailwind's scanner sees the
+// full literal (it never sees a concatenated fragment).
+//
+// The registry's AlertDialogHeader is a grid that places the media beside a
+// title/description pair. This design puts a third element in that column (the
+// confirm field), which the grid would auto-place back under the media, so the
+// header is laid out as the design's own structure instead: a row, 24px gap,
+// with a 6px-gapped column beside the media.
+// `max-w-sm` (384px) carries the important suffix because the primitive's own
+// `data-[size=default]:sm:max-w-lg` compiles to a higher-specificity selector
+// and would otherwise win, leaving the dialog 512px wide.
+const CONTENT = "gap-0 rounded-xl p-0 sm:max-w-sm!";
+const HEADER = "flex flex-row items-start gap-6 p-6 text-left";
+// Flat 10% in both themes. Only the destructive *button* carries a dark-mode
+// lift (its token is `custom/destructive\10-dark:destructive\20`); the media
+// square's fill is a static 10% tint in the design, and bumping it in dark made
+// the icon plate read twice as strong as the node.
+const MEDIA = "bg-destructive/10 text-destructive";
+const COLUMN = "flex min-w-0 flex-1 flex-col gap-1.5";
+const TITLE = "font-serif text-lg leading-7 font-normal";
+const CONFIRM_LABEL = "font-serif text-sm leading-5 font-normal text-foreground";
+const FOOTER = "flex-row items-center justify-end gap-2 px-6 pb-6";
+
+/**
+ * The delete-user confirmation dialog (Figma `656:49130`).
+ *
+ * **The copy is literally true.** `DELETE /users/{user_id}` is a hard delete:
+ * the service removes the user's memberships and the user row in one
+ * transaction, and sessions are cascade-deleted by the foreign key added in
+ * migration `000007`. There is no tombstone and no recovery window, which is
+ * what the design decisions log records (D2) and what the body text promises.
+ *
+ * That still contradicts ADR 024 (Accepted), which specifies deactivate and
+ * tombstone before purge — tracked in #694. If that decision reverses, this
+ * dialog's copy is the first thing that has to change.
+ */
+export function DeleteUserDialog({
+  userId,
+  name,
+  children,
+  open: controlledOpen,
+  onOpenChange,
+  onDeleted,
+}: {
+  userId: string;
+  /** Display name for the heading — the design reads `Delete {name}?`. */
+  name: string;
+  /**
+   * The trigger, for callers that have one (the detail screen's danger card).
+   *
+   * Opening from a menu must **not** use a trigger: a Radix menu marks the rest
+   * of the page `aria-hidden` while it is open, and nesting the dialog inside it
+   * means the menu is still open underneath — so when the dialog closes the list
+   * stays hidden from assistive tech and from Playwright's role queries. Those
+   * callers control `open` instead and let the menu close on select.
+   */
+  children?: ReactNode;
+  /** Controlled open state. Omit to let the trigger own it. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Called after a successful delete, for list invalidation or navigation. */
+  onDeleted: () => void | Promise<void>;
+}) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const open = controlledOpen ?? uncontrolledOpen;
+  const setOpen = onOpenChange ?? setUncontrolledOpen;
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      {children && <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>}
+      <AlertDialogContent className={CONTENT}>
+        {/* Remounted per opening so a typed confirmation or a failed attempt
+            never carries into the next one. */}
+        {open && (
+          <DeleteUserForm
+            userId={userId}
+            name={name}
+            onDeleted={onDeleted}
+            onClose={() => setOpen(false)}
+          />
+        )}
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function DeleteUserForm({
+  userId,
+  name,
+  onDeleted,
+  onClose,
+}: {
+  userId: string;
+  name: string;
+  onDeleted: () => void | Promise<void>;
+  onClose: () => void;
+}) {
+  const confirmId = useId();
+  const [confirmation, setConfirmation] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const confirmed = confirmation === CONFIRM_WORD;
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!confirmed || deleting) return;
+    setDeleting(true);
+    setError(undefined);
+    try {
+      await api.deleteUserByID(userId, { project_id: getConsoleProjectId() });
+      // Raised before the dialog closes, from the root-mounted toaster, so it
+      // outlives this subtree — the caller may navigate away on `onDeleted`.
+      toast.success(`${name} deleted`);
+      await onDeleted();
+      onClose();
+    } catch (cause) {
+      // Kept open on failure: the operator has already typed the confirmation,
+      // and closing would discard both that and the reason it failed.
+      setError(describeError(cause, "Could not delete the user."));
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit}>
+      <AlertDialogHeader className={HEADER}>
+        <AlertDialogMedia className={MEDIA}>
+          <TriangleAlert aria-hidden />
+        </AlertDialogMedia>
+        <div className={COLUMN}>
+          <AlertDialogTitle className={TITLE}>Delete {name}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This permanently deletes the user and all associated sessions, grants, and
+            profile data. This action cannot be undone.
+          </AlertDialogDescription>
+          {/* The column's own 6px gap separates this from the description; the
+              12px here is the field's internal label→input gap. */}
+          <div className="flex flex-col gap-3">
+            <Label htmlFor={confirmId} className={CONFIRM_LABEL}>
+              Type {CONFIRM_WORD} to confirm
+            </Label>
+            <Input
+              id={confirmId}
+              name="confirmation"
+              value={confirmation}
+              onChange={(event) => setConfirmation(event.target.value)}
+              // The confirmation is a literal string, not a word the browser
+              // should learn, complete, or correct on the operator's behalf.
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              className="h-9 rounded-md px-2.5 py-1 text-sm"
+            />
+          </div>
+          {error && (
+            <Alert variant="destructive" className="mt-1.5">
+              <AlertCircle aria-hidden />
+              <AlertTitle>{error}</AlertTitle>
+            </Alert>
+          )}
+        </div>
+      </AlertDialogHeader>
+
+      <AlertDialogFooter className={FOOTER}>
+        {/* `type="button"` is load-bearing: the Radix primitive renders a bare
+            `<button>`, which inside a `<form>` defaults to `type="submit"` — so
+            Cancel submitted the form and deleted the user it was meant to spare.
+
+            `px-2.5!` — `AlertDialogCancel` puts this className on the element
+            inside the Button's `asChild` slot, so it never passes through
+            tailwind-merge and the size variant's `px-4` would otherwise win. */}
+        <AlertDialogCancel type="button" className="px-2.5!" disabled={deleting}>
+          Cancel
+        </AlertDialogCancel>
+        {/* Not `AlertDialogAction`: that primitive closes the dialog on click,
+            which would tear down the pending state and the error surface before
+            the request settles. The close is driven by the request instead. */}
+        <Button
+          type="submit"
+          variant="destructive"
+          className="gap-1.5 px-2.5"
+          disabled={!confirmed || deleting}
+        >
+          {deleting && <Loader2 className="size-3 animate-spin" aria-hidden />}
+          Delete user
+        </Button>
+      </AlertDialogFooter>
+    </form>
+  );
+}

--- a/apps/console/src/components/project-access.spec.tsx
+++ b/apps/console/src/components/project-access.spec.tsx
@@ -1,10 +1,16 @@
-// Parked with the Projects block in the Add user drawer, which is hidden until
-// the backend can grant access: roles need ADR 034's app-group catalog (epic
-// #419), and `queryProjects` is scope-pinned to a single project (ADR 0004).
+// Parked with the Projects block in the Add user drawer. Two reasons, and both
+// have to clear before it comes back:
+//
+//   1. Design removed the project selector from the MVP (design decisions log
+//      D6, 2026-07-31). It is expected to return in a future version, which is
+//      why this is parked rather than deleted.
+//   2. The backend cannot grant access anyway: roles need ADR 034's app-group
+//      catalog (epic #419), and `queryProjects` is scope-pinned to a single
+//      project (ADR 0004).
 //
 // The component and these specs are kept intact — un-comment this file, the
 // block in `add-user-sheet.tsx` and the parked cases in its spec together when
-// the endpoints land.
+// design reinstates the block and the endpoints exist.
 //
 // import { render, screen } from "@testing-library/react";
 // import userEvent from "@testing-library/user-event";

--- a/apps/console/src/components/ui/alert-dialog.tsx
+++ b/apps/console/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-16 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/apps/console/src/components/ui/button.tsx
+++ b/apps/console/src/components/ui/button.tsx
@@ -10,8 +10,13 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        // Tinted, not solid. The registry default is `bg-destructive text-white`,
+        // but the design system's `Variant=Destructive` (`786:5825`) is a
+        // destructive/10 fill with destructive text — dark mode lifts the fill to
+        // /20 so it reads against the darker surface. Fixed here rather than at
+        // the call site so the next destructive button inherits it.
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/apps/console/src/components/ui/sonner.tsx
+++ b/apps/console/src/components/ui/sonner.tsx
@@ -1,0 +1,48 @@
+import { CircleCheckIcon, InfoIcon, Loader2Icon, OctagonXIcon, TriangleAlertIcon } from "lucide-react";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+import { useTheme } from "../../theme";
+
+/**
+ * The app-wide toaster.
+ *
+ * Adapted from the shadcn registry component in one respect: the registry
+ * version reads the theme from `next-themes`, which this app does not use. The
+ * console drives `data-theme` on `<html>` itself (`src/theme.ts`), so the
+ * resolved theme comes from that hook instead — adding `next-themes` would put
+ * a second, competing source of truth for the theme in the bundle.
+ *
+ * Sonner renders in a portal outside the app subtree, so it cannot inherit the
+ * token values through the cascade the way the rest of the UI does. The `style`
+ * block below maps its private custom properties onto the same semantic tokens
+ * (`--popover`, `--border`) every other surface uses, so it flips with
+ * `data-theme` rather than needing a light and a dark variant.
+ */
+function Toaster({ ...props }: ToasterProps) {
+  const { resolved } = useTheme();
+
+  return (
+    <Sonner
+      theme={resolved}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  );
+}
+
+export { Toaster };

--- a/apps/console/src/lib/api-error.ts
+++ b/apps/console/src/lib/api-error.ts
@@ -1,0 +1,33 @@
+import { ApiError } from "@zitadel/api/runtime/fetch";
+
+/**
+ * The message to show for a failed request.
+ *
+ * **The API owns this copy.** ADR 030 defines the error payload's `message` as
+ * the human-facing string, so it is rendered verbatim rather than mapped to
+ * console-authored text — the console has no design source for error strings and
+ * no i18n layer, so re-writing them would only fork the wording per client.
+ *
+ * The message lives in the response *body* (`error-details.yaml`).
+ * `ApiError.message` is a transport-level string (`POST /users returned 409`,
+ * built in `runtime/fetch.ts`) and must never reach an operator, so the body is
+ * read explicitly. `fallback` covers the case where there is no payload at all —
+ * a network failure or a non-JSON response.
+ *
+ * Attributing a `409` to a specific input is deliberately not attempted:
+ * `ErrUserAlreadyExists()` carries no details and ADR 030 records that `details`
+ * is never populated today, so the response cannot say which value collided.
+ * Guessing from the schema's `x-unique` markers would put console-authored copy
+ * under a field the server never named.
+ */
+export function describeError(cause: unknown, fallback: string): string {
+  if (cause instanceof ApiError) {
+    const body = cause.body;
+    if (body && typeof body === "object") {
+      const message = (body as Record<string, unknown>).message;
+      if (typeof message === "string" && message.trim() !== "") return message;
+    }
+    return fallback;
+  }
+  return cause instanceof Error ? cause.message : fallback;
+}

--- a/apps/console/src/nav.ts
+++ b/apps/console/src/nav.ts
@@ -3,13 +3,9 @@
  * headings; order is driven by `order`).
  *
  * Built routes attach their entry via `staticData` (Console ADR 0001) so the
- * sidebar stays in sync with the route tree. The design's sidebar also shows
- * screens that are not built yet; those are listed in `DESIGN_ONLY_NAV` so the
- * shell can render the full, pixel-accurate mock while marking un-built
- * destinations as non-navigable.
+ * sidebar stays in sync with the route tree — every row in the sidebar is a
+ * screen that exists.
  */
-import { Activity, AppWindow, BarChart3, Folder } from "lucide-react";
-
 import type { NavIcon } from "./components/app-shell/icons";
 
 export interface NavMeta {
@@ -22,16 +18,33 @@ export interface NavMeta {
 }
 
 /**
- * Sidebar entries for screens that exist in the Figma mock but are not built
- * yet. Rendered identically to real entries (so the sidebar matches the design
- * pixel-for-pixel) but without a route, so they are not navigable.
+ * Sidebar entries for screens in the Figma mock that are not built.
+ *
+ * **Empty on purpose.** These used to render as disabled rows so the sidebar
+ * matched the design pixel-for-pixel — but a disabled row still advertises a
+ * feature. It reads as "your account cannot do this" rather than "this does not
+ * exist", and four of the seven nav items were permanently inert. The sidebar
+ * now lists only screens that work, so a gap reads as a gap.
+ *
+ * Restore an entry when its screen has an endpoint behind it. None does today:
+ *
+ *   - App groups   — needs ADR 034's app-group catalog (epic #419)
+ *   - Applications — no application resource or endpoints exist
+ *   - Analytics    — no aggregate or time-series endpoint exists
+ *   - Activity Log — no audit-log read API (#350)
+ *
+ * ```ts
+ * import { Activity, AppWindow, BarChart3, Folder } from "lucide-react";
+ *
+ * export const DESIGN_ONLY_NAV: NavMeta[] = [
+ *   { label: "App groups", order: 3, icon: Folder },
+ *   { label: "Applications", order: 4, icon: AppWindow },
+ *   { label: "Analytics", order: 5, icon: BarChart3 },
+ *   { label: "Activity Log", order: 7, icon: Activity },
+ * ];
+ * ```
  */
-export const DESIGN_ONLY_NAV: NavMeta[] = [
-  { label: "App groups", order: 3, icon: Folder },
-  { label: "Applications", order: 4, icon: AppWindow },
-  { label: "Analytics", order: 5, icon: BarChart3 },
-  { label: "Activity Log", order: 7, icon: Activity },
-];
+export const DESIGN_ONLY_NAV: NavMeta[] = [];
 
 declare module "@tanstack/react-router" {
   interface StaticDataRouteOption {

--- a/apps/console/src/routes/__root.tsx
+++ b/apps/console/src/routes/__root.tsx
@@ -2,12 +2,18 @@ import { TanStackDevtools } from "@tanstack/react-devtools";
 import { Outlet, createRootRoute } from "@tanstack/react-router";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 
+import { Toaster } from "@/components/ui/sonner";
+
 import "../styles.css";
 
 /**
- * Minimal root: global styles, the outlet, and devtools. The app chrome
- * (sidebar, context bar) lives on the `_authed` pathless layout so the
+ * Minimal root: global styles, the outlet, the toaster, and devtools. The app
+ * chrome (sidebar, context bar) lives on the `_authed` pathless layout so the
  * login screen renders shell-less (Console ADR 0003).
+ *
+ * The toaster sits at the root rather than in the shell so a toast outlives the
+ * surface that raised it — deleting a user unmounts its dialog and re-renders
+ * the list underneath, and the confirmation has to survive both.
  */
 export const Route = createRootRoute({
   component: RootComponent,
@@ -17,6 +23,7 @@ function RootComponent() {
   return (
     <>
       <Outlet />
+      <Toaster />
       {import.meta.env.DEV && import.meta.env.MODE !== "test" && (
         // Bottom-left: right-anchored surfaces (the Add user drawer, and any
         // sheet after it) put their primary action in the bottom-right corner,

--- a/apps/console/src/routes/_authed/index.tsx
+++ b/apps/console/src/routes/_authed/index.tsx
@@ -34,7 +34,7 @@ function Home() {
   return (
     <ComingSoon
       title="Home"
-      description="The overview screen needs aggregate counts and a multi-project list, neither of which the API exposes yet. Users, Sessions and Projects show real data today."
+      description="The overview screen needs aggregate counts and a multi-project list, neither of which the API exposes yet. Users is the screen that has been designed and built."
       icon={LayoutDashboard}
     />
   );

--- a/apps/console/src/routes/_authed/index.tsx
+++ b/apps/console/src/routes/_authed/index.tsx
@@ -1,144 +1,171 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { FolderCheck, Plus, Search, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { LayoutDashboard } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-
-import { Page } from "../../components/layout";
+import { ComingSoon } from "../../components/coming-soon";
 
 /**
- * The "General" screen — the one fully-designed frame in the Figma handoff. It is
- * a static mock rendered with the designed dummy data (no API), so designers and
- * reviewers can see the handed-off layout built pixel-for-pixel. Real, API-backed
- * screens live under their own routes (Users, Sessions, Projects, Login flows).
+ * Home.
  *
- * Home is reached via the sidebar logo, so it has no sidebar nav entry (the
- * Figma sidebar has no "Get started" row).
+ * This screen was a **static mock** rendered with the designed dummy data — stat
+ * cards reading "SL Mobbin / 142 items", a "142 Total Projects +18,0%" figure, a
+ * "Browse all" list of invented folders owned by "Alex Smith", tabs labelled
+ * "Tab 2"–"Tab 5", and a Remove button wired to nothing. It was built to show the
+ * handed-off layout pixel-for-pixel, but on a screen that otherwise looks like a
+ * working console it reads as real data, and the numbers it shows are invented.
+ *
+ * The mock is parked below rather than deleted: the layout is the design's, and
+ * Home will be built on it once there is something true to put in it. What it
+ * needs and does not have:
+ *
+ *   - the stat figures: no aggregate/count endpoint exists (`GET /users` and
+ *     `POST /projects/query` return pages, and `POST /projects/query` is
+ *     scope-pinned to the caller's own project per Console ADR 0004)
+ *   - "Total Projects" and its trend: no multi-project list, no time series
+ *   - the "Browse all" rows: no resource behind them at all
+ *
+ * Restore the block below when those land, replacing the dummy constants with
+ * loader data — not before.
  */
 export const Route = createFileRoute("/_authed/")({
-  component: Dashboard,
+  component: Home,
 });
 
-const STAT_CARDS = [
-  { title: "SL Mobbin", subtitle: "142 items" },
-  { title: "SL Mobbin", subtitle: "142 items" },
-] as const;
-
-const TABS = ["Statistics", "Tab 2", "Tab 3", "Tab 4", "Tab 5"] as const;
-
-const BROWSE_ROWS = [
-  { title: "AS Mobbin", description: "Contains various files and project workflows for AS Mobbin." },
-  { title: "Demo folder", description: "Contains various files and project workflows for Demo folder." },
-  { title: "SL Mobbin", description: "Contains various files and project workflows for SL Mobbin." },
-  { title: "SL Mobbin", description: "Contains various files and project workflows for SL Mobbin." },
-  { title: "SL Mobbin", description: "Contains various files and project workflows for SL Mobbin." },
-] as const;
-
-function Dashboard() {
-  const [query, setQuery] = useState("");
-  const [activeTab, setActiveTab] = useState(0);
-  const rows = BROWSE_ROWS.filter((row) => row.title.toLowerCase().includes(query.trim().toLowerCase()));
-
+function Home() {
   return (
-    <Page>
-      <header className="flex items-center justify-between gap-4">
-        <div className="flex flex-col gap-2">
-          <h1 className="font-serif text-2xl tracking-tight text-foreground">General</h1>
-          <p className="text-sm text-muted-foreground">This is a sub headline</p>
-        </div>
-        <Button>
-          Primary action
-          <Plus aria-hidden />
-        </Button>
-      </header>
-
-      <Tabs
-        value={String(activeTab)}
-        onValueChange={(value) => setActiveTab(Number(value))}
-        className="mt-6"
-      >
-        <TabsList aria-label="Views">
-          {TABS.map((tab, index) => (
-            <TabsTrigger key={tab} value={String(index)}>
-              {tab}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </Tabs>
-
-      <div className="mt-8 grid gap-3 md:grid-cols-3">
-        {STAT_CARDS.map((card, index) => (
-          <div
-            key={index}
-            className="flex flex-col gap-4 rounded-lg bg-card p-6"
-          >
-            <FolderCheck size={24} className="text-foreground" aria-hidden />
-            <div className="flex flex-col gap-1">
-              <p className="text-base font-semibold leading-6 text-foreground">{card.title}</p>
-              <p className="text-xs leading-4 text-muted-foreground">{card.subtitle}</p>
-            </div>
-          </div>
-        ))}
-        <div className="flex flex-col gap-4 rounded-lg bg-card p-6">
-          <p className="text-2xl font-semibold tracking-[-0.5px] text-foreground">142</p>
-          <div className="flex flex-wrap items-center gap-1.5">
-            <p className="text-sm text-muted-foreground">Total Projects</p>
-            <Badge variant="secondary">+ 18,0%</Badge>
-          </div>
-        </div>
-      </div>
-
-      <section className="mt-8 pt-5">
-        <div className="mb-5 flex items-center justify-between gap-4">
-          <h2 className="font-serif text-base text-foreground">Browse all</h2>
-          <div className="relative w-full max-w-[360px]">
-            <Search
-              size={16}
-              className="pointer-events-none absolute left-3 top-1/2 shrink-0 -translate-y-1/2 text-foreground"
-              aria-hidden
-            />
-            <Input
-              type="search"
-              name="folder-search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search"
-              aria-label="Search"
-              className="pl-9"
-            />
-          </div>
-        </div>
-
-        <div className="overflow-hidden rounded-lg border border-border">
-          {rows.length === 0 ? (
-            <p className="p-5 text-sm text-muted-foreground">No results for “{query}”.</p>
-          ) : (
-            rows.map((row, index) => (
-              <div
-                key={index}
-                className="flex cursor-pointer items-center gap-5 border-b border-border p-5 transition-colors last:border-b-0 hover:bg-accent"
-              >
-                <FolderCheck size={24} className="shrink-0 text-foreground" aria-hidden />
-                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <p className="text-sm font-semibold text-foreground">{row.title}</p>
-                  <p className="truncate text-xs text-muted-foreground">{row.description}</p>
-                </div>
-                <span className="shrink-0 text-xs text-muted-foreground">Alex Smith</span>
-                <button
-                  type="button"
-                  aria-label={`Remove ${row.title}`}
-                  className="shrink-0 text-muted-foreground hover:text-foreground"
-                >
-                  <Trash2 size={20} aria-hidden />
-                </button>
-              </div>
-            ))
-          )}
-        </div>
-      </section>
-    </Page>
+    <ComingSoon
+      title="Home"
+      description="The overview screen needs aggregate counts and a multi-project list, neither of which the API exposes yet. Users, Sessions and Projects show real data today."
+      icon={LayoutDashboard}
+    />
   );
 }
+
+// --- Parked design mock (see the note above) --------------------------------
+//
+// import { FolderCheck, Plus, Search, Trash2 } from "lucide-react";
+// import { useState } from "react";
+//
+// import { Badge } from "@/components/ui/badge";
+// import { Button } from "@/components/ui/button";
+// import { Input } from "@/components/ui/input";
+// import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+//
+// import { Page } from "../../components/layout";
+//
+// const STAT_CARDS = [
+//   { title: "SL Mobbin", subtitle: "142 items" },
+//   { title: "SL Mobbin", subtitle: "142 items" },
+// ] as const;
+//
+// const TABS = ["Statistics", "Tab 2", "Tab 3", "Tab 4", "Tab 5"] as const;
+//
+// const BROWSE_ROWS = [
+//   { title: "AS Mobbin", description: "Contains various files and project workflows for AS Mobbin." },
+//   { title: "Demo folder", description: "Contains various files and project workflows for Demo folder." },
+//   { title: "SL Mobbin", description: "Contains various files and project workflows for SL Mobbin." },
+//   { title: "SL Mobbin", description: "Contains various files and project workflows for SL Mobbin." },
+//   { title: "SL Mobbin", description: "Contains various files and project workflows for SL Mobbin." },
+// ] as const;
+//
+// function Dashboard() {
+//   const [query, setQuery] = useState("");
+//   const [activeTab, setActiveTab] = useState(0);
+//   const rows = BROWSE_ROWS.filter((row) => row.title.toLowerCase().includes(query.trim().toLowerCase()));
+//
+//   return (
+//     <Page>
+//       <header className="flex items-center justify-between gap-4">
+//         <div className="flex flex-col gap-2">
+//           <h1 className="font-serif text-2xl tracking-tight text-foreground">General</h1>
+//           <p className="text-sm text-muted-foreground">This is a sub headline</p>
+//         </div>
+//         <Button>
+//           Primary action
+//           <Plus aria-hidden />
+//         </Button>
+//       </header>
+//
+//       <Tabs
+//         value={String(activeTab)}
+//         onValueChange={(value) => setActiveTab(Number(value))}
+//         className="mt-6"
+//       >
+//         <TabsList aria-label="Views">
+//           {TABS.map((tab, index) => (
+//             <TabsTrigger key={tab} value={String(index)}>
+//               {tab}
+//             </TabsTrigger>
+//           ))}
+//         </TabsList>
+//       </Tabs>
+//
+//       <div className="mt-8 grid gap-3 md:grid-cols-3">
+//         {STAT_CARDS.map((card, index) => (
+//           <div key={index} className="flex flex-col gap-4 rounded-lg bg-card p-6">
+//             <FolderCheck size={24} className="text-foreground" aria-hidden />
+//             <div className="flex flex-col gap-1">
+//               <p className="text-base font-semibold leading-6 text-foreground">{card.title}</p>
+//               <p className="text-xs leading-4 text-muted-foreground">{card.subtitle}</p>
+//             </div>
+//           </div>
+//         ))}
+//         <div className="flex flex-col gap-4 rounded-lg bg-card p-6">
+//           <p className="text-2xl font-semibold tracking-[-0.5px] text-foreground">142</p>
+//           <div className="flex flex-wrap items-center gap-1.5">
+//             <p className="text-sm text-muted-foreground">Total Projects</p>
+//             <Badge variant="secondary">+ 18,0%</Badge>
+//           </div>
+//         </div>
+//       </div>
+//
+//       <section className="mt-8 pt-5">
+//         <div className="mb-5 flex items-center justify-between gap-4">
+//           <h2 className="font-serif text-base text-foreground">Browse all</h2>
+//           <div className="relative w-full max-w-[360px]">
+//             <Search
+//               size={16}
+//               className="pointer-events-none absolute left-3 top-1/2 shrink-0 -translate-y-1/2 text-foreground"
+//               aria-hidden
+//             />
+//             <Input
+//               type="search"
+//               name="folder-search"
+//               value={query}
+//               onChange={(event) => setQuery(event.target.value)}
+//               placeholder="Search"
+//               aria-label="Search"
+//               className="pl-9"
+//             />
+//           </div>
+//         </div>
+//
+//         <div className="overflow-hidden rounded-lg border border-border">
+//           {rows.length === 0 ? (
+//             <p className="p-5 text-sm text-muted-foreground">No results for “{query}”.</p>
+//           ) : (
+//             rows.map((row, index) => (
+//               <div
+//                 key={index}
+//                 className="flex cursor-pointer items-center gap-5 border-b border-border p-5 transition-colors last:border-b-0 hover:bg-accent"
+//               >
+//                 <FolderCheck size={24} className="shrink-0 text-foreground" aria-hidden />
+//                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+//                   <p className="text-sm font-semibold text-foreground">{row.title}</p>
+//                   <p className="truncate text-xs text-muted-foreground">{row.description}</p>
+//                 </div>
+//                 <span className="shrink-0 text-xs text-muted-foreground">Alex Smith</span>
+//                 <button
+//                   type="button"
+//                   aria-label={`Remove ${row.title}`}
+//                   className="shrink-0 text-muted-foreground hover:text-foreground"
+//                 >
+//                   <Trash2 size={20} aria-hidden />
+//                 </button>
+//               </div>
+//             ))
+//           )}
+//         </div>
+//       </section>
+//     </Page>
+//   );
+// }

--- a/apps/console/src/routes/_authed/projects/index.tsx
+++ b/apps/console/src/routes/_authed/projects/index.tsx
@@ -1,14 +1,24 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Alert } from "@zitadel/ui-react";
-import { Boxes } from "lucide-react";
 
 import { api } from "../../../api/zitadel";
 import { getConsoleProjectId } from "../../../runtime/runtime";
 import { Page } from "../../../components/layout";
 import { KeyValueTable, PageHeader } from "../../../components/resource-page";
 
+/**
+ * The scoped project, read from `GET /projects/{project_id}`.
+ *
+ * **Reachable by URL, deliberately not in the sidebar.** The data is real, but
+ * this screen has had no design hand-off — Users is the only designed surface —
+ * and the layout here is a developer's key/value table, not a designed one. In
+ * the nav it read as a finished feature; at a URL it is what it is, a way to see
+ * the project the console is bound to.
+ *
+ * Restore `staticData: { nav: { label: "Projects", order: 1, icon: Boxes } }`
+ * when a design for it lands.
+ */
 export const Route = createFileRoute("/_authed/projects/")({
-  staticData: { nav: { label: "Projects", order: 1, icon: Boxes } },
   loader: () => api.getProject(getConsoleProjectId()),
   component: ProjectView,
 });

--- a/apps/console/src/routes/_authed/sessions/index.tsx
+++ b/apps/console/src/routes/_authed/sessions/index.tsx
@@ -1,70 +1,107 @@
-import { useRouter } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
-import { Button, Pill } from "@zitadel/ui-react";
 import { KeyRound } from "lucide-react";
-import { useState } from "react";
 
-import { api } from "../../../api/zitadel";
-import { getConsoleProjectId } from "../../../runtime/runtime";
-import { Page } from "../../../components/layout";
-import { DataTable, PageHeader } from "../../../components/resource-page";
+import { ComingSoon } from "../../../components/coming-soon";
 
+/**
+ * Sessions.
+ *
+ * **The screen was built against an endpoint that does not work.** `GET
+ * /sessions` is routed, documented and generated, but `sessionService.List` is a
+ * stub returning `ErrNotImplemented` (`internal/service/session.go`), so every
+ * load answered 501 and the sidebar link landed on the error boundary. This was
+ * the only console screen that failed outright.
+ *
+ * It has also lost its `staticData.nav` entry, so the sidebar no longer offers a
+ * destination that cannot load. Both come back together when #699 lands.
+ *
+ * The table below is parked rather than deleted, and is close to complete:
+ * `revokeSession` is fully implemented server-side, so the only missing piece is
+ * the list itself. Restore it, put the nav entry back, and check the columns
+ * against whatever shape `List` actually returns — this markup was written
+ * against the generated type, not against a response anyone has seen.
+ */
 export const Route = createFileRoute("/_authed/sessions/")({
-  staticData: { nav: { label: "Sessions", order: 6, icon: KeyRound } },
-  loader: () => api.listSessions({ project_id: getConsoleProjectId() }),
-  component: SessionsList,
+  component: SessionsPlaceholder,
 });
 
-function SessionsList() {
-  const { sessions } = Route.useLoaderData();
-  const router = useRouter();
-  const [revoking, setRevoking] = useState<string | null>(null);
-
-  async function revoke(sessionId: string) {
-    setRevoking(sessionId);
-    try {
-      await api.revokeSession(sessionId, { project_id: getConsoleProjectId() });
-      await router.invalidate();
-    } catch (error) {
-      console.error("Failed to revoke session", error);
-    } finally {
-      setRevoking(null);
-    }
-  }
-
+function SessionsPlaceholder() {
   return (
-    <Page>
-      <PageHeader title="Sessions" />
-      <DataTable
-        rows={sessions}
-        getRowKey={(session) => session.session_id}
-        emptyMessage="No active sessions."
-        columns={[
-          { header: "Session", cell: (session) => session.session_id },
-          { header: "User", cell: (session) => session.user_id ?? "anonymous" },
-          {
-            header: "State",
-            cell: (session) => (
-              <Pill tone={session.state === "active" ? "success" : "neutral"}>{session.state}</Pill>
-            ),
-          },
-          { header: "Created", cell: (session) => session.created_at },
-          { header: "Expires", cell: (session) => session.expires_at },
-          {
-            header: "",
-            cell: (session) => (
-              <Button
-                hierarchy="text"
-                size="small"
-                loading={revoking === session.session_id}
-                onClick={() => void revoke(session.session_id)}
-              >
-                Revoke
-              </Button>
-            ),
-          },
-        ]}
-      />
-    </Page>
+    <ComingSoon
+      title="Sessions"
+      description="Listing sessions needs an endpoint that is routed but not implemented — GET /sessions answers 501 today. Revoking already works, so this screen returns as soon as the list does."
+      icon={KeyRound}
+    />
   );
 }
+
+// --- Parked: the sessions table (see the note above) -------------------------
+//
+// import { useRouter } from "@tanstack/react-router";
+// import { Button, Pill } from "@zitadel/ui-react";
+// import { useState } from "react";
+//
+// import { api } from "../../../api/zitadel";
+// import { getConsoleProjectId } from "../../../runtime/runtime";
+// import { Page } from "../../../components/layout";
+// import { DataTable, PageHeader } from "../../../components/resource-page";
+//
+// export const Route = createFileRoute("/_authed/sessions/")({
+//   staticData: { nav: { label: "Sessions", order: 6, icon: KeyRound } },
+//   loader: () => api.listSessions({ project_id: getConsoleProjectId() }),
+//   component: SessionsList,
+// });
+//
+// function SessionsList() {
+//   const { sessions } = Route.useLoaderData();
+//   const router = useRouter();
+//   const [revoking, setRevoking] = useState<string | null>(null);
+//
+//   async function revoke(sessionId: string) {
+//     setRevoking(sessionId);
+//     try {
+//       await api.revokeSession(sessionId, { project_id: getConsoleProjectId() });
+//       await router.invalidate();
+//     } catch (error) {
+//       console.error("Failed to revoke session", error);
+//     } finally {
+//       setRevoking(null);
+//     }
+//   }
+//
+//   return (
+//     <Page>
+//       <PageHeader title="Sessions" />
+//       <DataTable
+//         rows={sessions}
+//         getRowKey={(session) => session.session_id}
+//         emptyMessage="No active sessions."
+//         columns={[
+//           { header: "Session", cell: (session) => session.session_id },
+//           { header: "User", cell: (session) => session.user_id ?? "anonymous" },
+//           {
+//             header: "State",
+//             cell: (session) => (
+//               <Pill tone={session.state === "active" ? "success" : "neutral"}>{session.state}</Pill>
+//             ),
+//           },
+//           { header: "Created", cell: (session) => session.created_at },
+//           { header: "Expires", cell: (session) => session.expires_at },
+//           {
+//             header: "",
+//             cell: (session) => (
+//               <Button
+//                 hierarchy="text"
+//                 size="small"
+//                 loading={revoking === session.session_id}
+//                 onClick={() => void revoke(session.session_id)}
+//               >
+//                 Revoke
+//               </Button>
+//             ),
+//           },
+//         ]}
+//       />
+//     </Page>
+//   );
+// }

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
-import { ArrowUpDown, MoreVertical, Plus, Search, Users } from "lucide-react";
+import { MoreVertical, Plus, Search, Users } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
 import { AddUserSheet } from "@/components/add-user-sheet";
+import { DeleteUserDialog } from "@/components/delete-user-dialog";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -28,7 +29,11 @@ import { userDisplayName } from "../../../lib/user";
 
 export const Route = createFileRoute("/_authed/users/")({
   staticData: { nav: { label: "Users", order: 2, icon: Users } },
-  loader: () => api.listUsers(),
+  // `limit` is asked for explicitly at the API's maximum rather than left at the
+  // default 20. `GET /users` orders by creation ascending with no `Load more`
+  // yet (#661), so the default silently hides the most recently created users —
+  // the ones an operator has just added and is most likely looking for.
+  loader: () => api.listUsers({ limit: 100 }),
   component: UsersScreen,
 });
 
@@ -51,7 +56,6 @@ function UsersScreen() {
   const users = Route.useLoaderData();
   const router = useRouter();
   const [query, setQuery] = useState("");
-  const [sortAsc, setSortAsc] = useState<boolean | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
   // ⌘F / Ctrl+F focuses the table search instead of the browser find bar —
@@ -74,9 +78,12 @@ function UsersScreen() {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, []);
 
+  // Search narrows the rows already fetched. `GET /users` takes no filter (ADR
+  // 031's query endpoint does not exist), so this cannot reach users outside the
+  // loaded page — which is why the table says so beneath it.
   const rows = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    let next = users.map(toUserRow).filter((user) => {
+    return users.map(toUserRow).filter((user) => {
       return (
         needle === "" ||
         user.name.toLowerCase().includes(needle) ||
@@ -84,13 +91,7 @@ function UsersScreen() {
         user.id.toLowerCase().includes(needle)
       );
     });
-    if (sortAsc !== null) {
-      next = [...next].sort((a, b) =>
-        sortAsc ? a.name.localeCompare(b.name) : b.name.localeCompare(a.name),
-      );
-    }
-    return next;
-  }, [users, query, sortAsc]);
+  }, [users, query]);
 
   return (
     <div className="px-4 pt-9 pb-8 sm:px-8">
@@ -136,13 +137,7 @@ function UsersScreen() {
           </colgroup>
           <TableHeader>
             <TableRow className="border-border border-b hover:bg-transparent">
-              <HeadCell
-                sortable
-                ariaSort={sortAsc === null ? "none" : sortAsc ? "ascending" : "descending"}
-                onSort={() => setSortAsc((value) => (value === null ? true : !value))}
-              >
-                Name
-              </HeadCell>
+              <HeadCell>Name</HeadCell>
               <HeadCell>Email</HeadCell>
               <HeadCell>ID</HeadCell>
               <TableHead className="h-14 px-2" />
@@ -179,7 +174,11 @@ function UsersScreen() {
                     {user.id}
                   </TableCell>
                   <TableCell className="h-11 px-2 py-0">
-                    <RowActions name={user.name} />
+                    <RowActions
+                      userId={user.id}
+                      name={user.name}
+                      onDeleted={() => router.invalidate()}
+                    />
                   </TableCell>
                 </TableRow>
               ))
@@ -187,6 +186,15 @@ function UsersScreen() {
           </TableBody>
         </Table>
       </div>
+      {/* D5: the list is one page and must not present itself as the whole set.
+          `GET /users` serves a fixed window (limit defaults to 20) with no
+          `Load more` yet — cursor pagination is #661. */}
+      {users.length > 0 && (
+        <p className="text-muted-foreground mt-3 text-xs">
+          Showing {rows.length} of the {users.length} users loaded. This is the first page,
+          not the full list, and search only matches what is loaded.
+        </p>
+      )}
     </div>
   );
 }
@@ -203,55 +211,84 @@ function toUserRow(user: Record<string, unknown>, index: number): UserRow {
   };
 }
 
-function HeadCell({
-  children,
-  sortable = false,
-  ariaSort,
-  onSort,
-}: {
-  children: ReactNode;
-  sortable?: boolean;
-  /** Current sort state for assistive tech; only set on sortable columns. */
-  ariaSort?: "none" | "ascending" | "descending";
-  onSort?: () => void;
-}) {
+/**
+ * Column header.
+ *
+ * Sorting was removed rather than left in place. The design decisions log (D5)
+ * rules out filtering and sorting for the MVP, and the affordance was misleading
+ * on its own terms: `GET /users` serves one page, so a client-side sort ordered
+ * only the rows already fetched while presenting itself as a total order. It
+ * comes back with the query endpoint that can sort the whole set (ADR 031).
+ */
+function HeadCell({ children }: { children: ReactNode }) {
   // Figma header labels use the display face (`font-serif` → APK Futural),
   // uppercase 12px with 0.96px tracking, inset by a ghost-button (h-9, px-2.5).
-  const label = (
-    <span className="text-muted-foreground inline-flex h-9 items-center gap-1.5 rounded-md px-2.5 py-2 font-serif text-xs tracking-[0.96px] uppercase">
-      {children}
-      {sortable && <ArrowUpDown className="size-4" aria-hidden />}
-    </span>
-  );
   return (
-    <TableHead className="h-14 px-2 align-middle" aria-sort={sortable ? ariaSort : undefined}>
-      {sortable ? (
-        <button type="button" onClick={onSort} className="hover:[&>span]:text-foreground">
-          {label}
-        </button>
-      ) : (
-        label
-      )}
+    <TableHead className="h-14 px-2 align-middle">
+      <span className="text-muted-foreground inline-flex h-9 items-center gap-1.5 rounded-md px-2.5 py-2 font-serif text-xs tracking-[0.96px] uppercase">
+        {children}
+      </span>
     </TableHead>
   );
 }
 
-function RowActions({ name }: { name: string }) {
+/**
+ * The row menu carries only actions that reach the API.
+ *
+ * The design's fuller menu is not buildable yet, and the entries were rendering
+ * as live controls that did nothing:
+ *
+ *   - `Edit user` — no `PATCH`/`PUT /users/{user_id}` endpoint (#693)
+ *   - `Deactivate` — no `status` field and no lifecycle endpoint (#553)
+ *   - `Reset password` — `PUT /users/{user_id}/password` exists, but the screen
+ *     that would collect the new password does not; the menu item alone had
+ *     nothing behind it
+ *
+ * They are left out rather than disabled so the menu is a list of things that
+ * work. Add each one back with the change that makes it real.
+ */
+function RowActions({
+  userId,
+  name,
+  onDeleted,
+}: {
+  userId: string;
+  name: string;
+  onDeleted: () => void | Promise<void>;
+}) {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" aria-label={`Actions for ${name}`}>
-          <MoreVertical aria-hidden />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-40">
-        <DropdownMenuItem>View details</DropdownMenuItem>
-        <DropdownMenuItem>Edit user</DropdownMenuItem>
-        <DropdownMenuItem>Reset password</DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem variant="destructive">Deactivate</DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" aria-label={`Actions for ${name}`}>
+            <MoreVertical aria-hidden />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuItem asChild>
+            <Link to="/users/$userId" params={{ userId }}>
+              View details
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onSelect={() => setDeleteOpen(true)}>
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {/* Outside the menu, and opened by state rather than a trigger, so the
+          menu closes on select. Nested inside, the still-open menu keeps the
+          rest of the page `aria-hidden` after the dialog is dismissed. */}
+      <DeleteUserDialog
+        userId={userId}
+        name={name}
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        onDeleted={onDeleted}
+      />
+    </>
   );
 }
 

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -187,8 +187,8 @@ function UsersScreen() {
         </Table>
       </div>
       {/* D5: the list is one page and must not present itself as the whole set.
-          `GET /users` serves a fixed window (limit defaults to 20) with no
-          `Load more` yet — cursor pagination is #661. */}
+          The loader asks for the API maximum, but that is still a fixed window
+          with no `Load more` behind it — cursor pagination is #661. */}
       {users.length > 0 && (
         <p className="text-muted-foreground mt-3 text-xs">
           Showing {rows.length} of the {users.length} users loaded. This is the first page,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ catalogs:
     shiki:
       specifier: ^4.2.0
       version: 4.2.0
+    sonner:
+      specifier: ^2.0.7
+      version: 2.0.7
     storybook:
       specifier: ^10.3.6
       version: 10.4.6
@@ -521,6 +524,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.8(react@19.2.8)
+      sonner:
+        specifier: 'catalog:'
+        version: 2.0.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tailwind-merge:
         specifier: 'catalog:'
         version: 3.6.0
@@ -14198,6 +14204,12 @@ packages:
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
@@ -30549,6 +30561,11 @@ snapshots:
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
+
+  sonner@2.0.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   sort-object-keys@1.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -89,6 +89,7 @@ catalog:
   safe-stable-stringify: ^2.5.0
   sharp: ^0.35.3
   shiki: ^4.2.0
+  sonner: ^2.0.7
   storybook: ^10.3.6
   tailwind-merge: ^3.6.0
   tailwindcss: ^4.2.4


### PR DESCRIPTION
# Which Problems Are Solved

The console cannot delete a user. `DELETE /users/{user_id}` landed in #637 with nothing calling it.

Alongside that, the users list and the app shell carry scaffolding from earlier work that reaches no endpoint — a row menu of actions with no handlers, a hardcoded organisation list, four permanently disabled nav rows, a Sessions screen whose service is unimplemented. None of this has shipped, so it is not broken behaviour; it is unfinished UI that makes it hard to tell which parts of the console are real.

The ticket also asked to settle the delete copy before building. The design says permanent and irreversible, ADR 024 says deactivate-then-tombstone. The endpoint that shipped is a hard delete — memberships and the user row go in one transaction, sessions cascade — so the design's copy matches what happens. The conflict with ADR 024 is raised as #694 rather than decided here.

# How the Problems Are Solved

- Adds the confirmation dialog from the design (`656:49130`), built on the shadcn `AlertDialog` that component documents. Confirmation is a case-sensitive `DELETE`, and success raises a toast.
- Adds `sonner` as the toaster, pointed at the console's existing `useTheme` rather than pulling in `next-themes`.
- The row menu carries `View details` and `Delete`. `Edit user` (#693), `Deactivate` (#553) and `Reset password` (no screen behind it) are left out until they work.

# Additional Changes

Unfinished surfaces are either taken out or parked, so the console shows what it can do and the gaps are visible. Each is commented in place with the issue that brings it back.

- **Sessions** is hidden, screen and nav entry. `GET /sessions` is routed but its service is unimplemented, so the screen could never load. Filed as #699.
- **The organisation switcher** listed four placeholder organisations with a hardcoded selection and a plan badge. Needs a team list endpoint (#620) and billing (#667).
- **Four disabled sidebar entries** (App groups, Applications, Analytics, Activity Log) are removed. A disabled row still advertises a feature.
- **Search and Documentation** in the sidebar footer had no handlers.
- **Home** was a static mock with invented figures and rows; it renders an empty state instead.
- **Projects** keeps its route but loses its nav entry — the data is real, but it has had no design hand-off, so beside Users it read as finished.
- Sorting on the users list is removed (design decisions log D5): it ordered only the fetched page while implying a total order. The list asks for the API maximum instead of the default 20, and says it is showing one page.
- `Button`'s `destructive` variant becomes a tint with destructive text, matching the design system's `Variant=Destructive`. This dialog is its first consumer.
- The three real-instance e2e suites shared `signIn` by copy-paste; it is now one helper.

# Additional Context

- Closes #632
- Unblocked by #637 (`DELETE /users/{user_id}`)
- Filed while working: #699, #693, #694
