### PR TITLE
feat(console): show schema-defined attributes as user list columns

### DIFF
--- a/.changeset/console-user-list-columns.md
+++ b/.changeset/console-user-list-columns.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": minor
+---
+
+The console's users list now takes its columns from the user schema, so it shows the attributes your schema actually defines instead of a fixed set. Users whose schema omits a column render it as empty rather than blank.

--- a/apps/console/src/components/delete-user-dialog.spec.tsx
+++ b/apps/console/src/components/delete-user-dialog.spec.tsx
@@ -120,7 +120,8 @@ describe("delete user dialog", () => {
     // row is gone from the invalidated list.
     expect(await screen.findByText("Maya Patel deleted")).toBeInTheDocument();
     await waitFor(() =>
-      expect(screen.queryByRole("link", { name: "Maya Patel" })).not.toBeInTheDocument(),
+      // The row's link is its first schema-driven column, not a combined name.
+      expect(screen.queryByRole("link", { name: "maya@acme.com" })).not.toBeInTheDocument(),
     );
   });
 
@@ -149,7 +150,7 @@ describe("delete user dialog", () => {
     // found: opening the dialog from inside the row menu left the menu open
     // underneath, and its `aria-hidden` on the rest of the page outlived the
     // dialog — so the list was invisible to assistive tech after cancelling.
-    expect(screen.getByRole("link", { name: "Maya Patel" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "maya@acme.com" })).toBeInTheDocument();
   });
 
   it("keeps the dialog open and shows the server's message when the delete fails", async () => {

--- a/apps/console/src/lib/schema.ts
+++ b/apps/console/src/lib/schema.ts
@@ -80,6 +80,31 @@ export function schemaFields(schema: UserSchema): SchemaField[] {
     }));
 }
 
+/**
+ * The columns the users table shows, unioned across every schema the loaded
+ * users actually reference.
+ *
+ * The design (`277:288291`) has no fixed column set: its `Filled` variant lists
+ * Given name / Family name / Company name / Email while `Minimal` lists only
+ * Email, because the user model is `additionalProperties: true` keyed on
+ * `$schema`. The design decisions log (D4) settles what to show — every
+ * available field rather than a curated default — so this unions rather than
+ * intersects: a project with both a `business` and a `minimal` schema shows the
+ * business columns, and minimal users render blank in them.
+ *
+ * Order follows {@link schemaFields} within a schema, and first-seen order
+ * across them, so adding a schema appends columns instead of reshuffling.
+ */
+export function schemaColumns(schemas: UserSchema[]): SchemaField[] {
+  const columns = new Map<string, SchemaField>();
+  for (const schema of schemas) {
+    for (const entry of schemaFields(schema)) {
+      if (!columns.has(entry.key)) columns.set(entry.key, entry);
+    }
+  }
+  return [...columns.values()];
+}
+
 function readProperties(schema: UserSchema): Record<string, Record<string, unknown>> {
   const properties = schema.properties;
   if (!properties || typeof properties !== "object") return {};

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -4,7 +4,6 @@ import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
 import { AddUserSheet } from "@/components/add-user-sheet";
 import { DeleteUserDialog } from "@/components/delete-user-dialog";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -25,7 +24,9 @@ import {
 
 import { api } from "../../../api/zitadel";
 import { field } from "../../../lib/record";
+import { type SchemaField, type UserSchema, schemaColumns } from "../../../lib/schema";
 import { userDisplayName } from "../../../lib/user";
+import { getConsoleProjectId } from "../../../runtime/runtime";
 
 export const Route = createFileRoute("/_authed/users/")({
   staticData: { nav: { label: "Users", order: 2, icon: Users } },
@@ -33,14 +34,70 @@ export const Route = createFileRoute("/_authed/users/")({
   // default 20. `GET /users` orders by creation ascending with no `Load more`
   // yet (#661), so the default silently hides the most recently created users —
   // the ones an operator has just added and is most likely looking for.
-  loader: () => api.listUsers({ limit: 100 }),
+  loader: async () => {
+    const projectId = getConsoleProjectId();
+    const users = await api.listUsers({ limit: 100 });
+
+    // Columns are the loaded users' own schemas, not every schema in the
+    // project: a schema nobody uses would add a column that is blank in every
+    // row. `listUsers` returns the attribute tree with `$schema` on it, so the
+    // set is known without a second list call.
+    const schemaIds = [...new Set(users.map((user) => field(user, "$schema")).filter(isPresent))];
+    const schemas = await Promise.all(
+      schemaIds.map(async (id) => {
+        try {
+          return (await api.getSchemaById(id, { project_id: projectId })) as UserSchema;
+        } catch {
+          // One unreadable schema costs its columns, not the screen. The rows
+          // still render from the fallback below.
+          return undefined;
+        }
+      }),
+    );
+
+    return { users, columns: columnsFor(users, schemas.filter(isPresent)) };
+  },
   component: UsersScreen,
 });
 
+function isPresent<T>(value: T | undefined | null): value is T {
+  return value !== undefined && value !== null;
+}
+
 interface UserRow {
   id: string;
+  /** Display name for the row menu and the delete dialog — not a column. */
   name: string;
-  email: string;
+  /** Rendered cell values, keyed by schema property. */
+  values: Record<string, string>;
+}
+
+/**
+ * Columns from the users' schemas, falling back to the keys the records
+ * themselves carry.
+ *
+ * The fallback matters because the schema fetch is best-effort and because a
+ * user may predate its schema. Without it an unreadable schema would render a
+ * table of rows with no columns — worse than showing the raw attributes.
+ */
+function columnsFor(users: Record<string, unknown>[], schemas: UserSchema[]): SchemaField[] {
+  const columns = schemaColumns(schemas);
+  if (columns.length > 0) return columns;
+
+  const keys = new Set<string>();
+  for (const user of users) {
+    for (const key of Object.keys(user)) {
+      // `id` gets its own column and `$schema` is machine metadata, not an
+      // attribute an operator reads.
+      if (key !== "id" && key !== "$schema") keys.add(key);
+    }
+  }
+  return [...keys].sort().map((key) => ({
+    key,
+    label: key,
+    required: false,
+    inputType: "text" as const,
+  }));
 }
 
 /** Platform-correct modifier for the search shortcut hint (⌘ on Apple, Ctrl elsewhere). */
@@ -53,7 +110,7 @@ function searchShortcutLabel(): string {
 }
 
 function UsersScreen() {
-  const users = Route.useLoaderData();
+  const { users, columns } = Route.useLoaderData();
   const router = useRouter();
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
@@ -81,17 +138,19 @@ function UsersScreen() {
   // Search narrows the rows already fetched. `GET /users` takes no filter (ADR
   // 031's query endpoint does not exist), so this cannot reach users outside the
   // loaded page — which is why the table says so beneath it.
+  //
+  // It matches every rendered column rather than a fixed name/email/id triple:
+  // the columns are schema-driven, so a hardcoded set would silently fail to
+  // search whatever the project's schema actually defines.
   const rows = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    return users.map(toUserRow).filter((user) => {
-      return (
-        needle === "" ||
-        user.name.toLowerCase().includes(needle) ||
-        user.email.toLowerCase().includes(needle) ||
-        user.id.toLowerCase().includes(needle)
+    return users.map((user, index) => toUserRow(user, index, columns)).filter((row) => {
+      if (needle === "") return true;
+      return [row.id, ...columns.map((column) => row.values[column.key] ?? "")].some((value) =>
+        value.toLowerCase().includes(needle),
       );
     });
-  }, [users, query]);
+  }, [users, query, columns]);
 
   return (
     <div className="px-4 pt-9 pb-8 sm:px-8">
@@ -127,49 +186,55 @@ function UsersScreen() {
         </div>
       </div>
 
-      <div className="border-sidebar-border bg-card mt-6 overflow-hidden rounded-2xl border">
-        <Table className="table-fixed text-xs">
-          <colgroup>
-            <col className="w-[240px]" />
-            <col className="w-[280px]" />
-            <col className="w-[280px]" />
-            <col className="w-[60px]" />
-          </colgroup>
+      {/* The column set is schema-driven and so has no fixed width; the design
+          scrolls the table horizontally rather than compressing cells (the
+          `Filled` variant shows a scrollbar under the rows). */}
+      <div className="border-sidebar-border bg-card mt-6 overflow-x-auto rounded-2xl border">
+        <Table className="text-xs">
           <TableHeader>
             <TableRow className="border-border border-b hover:bg-transparent">
-              <HeadCell>Name</HeadCell>
-              <HeadCell>Email</HeadCell>
+              {columns.map((column) => (
+                <HeadCell key={column.key}>{column.label}</HeadCell>
+              ))}
               <HeadCell>ID</HeadCell>
-              <TableHead className="h-14 px-2" />
+              <TableHead className="h-14 w-[60px] px-2" />
             </TableRow>
           </TableHeader>
           <TableBody>
             {rows.length === 0 ? (
               <TableRow className="border-0 hover:bg-transparent">
-                <TableCell colSpan={4} className="text-muted-foreground h-24 text-center">
+                <TableCell
+                  colSpan={columns.length + 2}
+                  className="text-muted-foreground h-24 text-center"
+                >
                   {users.length === 0 ? "No users yet." : "No users match the current filters."}
                 </TableCell>
               </TableRow>
             ) : (
               rows.map((user) => (
                 <TableRow key={user.id} className="hover:bg-muted/40 border-0">
-                  <TableCell className="h-11 truncate px-4 py-0">
-                    <div className="flex items-center gap-2">
-                      <Avatar size="sm">
-                        <AvatarFallback>{initials(user.name)}</AvatarFallback>
-                      </Avatar>
-                      <Link
-                        to="/users/$userId"
-                        params={{ userId: user.id }}
-                        className="text-foreground truncate font-medium underline-offset-2 hover:underline"
-                      >
-                        {user.name}
-                      </Link>
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground h-11 truncate px-2 py-0">
-                    {user.email}
-                  </TableCell>
+                  {columns.map((column, index) => (
+                    <TableCell
+                      key={column.key}
+                      className="text-muted-foreground h-11 max-w-[280px] truncate px-2 py-0 first:px-4"
+                    >
+                      {/* The first column carries the link to the detail screen.
+                          There is no separate name column to hang it on — the
+                          design's columns are the schema's own properties, and
+                          which one comes first depends on the schema. */}
+                      {index === 0 ? (
+                        <Link
+                          to="/users/$userId"
+                          params={{ userId: user.id }}
+                          className="text-foreground truncate font-medium underline-offset-2 hover:underline"
+                        >
+                          {user.values[column.key] || user.id}
+                        </Link>
+                      ) : (
+                        (user.values[column.key] ?? "—")
+                      )}
+                    </TableCell>
+                  ))}
                   <TableCell className="text-foreground h-11 truncate px-2 py-0">
                     {user.id}
                   </TableCell>
@@ -199,15 +264,27 @@ function UsersScreen() {
   );
 }
 
-function toUserRow(user: Record<string, unknown>, index: number): UserRow {
+function toUserRow(
+  user: Record<string, unknown>,
+  index: number,
+  columns: SchemaField[],
+): UserRow {
   const id = field(user, "id") ?? `unknown-user-${index}`;
-  const email = field(user, "email") ?? "—";
+  const values: Record<string, string> = {};
+  for (const column of columns) {
+    // Only scalars are read. A property whose value is an object or array has no
+    // one-line rendering, and `JSON.stringify` in a table cell is noise — the
+    // detail screen is where a structured attribute belongs.
+    const value = field(user, column.key);
+    if (value !== undefined) values[column.key] = value;
+  }
   return {
     id,
-    // Fall back to the email, then the id: a `minimal` user schema defines only
-    // `email`, so a name is genuinely absent rather than missing.
-    name: userDisplayName(user) ?? (email === "—" ? id : email),
-    email,
+    values,
+    // Used for the row menu's accessible name and the delete dialog's heading,
+    // not as a column. Falls back to the email and then the id: a `minimal`
+    // schema defines only `email`, so a name is genuinely absent, not missing.
+    name: userDisplayName(user) ?? field(user, "email") ?? id,
   };
 }
 
@@ -290,13 +367,4 @@ function RowActions({
       />
     </>
   );
-}
-
-function initials(name: string): string {
-  return name
-    .split(" ")
-    .map((part) => part[0])
-    .slice(0, 2)
-    .join("")
-    .toUpperCase();
 }

--- a/apps/console/src/routes/_authed/users/users.spec.tsx
+++ b/apps/console/src/routes/_authed/users/users.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -15,6 +15,7 @@ vi.mock("@/auth/session", async (importOriginal) => {
 vi.stubEnv("VITE_CONSOLE_API_BASE", "http://localhost/api");
 
 const USERS_URL = "http://localhost/api/users";
+const SCHEMAS_URL = "http://localhost/api/schemas";
 const server = setupServer();
 
 beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
@@ -49,8 +50,70 @@ describe("users screen", () => {
     );
     await renderUsers();
     expect(await screen.findByRole("heading", { name: "Users" })).toBeInTheDocument();
-    expect(await screen.findByRole("link", { name: "Maya Patel" })).toBeInTheDocument();
-    expect(screen.getByText("maya.patel@acme.com")).toBeInTheDocument();
+    // Columns are the schema's properties (design `277:288291`, decisions log
+    // D4), so there is no combined "Name" column — the first property carries
+    // the link to the detail screen.
+    expect(await screen.findByRole("link", { name: "maya.patel@acme.com" })).toBeInTheDocument();
+    expect(screen.getByText("Maya")).toBeInTheDocument();
+    expect(screen.getByText("Patel")).toBeInTheDocument();
+  });
+
+  it("builds the columns from the schema the users reference", async () => {
+    server.use(
+      http.get(USERS_URL, () =>
+        HttpResponse.json([
+          { id: "user_1", $schema: "sch_business", email: "maya@acme.com", companyName: "Acme" },
+        ]),
+      ),
+      http.get(`${SCHEMAS_URL}/sch_business`, () =>
+        HttpResponse.json({
+          title: "Business",
+          required: ["email"],
+          properties: {
+            email: { type: "string", format: "email" },
+            companyName: { type: "string", title: "Company name" },
+          },
+        }),
+      ),
+    );
+    await renderUsers();
+
+    // The header comes from the schema's own `title`, not from the record keys.
+    expect(await screen.findByText("Company name")).toBeInTheDocument();
+    // Scoped to the table: the app shell's organisation switcher also renders an
+    // "Acme" label.
+    const table = within(screen.getByRole("table"));
+    expect(table.getByText("Acme")).toBeInTheDocument();
+    expect(table.getByText("maya@acme.com")).toBeInTheDocument();
+  });
+
+  it("renders a placeholder where a user's schema does not define a column", async () => {
+    // Columns union across schemas (D4), so a minimal user sits in a table that
+    // also has business columns. The cell must read as empty, not as missing.
+    server.use(
+      http.get(USERS_URL, () =>
+        HttpResponse.json([
+          { id: "user_1", $schema: "sch_business", email: "maya@acme.com", companyName: "Acme" },
+          { id: "user_2", $schema: "sch_business", email: "min@acme.com" },
+        ]),
+      ),
+      http.get(`${SCHEMAS_URL}/sch_business`, () =>
+        HttpResponse.json({
+          properties: {
+            email: { type: "string", format: "email" },
+            companyName: { type: "string", title: "Company name" },
+          },
+        }),
+      ),
+    );
+    await renderUsers();
+
+    // `schemaFields` orders properties by key, so `companyName` is the first
+    // column and therefore the linked one. The user without a company falls back
+    // to its id rather than rendering an empty link.
+    expect(await screen.findByRole("link", { name: "Acme" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "user_2" })).toBeInTheDocument();
+    expect(within(screen.getByRole("table")).getByText("min@acme.com")).toBeInTheDocument();
   });
 
   it("derives the display name the way the platform does", async () => {
@@ -73,9 +136,11 @@ describe("users screen", () => {
       ),
     );
     await renderUsers();
-    expect(await screen.findByRole("link", { name: "Ada L." })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Grace Hopper" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Radia" })).toBeInTheDocument();
+    // The derived name is no longer a column; it names the row's actions and
+    // titles the delete dialog, which is where a wrong derivation would show.
+    expect(await screen.findByRole("button", { name: "Actions for Ada L." })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Actions for Grace Hopper" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Actions for Radia" })).toBeInTheDocument();
   });
 
   it("ignores non-identity attributes when deriving the name", async () => {
@@ -88,11 +153,12 @@ describe("users screen", () => {
       ),
     );
     await renderUsers();
-    expect(await screen.findByRole("link", { name: "kenji@acme.com" })).toBeInTheDocument();
-    expect(screen.queryByText("nope")).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "Actions for kenji@acme.com" }),
+    ).toBeInTheDocument();
   });
 
-  it("uses schema-defined email as the display name and shows the user id", async () => {
+  it("shows the user id alongside the schema's own attributes", async () => {
     server.use(
       http.get(USERS_URL, () =>
         HttpResponse.json([{ id: "user_1", email: "kenji@acme.com", status: "Blocked" }]),
@@ -101,7 +167,11 @@ describe("users screen", () => {
     await renderUsers();
     expect(await screen.findByRole("link", { name: "kenji@acme.com" })).toBeInTheDocument();
     expect(screen.getByText("user_1")).toBeInTheDocument();
-    expect(screen.queryByText("Blocked")).not.toBeInTheDocument();
+    // `status` renders because this record carries it — the table shows what the
+    // data has (D4). What is still absent is a *base-model* status the console
+    // could count on for every user (#553); nothing is invented for records
+    // without one.
+    expect(screen.getByText("Blocked")).toBeInTheDocument();
   });
 
   it("renders the not-authorized state on a 401 with a live session (no redirect loop)", async () => {
@@ -133,7 +203,7 @@ describe("users screen", () => {
     }
   });
 
-  it("filters live users by name, email, or id", async () => {
+  it("filters live users across every rendered column, and by id", async () => {
     server.use(
       http.get(USERS_URL, () =>
         HttpResponse.json([
@@ -143,11 +213,19 @@ describe("users screen", () => {
       ),
     );
     await renderUsers();
-    expect(await screen.findByText("Maya Patel")).toBeInTheDocument();
+    const table = () => within(screen.getByRole("table"));
+    expect(await screen.findByText("Maya")).toBeInTheDocument();
 
+    // By id — not a column an operator reads off, but the one they paste.
     await userEvent.type(screen.getByRole("searchbox", { name: "Search users" }), "user_2");
+    expect(await screen.findByText("Sasha")).toBeInTheDocument();
+    expect(table().queryByText("Maya")).not.toBeInTheDocument();
 
-    expect(await screen.findByText("Sasha Kim")).toBeInTheDocument();
-    expect(screen.queryByText("Maya Patel")).not.toBeInTheDocument();
+    // By a schema property that is not the first column: search covers whatever
+    // the schema defines rather than a fixed name/email pair.
+    await userEvent.clear(screen.getByRole("searchbox", { name: "Search users" }));
+    await userEvent.type(screen.getByRole("searchbox", { name: "Search users" }), "Patel");
+    expect(await screen.findByText("Maya")).toBeInTheDocument();
+    expect(table().queryByText("Sasha")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Which Problems Are Solved

The users list shows a fixed Name / Email / ID triple. The user model is `additionalProperties: true` keyed on `$schema`, so whatever a project's schema defines does not appear, and the "Name" column is assembled from parts a schema might not have. Search matches the same fixed set rather than the columns on screen.

# How the Problems Are Solved

- Columns come from the schemas the loaded users reference, unioned across them. This is what the design's variants show: `Filled` lists Given name / Family name / Company name / Email, `Minimal` lists only Email. The decisions log settles the rule (D4): show every available field.
- A user whose schema omits a column renders an em dash, so empty reads as empty rather than missing.
- The first column links to the detail screen; the design has no combined name column to hang it on. The derived display name still names the row's actions and titles the delete dialog.
- Search covers every rendered column.
- Falls back to the keys the records carry if a schema cannot be read, so an unreadable schema costs its labels rather than the screen.

# Additional Changes

None.

# Additional Context

Part of #630, not all of it. Still blocked: Status (#553), Team (#620), Last login (no field), `Load more` (#661). Per-column sort is out of the MVP by decision D5.

Known gap worth its own issue: columns are ordered alphabetically because `GET /schemas/{id}` serialises `properties` from a Go map and randomises the order. The authored order belongs to the schema document and should reach the console through the API.
