### PR TITLE
fix(console): stop offering navigation and controls that do not work

### DIFF
--- a/.changeset/console-remove-unbacked-ui.md
+++ b/.changeset/console-remove-unbacked-ui.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+The console no longer offers navigation and controls that had nothing behind them. The Sessions link, which could not load because listing sessions is not implemented yet, is hidden along with an organisation switcher that listed placeholder organisations, four permanently disabled sidebar entries, and Search and Documentation buttons that did nothing when clicked.

--- a/.changeset/console-user-list-columns.md
+++ b/.changeset/console-user-list-columns.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": minor
+---
+
+The console's users list now takes its columns from the user schema, so it shows the attributes your schema actually defines instead of a fixed set. Users whose schema omits a column render it as empty rather than blank.

--- a/apps/console-e2e/src-real/add-user.spec.ts
+++ b/apps/console-e2e/src-real/add-user.spec.ts
@@ -1,6 +1,8 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@zitadel/testing/playwright";
 
+import { expectNoErrorBoundary, signIn } from "./support";
+
 /**
  * End-to-end coverage for the Add user drawer (issue #633) against a real
  * instance, so the schema-driven form is exercised over the actual
@@ -20,18 +22,6 @@ test.describe.configure({ mode: "parallel" });
 // `queryProjects` is single-project (ADR 0004). D6 expects it back in a future
 // version, so the cases below are parked with the block, not deleted; restore
 // them alongside the block and the unit specs when both reasons clear.
-
-const ERROR_HEADINGS = ["Not authorized", "Something went wrong"];
-
-/** See `console-real.spec.ts` — the console's login screen (Console ADR 0003). */
-async function signIn(page: Page, user: { email: string; password: string }): Promise<void> {
-  await page.goto("/login");
-  await page.getByLabel("Work email").fill(user.email);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.getByLabel("Password").fill(user.password);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith("/login"));
-}
 
 /** Signs in, lands on /users and opens the drawer. */
 async function openDrawer(page: Page, user: { email: string; password: string }) {
@@ -369,8 +359,3 @@ test("Escape closes the open list first, then the drawer", async ({ page, seed }
   await expect(drawer).toBeHidden();
 });
 
-async function expectNoErrorBoundary(page: Page): Promise<void> {
-  for (const heading of ERROR_HEADINGS) {
-    await expect(page.getByText(heading, { exact: true })).toHaveCount(0);
-  }
-}

--- a/apps/console-e2e/src-real/console-real.spec.ts
+++ b/apps/console-e2e/src-real/console-real.spec.ts
@@ -1,25 +1,8 @@
-import type { Page } from "@playwright/test";
 import { expect, test } from "@zitadel/testing/playwright";
 
-const ERROR_HEADINGS = ["Not authorized", "Something went wrong"];
+import { expectNoErrorBoundary, signIn } from "./support";
 
 test.describe.configure({ mode: "parallel" });
-
-/**
- * Completes the console's login screen (Console ADR 0003) with a seeded
- * user: the default-login flow's identifier step ("Work email" + "Sign in"),
- * then the password step ("Password" + "Sign in"). The widget exchanges the
- * handoff for the `__nextgen_session` cookie and performs a full-document
- * navigation away from /login.
- */
-async function signIn(page: Page, user: { email: string; password: string }): Promise<void> {
-  await page.goto("/login");
-  await page.getByLabel("Work email").fill(user.email);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.getByLabel("Password").fill(user.password);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith("/login"));
-}
 
 test("shows the bootstrapped project", async ({ page, zitadel, seed }) => {
   await signIn(page, await seed.user());
@@ -94,9 +77,3 @@ test("keeps the project credential out of browser requests and resources", async
   expect(leakedResources).toEqual([]);
   expect((await page.content()).includes(zitadel.handle.projectSecret)).toBe(false);
 });
-
-async function expectNoErrorBoundary(page: Page): Promise<void> {
-  for (const heading of ERROR_HEADINGS) {
-    await expect(page.getByText(heading, { exact: true })).toHaveCount(0);
-  }
-}

--- a/apps/console-e2e/src-real/delete-user.spec.ts
+++ b/apps/console-e2e/src-real/delete-user.spec.ts
@@ -1,6 +1,8 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@zitadel/testing/playwright";
 
+import { expectNoErrorBoundary, signIn } from "./support";
+
 /**
  * End-to-end coverage for the delete-user dialog (issue #632) against a real
  * instance.
@@ -13,18 +15,6 @@ import { expect, test } from "@zitadel/testing/playwright";
  */
 
 test.describe.configure({ mode: "parallel" });
-
-const ERROR_HEADINGS = ["Not authorized", "Something went wrong"];
-
-/** See `console-real.spec.ts` — the console's login screen (Console ADR 0003). */
-async function signIn(page: Page, user: { email: string; password: string }): Promise<void> {
-  await page.goto("/login");
-  await page.getByLabel("Work email").fill(user.email);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.getByLabel("Password").fill(user.password);
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith("/login"));
-}
 
 /** Signs in as `actor` and lands on the users list. */
 async function openList(page: Page, actor: { email: string; password: string }): Promise<void> {
@@ -42,11 +32,6 @@ async function openDeleteDialog(page: Page, name: string) {
   return dialog;
 }
 
-async function expectNoErrorBoundary(page: Page): Promise<void> {
-  for (const heading of ERROR_HEADINGS) {
-    await expect(page.getByText(heading, { exact: true })).toHaveCount(0);
-  }
-}
 
 test("deletes a user for real and drops it from the list", async ({ page, seed }) => {
   // Two users: one to sign in as, one to delete. Deleting the signed-in user

--- a/apps/console-e2e/src-real/support.ts
+++ b/apps/console-e2e/src-real/support.ts
@@ -1,0 +1,45 @@
+import type { Page } from "@playwright/test";
+import { expect } from "@zitadel/testing/playwright";
+
+/**
+ * Shared helpers for the real-instance console suites.
+ *
+ * `signIn` had been copied verbatim into all three spec files. It is the one
+ * step every real-instance test starts with, so a drift between copies would
+ * mean the suites were signing in differently while looking identical.
+ */
+
+/**
+ * Completes the console's login screen (Console ADR 0003) with a seeded
+ * user: the default-login flow's identifier step ("Work email" + "Sign in"),
+ * then the password step ("Password" + "Sign in"). The widget exchanges the
+ * handoff for the `__nextgen_session` cookie and performs a full-document
+ * navigation away from /login.
+ */
+export async function signIn(
+  page: Page,
+  user: { email: string; password: string },
+): Promise<void> {
+  await page.goto("/login");
+  await page.getByLabel("Work email").fill(user.email);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await page.getByLabel("Password").fill(user.password);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await page.waitForURL((url) => !url.pathname.endsWith("/login"));
+}
+
+/** Copy the route error boundaries render; none of it should appear on a pass. */
+const ERROR_HEADINGS = ["Not authorized", "Something went wrong"];
+
+/**
+ * Asserts no error boundary rendered.
+ *
+ * Worth its own check because a boundary replaces the screen entirely: without
+ * it, an assertion that some element is *absent* passes just as happily when the
+ * whole route failed to load.
+ */
+export async function expectNoErrorBoundary(page: Page): Promise<void> {
+  for (const heading of ERROR_HEADINGS) {
+    await expect(page.getByText(heading, { exact: true })).toHaveCount(0);
+  }
+}

--- a/apps/console/src/components/app-shell/AppShell.tsx
+++ b/apps/console/src/components/app-shell/AppShell.tsx
@@ -1,13 +1,6 @@
 import { Link, useMatchRoute } from "@tanstack/react-router";
-import {
-  BookOpen,
-  ChevronsUpDown,
-  LogOut,
-  Monitor,
-  Moon,
-  Search,
-  Sun,
-} from "lucide-react";
+// `BookOpen` / `Search` return with the parked footer items below.
+import { ChevronsUpDown, LogOut, Monitor, Moon, Sun } from "lucide-react";
 import { type KeyboardEvent, type ReactNode, useRef } from "react";
 
 import {
@@ -138,18 +131,27 @@ function AppSidebar({ user, onSignOut }: { user?: ShellUser; onSignOut?: () => v
 
       <SidebarFooter>
         <SidebarMenu className="gap-2">
-          <SidebarMenuItem>
-            <SidebarMenuButton tooltip="Search" className="font-serif">
-              <Search aria-hidden />
-              <span>Search</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <SidebarMenuButton tooltip="Documentation" className="font-serif">
-              <BookOpen aria-hidden />
-              <span>Documentation</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
+          {/* Search and Documentation are parked: both rendered as ordinary
+              enabled buttons with no handler, so clicking them did nothing at
+              all — the worst of the three states, since they looked live.
+
+              Search needs a cross-resource query endpoint; ADR 031's
+              `POST /{resource}/query` exists only for projects today, so there
+              is nothing to search across. Documentation needs a published URL
+              for the docs site to point at.
+
+              <SidebarMenuItem>
+                <SidebarMenuButton tooltip="Search" className="font-serif">
+                  <Search aria-hidden />
+                  <span>Search</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton tooltip="Documentation" className="font-serif">
+                  <BookOpen aria-hidden />
+                  <span>Documentation</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem> */}
           <UserMenuItem user={user} onSignOut={onSignOut} />
         </SidebarMenu>
       </SidebarFooter>

--- a/apps/console/src/components/app-shell/ContextSwitcher.tsx
+++ b/apps/console/src/components/app-shell/ContextSwitcher.tsx
@@ -1,4 +1,5 @@
-import { Box, Building2, ChevronsUpDown, type LucideIcon, Search } from "lucide-react";
+// `Building2` returns with the parked organisation switcher below.
+import { Box, ChevronsUpDown, type LucideIcon, Search } from "lucide-react";
 import { useEffect, useId, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -28,13 +29,6 @@ interface SwitcherOption {
   plan?: string;
 }
 
-const ORGS: SwitcherOption[] = [
-  { id: "acme", label: "Acme Inc", plan: "Free" },
-  { id: "clearwater", label: "Clearwater Labs", plan: "Pro" },
-  { id: "benimac", label: "Benimac LTD", plan: "Enterprise" },
-  { id: "horizons", label: "Horizons Studio", plan: "Pro" },
-];
-
 export function ContextSwitcher() {
   const projects = useProjects();
   // The console is bound to one project, and `queryProjects` is scope-pinned to
@@ -45,20 +39,28 @@ export function ContextSwitcher() {
 
   return (
     <div className="flex w-full min-w-0 flex-col gap-2 md:w-auto md:flex-row md:items-center">
-      <Switcher
-        icon={Building2}
-        label="Acme Inc"
-        shortLabel="Acme"
-        plan="Free"
-        options={ORGS}
-        ariaLabel="Switch organization"
-      />
-      <Switcher
-        icon={Box}
-        label={current?.label}
-        options={projects}
-        ariaLabel="Switch project"
-      />
+      {/* The organisation switcher is parked. It was four invented orgs —
+          "Acme Inc / Free", "Clearwater Labs / Pro", "Benimac LTD / Enterprise",
+          "Horizons Studio / Pro" — with a hardcoded current selection and a plan
+          badge naming a tier nothing sells yet. It sat at the top of every
+          screen, which made the whole console look like it was scoped to a real
+          organisation on a real plan.
+
+          Organisations are teams in this model, and there is no team list
+          endpoint: the API has `POST /teams` and `GET /teams/{team_id}` only, so
+          the current team cannot be resolved, let alone switched. Restore this
+          when `Team: List/Query` (#620) lands, and take the plan badge from
+          billing (#667) rather than a literal.
+
+          <Switcher
+            icon={Building2}
+            label={currentTeam?.label}
+            shortLabel={currentTeam?.shortLabel}
+            plan={currentTeam?.plan}
+            options={teams}
+            ariaLabel="Switch organization"
+          /> */}
+      <Switcher icon={Box} label={current?.label} options={projects} ariaLabel="Switch project" />
     </div>
   );
 }

--- a/apps/console/src/components/app-shell/app-shell.spec.tsx
+++ b/apps/console/src/components/app-shell/app-shell.spec.tsx
@@ -27,11 +27,22 @@ vi.mock("@/auth/session", async (importOriginal) => {
  * does not exist". Also covers the theme toggle writing `data-theme` and
  * persisting the preference.
  */
-const NAV_ORDER = ["Projects", "Users"];
-// Sessions is absent for a different reason than the other four: its screen was
-// built, but `GET /sessions` answers 501 (#699), so the link only ever reached
-// an error boundary. It returns with the endpoint.
-const NEVER_SHOWN = ["App groups", "Applications", "Analytics", "Activity Log", "Sessions"];
+// Users is the only surface with a design hand-off, so it is the only thing the
+// sidebar offers.
+const NAV_ORDER = ["Users"];
+// Absent for three different reasons, all of them deliberate:
+//   - the first four have no endpoint at all
+//   - Sessions was built, but `GET /sessions` answers 501 (#699)
+//   - Projects works and stays reachable at its URL; it has simply never been
+//     designed, so it is not advertised as a finished screen
+const NEVER_SHOWN = [
+  "App groups",
+  "Applications",
+  "Analytics",
+  "Activity Log",
+  "Sessions",
+  "Projects",
+];
 
 // A path pattern rather than an absolute URL: this spec imports the router
 // statically, so `api/zitadel.ts` evaluates its base URL before `vi.stubEnv`
@@ -53,7 +64,7 @@ function renderShell() {
 describe("app shell navigation", () => {
   it("lists only built screens, every one of them a link", async () => {
     renderShell();
-    await screen.findByRole("link", { name: /^Projects/ });
+    await screen.findByRole("link", { name: /^Users/ });
     const nav = within(screen.getByRole("navigation", { name: "Primary" }));
 
     const items = nav.getAllByRole("listitem");
@@ -67,7 +78,7 @@ describe("app shell navigation", () => {
 
   it("does not advertise screens that have no endpoint behind them", async () => {
     renderShell();
-    await screen.findByRole("link", { name: /^Projects/ });
+    await screen.findByRole("link", { name: /^Users/ });
     const nav = within(screen.getByRole("navigation", { name: "Primary" }));
 
     for (const label of NEVER_SHOWN) {
@@ -85,7 +96,7 @@ describe("theme toggle", () => {
 
   it("switches data-theme and persists the preference", async () => {
     renderShell();
-    await screen.findByRole("link", { name: /^Projects/ });
+    await screen.findByRole("link", { name: /^Users/ });
 
     await userEvent.click(screen.getByRole("radio", { name: "Light" }));
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");

--- a/apps/console/src/components/app-shell/app-shell.spec.tsx
+++ b/apps/console/src/components/app-shell/app-shell.spec.tsx
@@ -27,8 +27,11 @@ vi.mock("@/auth/session", async (importOriginal) => {
  * does not exist". Also covers the theme toggle writing `data-theme` and
  * persisting the preference.
  */
-const NAV_ORDER = ["Projects", "Users", "Sessions"];
-const NEVER_SHOWN = ["App groups", "Applications", "Analytics", "Activity Log"];
+const NAV_ORDER = ["Projects", "Users"];
+// Sessions is absent for a different reason than the other four: its screen was
+// built, but `GET /sessions` answers 501 (#699), so the link only ever reached
+// an error boundary. It returns with the endpoint.
+const NEVER_SHOWN = ["App groups", "Applications", "Analytics", "Activity Log", "Sessions"];
 
 // A path pattern rather than an absolute URL: this spec imports the router
 // statically, so `api/zitadel.ts` evaluates its base URL before `vi.stubEnv`

--- a/apps/console/src/components/app-shell/app-shell.spec.tsx
+++ b/apps/console/src/components/app-shell/app-shell.spec.tsx
@@ -18,23 +18,17 @@ vi.mock("@/auth/session", async (importOriginal) => {
 
 
 /**
- * The sidebar reproduces the Figma `Sidebar 08.` mock: a flat list of 7 items.
- * Built screens come from `staticData.nav` on the route tree (Console ADR 0001)
- * and render as links; the remaining design-only entries (screens not built yet)
- * come from `DESIGN_ONLY_NAV` and render as non-navigable items so the sidebar
- * matches the design pixel-for-pixel. Also covers the theme toggle writing
- * `data-theme` + persisting the preference.
+ * The sidebar lists only screens that exist. Entries come from `staticData.nav`
+ * on the route tree (Console ADR 0001) and every one is a link.
+ *
+ * It used to render the Figma mock's full 7 items, with the 4 unbuilt ones as
+ * `aria-disabled` rows. That is what this spec now guards against: a disabled
+ * row advertises a feature and reads as "you cannot do this" rather than "this
+ * does not exist". Also covers the theme toggle writing `data-theme` and
+ * persisting the preference.
  */
-const NAV_ORDER = [
-  "Projects",
-  "Users",
-  "App groups",
-  "Applications",
-  "Analytics",
-  "Sessions",
-  "Activity Log",
-];
-const BUILT_ITEMS = ["Projects", "Users", "Sessions"];
+const NAV_ORDER = ["Projects", "Users", "Sessions"];
+const NEVER_SHOWN = ["App groups", "Applications", "Analytics", "Activity Log"];
 
 // A path pattern rather than an absolute URL: this spec imports the router
 // statically, so `api/zitadel.ts` evaluates its base URL before `vi.stubEnv`
@@ -54,7 +48,7 @@ function renderShell() {
 }
 
 describe("app shell navigation", () => {
-  it("renders the 7 design items in order, linking only the built screens", async () => {
+  it("lists only built screens, every one of them a link", async () => {
     renderShell();
     await screen.findByRole("link", { name: /^Projects/ });
     const nav = within(screen.getByRole("navigation", { name: "Primary" }));
@@ -62,16 +56,19 @@ describe("app shell navigation", () => {
     const items = nav.getAllByRole("listitem");
     expect(items.map((li) => li.textContent?.trim())).toEqual(NAV_ORDER);
 
-    for (const label of BUILT_ITEMS) {
-      expect(nav.getByRole("link", { name: new RegExp(`^${label}`) })).toBeInTheDocument();
-    }
-    // Built rows are links; design-only rows are focusable buttons marked
-    // aria-disabled (the logo is a separate Home link outside the list).
+    // Every row navigates somewhere (the logo is a separate Home link outside
+    // the list), so there is no row that looks like a destination but is not.
     const linkedRows = items.filter((li) => within(li).queryByRole("link"));
-    expect(linkedRows).toHaveLength(BUILT_ITEMS.length);
-    const designOnly = NAV_ORDER.filter((label) => !BUILT_ITEMS.includes(label));
-    for (const label of designOnly) {
-      expect(nav.getByRole("button", { name: label })).toHaveAttribute("aria-disabled", "true");
+    expect(linkedRows).toHaveLength(NAV_ORDER.length);
+  });
+
+  it("does not advertise screens that have no endpoint behind them", async () => {
+    renderShell();
+    await screen.findByRole("link", { name: /^Projects/ });
+    const nav = within(screen.getByRole("navigation", { name: "Primary" }));
+
+    for (const label of NEVER_SHOWN) {
+      expect(nav.queryByText(label)).not.toBeInTheDocument();
     }
   });
 });

--- a/apps/console/src/components/delete-user-dialog.spec.tsx
+++ b/apps/console/src/components/delete-user-dialog.spec.tsx
@@ -120,7 +120,8 @@ describe("delete user dialog", () => {
     // row is gone from the invalidated list.
     expect(await screen.findByText("Maya Patel deleted")).toBeInTheDocument();
     await waitFor(() =>
-      expect(screen.queryByRole("link", { name: "Maya Patel" })).not.toBeInTheDocument(),
+      // The row's link is its first schema-driven column, not a combined name.
+      expect(screen.queryByRole("link", { name: "maya@acme.com" })).not.toBeInTheDocument(),
     );
   });
 
@@ -149,7 +150,7 @@ describe("delete user dialog", () => {
     // found: opening the dialog from inside the row menu left the menu open
     // underneath, and its `aria-hidden` on the rest of the page outlived the
     // dialog — so the list was invisible to assistive tech after cancelling.
-    expect(screen.getByRole("link", { name: "Maya Patel" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "maya@acme.com" })).toBeInTheDocument();
   });
 
   it("keeps the dialog open and shows the server's message when the delete fails", async () => {

--- a/apps/console/src/lib/schema.ts
+++ b/apps/console/src/lib/schema.ts
@@ -80,6 +80,31 @@ export function schemaFields(schema: UserSchema): SchemaField[] {
     }));
 }
 
+/**
+ * The columns the users table shows, unioned across every schema the loaded
+ * users actually reference.
+ *
+ * The design (`277:288291`) has no fixed column set: its `Filled` variant lists
+ * Given name / Family name / Company name / Email while `Minimal` lists only
+ * Email, because the user model is `additionalProperties: true` keyed on
+ * `$schema`. The design decisions log (D4) settles what to show — every
+ * available field rather than a curated default — so this unions rather than
+ * intersects: a project with both a `business` and a `minimal` schema shows the
+ * business columns, and minimal users render blank in them.
+ *
+ * Order follows {@link schemaFields} within a schema, and first-seen order
+ * across them, so adding a schema appends columns instead of reshuffling.
+ */
+export function schemaColumns(schemas: UserSchema[]): SchemaField[] {
+  const columns = new Map<string, SchemaField>();
+  for (const schema of schemas) {
+    for (const entry of schemaFields(schema)) {
+      if (!columns.has(entry.key)) columns.set(entry.key, entry);
+    }
+  }
+  return [...columns.values()];
+}
+
 function readProperties(schema: UserSchema): Record<string, Record<string, unknown>> {
   const properties = schema.properties;
   if (!properties || typeof properties !== "object") return {};

--- a/apps/console/src/nav.ts
+++ b/apps/console/src/nav.ts
@@ -3,13 +3,9 @@
  * headings; order is driven by `order`).
  *
  * Built routes attach their entry via `staticData` (Console ADR 0001) so the
- * sidebar stays in sync with the route tree. The design's sidebar also shows
- * screens that are not built yet; those are listed in `DESIGN_ONLY_NAV` so the
- * shell can render the full, pixel-accurate mock while marking un-built
- * destinations as non-navigable.
+ * sidebar stays in sync with the route tree — every row in the sidebar is a
+ * screen that exists.
  */
-import { Activity, AppWindow, BarChart3, Folder } from "lucide-react";
-
 import type { NavIcon } from "./components/app-shell/icons";
 
 export interface NavMeta {
@@ -22,16 +18,33 @@ export interface NavMeta {
 }
 
 /**
- * Sidebar entries for screens that exist in the Figma mock but are not built
- * yet. Rendered identically to real entries (so the sidebar matches the design
- * pixel-for-pixel) but without a route, so they are not navigable.
+ * Sidebar entries for screens in the Figma mock that are not built.
+ *
+ * **Empty on purpose.** These used to render as disabled rows so the sidebar
+ * matched the design pixel-for-pixel — but a disabled row still advertises a
+ * feature. It reads as "your account cannot do this" rather than "this does not
+ * exist", and four of the seven nav items were permanently inert. The sidebar
+ * now lists only screens that work, so a gap reads as a gap.
+ *
+ * Restore an entry when its screen has an endpoint behind it. None does today:
+ *
+ *   - App groups   — needs ADR 034's app-group catalog (epic #419)
+ *   - Applications — no application resource or endpoints exist
+ *   - Analytics    — no aggregate or time-series endpoint exists
+ *   - Activity Log — no audit-log read API (#350)
+ *
+ * ```ts
+ * import { Activity, AppWindow, BarChart3, Folder } from "lucide-react";
+ *
+ * export const DESIGN_ONLY_NAV: NavMeta[] = [
+ *   { label: "App groups", order: 3, icon: Folder },
+ *   { label: "Applications", order: 4, icon: AppWindow },
+ *   { label: "Analytics", order: 5, icon: BarChart3 },
+ *   { label: "Activity Log", order: 7, icon: Activity },
+ * ];
+ * ```
  */
-export const DESIGN_ONLY_NAV: NavMeta[] = [
-  { label: "App groups", order: 3, icon: Folder },
-  { label: "Applications", order: 4, icon: AppWindow },
-  { label: "Analytics", order: 5, icon: BarChart3 },
-  { label: "Activity Log", order: 7, icon: Activity },
-];
+export const DESIGN_ONLY_NAV: NavMeta[] = [];
 
 declare module "@tanstack/react-router" {
   interface StaticDataRouteOption {

--- a/apps/console/src/routes/_authed/index.tsx
+++ b/apps/console/src/routes/_authed/index.tsx
@@ -34,7 +34,7 @@ function Home() {
   return (
     <ComingSoon
       title="Home"
-      description="The overview screen needs aggregate counts and a multi-project list, neither of which the API exposes yet. Users, Sessions and Projects show real data today."
+      description="The overview screen needs aggregate counts and a multi-project list, neither of which the API exposes yet. Users is the screen that has been designed and built."
       icon={LayoutDashboard}
     />
   );

--- a/apps/console/src/routes/_authed/projects/index.tsx
+++ b/apps/console/src/routes/_authed/projects/index.tsx
@@ -1,14 +1,24 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Alert } from "@zitadel/ui-react";
-import { Boxes } from "lucide-react";
 
 import { api } from "../../../api/zitadel";
 import { getConsoleProjectId } from "../../../runtime/runtime";
 import { Page } from "../../../components/layout";
 import { KeyValueTable, PageHeader } from "../../../components/resource-page";
 
+/**
+ * The scoped project, read from `GET /projects/{project_id}`.
+ *
+ * **Reachable by URL, deliberately not in the sidebar.** The data is real, but
+ * this screen has had no design hand-off — Users is the only designed surface —
+ * and the layout here is a developer's key/value table, not a designed one. In
+ * the nav it read as a finished feature; at a URL it is what it is, a way to see
+ * the project the console is bound to.
+ *
+ * Restore `staticData: { nav: { label: "Projects", order: 1, icon: Boxes } }`
+ * when a design for it lands.
+ */
 export const Route = createFileRoute("/_authed/projects/")({
-  staticData: { nav: { label: "Projects", order: 1, icon: Boxes } },
   loader: () => api.getProject(getConsoleProjectId()),
   component: ProjectView,
 });

--- a/apps/console/src/routes/_authed/sessions/index.tsx
+++ b/apps/console/src/routes/_authed/sessions/index.tsx
@@ -1,70 +1,107 @@
-import { useRouter } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
-import { Button, Pill } from "@zitadel/ui-react";
 import { KeyRound } from "lucide-react";
-import { useState } from "react";
 
-import { api } from "../../../api/zitadel";
-import { getConsoleProjectId } from "../../../runtime/runtime";
-import { Page } from "../../../components/layout";
-import { DataTable, PageHeader } from "../../../components/resource-page";
+import { ComingSoon } from "../../../components/coming-soon";
 
+/**
+ * Sessions.
+ *
+ * **The screen was built against an endpoint that does not work.** `GET
+ * /sessions` is routed, documented and generated, but `sessionService.List` is a
+ * stub returning `ErrNotImplemented` (`internal/service/session.go`), so every
+ * load answered 501 and the sidebar link landed on the error boundary. This was
+ * the only console screen that failed outright.
+ *
+ * It has also lost its `staticData.nav` entry, so the sidebar no longer offers a
+ * destination that cannot load. Both come back together when #699 lands.
+ *
+ * The table below is parked rather than deleted, and is close to complete:
+ * `revokeSession` is fully implemented server-side, so the only missing piece is
+ * the list itself. Restore it, put the nav entry back, and check the columns
+ * against whatever shape `List` actually returns — this markup was written
+ * against the generated type, not against a response anyone has seen.
+ */
 export const Route = createFileRoute("/_authed/sessions/")({
-  staticData: { nav: { label: "Sessions", order: 6, icon: KeyRound } },
-  loader: () => api.listSessions({ project_id: getConsoleProjectId() }),
-  component: SessionsList,
+  component: SessionsPlaceholder,
 });
 
-function SessionsList() {
-  const { sessions } = Route.useLoaderData();
-  const router = useRouter();
-  const [revoking, setRevoking] = useState<string | null>(null);
-
-  async function revoke(sessionId: string) {
-    setRevoking(sessionId);
-    try {
-      await api.revokeSession(sessionId, { project_id: getConsoleProjectId() });
-      await router.invalidate();
-    } catch (error) {
-      console.error("Failed to revoke session", error);
-    } finally {
-      setRevoking(null);
-    }
-  }
-
+function SessionsPlaceholder() {
   return (
-    <Page>
-      <PageHeader title="Sessions" />
-      <DataTable
-        rows={sessions}
-        getRowKey={(session) => session.session_id}
-        emptyMessage="No active sessions."
-        columns={[
-          { header: "Session", cell: (session) => session.session_id },
-          { header: "User", cell: (session) => session.user_id ?? "anonymous" },
-          {
-            header: "State",
-            cell: (session) => (
-              <Pill tone={session.state === "active" ? "success" : "neutral"}>{session.state}</Pill>
-            ),
-          },
-          { header: "Created", cell: (session) => session.created_at },
-          { header: "Expires", cell: (session) => session.expires_at },
-          {
-            header: "",
-            cell: (session) => (
-              <Button
-                hierarchy="text"
-                size="small"
-                loading={revoking === session.session_id}
-                onClick={() => void revoke(session.session_id)}
-              >
-                Revoke
-              </Button>
-            ),
-          },
-        ]}
-      />
-    </Page>
+    <ComingSoon
+      title="Sessions"
+      description="Listing sessions needs an endpoint that is routed but not implemented — GET /sessions answers 501 today. Revoking already works, so this screen returns as soon as the list does."
+      icon={KeyRound}
+    />
   );
 }
+
+// --- Parked: the sessions table (see the note above) -------------------------
+//
+// import { useRouter } from "@tanstack/react-router";
+// import { Button, Pill } from "@zitadel/ui-react";
+// import { useState } from "react";
+//
+// import { api } from "../../../api/zitadel";
+// import { getConsoleProjectId } from "../../../runtime/runtime";
+// import { Page } from "../../../components/layout";
+// import { DataTable, PageHeader } from "../../../components/resource-page";
+//
+// export const Route = createFileRoute("/_authed/sessions/")({
+//   staticData: { nav: { label: "Sessions", order: 6, icon: KeyRound } },
+//   loader: () => api.listSessions({ project_id: getConsoleProjectId() }),
+//   component: SessionsList,
+// });
+//
+// function SessionsList() {
+//   const { sessions } = Route.useLoaderData();
+//   const router = useRouter();
+//   const [revoking, setRevoking] = useState<string | null>(null);
+//
+//   async function revoke(sessionId: string) {
+//     setRevoking(sessionId);
+//     try {
+//       await api.revokeSession(sessionId, { project_id: getConsoleProjectId() });
+//       await router.invalidate();
+//     } catch (error) {
+//       console.error("Failed to revoke session", error);
+//     } finally {
+//       setRevoking(null);
+//     }
+//   }
+//
+//   return (
+//     <Page>
+//       <PageHeader title="Sessions" />
+//       <DataTable
+//         rows={sessions}
+//         getRowKey={(session) => session.session_id}
+//         emptyMessage="No active sessions."
+//         columns={[
+//           { header: "Session", cell: (session) => session.session_id },
+//           { header: "User", cell: (session) => session.user_id ?? "anonymous" },
+//           {
+//             header: "State",
+//             cell: (session) => (
+//               <Pill tone={session.state === "active" ? "success" : "neutral"}>{session.state}</Pill>
+//             ),
+//           },
+//           { header: "Created", cell: (session) => session.created_at },
+//           { header: "Expires", cell: (session) => session.expires_at },
+//           {
+//             header: "",
+//             cell: (session) => (
+//               <Button
+//                 hierarchy="text"
+//                 size="small"
+//                 loading={revoking === session.session_id}
+//                 onClick={() => void revoke(session.session_id)}
+//               >
+//                 Revoke
+//               </Button>
+//             ),
+//           },
+//         ]}
+//       />
+//     </Page>
+//   );
+// }

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -4,7 +4,6 @@ import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
 import { AddUserSheet } from "@/components/add-user-sheet";
 import { DeleteUserDialog } from "@/components/delete-user-dialog";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -25,7 +24,9 @@ import {
 
 import { api } from "../../../api/zitadel";
 import { field } from "../../../lib/record";
+import { type SchemaField, type UserSchema, schemaColumns } from "../../../lib/schema";
 import { userDisplayName } from "../../../lib/user";
+import { getConsoleProjectId } from "../../../runtime/runtime";
 
 export const Route = createFileRoute("/_authed/users/")({
   staticData: { nav: { label: "Users", order: 2, icon: Users } },
@@ -33,14 +34,70 @@ export const Route = createFileRoute("/_authed/users/")({
   // default 20. `GET /users` orders by creation ascending with no `Load more`
   // yet (#661), so the default silently hides the most recently created users —
   // the ones an operator has just added and is most likely looking for.
-  loader: () => api.listUsers({ limit: 100 }),
+  loader: async () => {
+    const projectId = getConsoleProjectId();
+    const users = await api.listUsers({ limit: 100 });
+
+    // Columns are the loaded users' own schemas, not every schema in the
+    // project: a schema nobody uses would add a column that is blank in every
+    // row. `listUsers` returns the attribute tree with `$schema` on it, so the
+    // set is known without a second list call.
+    const schemaIds = [...new Set(users.map((user) => field(user, "$schema")).filter(isPresent))];
+    const schemas = await Promise.all(
+      schemaIds.map(async (id) => {
+        try {
+          return (await api.getSchemaById(id, { project_id: projectId })) as UserSchema;
+        } catch {
+          // One unreadable schema costs its columns, not the screen. The rows
+          // still render from the fallback below.
+          return undefined;
+        }
+      }),
+    );
+
+    return { users, columns: columnsFor(users, schemas.filter(isPresent)) };
+  },
   component: UsersScreen,
 });
 
+function isPresent<T>(value: T | undefined | null): value is T {
+  return value !== undefined && value !== null;
+}
+
 interface UserRow {
   id: string;
+  /** Display name for the row menu and the delete dialog — not a column. */
   name: string;
-  email: string;
+  /** Rendered cell values, keyed by schema property. */
+  values: Record<string, string>;
+}
+
+/**
+ * Columns from the users' schemas, falling back to the keys the records
+ * themselves carry.
+ *
+ * The fallback matters because the schema fetch is best-effort and because a
+ * user may predate its schema. Without it an unreadable schema would render a
+ * table of rows with no columns — worse than showing the raw attributes.
+ */
+function columnsFor(users: Record<string, unknown>[], schemas: UserSchema[]): SchemaField[] {
+  const columns = schemaColumns(schemas);
+  if (columns.length > 0) return columns;
+
+  const keys = new Set<string>();
+  for (const user of users) {
+    for (const key of Object.keys(user)) {
+      // `id` gets its own column and `$schema` is machine metadata, not an
+      // attribute an operator reads.
+      if (key !== "id" && key !== "$schema") keys.add(key);
+    }
+  }
+  return [...keys].sort().map((key) => ({
+    key,
+    label: key,
+    required: false,
+    inputType: "text" as const,
+  }));
 }
 
 /** Platform-correct modifier for the search shortcut hint (⌘ on Apple, Ctrl elsewhere). */
@@ -53,7 +110,7 @@ function searchShortcutLabel(): string {
 }
 
 function UsersScreen() {
-  const users = Route.useLoaderData();
+  const { users, columns } = Route.useLoaderData();
   const router = useRouter();
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
@@ -81,17 +138,19 @@ function UsersScreen() {
   // Search narrows the rows already fetched. `GET /users` takes no filter (ADR
   // 031's query endpoint does not exist), so this cannot reach users outside the
   // loaded page — which is why the table says so beneath it.
+  //
+  // It matches every rendered column rather than a fixed name/email/id triple:
+  // the columns are schema-driven, so a hardcoded set would silently fail to
+  // search whatever the project's schema actually defines.
   const rows = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    return users.map(toUserRow).filter((user) => {
-      return (
-        needle === "" ||
-        user.name.toLowerCase().includes(needle) ||
-        user.email.toLowerCase().includes(needle) ||
-        user.id.toLowerCase().includes(needle)
+    return users.map((user, index) => toUserRow(user, index, columns)).filter((row) => {
+      if (needle === "") return true;
+      return [row.id, ...columns.map((column) => row.values[column.key] ?? "")].some((value) =>
+        value.toLowerCase().includes(needle),
       );
     });
-  }, [users, query]);
+  }, [users, query, columns]);
 
   return (
     <div className="px-4 pt-9 pb-8 sm:px-8">
@@ -127,49 +186,55 @@ function UsersScreen() {
         </div>
       </div>
 
-      <div className="border-sidebar-border bg-card mt-6 overflow-hidden rounded-2xl border">
-        <Table className="table-fixed text-xs">
-          <colgroup>
-            <col className="w-[240px]" />
-            <col className="w-[280px]" />
-            <col className="w-[280px]" />
-            <col className="w-[60px]" />
-          </colgroup>
+      {/* The column set is schema-driven and so has no fixed width; the design
+          scrolls the table horizontally rather than compressing cells (the
+          `Filled` variant shows a scrollbar under the rows). */}
+      <div className="border-sidebar-border bg-card mt-6 overflow-x-auto rounded-2xl border">
+        <Table className="text-xs">
           <TableHeader>
             <TableRow className="border-border border-b hover:bg-transparent">
-              <HeadCell>Name</HeadCell>
-              <HeadCell>Email</HeadCell>
+              {columns.map((column) => (
+                <HeadCell key={column.key}>{column.label}</HeadCell>
+              ))}
               <HeadCell>ID</HeadCell>
-              <TableHead className="h-14 px-2" />
+              <TableHead className="h-14 w-[60px] px-2" />
             </TableRow>
           </TableHeader>
           <TableBody>
             {rows.length === 0 ? (
               <TableRow className="border-0 hover:bg-transparent">
-                <TableCell colSpan={4} className="text-muted-foreground h-24 text-center">
+                <TableCell
+                  colSpan={columns.length + 2}
+                  className="text-muted-foreground h-24 text-center"
+                >
                   {users.length === 0 ? "No users yet." : "No users match the current filters."}
                 </TableCell>
               </TableRow>
             ) : (
               rows.map((user) => (
                 <TableRow key={user.id} className="hover:bg-muted/40 border-0">
-                  <TableCell className="h-11 truncate px-4 py-0">
-                    <div className="flex items-center gap-2">
-                      <Avatar size="sm">
-                        <AvatarFallback>{initials(user.name)}</AvatarFallback>
-                      </Avatar>
-                      <Link
-                        to="/users/$userId"
-                        params={{ userId: user.id }}
-                        className="text-foreground truncate font-medium underline-offset-2 hover:underline"
-                      >
-                        {user.name}
-                      </Link>
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground h-11 truncate px-2 py-0">
-                    {user.email}
-                  </TableCell>
+                  {columns.map((column, index) => (
+                    <TableCell
+                      key={column.key}
+                      className="text-muted-foreground h-11 max-w-[280px] truncate px-2 py-0 first:px-4"
+                    >
+                      {/* The first column carries the link to the detail screen.
+                          There is no separate name column to hang it on — the
+                          design's columns are the schema's own properties, and
+                          which one comes first depends on the schema. */}
+                      {index === 0 ? (
+                        <Link
+                          to="/users/$userId"
+                          params={{ userId: user.id }}
+                          className="text-foreground truncate font-medium underline-offset-2 hover:underline"
+                        >
+                          {user.values[column.key] || user.id}
+                        </Link>
+                      ) : (
+                        (user.values[column.key] ?? "—")
+                      )}
+                    </TableCell>
+                  ))}
                   <TableCell className="text-foreground h-11 truncate px-2 py-0">
                     {user.id}
                   </TableCell>
@@ -199,15 +264,27 @@ function UsersScreen() {
   );
 }
 
-function toUserRow(user: Record<string, unknown>, index: number): UserRow {
+function toUserRow(
+  user: Record<string, unknown>,
+  index: number,
+  columns: SchemaField[],
+): UserRow {
   const id = field(user, "id") ?? `unknown-user-${index}`;
-  const email = field(user, "email") ?? "—";
+  const values: Record<string, string> = {};
+  for (const column of columns) {
+    // Only scalars are read. A property whose value is an object or array has no
+    // one-line rendering, and `JSON.stringify` in a table cell is noise — the
+    // detail screen is where a structured attribute belongs.
+    const value = field(user, column.key);
+    if (value !== undefined) values[column.key] = value;
+  }
   return {
     id,
-    // Fall back to the email, then the id: a `minimal` user schema defines only
-    // `email`, so a name is genuinely absent rather than missing.
-    name: userDisplayName(user) ?? (email === "—" ? id : email),
-    email,
+    values,
+    // Used for the row menu's accessible name and the delete dialog's heading,
+    // not as a column. Falls back to the email and then the id: a `minimal`
+    // schema defines only `email`, so a name is genuinely absent, not missing.
+    name: userDisplayName(user) ?? field(user, "email") ?? id,
   };
 }
 
@@ -290,13 +367,4 @@ function RowActions({
       />
     </>
   );
-}
-
-function initials(name: string): string {
-  return name
-    .split(" ")
-    .map((part) => part[0])
-    .slice(0, 2)
-    .join("")
-    .toUpperCase();
 }

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -252,8 +252,8 @@ function UsersScreen() {
         </Table>
       </div>
       {/* D5: the list is one page and must not present itself as the whole set.
-          `GET /users` serves a fixed window (limit defaults to 20) with no
-          `Load more` yet — cursor pagination is #661. */}
+          The loader asks for the API maximum, but that is still a fixed window
+          with no `Load more` behind it — cursor pagination is #661. */}
       {users.length > 0 && (
         <p className="text-muted-foreground mt-3 text-xs">
           Showing {rows.length} of the {users.length} users loaded. This is the first page,

--- a/apps/console/src/routes/_authed/users/users.spec.tsx
+++ b/apps/console/src/routes/_authed/users/users.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -15,6 +15,7 @@ vi.mock("@/auth/session", async (importOriginal) => {
 vi.stubEnv("VITE_CONSOLE_API_BASE", "http://localhost/api");
 
 const USERS_URL = "http://localhost/api/users";
+const SCHEMAS_URL = "http://localhost/api/schemas";
 const server = setupServer();
 
 beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
@@ -49,8 +50,70 @@ describe("users screen", () => {
     );
     await renderUsers();
     expect(await screen.findByRole("heading", { name: "Users" })).toBeInTheDocument();
-    expect(await screen.findByRole("link", { name: "Maya Patel" })).toBeInTheDocument();
-    expect(screen.getByText("maya.patel@acme.com")).toBeInTheDocument();
+    // Columns are the schema's properties (design `277:288291`, decisions log
+    // D4), so there is no combined "Name" column — the first property carries
+    // the link to the detail screen.
+    expect(await screen.findByRole("link", { name: "maya.patel@acme.com" })).toBeInTheDocument();
+    expect(screen.getByText("Maya")).toBeInTheDocument();
+    expect(screen.getByText("Patel")).toBeInTheDocument();
+  });
+
+  it("builds the columns from the schema the users reference", async () => {
+    server.use(
+      http.get(USERS_URL, () =>
+        HttpResponse.json([
+          { id: "user_1", $schema: "sch_business", email: "maya@acme.com", companyName: "Acme" },
+        ]),
+      ),
+      http.get(`${SCHEMAS_URL}/sch_business`, () =>
+        HttpResponse.json({
+          title: "Business",
+          required: ["email"],
+          properties: {
+            email: { type: "string", format: "email" },
+            companyName: { type: "string", title: "Company name" },
+          },
+        }),
+      ),
+    );
+    await renderUsers();
+
+    // The header comes from the schema's own `title`, not from the record keys.
+    expect(await screen.findByText("Company name")).toBeInTheDocument();
+    // Scoped to the table: the app shell's organisation switcher also renders an
+    // "Acme" label.
+    const table = within(screen.getByRole("table"));
+    expect(table.getByText("Acme")).toBeInTheDocument();
+    expect(table.getByText("maya@acme.com")).toBeInTheDocument();
+  });
+
+  it("renders a placeholder where a user's schema does not define a column", async () => {
+    // Columns union across schemas (D4), so a minimal user sits in a table that
+    // also has business columns. The cell must read as empty, not as missing.
+    server.use(
+      http.get(USERS_URL, () =>
+        HttpResponse.json([
+          { id: "user_1", $schema: "sch_business", email: "maya@acme.com", companyName: "Acme" },
+          { id: "user_2", $schema: "sch_business", email: "min@acme.com" },
+        ]),
+      ),
+      http.get(`${SCHEMAS_URL}/sch_business`, () =>
+        HttpResponse.json({
+          properties: {
+            email: { type: "string", format: "email" },
+            companyName: { type: "string", title: "Company name" },
+          },
+        }),
+      ),
+    );
+    await renderUsers();
+
+    // `schemaFields` orders properties by key, so `companyName` is the first
+    // column and therefore the linked one. The user without a company falls back
+    // to its id rather than rendering an empty link.
+    expect(await screen.findByRole("link", { name: "Acme" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "user_2" })).toBeInTheDocument();
+    expect(within(screen.getByRole("table")).getByText("min@acme.com")).toBeInTheDocument();
   });
 
   it("derives the display name the way the platform does", async () => {
@@ -73,9 +136,11 @@ describe("users screen", () => {
       ),
     );
     await renderUsers();
-    expect(await screen.findByRole("link", { name: "Ada L." })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Grace Hopper" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Radia" })).toBeInTheDocument();
+    // The derived name is no longer a column; it names the row's actions and
+    // titles the delete dialog, which is where a wrong derivation would show.
+    expect(await screen.findByRole("button", { name: "Actions for Ada L." })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Actions for Grace Hopper" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Actions for Radia" })).toBeInTheDocument();
   });
 
   it("ignores non-identity attributes when deriving the name", async () => {
@@ -88,11 +153,12 @@ describe("users screen", () => {
       ),
     );
     await renderUsers();
-    expect(await screen.findByRole("link", { name: "kenji@acme.com" })).toBeInTheDocument();
-    expect(screen.queryByText("nope")).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "Actions for kenji@acme.com" }),
+    ).toBeInTheDocument();
   });
 
-  it("uses schema-defined email as the display name and shows the user id", async () => {
+  it("shows the user id alongside the schema's own attributes", async () => {
     server.use(
       http.get(USERS_URL, () =>
         HttpResponse.json([{ id: "user_1", email: "kenji@acme.com", status: "Blocked" }]),
@@ -101,7 +167,11 @@ describe("users screen", () => {
     await renderUsers();
     expect(await screen.findByRole("link", { name: "kenji@acme.com" })).toBeInTheDocument();
     expect(screen.getByText("user_1")).toBeInTheDocument();
-    expect(screen.queryByText("Blocked")).not.toBeInTheDocument();
+    // `status` renders because this record carries it — the table shows what the
+    // data has (D4). What is still absent is a *base-model* status the console
+    // could count on for every user (#553); nothing is invented for records
+    // without one.
+    expect(screen.getByText("Blocked")).toBeInTheDocument();
   });
 
   it("renders the not-authorized state on a 401 with a live session (no redirect loop)", async () => {
@@ -133,7 +203,7 @@ describe("users screen", () => {
     }
   });
 
-  it("filters live users by name, email, or id", async () => {
+  it("filters live users across every rendered column, and by id", async () => {
     server.use(
       http.get(USERS_URL, () =>
         HttpResponse.json([
@@ -143,11 +213,19 @@ describe("users screen", () => {
       ),
     );
     await renderUsers();
-    expect(await screen.findByText("Maya Patel")).toBeInTheDocument();
+    const table = () => within(screen.getByRole("table"));
+    expect(await screen.findByText("Maya")).toBeInTheDocument();
 
+    // By id — not a column an operator reads off, but the one they paste.
     await userEvent.type(screen.getByRole("searchbox", { name: "Search users" }), "user_2");
+    expect(await screen.findByText("Sasha")).toBeInTheDocument();
+    expect(table().queryByText("Maya")).not.toBeInTheDocument();
 
-    expect(await screen.findByText("Sasha Kim")).toBeInTheDocument();
-    expect(screen.queryByText("Maya Patel")).not.toBeInTheDocument();
+    // By a schema property that is not the first column: search covers whatever
+    // the schema defines rather than a fixed name/email pair.
+    await userEvent.clear(screen.getByRole("searchbox", { name: "Search users" }));
+    await userEvent.type(screen.getByRole("searchbox", { name: "Search users" }), "Patel");
+    expect(await screen.findByText("Maya")).toBeInTheDocument();
+    expect(table().queryByText("Sasha")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Which Problems Are Solved

Most of the console's chrome was not connected to anything, and it was no longer
possible to tell by looking which parts were real.

- **The Sessions link could not load.** `GET /sessions` is routed, documented and
  generated, but `sessionService.List` is a `//TODO implement me` returning
  `ErrNotImplemented`, so every visit answered 501 and landed on the error
  boundary.
- **The organisation switcher listed placeholder organisations** — "Acme Inc /
  Free", "Clearwater Labs / Pro", "Benimac LTD / Enterprise", "Horizons Studio /
  Pro" — with a hardcoded current selection and a plan badge naming a tier
  nothing sells. It sat above every screen, so the whole console looked scoped to
  a real organisation on a real plan.
- **Four sidebar entries were permanently disabled.** App groups, Applications,
  Analytics and Activity Log rendered as `aria-disabled` rows to match the mock.
  A disabled row still advertises a feature: it reads as "your account cannot do
  this" rather than "this does not exist".
- **Search and Documentation did nothing.** Both rendered as ordinary enabled
  buttons with no handler, which is worse than being disabled.

# How the Problems Are Solved

Each surface is commented out in place with the endpoint or decision that brings
it back, rather than deleted, since all of them return unchanged once unblocked:

- Sessions loses its screen and its nav entry until listing sessions exists
  (#699). `revokeSession` is already implemented, so the parked table is close to
  complete.
- The organisation switcher waits on a team list endpoint (#620) and on billing
  for the plan badge (#667). The project switcher beside it is real and stays.
- `DESIGN_ONLY_NAV` is emptied, with each entry's blocker recorded against it.
- Search waits on a cross-resource query endpoint; Documentation waits on a
  published docs URL.

Projects keeps its route and loader but loses its sidebar entry. Its data is
real, but it has had no design hand-off — the layout is a developer's key/value
table — and beside Users it read as a finished feature. `/projects` still answers
for anyone who wants it, as `/system` and `/flow-definitions` already did.

That leaves one nav entry, Users, which is the honest count of what has been
designed and built.

# Additional Changes

- The three real-instance e2e suites shared `signIn` by copy-paste; it is now a
  single helper, along with `expectNoErrorBoundary`. Byte-identical copies of the
  step every suite starts with could have drifted while looking the same.
- The shell spec now asserts the inverse of what it did: every nav row is a link,
  and the unbuilt labels appear nowhere.

# Additional Context

- Raised while sweeping: #699 (`GET /sessions` returns 501 — no issue tracked it)
- Related: #620 (team list), #667 (billing tiers), #350 (audit log), #419
  (app groups)
