### PR TITLE
ci: shard full-pr into parallel resource jobs behind the aggregated gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,23 +12,31 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  # Moon marks failed tasks by color alone, so a failed `moon ci` can end at
+  # "Tasks: 1 failed" with no named target. The summary names them in plain
+  # text and replays each failed task's own output. Green runs pay only a
+  # pass/fail list; the replay section is empty when nothing failed.
+  MOON_SUMMARY: detailed
+
+# The work is split into shard jobs by resource conflict, not by category:
+# the moon graph and Go suites share one machine, the release snapshot feeds
+# the journey shards through an artifact, and the real-instance browser
+# suites get machines of their own so their embedded-Postgres instances
+# cannot contend with anything else. Branch protection requires the single
+# context `full-pr`; that job aggregates the shard results, so the required
+# check's name survives the split.
 jobs:
-  full-pr:
+  graph:
     # Fork PRs execute untrusted repository code. Keep them off Depot runners,
     # which inject DEPOT_CACHE_TOKEN independently of GitHub secret filtering.
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-24.04' || 'depot-ubuntu-24.04-16' }}
-    timeout-minutes: 120
+    timeout-minutes: 60
     permissions:
       contents: read
       # Required to mint the OIDC token for Workload Identity Federation when
       # authenticating to the Spanner test instance (trusted runs only).
       id-token: write
-    env:
-      # Moon marks failed tasks by color alone, so a failed `moon ci` can end at
-      # "Tasks: 1 failed" with no named target. The summary names them in plain
-      # text and replays each failed task's own output. Green runs pay only a
-      # pass/fail list; the replay section is empty when nothing failed.
-      MOON_SUMMARY: detailed
     steps:
       - uses: actions/checkout@v6
         with:
@@ -122,57 +130,48 @@ jobs:
           ZITADEL_TEST_SPANNER_INSTANCE: ${{ vars.SPANNER_TEST_INSTANCE }}
         run: moon run server:test-spanner
 
+  snapshot:
+    # Fork note: see the `graph` job.
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-24.04' || 'depot-ubuntu-24.04-16' }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    # The journey shards gate on this mode instead of detecting their own:
+    # they consume this job's artifact, so its mode is the one that counts.
+    outputs:
+      mode: ${{ steps.ci-mode.outputs.mode }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: pnpm/action-setup@v5
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Put workspace binaries on PATH
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Detect CI mode
+        id: ci-mode
+        run: node scripts/ci-mode.mjs "${{ github.event.pull_request.base.sha || 'origin/main' }}"
+
       - name: Build release snapshot without container
         if: ${{ steps.ci-mode.outputs.mode == 'full' }}
         run: env -u CI -u GITHUB_ACTIONS moon run release:snapshot -- --skip-container
-
-      - name: Run binary fresh-app journey
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: |
-          version="$(node -p "require('./apps/server/package.json').version")"
-          env -u CI -u GITHUB_ACTIONS moon run cli-journey-e2e:e2e-local -- \
-            --runtime binary \
-            --concurrency 5 \
-            --work-dir "${RUNNER_TEMP}/ci-journey" \
-            --tarballs-dir "dist/release/${version}/npm"
-
-      # One framework is enough here: the preset decides the scaffolded
-      # flow shape, not the SDK — the matrix above already covers SDKs.
-      - name: Run passkey-first preset journey
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: |
-          version="$(node -p "require('./apps/server/package.json').version")"
-          env -u CI -u GITHUB_ACTIONS moon run cli-journey-e2e:e2e-local -- \
-            --runtime binary \
-            --framework next \
-            --preset passkey-first \
-            --work-dir "${RUNNER_TEMP}/ci-journey-passkey-first" \
-            --tarballs-dir "dist/release/${version}/npm"
-
-      # Customer-configuration proof for @zitadel/testing: a fresh app
-      # installs the kit from the journey registry and runs its withZitadel()
-      # suite against the published binary — embedded UIs, no repo env
-      # overrides (unlike the in-repo e2e-real lanes below).
-      - name: Run test-kit consumer journey
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: |
-          version="$(node -p "require('./apps/server/package.json').version")"
-          env -u CI -u GITHUB_ACTIONS moon run cli-journey-e2e:e2e-testkit -- \
-            --work-dir "${RUNNER_TEMP}/ci-journey-testkit" \
-            --tarballs-dir "dist/release/${version}/npm"
-
-      # Gates the test-kit's central promise: boot a real seeded instance,
-      # then drive the real browser login with per-test users. Reuses the Go
-      # build cache and Playwright Chromium installed above.
-      - name: Run @zitadel/testing real-instance suites
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: env -u CI -u GITHUB_ACTIONS moon run testing:test-integration demo-next-e2e:e2e-real
-
-      # Dogfoods @zitadel/testing through a second consumer. Keep this separate
-      # from the demo suite so two embedded-Postgres instances do not contend.
-      - name: Run console real-instance suite
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
-        run: env -u CI -u GITHUB_ACTIONS moon run console-e2e:e2e-real
 
       - name: Validate version PR
         if: ${{ steps.ci-mode.outputs.mode == 'version-only' }}
@@ -197,17 +196,219 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  journey-fresh-app:
+    needs: snapshot
+    if: ${{ needs.snapshot.outputs.mode == 'full' }}
+    # Fork note: see the `graph` job.
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-24.04' || 'depot-ubuntu-24.04-16' }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: pnpm/action-setup@v5
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Put workspace binaries on PATH
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        run: corepack pnpm --filter @zitadel/components exec playwright install chromium
+
+      # The journey tasks depend only on cli:build and testing:build; the
+      # release tarballs they consume come from the snapshot shard's artifact,
+      # so nothing rebuilds the release here.
+      - name: Download release snapshot
+        uses: actions/download-artifact@v4
+        with:
+          name: release-snapshot
+          path: dist/release
+
+      - name: Run binary fresh-app journey
+        run: |
+          version="$(node -p "require('./apps/server/package.json').version")"
+          env -u CI -u GITHUB_ACTIONS moon run cli-journey-e2e:e2e-local -- \
+            --runtime binary \
+            --concurrency 5 \
+            --work-dir "${RUNNER_TEMP}/ci-journey" \
+            --tarballs-dir "dist/release/${version}/npm"
+
       - name: Upload journey diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: journey-diagnostics
+          name: journey-diagnostics-fresh-app
+          path: ${{ runner.temp }}/ci-journey/diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Carries the passkey-first preset journey and the test-kit consumer
+  # journey: two more scaffold-a-fresh-app paths over the same tarballs,
+  # paired here because together they balance the fresh-app shard's runtime.
+  journey-presets:
+    needs: snapshot
+    if: ${{ needs.snapshot.outputs.mode == 'full' }}
+    # Fork note: see the `graph` job.
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-24.04' || 'depot-ubuntu-24.04-16' }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: pnpm/action-setup@v5
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Put workspace binaries on PATH
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        run: corepack pnpm --filter @zitadel/components exec playwright install chromium
+
+      - name: Download release snapshot
+        uses: actions/download-artifact@v4
+        with:
+          name: release-snapshot
+          path: dist/release
+
+      # One framework is enough here: the preset decides the scaffolded
+      # flow shape, not the SDK — the fresh-app shard's matrix already
+      # covers SDKs.
+      - name: Run passkey-first preset journey
+        run: |
+          version="$(node -p "require('./apps/server/package.json').version")"
+          env -u CI -u GITHUB_ACTIONS moon run cli-journey-e2e:e2e-local -- \
+            --runtime binary \
+            --framework next \
+            --preset passkey-first \
+            --work-dir "${RUNNER_TEMP}/ci-journey-passkey-first" \
+            --tarballs-dir "dist/release/${version}/npm"
+
+      # Customer-configuration proof for @zitadel/testing: a fresh app
+      # installs the kit from the journey registry and runs its withZitadel()
+      # suite against the published binary — embedded UIs, no repo env
+      # overrides (unlike the in-repo e2e-real lanes in the browser-e2e job).
+      - name: Run test-kit consumer journey
+        run: |
+          version="$(node -p "require('./apps/server/package.json').version")"
+          env -u CI -u GITHUB_ACTIONS moon run cli-journey-e2e:e2e-testkit -- \
+            --work-dir "${RUNNER_TEMP}/ci-journey-testkit" \
+            --tarballs-dir "dist/release/${version}/npm"
+
+      - name: Upload journey diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: journey-diagnostics-presets
           path: |
-            ${{ runner.temp }}/ci-journey/diagnostics
             ${{ runner.temp }}/ci-journey-passkey-first/diagnostics
             ${{ runner.temp }}/ci-journey-testkit/diagnostics
           if-no-files-found: ignore
           retention-days: 7
+
+  browser-e2e:
+    # Fork note: see the `graph` job.
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-24.04' || 'depot-ubuntu-24.04-16' }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: pnpm/action-setup@v5
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Put workspace binaries on PATH
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Detect CI mode
+        id: ci-mode
+        run: node scripts/ci-mode.mjs "${{ github.event.pull_request.base.sha || 'origin/main' }}"
+
+      - name: Cache Playwright browsers
+        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        run: corepack pnpm --filter @zitadel/components exec playwright install chromium
+
+      # Gates the test-kit's central promise: boot a real seeded instance,
+      # then drive the real browser login with per-test users.
+      - name: Run @zitadel/testing real-instance suites
+        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        run: env -u CI -u GITHUB_ACTIONS moon run testing:test-integration demo-next-e2e:e2e-real
+
+      # Dogfoods @zitadel/testing through a second consumer. Still a separate
+      # step after the demo suite so two embedded-Postgres instances do not
+      # contend on this machine; the other shards run on machines of their own.
+      - name: Run console real-instance suite
+        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        run: env -u CI -u GITHUB_ACTIONS moon run console-e2e:e2e-real
 
       # The handshake is deliberately excluded: it carries the project secret.
       - name: Upload console e2e diagnostics
@@ -220,3 +421,23 @@ jobs:
             apps/console-e2e/playwright-report
           if-no-files-found: ignore
           retention-days: 7
+
+  # The one required branch-protection context. It carries no work of its
+  # own: it fails unless every shard reports the result the detected CI mode
+  # expects (journey shards skip on version-only PRs, everything else must
+  # succeed). `always()` keeps it reporting when a shard fails or is skipped —
+  # a bare `needs` would leave the required check pending forever.
+  full-pr:
+    needs: [graph, snapshot, journey-fresh-app, journey-presets, browser-e2e]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify shard results
+        env:
+          SHARD_RESULTS: ${{ toJSON(needs) }}
+        run: node scripts/verify-shard-results.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,8 +188,9 @@ deterministic CI-style proof of the fresh-app path, and
 against the same local package train.
 
 In CI the branch-protection check is the GitHub Actions context `full-pr`,
-shown in the pull request UI as `ci / full-pr`; it consumes the workflow's
-packed npm tarballs instead of public Zitadel packages. Changesets PR comments
+shown in the pull request UI as `ci / full-pr`; it aggregates parallel shard
+jobs, and the journey shards consume the workflow's packed npm tarballs
+instead of public Zitadel packages. Changesets PR comments
 are informational release-intent feedback and are not branch-protection
 requirements. Mirror the gate locally with
 `moon run workspace:check -- --full`; the full step list is in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,24 +249,32 @@ the Moon tasks below. To re-run a single failing task, use
 
 Branch protection requires the GitHub Actions context `full-pr`, shown in the
 pull request UI as `ci / full-pr` and defined in
-[`.github/workflows/ci.yml`](.github/workflows/ci.yml). The job installs
-dependencies, then picks one of two modes via `scripts/ci-mode.mjs`:
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml). `full-pr` runs no
+checks of its own: the work runs in parallel shard jobs split by resource
+conflict, and `full-pr` fails unless every shard reports the result the
+detected CI mode expects (`scripts/verify-shard-results.mjs`). Each shard
+installs dependencies, then picks one of two modes via `scripts/ci-mode.mjs`:
 
-**Full mode** (normal PRs) runs, in order:
+**Full mode** (normal PRs) runs, per shard:
 
-- `moon run server:check-generate` — Go generated-file drift check.
-- Playwright Chromium install for `@zitadel/components`.
-- `moon ci :lint :typecheck :build :test :test-browser`.
-- `moon run server:test`, then `moon run server:test-postgres` (Spanner
-  integration is not run in CI yet; see the note in the workflow).
-- `moon run release:snapshot -- --skip-container` — a non-publishing release
-  snapshot.
-- The fresh-app consumer journey (`cli-journey-e2e:e2e-local`) with the npm
-  binary runtime against the snapshot's packed tarballs, plus one
-  passkey-first preset journey run.
+- `graph` — `moon run server:check-generate` (Go generated-file drift check),
+  Playwright Chromium install for `@zitadel/components`,
+  `moon ci :lint :typecheck :build :test :test-browser :check-adrs`, then
+  `moon run server:test`, `server:test-postgres`, and `server:test-spanner`
+  (emulator, or the Spanner test instance on trusted runs).
+- `snapshot` — `moon run release:snapshot -- --skip-container`, a
+  non-publishing release snapshot uploaded as the `release-snapshot`
+  artifact.
+- `journey-fresh-app` and `journey-presets` — download that artifact and run
+  the fresh-app consumer journey (`cli-journey-e2e:e2e-local`) with the npm
+  binary runtime against the packed tarballs, one passkey-first preset
+  journey, and the test-kit consumer journey (`cli-journey-e2e:e2e-testkit`).
+- `browser-e2e` — the real-instance suites: `testing:test-integration` with
+  `demo-next-e2e:e2e-real`, then `console-e2e:e2e-real`.
 
-**Version-only mode** (Changesets version PRs) runs `release:version`,
-`release:pack`, and tarball verification instead.
+**Version-only mode** (Changesets version PRs): the `snapshot` shard runs
+`release:version`, `release:pack`, and tarball verification instead; the
+other shards skip their steps and the journey shards do not start.
 
 CI consumes the workflow's packed npm tarballs, not public Zitadel packages.
 Changesets PR comments are informational release-intent feedback, not a

--- a/README.md
+++ b/README.md
@@ -108,13 +108,14 @@ For product direction and the four pillars, see [VISION.md](VISION.md).
 ## CI
 
 Pull requests are gated by the GitHub Actions context `full-pr`, shown in the
-pull request UI as `ci / full-pr`. On a 16-core runner it runs a Go
-generated-file drift check, lint, type checks, builds, unit and browser
-tests, Go tests including Postgres integration, a non-publishing release
-snapshot, and fresh-app journeys against the snapshot's npm tarballs.
+pull request UI as `ci / full-pr`. It aggregates parallel shard jobs that run
+a Go generated-file drift check, lint, type checks, builds, unit and browser
+tests, Go tests including Postgres and Spanner integration, a non-publishing
+release snapshot, fresh-app journeys against the snapshot's npm tarballs, and
+the real-instance browser suites.
 Changesets version PRs run a smaller release validation path instead, and
 Changesets comments give release-intent feedback without adding a blocking
-gate. The full step list lives in
+gate. The shard and step list lives in
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and
 [CONTRIBUTING.md](CONTRIBUTING.md#what-ci-runs).
 

--- a/moon.yml
+++ b/moon.yml
@@ -43,6 +43,18 @@ tasks:
       cache: false
       runInCI: false
 
+  # Matched by the `:test` target in the ci workflow's `moon ci` call, so the
+  # aggregator's judgment logic never becomes a test file nothing executes.
+  test:
+    command: "node --test scripts/verify-shard-results.test.mjs"
+    inputs:
+      - "scripts/verify-shard-results.mjs"
+      - "scripts/verify-shard-results.test.mjs"
+      - "scripts/dev-process.mjs"
+    options:
+      cache: true
+      runInCI: true
+
   check-typecheck:
     script: "node --test scripts/check-typecheck-programs.test.mjs && node scripts/check-typecheck-programs.mjs"
     inputs:

--- a/packages/testing/AGENTS.md
+++ b/packages/testing/AGENTS.md
@@ -114,9 +114,10 @@ a `testing:build` task dep.
   `env -u CI moon run cli-journey-e2e:e2e-testkit` (customer install path).
 
 The real-instance lanes carry `runInCI: false`, but that only keeps them
-out of moon's automatic CI selection — `full-pr` runs all of them through
-explicit `env -u CI` workflow steps (`.github/workflows/ci.yml`). Locally,
-use the same `env -u CI` incantation.
+out of moon's automatic CI selection — the ci workflow's shard jobs run all
+of them through explicit `env -u CI` steps, aggregated by the required
+`full-pr` check (`.github/workflows/ci.yml`). Locally, use the same
+`env -u CI` incantation.
 
 Serialize moon invocations — two concurrent graphs produce spurious
 failures. Orphaned runtimes from aborted e2e runs squat fixed ports;

--- a/scripts/verify-shard-results.mjs
+++ b/scripts/verify-shard-results.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import { appendFile } from "node:fs/promises";
+
+import { isDirectRun } from "./dev-process.mjs";
+
+// Every shard job the `full-pr` aggregator depends on, and when its result
+// counts as passing. "always" shards run in every CI mode (their steps skip
+// internally on version-only PRs, so the job still succeeds). "full-mode-only"
+// shards are gated at the job level on the snapshot shard's detected mode, so
+// on anything but a full run the expected result is "skipped" — a shard that
+// ran anyway means the gate broke, and that fails the aggregate too.
+//
+// This map and the `needs:` list of the `full-pr` job in
+// .github/workflows/ci.yml must stay in sync; drift in either direction is a
+// failure, never a silent pass.
+const EXPECTATIONS = {
+  graph: "always",
+  snapshot: "always",
+  "browser-e2e": "always",
+  "journey-fresh-app": "full-mode-only",
+  "journey-presets": "full-mode-only",
+};
+
+/**
+ * Judge the aggregate result from the `needs` context of the `full-pr` job.
+ * Returns a list of problems; an empty list is a pass.
+ */
+export function verifyShardResults(needs) {
+  const problems = [];
+  const mode = needs?.snapshot?.outputs?.mode;
+
+  for (const [job, expectation] of Object.entries(EXPECTATIONS)) {
+    const result = needs?.[job]?.result;
+    if (result === undefined) {
+      problems.push(
+        `${job}: missing from the aggregator's needs — ci.yml and verify-shard-results.mjs drifted`,
+      );
+      continue;
+    }
+    const expectSkip = expectation === "full-mode-only" && mode !== "full";
+    const expected = expectSkip ? "skipped" : "success";
+    if (result !== expected) {
+      const context = expectSkip ? ` in mode "${mode ?? "unknown"}"` : "";
+      problems.push(`${job}: result "${result}", expected "${expected}"${context}`);
+    }
+  }
+
+  for (const job of Object.keys(needs ?? {})) {
+    if (!(job in EXPECTATIONS)) {
+      problems.push(`${job}: not covered by verify-shard-results.mjs — add an expectation`);
+    }
+  }
+
+  return problems;
+}
+
+async function main() {
+  const raw = process.env.SHARD_RESULTS;
+  if (!raw) {
+    console.error("SHARD_RESULTS is not set; the workflow must pass toJSON(needs).");
+    process.exit(1);
+  }
+
+  const problems = verifyShardResults(JSON.parse(raw));
+  if (problems.length === 0) {
+    console.log("All shards reported the expected result.");
+    return;
+  }
+
+  for (const problem of problems) {
+    console.error(problem);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const lines = ["## full-pr shard results", "", ...problems.map((p) => `- ${p}`), ""];
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, lines.join("\n"));
+  }
+  process.exit(1);
+}
+
+if (isDirectRun(import.meta.url)) {
+  await main();
+}

--- a/scripts/verify-shard-results.test.mjs
+++ b/scripts/verify-shard-results.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { verifyShardResults } from "./verify-shard-results.mjs";
+
+function needsFixture({ mode = "full", ...overrides } = {}) {
+  const journeyResult = mode === "full" ? "success" : "skipped";
+  return {
+    graph: { result: "success", outputs: {} },
+    snapshot: { result: "success", outputs: { mode } },
+    "browser-e2e": { result: "success", outputs: {} },
+    "journey-fresh-app": { result: journeyResult, outputs: {} },
+    "journey-presets": { result: journeyResult, outputs: {} },
+    ...overrides,
+  };
+}
+
+test("full mode with every shard green passes", () => {
+  assert.deepEqual(verifyShardResults(needsFixture()), []);
+});
+
+test("version-only mode expects the journey shards to be skipped", () => {
+  assert.deepEqual(verifyShardResults(needsFixture({ mode: "version-only" })), []);
+});
+
+test("a failed shard fails the aggregate", () => {
+  const problems = verifyShardResults(
+    needsFixture({ "browser-e2e": { result: "failure", outputs: {} } }),
+  );
+  assert.deepEqual(problems, ['browser-e2e: result "failure", expected "success"']);
+});
+
+test("a cancelled shard fails the aggregate", () => {
+  const problems = verifyShardResults(needsFixture({ graph: { result: "cancelled", outputs: {} } }));
+  assert.deepEqual(problems, ['graph: result "cancelled", expected "success"']);
+});
+
+test("a journey shard skipped on a full run fails the aggregate", () => {
+  const problems = verifyShardResults(
+    needsFixture({ "journey-presets": { result: "skipped", outputs: {} } }),
+  );
+  assert.deepEqual(problems, ['journey-presets: result "skipped", expected "success"']);
+});
+
+test("a journey shard that ran despite a version-only mode fails the aggregate", () => {
+  const problems = verifyShardResults(
+    needsFixture({
+      mode: "version-only",
+      "journey-fresh-app": { result: "success", outputs: {} },
+    }),
+  );
+  assert.deepEqual(problems, [
+    'journey-fresh-app: result "success", expected "skipped" in mode "version-only"',
+  ]);
+});
+
+test("a failed snapshot fails once, with journeys legitimately skipped", () => {
+  const problems = verifyShardResults(
+    needsFixture({
+      snapshot: { result: "failure", outputs: {} },
+      "journey-fresh-app": { result: "skipped", outputs: {} },
+      "journey-presets": { result: "skipped", outputs: {} },
+    }),
+  );
+  assert.deepEqual(problems, ['snapshot: result "failure", expected "success"']);
+});
+
+test("a shard missing from needs is drift, not a pass", () => {
+  const needs = needsFixture();
+  delete needs["journey-presets"];
+  const problems = verifyShardResults(needs);
+  assert.deepEqual(problems, [
+    "journey-presets: missing from the aggregator's needs — ci.yml and verify-shard-results.mjs drifted",
+  ]);
+});
+
+test("a shard unknown to the expectations is drift, not a pass", () => {
+  const problems = verifyShardResults(
+    needsFixture({ rehearsal: { result: "success", outputs: {} } }),
+  );
+  assert.deepEqual(problems, [
+    "rehearsal: not covered by verify-shard-results.mjs — add an expectation",
+  ]);
+});


### PR DESCRIPTION
## Summary

Closes the wall-clock half of the CI cost discussion: `full-pr` spent ~8 of its 10–13 minutes in the serial `env -u CI` tail, whose tasks boot real instances, carry `cache: false`, and can never cache-skip — while the moon graph itself is already 0.6–0.8 min on the Depot remote cache. Parallelism was the only remaining lever, so the single job becomes shard jobs split by resource conflict:

- `graph` — PR-title check, CI-mode detection, `server:check-generate`, `moon ci :lint :typecheck :build :test :test-browser :check-adrs`, `server:test`, and the Postgres/Spanner integration suites (keeps the WIF `id-token` permission to itself).
- `snapshot` — `release:snapshot -- --skip-container` (or the version-PR validation path in version-only mode), uploading `dist/release` as the `release-snapshot` artifact.
- `journey-fresh-app` / `journey-presets` — fan out from `snapshot` via the artifact; the journey tasks dep only on `cli:build`/`testing:build`, so nothing rebuilds the release. `journey-presets` pairs the passkey-first preset with the test-kit consumer journey to balance the fresh-app shard (~2.7 vs ~2.5 min).
- `browser-e2e` — `testing:test-integration` + `demo-next-e2e:e2e-real`, then `console-e2e:e2e-real`; the console suite still runs after the demo suite on the same machine (embedded-Postgres contention), but no longer behind the journeys.
- `full-pr` — the unchanged required branch-protection context, now an aggregator: `scripts/verify-shard-results.mjs` fails it on any failed, cancelled, or wrongly-skipped shard, and on drift between the `needs:` list and the script's expectations (both directions, loud). Journey shards gate on the snapshot shard's detected mode, so version-only PRs skip them legitimately.

Expected critical path: setup + snapshot → fresh-app journey ≈ 5–6 min against the 10–13 min baseline. A flaky shard now fails alone and "re-run failed jobs" reruns only that shard. Fork PRs keep the GH-hosted-runner ternary on every shard; the aggregator runs on a plain runner and needs no install (script chain is node-builtins only).

Docs updated where the single-job layout was described (CONTRIBUTING `#what-ci-runs` as the canonical list — also fixing its stale claim that Spanner doesn't run in CI — plus pointer-level wording in README, AGENTS.md, and packages/testing/AGENTS.md).

## Validation

- `node --test scripts/verify-shard-results.test.mjs` — 9/9 pass.
- `moon run workspace:test` — the new task runs the same tests green through moon (it's matched by `:test` in the graph shard's `moon ci`).
- Fixture-ran `scripts/verify-shard-results.mjs` with full-green (exit 0) and failed/cancelled/skipped-journey fixtures (exit 1, named problems).
- YAML parse of `.github/workflows/ci.yml` and `moon.yml`.
- This PR's own CI run is the real proof: shard wall-clock vs the ~10–13 min baseline, and the `full-pr` aggregate going green. Timings will be posted in a comment after the run.
- Not run: a deliberately failing shard on this branch; the eject path is covered by the unit fixtures above.

## Release notes / changeset

- No changeset required — no shipped behavior changed (CI workflow, CI-glue scripts, and docs only).

## Notes

- The `merge_group` trigger, per-ref concurrency, and single required context are deliberately preserved: this is the groundwork for enabling the merge queue and dropping the strict up-to-date requirement afterwards.
- All shards stay on `depot-ubuntu-24.04-16`; right-sizing individual shards (the journeys likely don't need 16 cores) is a follow-up cost knob, kept out of this PR to avoid mixing a perf change into the split.
- Version-only PRs now spin up `graph`/`browser-e2e` runners that skip their steps (~2–3 wasted runner-minutes per changesets-PR update); acceptable until a cheap job-level gate exists that doesn't serialize the full-mode critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)