### PR TITLE
ci: gate full-mode tail steps on moon affected-task selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,23 +65,27 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: node scripts/check-pr-title.mjs --title "$PR_TITLE" --base "$BASE_SHA" --summary
 
+      # Emits `mode` plus per-lane affected gates (go_tests, snapshot,
+      # journeys, suites_*, browsers) computed from moon's affected task
+      # selection. Gates fail open — unclaimed files, empty diffs, and query
+      # failures all force a full run. Logic + tests: scripts/ci-mode.mjs.
       - name: Detect CI mode
         id: ci-mode
         run: node scripts/ci-mode.mjs "${{ github.event.pull_request.base.sha || 'origin/main' }}"
 
       - name: Check Go generated files
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.go_tests == 'true' }}
         run: moon run server:check-generate
 
       - name: Cache Playwright browsers
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.browsers == 'true' }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Playwright Chromium
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.browsers == 'true' }}
         run: corepack pnpm --filter @zitadel/components exec playwright install chromium
 
       - name: Run Moon build and test graph
@@ -94,11 +98,11 @@ jobs:
         run: node scripts/report-moon-failures.mjs
 
       - name: Run Go tests
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.go_tests == 'true' }}
         run: moon run server:test
 
       - name: Run Go integration tests (postgres)
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.go_tests == 'true' }}
         run: moon run server:test-postgres
 
       # Auth when SPANNER_TEST_INSTANCE is set (trusted runs). Vars are safe in
@@ -106,32 +110,34 @@ jobs:
       # Auth hard-fails if the var is set but WIF is broken (no silent fallback).
       - name: Authenticate to Google Cloud (Spanner test instance)
         id: spanner-auth
-        if: ${{ steps.ci-mode.outputs.mode == 'full' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && vars.SPANNER_TEST_INSTANCE != '' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.go_tests == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && vars.SPANNER_TEST_INSTANCE != '' }}
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Run Go integration tests (spanner emulator)
-        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.spanner-auth.outcome != 'success' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.go_tests == 'true' && steps.spanner-auth.outcome != 'success' }}
         run: moon run server:test-spanner
 
       - name: Run Go integration tests (spanner test instance)
-        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.spanner-auth.outcome == 'success' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.go_tests == 'true' && steps.spanner-auth.outcome == 'success' }}
         env:
           ZITADEL_TEST_SPANNER_INSTANCE: ${{ vars.SPANNER_TEST_INSTANCE }}
         run: moon run server:test-spanner
 
       - name: Run Go integration tests (sqlite)
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.go_tests == 'true' }}
         run: moon run server:test-sqlite
 
+      # The snapshot exists here to feed the journeys, so it shares their gate
+      # (the tarball handoff is a filesystem contract moon cannot see).
       - name: Build release snapshot without container
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.snapshot == 'true' }}
         run: env -u CI -u GITHUB_ACTIONS moon run release:snapshot -- --skip-container
 
       - name: Run binary fresh-app journey
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.journeys == 'true' }}
         run: |
           version="$(node -p "require('./apps/server/package.json').version")"
           env -u CI -u GITHUB_ACTIONS moon run cli-journey-e2e:e2e-local -- \
@@ -143,7 +149,7 @@ jobs:
       # One framework is enough here: the preset decides the scaffolded
       # flow shape, not the SDK — the matrix above already covers SDKs.
       - name: Run passkey-first preset journey
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.journeys == 'true' }}
         run: |
           version="$(node -p "require('./apps/server/package.json').version")"
           env -u CI -u GITHUB_ACTIONS moon run cli-journey-e2e:e2e-local -- \
@@ -158,7 +164,7 @@ jobs:
       # suite against the published binary — embedded UIs, no repo env
       # overrides (unlike the in-repo e2e-real lanes below).
       - name: Run test-kit consumer journey
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.journeys == 'true' }}
         run: |
           version="$(node -p "require('./apps/server/package.json').version")"
           env -u CI -u GITHUB_ACTIONS moon run cli-journey-e2e:e2e-testkit -- \
@@ -169,13 +175,13 @@ jobs:
       # then drive the real browser login with per-test users. Reuses the Go
       # build cache and Playwright Chromium installed above.
       - name: Run @zitadel/testing real-instance suites
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.suites_testing_demo == 'true' }}
         run: env -u CI -u GITHUB_ACTIONS moon run testing:test-integration demo-next-e2e:e2e-real
 
       # Dogfoods @zitadel/testing through a second consumer. Keep this separate
       # from the demo suite so two local-server instances do not contend.
       - name: Run console real-instance suite
-        if: ${{ steps.ci-mode.outputs.mode == 'full' }}
+        if: ${{ steps.ci-mode.outputs.mode == 'full' && steps.ci-mode.outputs.suites_console == 'true' }}
         run: env -u CI -u GITHUB_ACTIONS moon run console-e2e:e2e-real
 
       - name: Validate version PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,7 +259,7 @@ dependencies, then picks one of two modes via `scripts/ci-mode.mjs`:
 
 - `moon run server:check-generate` — Go generated-file drift check.
 - Playwright Chromium install for `@zitadel/components`.
-- `moon ci :lint :typecheck :build :test :test-browser`.
+- `moon ci :lint :typecheck :build :test :test-browser :check-adrs`.
 - `moon run server:test`, then `moon run server:test-postgres`,
   `moon run server:test-spanner` (Spanner emulator testcontainer, or a
   real instance when `SPANNER_TEST_INSTANCE` is set), and
@@ -267,8 +267,21 @@ dependencies, then picks one of two modes via `scripts/ci-mode.mjs`:
 - `moon run release:snapshot -- --skip-container` — a non-publishing release
   snapshot.
 - The fresh-app consumer journey (`cli-journey-e2e:e2e-local`) with the npm
-  binary runtime against the snapshot's packed tarballs, plus one
-  passkey-first preset journey run.
+  binary runtime against the snapshot's packed tarballs, one passkey-first
+  preset journey run, and the test-kit consumer journey
+  (`cli-journey-e2e:e2e-testkit`).
+- The real-instance suites: `testing:test-integration` with
+  `demo-next-e2e:e2e-real`, then `console-e2e:e2e-real`.
+
+Within full mode, the steps after the `moon ci` graph are additionally gated
+by moon's affected task selection (`moon query tasks --affected --downstream
+deep`, computed in `scripts/ci-mode.mjs`): a lane is skipped when the diff
+provably cannot reach its tasks — a docs-only PR runs almost nothing, a
+frontend-only PR skips the Go suites. The gates fail open: files no moon task
+claims (workflow definitions, `scripts/`, moon config, root manifests), an
+empty diff, or a failed query all force the complete run. The journeys and
+the snapshot share one gate because the tarball handoff between them is a
+filesystem contract moon cannot see.
 
 **Version-only mode** (Changesets version PRs) runs `release:version`,
 `release:pack`, and tarball verification instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,10 +277,14 @@ Within full mode, the steps after the `moon ci` graph are additionally gated
 by moon's affected task selection (`moon query tasks --affected --downstream
 deep`, computed in `scripts/ci-mode.mjs`): a lane is skipped when the diff
 provably cannot reach its tasks — a docs-only PR runs almost nothing, a
-frontend-only PR skips the Go suites. The gates fail open: files no moon task
-claims (workflow definitions, `scripts/`, moon config, root manifests), an
-empty diff, or a failed query all force the complete run. The journeys and
-the snapshot share one gate because the tarball handoff between them is a
+frontend-only PR skips the Go suites. The gates fail open: known repo-wide
+files no moon task claims (workflow definitions, `scripts/`, moon config,
+root manifests and compiler/release inputs such as `tsconfig.base.json`), an
+empty diff, or a failed query all force the complete run — and when the
+query returns an empty affected set, the run is only skipped if every
+changed file is on a narrow explicitly-inert allowlist (`docs/`, root agent
+notes), because unclaimed files are not assumed inert. The journeys and the
+snapshot share one gate because the tarball handoff between them is a
 filesystem contract moon cannot see.
 
 **Version-only mode** (Changesets version PRs) runs `release:version`,

--- a/moon.yml
+++ b/moon.yml
@@ -43,6 +43,18 @@ tasks:
       cache: false
       runInCI: false
 
+  # Matched by the `:test` target in the ci workflow's `moon ci` call, so the
+  # affected-gate logic never becomes a test file nothing executes.
+  test:
+    command: "node --test scripts/ci-mode.test.mjs"
+    inputs:
+      - "scripts/ci-mode.mjs"
+      - "scripts/ci-mode.test.mjs"
+      - "scripts/dev-process.mjs"
+    options:
+      cache: true
+      runInCI: true
+
   check-typecheck:
     script: "node --test scripts/check-typecheck-programs.test.mjs && node scripts/check-typecheck-programs.mjs"
     inputs:

--- a/scripts/ci-mode.mjs
+++ b/scripts/ci-mode.mjs
@@ -2,22 +2,122 @@
 import { appendFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
-const base = process.argv[2] || "origin/main";
-const result = spawnSync("git", ["diff", "--name-only", `${base}...HEAD`], {
-  encoding: "utf8",
-});
+import { isDirectRun } from "./dev-process.mjs";
 
-if (result.status !== 0) {
-  process.stderr.write(result.stderr);
-  process.exit(result.status ?? 1);
+// Decides what the ci workflow runs, in two layers:
+//
+// 1. `mode` — `version-only` for Changesets version PRs, else `full`.
+// 2. Affected gates — within full mode, the expensive tail steps (Go suites,
+//    release snapshot, journeys, real-instance e2e) are skipped when moon's
+//    affected task selection proves the change cannot reach them. Selection
+//    uses `moon query tasks --affected --downstream deep`: the deep dependent
+//    walk is what makes multi-hop chains (console → server:build → e2e
+//    suites) select correctly — `moon ci`'s own selection only marks direct
+//    dependents, which is not enough here.
+//
+// The gates fail open: files no task claims (workflow definitions, scripts/,
+// moon config, root manifests) force a full run, an empty diff forces a full
+// run, and a failing or unparsable query forces a full run. A gate may only
+// ever skip work that provably cannot be affected.
+
+// Files whose effects moon cannot see (nothing lists them as task inputs).
+// Any touched file matching here disables all gating for the run.
+const FORCE_FULL_PREFIXES = [".github/", ".moon/", "scripts/"];
+const FORCE_FULL_FILES = new Set([
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  ".nvmrc",
+  ".changeset/config.json",
+]);
+
+// Workflow steps run fixed targets, so gates are membership checks on the
+// affected set. Journeys and the snapshot are coupled both ways: the journeys
+// consume the snapshot's tarballs through the filesystem (no moon dep edge
+// exists), so either being affected must run both.
+const GO_TEST_TARGETS = [
+  "server:check-generate",
+  "server:test",
+  "server:test-postgres",
+  "server:test-spanner",
+  "server:test-sqlite",
+];
+const TESTING_DEMO_TARGETS = ["testing:test-integration", "demo-next-e2e:e2e-real"];
+const CONSOLE_E2E_TARGET = "console-e2e:e2e-real";
+const SNAPSHOT_TARGET = "release:snapshot";
+const JOURNEY_PROJECT_PREFIX = "cli-journey-e2e:";
+
+const ALL_GATES = ["go_tests", "snapshot", "journeys", "suites_testing_demo", "suites_console", "browsers"];
+
+export function computeMode(files) {
+  return files.length > 0 && files.every(isVersionOutputFile) ? "version-only" : "full";
 }
 
-const files = result.stdout.split(/\r?\n/).filter(Boolean);
-const mode = files.length > 0 && files.every(isVersionOutputFile) ? "version-only" : "full";
+export function forceFullReason(files) {
+  if (files.length === 0) {
+    return "empty diff";
+  }
+  const trigger = files.find(
+    (file) =>
+      FORCE_FULL_PREFIXES.some((prefix) => file.startsWith(prefix)) ||
+      FORCE_FULL_FILES.has(file) ||
+      file.split("/").at(-1) === "moon.yml",
+  );
+  return trigger ? `unclaimed file ${trigger}` : null;
+}
 
-console.log(`mode=${mode}`);
-if (process.env.GITHUB_OUTPUT) {
-  appendFileSync(process.env.GITHUB_OUTPUT, `mode=${mode}\n`);
+/**
+ * Compute the step gates for a run. `targets` is the affected task set
+ * (`project:task` strings) from moon, or null when the query failed —
+ * which fails open.
+ */
+export function resolveGates({ mode, files, targets }) {
+  if (mode === "version-only") {
+    return { gates: Object.fromEntries(ALL_GATES.map((g) => [g, false])), reason: "version-only" };
+  }
+  const forced = forceFullReason(files) ?? (targets === null ? "affected query failed" : null);
+  if (forced) {
+    return { gates: Object.fromEntries(ALL_GATES.map((g) => [g, true])), reason: forced };
+  }
+  const set = new Set(targets);
+  const journeys =
+    targets.some((t) => t.startsWith(JOURNEY_PROJECT_PREFIX)) || set.has(SNAPSHOT_TARGET);
+  const suitesTestingDemo = TESTING_DEMO_TARGETS.some((t) => set.has(t));
+  const suitesConsole = set.has(CONSOLE_E2E_TARGET);
+  const gates = {
+    go_tests: GO_TEST_TARGETS.some((t) => set.has(t)),
+    // The snapshot exists in PR CI to feed the journeys, so the gates are one.
+    snapshot: journeys,
+    journeys,
+    suites_testing_demo: suitesTestingDemo,
+    suites_console: suitesConsole,
+    browsers:
+      suitesTestingDemo ||
+      suitesConsole ||
+      journeys ||
+      targets.some((t) => t.endsWith(":test-browser")),
+  };
+  return { gates, reason: null };
+}
+
+export function queryAffectedTargets(base, spawn = spawnSync) {
+  const result = spawn("moon", ["query", "tasks", "--affected", "--downstream", "deep"], {
+    encoding: "utf8",
+    env: { ...process.env, MOON_BASE: base },
+  });
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr ?? "");
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(result.stdout);
+    const tasks = parsed?.tasks ?? {};
+    return Object.entries(tasks).flatMap(([project, projectTasks]) =>
+      Object.keys(projectTasks).map((task) => `${project}:${task}`),
+    );
+  } catch {
+    return null;
+  }
 }
 
 function isVersionOutputFile(file) {
@@ -27,4 +127,42 @@ function isVersionOutputFile(file) {
     file.startsWith(".changeset/") ||
     file.endsWith("/package.json") ||
     file.endsWith("/CHANGELOG.md");
+}
+
+function main() {
+  const base = process.argv[2] || "origin/main";
+  const diff = spawnSync("git", ["diff", "--name-only", `${base}...HEAD`], {
+    encoding: "utf8",
+  });
+  if (diff.status !== 0) {
+    process.stderr.write(diff.stderr);
+    process.exit(diff.status ?? 1);
+  }
+  const files = diff.stdout.split(/\r?\n/).filter(Boolean);
+  const mode = computeMode(files);
+
+  const needsQuery = mode === "full" && forceFullReason(files) === null;
+  const targets = needsQuery ? queryAffectedTargets(base) : [];
+  const { gates, reason } = resolveGates({ mode, files, targets });
+
+  const lines = [`mode=${mode}`, ...ALL_GATES.map((g) => `${g}=${gates[g]}`)];
+  for (const line of lines) {
+    console.log(line);
+  }
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, lines.join("\n") + "\n");
+  }
+  const skipped = ALL_GATES.filter((g) => !gates[g]);
+  if (process.env.GITHUB_STEP_SUMMARY && mode === "full") {
+    const note = reason
+      ? `CI gating: full run (${reason}).`
+      : skipped.length === 0
+        ? "CI gating: all lanes affected."
+        : `CI gating: skipped by affected-selection: ${skipped.join(", ")}.`;
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, note + "\n");
+  }
+}
+
+if (isDirectRun(import.meta.url)) {
+  main();
 }

--- a/scripts/ci-mode.mjs
+++ b/scripts/ci-mode.mjs
@@ -110,8 +110,13 @@ export function queryAffectedTargets(base, spawn = spawnSync) {
     return null;
   }
   try {
-    const parsed = JSON.parse(result.stdout);
-    const tasks = parsed?.tasks ?? {};
+    const tasks = JSON.parse(result.stdout)?.tasks;
+    // An empty `tasks` object is a legitimate answer (a diff no task claims,
+    // e.g. a runbook edit) and gates everything off. A missing or non-object
+    // `tasks` key means the output schema changed under us — fail open.
+    if (typeof tasks !== "object" || tasks === null || Array.isArray(tasks)) {
+      return null;
+    }
     return Object.entries(tasks).flatMap(([project, projectTasks]) =>
       Object.keys(projectTasks).map((task) => `${project}:${task}`),
     );

--- a/scripts/ci-mode.mjs
+++ b/scripts/ci-mode.mjs
@@ -15,13 +15,19 @@ import { isDirectRun } from "./dev-process.mjs";
 //    suites) select correctly — `moon ci`'s own selection only marks direct
 //    dependents, which is not enough here.
 //
-// The gates fail open: files no task claims (workflow definitions, scripts/,
-// moon config, root manifests) force a full run, an empty diff forces a full
-// run, and a failing or unparsable query forces a full run. A gate may only
-// ever skip work that provably cannot be affected.
+// The gates fail open: known repo-wide files no task claims (workflow
+// definitions, scripts/, moon config, root manifests and compiler/release
+// inputs) force a full run, an empty diff forces a full run, a failing or
+// unparsable query forces a full run, and an empty affected set forces a
+// full run unless every changed file is on the explicit inert allowlist —
+// unclaimed files are not assumed inert. A gate may only ever skip work
+// that provably cannot be affected.
 
-// Files whose effects moon cannot see (nothing lists them as task inputs).
-// Any touched file matching here disables all gating for the run.
+// Files whose effects moon cannot see (nothing lists them as task inputs)
+// but which reach builds, tests, or release artifacts anyway. Any touched
+// file matching here disables all gating for the run — even when the rest
+// of the diff produced a non-empty affected set, because moon's answer says
+// nothing about these files.
 const FORCE_FULL_PREFIXES = [".github/", ".moon/", "scripts/"];
 const FORCE_FULL_FILES = new Set([
   "package.json",
@@ -29,7 +35,29 @@ const FORCE_FULL_FILES = new Set([
   "pnpm-workspace.yaml",
   ".nvmrc",
   ".changeset/config.json",
+  // Repo-wide compiler/release inputs no task claims: nearly every workspace
+  // tsconfig extends the base, and the release archives ship the root
+  // README/LICENSE files.
+  "tsconfig.base.json",
+  "LICENSE",
+  "LICENSING.md",
+  "README.md",
 ]);
+
+// The ONLY files allowed to produce a skip when moon claims nothing in the
+// diff. Unclaimed ≠ inert (tsconfig.base.json is unclaimed and breaks every
+// typecheck), so an empty affected set fails open unless every changed file
+// is on this list. Keep it narrow; growing it requires proving the file
+// reaches no build, test, or shipped artifact.
+const INERT_UNCLAIMED_PREFIXES = ["docs/"];
+const INERT_UNCLAIMED_FILES = new Set(["AGENTS.md", "CLAUDE.md"]);
+
+function isInertWhenUnclaimed(file) {
+  return (
+    INERT_UNCLAIMED_PREFIXES.some((prefix) => file.startsWith(prefix)) ||
+    INERT_UNCLAIMED_FILES.has(file)
+  );
+}
 
 // Workflow steps run fixed targets, so gates are membership checks on the
 // affected set. Journeys and the snapshot are coupled both ways: the journeys
@@ -75,7 +103,12 @@ export function resolveGates({ mode, files, targets }) {
   if (mode === "version-only") {
     return { gates: Object.fromEntries(ALL_GATES.map((g) => [g, false])), reason: "version-only" };
   }
-  const forced = forceFullReason(files) ?? (targets === null ? "affected query failed" : null);
+  const forced =
+    forceFullReason(files) ??
+    (targets === null ? "affected query failed" : null) ??
+    (targets.length === 0 && !files.every(isInertWhenUnclaimed)
+      ? "empty affected set for files outside the inert allowlist"
+      : null);
   if (forced) {
     return { gates: Object.fromEntries(ALL_GATES.map((g) => [g, true])), reason: forced };
   }
@@ -111,9 +144,10 @@ export function queryAffectedTargets(base, spawn = spawnSync) {
   }
   try {
     const tasks = JSON.parse(result.stdout)?.tasks;
-    // An empty `tasks` object is a legitimate answer (a diff no task claims,
-    // e.g. a runbook edit) and gates everything off. A missing or non-object
-    // `tasks` key means the output schema changed under us — fail open.
+    // An empty `tasks` object is a valid query answer, but resolveGates only
+    // accepts it as a skip when every changed file is on the inert
+    // allowlist — unclaimed is not the same as inert. A missing or
+    // non-object `tasks` key means the output schema changed — fail open.
     if (typeof tasks !== "object" || tasks === null || Array.isArray(tasks)) {
       return null;
     }

--- a/scripts/ci-mode.test.mjs
+++ b/scripts/ci-mode.test.mjs
@@ -137,16 +137,33 @@ test("a failed affected query fails open", () => {
   assert.equal(reason, "affected query failed");
 });
 
-test("an empty affected set from a valid query legitimately gates everything off", () => {
-  // e.g. a runbook edit: claimed by no task, and inert by construction —
-  // the force-full globs are what bound the dangerous unclaimed families.
+test("an empty affected set skips only for allowlisted-inert files", () => {
+  for (const file of ["docs/runbooks/manual-release.md", "docs/design/notes.md", "AGENTS.md"]) {
+    const { gates, reason } = resolveGates({ mode: "full", files: [file], targets: [] });
+    assert.equal(reason, null, file);
+    assert.ok(allFalse(gates), file);
+  }
+});
+
+test("an empty affected set for unallowlisted files fails open (tsconfig.base.json repro)", () => {
+  // moon's input graph does not claim these, yet they reach typechecks and
+  // release archives — unclaimed is not inert.
+  for (const file of ["tsconfig.base.json", "LICENSE", "README.md", "VISION.md"]) {
+    const { gates } = resolveGates({ mode: "full", files: [file], targets: [] });
+    assert.ok(allTrue(gates), `${file} must force a full run on an empty set`);
+  }
+});
+
+test("known repo-wide inputs force full even when the rest of the diff is claimed", () => {
+  // Mixed diff: an ADR (claimed, selects check-adrs) plus tsconfig.base.json.
+  // The non-empty set must not mask the unclaimed dangerous file.
   const { gates, reason } = resolveGates({
     mode: "full",
-    files: ["docs/runbooks/manual-release.md"],
-    targets: [],
+    files: ["docs/adrs/001-server-cli-cobra-viper.md", "tsconfig.base.json"],
+    targets: DOCS_CLASS,
   });
-  assert.equal(reason, null);
-  assert.ok(allFalse(gates));
+  assert.ok(allTrue(gates));
+  assert.match(reason, /tsconfig\.base\.json/);
 });
 
 function fakeSpawn(result) {

--- a/scripts/ci-mode.test.mjs
+++ b/scripts/ci-mode.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { computeMode, forceFullReason, resolveGates } from "./ci-mode.mjs";
+import { computeMode, forceFullReason, queryAffectedTargets, resolveGates } from "./ci-mode.mjs";
 
 // Affected sets below are real `moon query tasks --affected --downstream deep`
 // results captured on 2026-08-03 (post-#665 main) for one representative
@@ -135,4 +135,39 @@ test("a failed affected query fails open", () => {
   });
   assert.ok(allTrue(gates));
   assert.equal(reason, "affected query failed");
+});
+
+test("an empty affected set from a valid query legitimately gates everything off", () => {
+  // e.g. a runbook edit: claimed by no task, and inert by construction —
+  // the force-full globs are what bound the dangerous unclaimed families.
+  const { gates, reason } = resolveGates({
+    mode: "full",
+    files: ["docs/runbooks/manual-release.md"],
+    targets: [],
+  });
+  assert.equal(reason, null);
+  assert.ok(allFalse(gates));
+});
+
+function fakeSpawn(result) {
+  return () => ({ status: 0, stdout: "", stderr: "", ...result });
+}
+
+test("queryAffectedTargets parses the grouped task map", () => {
+  const targets = queryAffectedTargets(
+    "HEAD",
+    fakeSpawn({ stdout: '{"tasks":{"server":{"test":{},"build":{}},"release":{"snapshot":{}}}}' }),
+  );
+  assert.deepEqual(targets?.sort(), ["release:snapshot", "server:build", "server:test"]);
+});
+
+test("queryAffectedTargets returns an empty set for an empty tasks map", () => {
+  assert.deepEqual(queryAffectedTargets("HEAD", fakeSpawn({ stdout: '{"tasks":{}}' })), []);
+});
+
+test("queryAffectedTargets fails open on schema drift, garbage output, and nonzero exits", () => {
+  assert.equal(queryAffectedTargets("HEAD", fakeSpawn({ stdout: '{"unexpected":true}' })), null);
+  assert.equal(queryAffectedTargets("HEAD", fakeSpawn({ stdout: '{"tasks":[1,2]}' })), null);
+  assert.equal(queryAffectedTargets("HEAD", fakeSpawn({ stdout: "not json" })), null);
+  assert.equal(queryAffectedTargets("HEAD", fakeSpawn({ status: 1, stderr: "boom" })), null);
 });

--- a/scripts/ci-mode.test.mjs
+++ b/scripts/ci-mode.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { computeMode, forceFullReason, resolveGates } from "./ci-mode.mjs";
+
+// Affected sets below are real `moon query tasks --affected --downstream deep`
+// results captured on 2026-08-03 (post-#665 main) for one representative
+// touched file per change class.
+
+const GO_CLASS = [
+  "console-e2e:e2e-real", "demo-next-e2e:e2e-real", "release:snapshot",
+  "server:build", "server:check-generate", "server:format", "server:generate",
+  "server:openapi", "server:test", "server:test-postgres", "server:test-spanner",
+  "server:test-sqlite", "server:vet", "testing:test-integration",
+];
+const DOCS_CLASS = ["workspace:check-adrs"];
+const JOURNEY_CLASS = [
+  "cli-journey-e2e:e2e", "cli-journey-e2e:e2e-local", "cli-journey-e2e:e2e-testkit",
+  "cli-journey-e2e:lint", "cli-journey-e2e:test",
+];
+const CONSOLE_CLASS = [
+  "console-e2e:e2e", "console-e2e:e2e-real", "console:build", "console:build-release",
+  "console:dev", "console:dev-real", "console:lint", "console:preview", "console:test",
+  "console:typecheck", "demo-next-e2e:e2e-real", "release:pack", "release:publish",
+  "release:snapshot", "server:build", "testing:test-integration",
+];
+const COMPONENTS_SLICE = ["components:build", "components:test-browser", "components:lint"];
+
+function allTrue(gates) {
+  return Object.values(gates).every(Boolean);
+}
+function allFalse(gates) {
+  return Object.values(gates).every((v) => v === false);
+}
+
+test("mode: changeset/version files only is version-only", () => {
+  assert.equal(computeMode([".changeset/x.md", "apps/server/package.json"]), "version-only");
+  assert.equal(computeMode([".changeset/x.md", "internal/a.go"]), "full");
+  assert.equal(computeMode([]), "full");
+});
+
+test("version-only mode turns every gate off", () => {
+  const { gates } = resolveGates({ mode: "version-only", files: [".changeset/x.md"], targets: [] });
+  assert.ok(allFalse(gates));
+});
+
+test("docs-only change gates everything off", () => {
+  const { gates, reason } = resolveGates({
+    mode: "full",
+    files: ["docs/adrs/001-server-cli-cobra-viper.md"],
+    targets: DOCS_CLASS,
+  });
+  assert.equal(reason, null);
+  assert.ok(allFalse(gates));
+});
+
+test("go change runs go suites, snapshot, journeys (via snapshot), and both suites", () => {
+  const { gates } = resolveGates({ mode: "full", files: ["internal/a.go"], targets: GO_CLASS });
+  assert.deepEqual(gates, {
+    go_tests: true,
+    snapshot: true,
+    journeys: true,
+    suites_testing_demo: true,
+    suites_console: true,
+    browsers: true,
+  });
+});
+
+test("journey-only change runs journeys and the snapshot that feeds them, nothing else", () => {
+  const { gates } = resolveGates({
+    mode: "full",
+    files: ["apps/cli-journey-e2e/src/user-journey.spec.ts"],
+    targets: JOURNEY_CLASS,
+  });
+  assert.deepEqual(gates, {
+    go_tests: false,
+    snapshot: true,
+    journeys: true,
+    suites_testing_demo: false,
+    suites_console: false,
+    browsers: true,
+  });
+});
+
+test("console change runs suites and snapshot-coupled journeys but no go suites", () => {
+  const { gates } = resolveGates({
+    mode: "full",
+    files: ["apps/console/src/api/zitadel.ts"],
+    targets: CONSOLE_CLASS,
+  });
+  assert.equal(gates.go_tests, false);
+  assert.equal(gates.suites_console, true);
+  assert.equal(gates.suites_testing_demo, true);
+  assert.equal(gates.journeys, true);
+  assert.equal(gates.snapshot, true);
+});
+
+test(":test-browser affectedness alone keeps the browser install", () => {
+  const { gates } = resolveGates({
+    mode: "full",
+    files: ["packages/components/src/atoms/index.ts"],
+    targets: COMPONENTS_SLICE,
+  });
+  assert.equal(gates.browsers, true);
+  assert.equal(gates.journeys, false);
+});
+
+test("unclaimed files force a full run", () => {
+  for (const file of [
+    ".github/workflows/ci.yml",
+    "scripts/ci-mode.mjs",
+    ".moon/workspace.yml",
+    "moon.yml",
+    "apps/server/moon.yml",
+    "pnpm-workspace.yaml",
+    ".nvmrc",
+  ]) {
+    assert.ok(forceFullReason([file]), `${file} should force full`);
+    const { gates } = resolveGates({ mode: "full", files: [file], targets: DOCS_CLASS });
+    assert.ok(allTrue(gates), `${file} should gate everything on`);
+  }
+});
+
+test("an empty diff forces a full run", () => {
+  const { gates, reason } = resolveGates({ mode: "full", files: [], targets: [] });
+  assert.ok(allTrue(gates));
+  assert.equal(reason, "empty diff");
+});
+
+test("a failed affected query fails open", () => {
+  const { gates, reason } = resolveGates({
+    mode: "full",
+    files: ["internal/a.go"],
+    targets: null,
+  });
+  assert.ok(allTrue(gates));
+  assert.equal(reason, "affected query failed");
+});


### PR DESCRIPTION
## Summary

Rung 1 of the CI-speed ladder: within full mode, the tail steps — Go suites, release snapshot, all three journeys, both real-instance e2e steps, and the Playwright install — are now gated on moon's affected task selection instead of running unconditionally. `scripts/ci-mode.mjs` computes per-lane gates from `moon query tasks --affected --downstream deep` (`MOON_BASE` = the PR base sha it already receives; the **deep** dependent walk is what resolves multi-hop chains like console → `server:build` → e2e suites, which `moon ci`'s own direct-only dependent marking would miss), and ci.yml consumes them as step conditions.

Measured class matrix behind the gate rules (lab on post-#665 main): docs-only selects exactly 1 task (`workspace:check-adrs`); journey-spec-only selects 5; go changes select the suites + snapshot through dependents; components selects 91 (correctly full). Net effect: docs/ADR-only PRs (~11% of the last 45 merges) drop from ~11 min to the graph + setup; frontend-only PRs skip the Go suites; go/mixed PRs are unchanged.

**Fail-open posture** — a gate may only skip work that provably cannot be affected:
- files no moon task claims (`.github/`, `scripts/`, `.moon/`, any `moon.yml`, root manifests) force the complete run
- an empty diff forces the complete run (workflow_dispatch on an unmodified branch)
- a failing or unparsable `moon query` forces the complete run, with a step-summary note
- journeys and the snapshot share one gate: the tarball handoff between them is a filesystem contract moon cannot see

Gate logic is a pure exported function; `workspace:test` (matched by `:test` in the existing `moon ci` call) runs its node-test suite so the logic is executed in CI, not just locally.

## Validation

- `node --test scripts/ci-mode.test.mjs` — 10/10 (fixtures are the real captured affected sets per change class).
- `moon run workspace:test` — same suite through moon, proving `:test` selection.
- Live smokes against real moon queries: implementation diff → force-full (all gates true); committed docs-only diff → all gates false; committed go diff → all gates true.
- YAML parse of ci.yml + moon.yml.
- This PR's own run force-fulls (it touches `scripts/` and `.github/`) — that is the safety rule working, and it doubles as a fresh post-#665 full-run baseline. The live skip demo is the stacked docs-only draft canary PR on this branch: its run should skip every gated lane.

## Release notes / changeset

- No changeset required — no shipped behavior changed (CI workflow + CI-glue script + docs).

## Notes

- Rung 2 (per-variant journey/suite gating with an explicit variant↔surface map) and rung 3 (affected-scoped framework matrix for the fresh-app journey) build on this same probe; deliberately not in this PR.
- Local direct runs of the probe against a shallow clone under-report (`moon query` sees an empty diff); CI checkouts use `fetch-depth: 0`, and the empty-diff case force-fulls anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)