### PR TITLE
docs: affected-gate canary (do not merge)

### DIFF
--- a/docs/adrs/001-server-cli-cobra-viper.md
+++ b/docs/adrs/001-server-cli-cobra-viper.md
@@ -62,3 +62,4 @@ In ZITADEL we started supporting native environment variables. For example the s
 
 1. We should ensure support for `OTEL_` variables in Nextgen.
 2. We should document support for `PG*` variables, which are consumed by [`pgconn.ParseConfig()`](http://pkg.go.dev/github.com/jackc/pgx/v5@v5.9.2/pgconn#ParseConfig), mimicking libpq behavior.
+


### PR DESCRIPTION
Draft canary stacked on #731: the diff against its base is one docs file, so the gated lanes (go suites, snapshot, journeys, real-instance suites, browser install) should all skip and the run should finish in ~2–3 min. Will be closed after the timing is recorded.