### PR TITLE
refactor: drive the account and pill gradients from Figma tokens

### DIFF
--- a/apps/console/src/components/app-shell/AppShell.tsx
+++ b/apps/console/src/components/app-shell/AppShell.tsx
@@ -185,7 +185,7 @@ function UserMenuItem({ user, onSignOut }: { user?: ShellUser; onSignOut?: () =>
           >
             <span
               aria-hidden
-              className="size-8 shrink-0 rounded-lg bg-[linear-gradient(232deg,#f25543_17%,#0f0f11_75%)]"
+              className="size-8 shrink-0 rounded-lg bg-[linear-gradient(232deg,var(--zl-gradient-red-start)_17%,var(--zl-gradient-base-end)_75%)]"
             />
             <span className="flex min-w-0 flex-1 flex-col gap-0.5 leading-none">
               <span className="truncate text-[14px] text-sidebar-foreground">{displayName}</span>

--- a/packages/shared-component-styles/src/pill.css
+++ b/packages/shared-component-styles/src/pill.css
@@ -15,8 +15,16 @@
   line-height: 1.25rem;
   letter-spacing: 0;
   text-transform: none;
+  /* Gradient stops come from Figma's `Gradient Colors` collection, which is
+     themed — so the pill's sheen now follows light mode instead of staying on
+     the dark values. `color-mix` applies the 0.6 alpha the design calls for,
+     which `rgb()` cannot do against a hex custom property. */
   background:
-    linear-gradient(182deg, rgb(72 74 87 / 0.6) 28.65%, rgb(15 15 17 / 0.6) 81.82%),
+    linear-gradient(
+      182deg,
+      color-mix(in srgb, var(--zl-gradient-neutral-start, #484a57) 60%, transparent) 28.65%,
+      color-mix(in srgb, var(--zl-gradient-base-end, #0f0f11) 60%, transparent) 81.82%
+    ),
     var(--zl-color-surface-default-primary-gray, #252528);
   color: var(--zl-color-text-primary-white, #f4f4f6);
   border: 1px solid var(--zl-color-border-default-gray-200, #484a57);


### PR DESCRIPTION
# Which Problems Are Solved

The console account swatch and the `<zl-pill>` sheen hand-copy the hex values of Figma's `Gradient Colors` collection, so they cannot follow the theme and drift whenever the collection changes.

# How the Problems Are Solved

- `AppShell.tsx` and `pill.css` reference `--zl-gradient-red-start`, `--zl-gradient-neutral-start` and `--zl-gradient-base-end` instead of literals.
- `pill.css` applies the design's 0.6 alpha with `color-mix`, since `rgb()` cannot take a hex custom property. First use of `color-mix` in this repo.

# Additional Changes

None. `layout-chrome.css` keeps its `--zl-color-icon-default-purple` / `-pink` references: the gradient collection has no equivalent pair, so swapping would change colours rather than tokenise them.

# Additional Context

Dark mode is unchanged — the resolved stops are byte-identical to the literals they replace (`#f25543` / `#0f0f11`, and `rgb(72 74 87 / .6)` / `rgb(15 15 17 / .6)`).

Light mode needs a design decision before this can merge. `--zl-gradient-base-end` is `#fafafa` in light, which is exactly `--zl-sidebar` (`#fafafa`), so the account swatch dissolves into the sidebar at its 75% stop. The pill sheen ends on `#fafafa` at 60% over a `#ffffff` pill surface, which is effectively invisible. Those light values read as a page-background fade for a large surface, not stops for a small chip that has to hold an edge.

Options: keep both second stops dark in all themes and leave them as literals, pair `--zl-gradient-red-start` with a stop that retains contrast in light, or accept the fade as intended.

Depends on #727, which is merged.