### PR TITLE
feat: collect nested user-schema fields by dotted path

### DIFF
--- a/.changeset/nested-user-schema-fields.md
+++ b/.changeset/nested-user-schema-fields.md
@@ -1,0 +1,16 @@
+---
+"@zitadel/server": minor
+"@zitadel/config": minor
+---
+
+Flow steps can now collect nested user-schema properties by their dotted path,
+for example `"fields": ["address.street"]`. The field renders like any other
+scalar input and its value is stored under the same `address.street` attribute
+key the user API already uses, so it reads back as a nested object.
+
+A nested field is only marked required when every object above it is required
+too, and a step that requires an object must now collect one of its leaves
+rather than the object itself. Naming an object- or array-typed property
+directly is rejected when the flow definition is saved instead of failing part
+way through the flow. Schema property names may no longer contain a dot, which
+would be indistinguishable from a nested path.

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -2890,8 +2890,9 @@ func (s *FactorMethod) UnmarshalText(data []byte) error {
 // Does not contain display text — only a `text_key` resolved client-side.
 // Ref: #
 type Field struct {
-	// Field name, matching a property in the flow's user schema. Carries
-	// the submitted value back to the engine.
+	// Field name, matching a property in the flow's user schema — a
+	// dotted path (`address.street`) for a nested property. Carries the
+	// submitted value back to the engine.
 	Name string `json:"name"`
 	// The input kind the client should render. Encodes the formats and
 	// JSON types that map to a familiar HTML input: `email`, `url`,
@@ -2902,7 +2903,8 @@ type Field struct {
 	// Localization key for the field label.
 	TextKey string `json:"text_key"`
 	// The field MUST be present and non-empty on submit. Mirrors the
-	// schema's top-level `required` array.
+	// schema's `required` array at every level of the field's path: a
+	// nested leaf is required only when each of its ancestors is too.
 	Required OptBool `json:"required"`
 	// Pre-filled value (e.g., an identifier carried over from a pivot).
 	Value jx.Raw `json:"value"`
@@ -3829,10 +3831,12 @@ type FlowDefinitionStep struct {
 	// and returned in the API response as `step.name`.
 	Name string `json:"name"`
 	// Schema property names to collect from the user. Each entry references
-	// a property in the flow's user schema. The engine resolves field type,
+	// a property in the flow's user schema, naming a nested one by its
+	// dotted path (`address.street`). The engine resolves field type,
 	// validation rules, and implicit outcomes from schema annotations
 	// (e.g. a property with `x-unique` set implies a `user_not_found`
-	// transition outcome).
+	// transition outcome). An object- or array-typed property has no
+	// field-shaped input: collect its leaves instead.
 	Fields []string `json:"fields"`
 	// Ordered list of actions the user can take. The action name is what the
 	// frontend sends back in the submit request. If omitted, the engine

--- a/api/openapi/components/flows/field.yaml
+++ b/api/openapi/components/flows/field.yaml
@@ -7,8 +7,9 @@ properties:
   name:
     type: string
     description: |
-      Field name, matching a property in the flow's user schema. Carries
-      the submitted value back to the engine.
+      Field name, matching a property in the flow's user schema — a
+      dotted path (`address.street`) for a nested property. Carries the
+      submitted value back to the engine.
     example: email
   type:
     type: string
@@ -28,7 +29,8 @@ properties:
     default: false
     description: |
       The field MUST be present and non-empty on submit. Mirrors the
-      schema's top-level `required` array.
+      schema's `required` array at every level of the field's path: a
+      nested leaf is required only when each of its ancestors is too.
   value:
     description: Pre-filled value (e.g., an identifier carried over from a pivot).
   validation:

--- a/api/openapi/components/flows/flow-definition-step.yaml
+++ b/api/openapi/components/flows/flow-definition-step.yaml
@@ -22,10 +22,12 @@ properties:
     type: array
     description: |
       Schema property names to collect from the user. Each entry references
-      a property in the flow's user schema. The engine resolves field type,
+      a property in the flow's user schema, naming a nested one by its
+      dotted path (`address.street`). The engine resolves field type,
       validation rules, and implicit outcomes from schema annotations
       (e.g. a property with `x-unique` set implies a `user_not_found`
-      transition outcome).
+      transition outcome). An object- or array-typed property has no
+      field-shaped input: collect its leaves instead.
     items:
       type: string
     default: []

--- a/api/openapi/endpoints/flow_definitions/examples/07-nested-profile-fields/README.md
+++ b/api/openapi/endpoints/flow_definitions/examples/07-nested-profile-fields/README.md
@@ -1,0 +1,68 @@
+# 07 — Nested Profile Fields
+
+Two-step signup that collects an object-typed schema property one leaf at a
+time. Credentials land on the first step, the `address` leaves on the second,
+and `on_success: create_user` writes the whole document at the end.
+
+## Capabilities exercised
+
+- **Nested properties by dotted path.** `address.street` addresses the `street`
+  property of the object-typed `address` property. The engine walks one
+  `properties` level per segment.
+- Ancestor-chain manifest: `create_user`'s manifest is `[identifier, password]`
+  and both are collected on `signup`, an upstream step, so the validator accepts
+  the writer on `address`.
+- Terminal `complete: show`.
+
+## Graph
+
+```mermaid
+flowchart TD
+    start([Start: purpose=register]) --> signup
+    signup["signup<br/>fields: email, password"]
+    address["address<br/>fields: address.street, address.city, address.zipCode<br/>on_success: create_user"]
+    done([done<br/>complete: show])
+
+    signup -- submit --> address
+    address -- submit --> done
+```
+
+## Walk-through
+
+1. `POST /flow` with `purpose: register` → engine returns the `signup` step.
+2. The user submits `email` and `password`.
+3. The `address` step renders **three ordinary text inputs**, named
+   `address.street`, `address.city`, and `address.zipCode`. A nested leaf is a
+   scalar, so it needs no new field type — the dotted name is the only
+   difference.
+4. The client submits them flat, keyed by those same names. The engine merges
+   them into a nested document:
+
+   ```json
+   { "email": "…", "address": { "street": "…", "city": "…", "zipCode": "…" } }
+   ```
+
+5. `on_success: create_user` validates that document against the user schema —
+   including `address`'s own `properties` — then stores one attribute per leaf,
+   keyed `address.street`, `address.city`, `address.zipCode`. Reading the user
+   back returns `address` as a nested object.
+
+## Notes
+
+- **The field path and the attribute key are the same string.** That is the
+  point of the dotted spelling: a step's `fields` entry, the wire field `name`,
+  the submitted key, and the stored attribute key never diverge.
+- **`required` is conjunctive over the chain.** A leaf is marked required only
+  when every object above it is required too. In the example schema `address`
+  is optional at the root, so these three leaves render optional even though
+  `address` lists `street` and `city` in its own `required` — which is exactly
+  what schema validation accepts for the document as a whole. Making `address`
+  required at the root would make `address.street` and `address.city` required
+  here, and the definition would be rejected if it collected neither.
+- **Name a leaf, never the object.** `"fields": ["address"]` is rejected when
+  the definition is saved: an object has no field-shaped input. The same holds
+  for an array-typed property.
+- A nested leaf may carry `x-unique`, which makes it an identifier field and
+  contributes the `user_not_found` / `user_already_exists` outcomes exactly as a
+  top-level one would. This example keeps its leaves plain so the graph stays
+  about nesting.

--- a/api/openapi/endpoints/flow_definitions/examples/07-nested-profile-fields/flow-definition.json
+++ b/api/openapi/endpoints/flow_definitions/examples/07-nested-profile-fields/flow-definition.json
@@ -1,0 +1,58 @@
+{
+  "project_id": "${PROJECT_ID}",
+  "schema_uri": "https://nextgen.com/flow-definition.json",
+  "flow_definition": {
+    "name": "nested-profile-register",
+    "status": "active",
+    "user_schema": "${USER_SCHEMA_URL}",
+    "purposes": {
+      "register": "signup"
+    },
+    "steps": [
+      {
+        "name": "signup",
+        "fields": [
+          "email",
+          "x-auth-methods#password"
+        ],
+        "actions": [
+          {
+            "name": "submit",
+            "kind": "submit",
+            "primary": true
+          }
+        ],
+        "transitions": {
+          "submit": {
+            "target": "address"
+          }
+        }
+      },
+      {
+        "name": "address",
+        "fields": [
+          "address.street",
+          "address.city",
+          "address.zipCode"
+        ],
+        "actions": [
+          {
+            "name": "submit",
+            "kind": "submit",
+            "primary": true
+          }
+        ],
+        "on_success": "create_user",
+        "transitions": {
+          "submit": {
+            "target": "done"
+          }
+        }
+      },
+      {
+        "name": "done",
+        "complete": "show"
+      }
+    ]
+  }
+}

--- a/api/openapi/endpoints/flow_definitions/examples/README.md
+++ b/api/openapi/endpoints/flow_definitions/examples/README.md
@@ -22,6 +22,7 @@ For the shape and validation rules, see
 | [04](./04-passkey-register/) | `register` | passkey | Passkey signup with provisional user finalized on verify. |
 | [05](./05-combined-login-register/) | `login` + `register` | password | Flip-table coverage between sub-flows. |
 | [06](./06-combined-password-passkey/) | `login` + `register` | password, passkey | Both methods on both purposes plus post-signup passkey upsell. |
+| [07](./07-nested-profile-fields/) | `register` | password | Nested schema properties collected by dotted path. |
 
 The existing `default-login-flow-definition.json` at the root of this folder is
 embedded by the server as the default project flow; it mirrors example 06 but
@@ -35,7 +36,9 @@ the properties present on the step — there is no step `type`:
 - A step with `fields` collects user input validated against the
   `user_schema`. Schema annotations (`x-unique`, `x-auth-methods`)
   and reserved credential field names (`x-auth-methods#<method>`)
-  drive implicit dispatch behavior at runtime.
+  drive implicit dispatch behavior at runtime. A nested property is named by
+  its dotted path (`address.street`) — the object itself has no field-shaped
+  input, so collect its leaves.
 - A step with `actions` exposes user-selectable buttons. Two action names are
   engine-handled — `passkey` (login) and `passkey_register` (signup) — and
   trigger the two-phase WebAuthn ceremony.

--- a/api/openapi/endpoints/flow_definitions/examples_test.go
+++ b/api/openapi/endpoints/flow_definitions/examples_test.go
@@ -35,7 +35,16 @@ var exampleUserSchema = []byte(`{
     "givenName":   { "type": "string" },
     "familyName":  { "type": "string" },
     "phoneNumber": { "type": "string" },
-    "dateOfBirth": { "type": "string", "format": "date" }
+    "dateOfBirth": { "type": "string", "format": "date" },
+    "address": {
+      "type": "object",
+      "required": ["street", "city"],
+      "properties": {
+        "street":  { "type": "string", "minLength": 1 },
+        "city":    { "type": "string", "minLength": 1 },
+        "zipCode": { "type": "string" }
+      }
+    }
   }
 }`)
 
@@ -67,6 +76,7 @@ func TestExampleFlowDefinitions(t *testing.T) {
 		{"04-passkey-register", "examples/04-passkey-register/flow-definition.json"},
 		{"05-combined-login-register", "examples/05-combined-login-register/flow-definition.json"},
 		{"06-combined-password-passkey", "examples/06-combined-password-passkey/flow-definition.json"},
+		{"07-nested-profile-fields", "examples/07-nested-profile-fields/flow-definition.json"},
 	}
 
 	for _, ex := range examples {

--- a/api/openapi/endpoints/schemas/flow-definition.json
+++ b/api/openapi/endpoints/schemas/flow-definition.json
@@ -151,7 +151,7 @@
               "password"
             ]
           ],
-          "description": "Schema property names to collect from the user on this step. Each entry must resolve to a property in the definition's `user_schema`, or use the reserved token `x-auth-methods#<method>` (e.g. `x-auth-methods#password`) to collect a credential proof for a method enabled at the schema root. The engine reads the schema's `x-*` annotations to derive: - field type and validation (rendered into the runtime payload), - implicit transition outcomes - e.g. a property with a non-empty `x-unique` scope makes `user_not_found` a valid `transitions` key on this step."
+          "description": "Schema property names to collect from the user on this step. Each entry must resolve to a property in the definition's `user_schema` — naming a nested property by its dotted path (`address.street`), since an object- or array-typed property has no field-shaped input — or use the reserved token `x-auth-methods#<method>` (e.g. `x-auth-methods#password`) to collect a credential proof for a method enabled at the schema root. The engine reads the schema's `x-*` annotations to derive: - field type and validation (rendered into the runtime payload), - implicit transition outcomes - e.g. a property with a non-empty `x-unique` scope makes `user_not_found` a valid `transitions` key on this step."
         },
         "actions": {
           "type": "array",

--- a/internal/domain/attribute.go
+++ b/internal/domain/attribute.go
@@ -82,31 +82,39 @@ func (attrs *Attributes) UnmarshalJSON(data []byte) error {
 func (attrs Attributes) ToMap() (map[string]any, error) {
 	tree := make(map[string]any)
 	for _, attr := range attrs {
-		keyNodes := attr.Key.Nodes()
-
-		subTree := tree
-		for len(keyNodes) > 1 {
-			// not a leaf node, traverse down the tree
-
-			var m map[string]any
-			v, ok := subTree[keyNodes[0]]
-			if !ok {
-				// nested map does not yet exist, create a new one
-				m = make(map[string]any)
-			} else if m, ok = v.(map[string]any); !ok {
-				// if the key overlaps with another value which is not an object, error to be sure
-				return nil, fmt.Errorf("the given key already exists in the map with a value which is not a map (%s)", keyNodes[0])
-			}
-
-			subTree[keyNodes[0]] = m
-			subTree = m
-			keyNodes = keyNodes[1:]
+		if err := setNested(tree, attr.Key, attr.Value); err != nil {
+			return nil, err
 		}
-
-		subTree[keyNodes[0]] = attr.Value
-
 	}
 	return tree, nil
+}
+
+// setNested writes value into tree at the dotted key, creating the
+// intermediate maps it descends through.
+func setNested(tree map[string]any, key AttributeKey, value any) error {
+	keyNodes := key.Nodes()
+
+	subTree := tree
+	for len(keyNodes) > 1 {
+		// not a leaf node, traverse down the tree
+
+		var m map[string]any
+		v, ok := subTree[keyNodes[0]]
+		if !ok {
+			// nested map does not yet exist, create a new one
+			m = make(map[string]any)
+		} else if m, ok = v.(map[string]any); !ok {
+			// if the key overlaps with another value which is not an object, error to be sure
+			return fmt.Errorf("the given key already exists in the map with a value which is not a map (%s)", keyNodes[0])
+		}
+
+		subTree[keyNodes[0]] = m
+		subTree = m
+		keyNodes = keyNodes[1:]
+	}
+
+	subTree[keyNodes[0]] = value
+	return nil
 }
 
 func (attrs Attributes) MarshalJSON() ([]byte, error) {

--- a/internal/domain/attribute_test.go
+++ b/internal/domain/attribute_test.go
@@ -238,6 +238,29 @@ func TestAttributes_ToMap(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "nested beyond one level",
+				attributes: Attributes{
+					{"email", "test@example.com"},
+					{"address.street", "main street"},
+					{"address.geo.latitude", 45.0},
+					{"address.geo.datum.reference.epsg", "EPSG:4326"},
+				},
+				expected: map[string]any{
+					"email": "test@example.com",
+					"address": map[string]any{
+						"street": "main street",
+						"geo": map[string]any{
+							"latitude": 45.0,
+							"datum": map[string]any{
+								"reference": map[string]any{
+									"epsg": "EPSG:4326",
+								},
+							},
+						},
+					},
+				},
+			},
 		}
 
 		for _, tc := range tcs {
@@ -249,6 +272,20 @@ func TestAttributes_ToMap(t *testing.T) {
 				assert.EqualValues(t, tc.expected, m)
 			})
 		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		// A scalar and a path descending through the same node cannot both
+		// be written: the second write would have to traverse into a string.
+		attrs := Attributes{
+			{"address", "main street"},
+			{"address.city", "examplus"},
+		}
+
+		_, err := attrs.ToMap()
+		assert.ErrorContains(t, err, "address")
 	})
 }
 

--- a/internal/domain/flow_definition_validator.go
+++ b/internal/domain/flow_definition_validator.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/ianlancetaylor/jsonschema"
 )
@@ -115,7 +116,7 @@ func resolveAllStepFields(schema *jsonschema.Schema, steps []FlowDefinitionStep)
 	}
 
 	// validate that all required fields in the schema are present in the flow definition
-	if err := validateRequiredUserSchemaFields(sr.RequiredSet(), steps); err != nil {
+	if err := validateRequiredUserSchemaFields(sr.RequiredLeafPaths(), steps); err != nil {
 		return nil, err
 	}
 
@@ -192,7 +193,18 @@ func validateRequiredUserSchemaFields(required map[string]struct{}, steps []Flow
 	}
 	missingFields := make([]string, 0, len(required))
 	for requiredField := range required {
-		if _, ok := fields[requiredField]; !ok {
+		// A required leaf is covered only by itself; a required object
+		// that declares no `required` of its own is covered by any field
+		// beneath it, since the object materializes once a child is
+		// collected.
+		covered := false
+		for f := range fields {
+			if f == requiredField || strings.HasPrefix(f, requiredField+".") {
+				covered = true
+				break
+			}
+		}
+		if !covered {
 			missingFields = append(missingFields, requiredField)
 		}
 	}

--- a/internal/domain/flow_definition_validator_test.go
+++ b/internal/domain/flow_definition_validator_test.go
@@ -1593,6 +1593,101 @@ func TestValidator_MissingRequiredUserSchemaFields(t *testing.T) {
 	assert.ErrorIs(t, err, domain.ErrFlowDefinitionInvalid(`required fields [first_name last_name] in user schema are missing in the flow definition steps`, nil))
 }
 
+// userSchemaRequiredNested makes `address` required and gives it a
+// required leaf of its own, so coverage has to be checked one level
+// down. `billing` is required but declares no `required`, so any leaf
+// beneath it covers the object.
+var userSchemaRequiredNested = []byte(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tenant.com/schemas/nested-user.json",
+  "type": "object",
+  "required": ["email", "address", "billing"],
+  "x-auth-methods": {
+    "password": { "enabled": true, "position": 0 }
+  },
+  "properties": {
+    "email": { "type": "string", "format": "email", "x-unique": "team" },
+    "address": {
+      "type": "object",
+      "required": ["street"],
+      "properties": {
+        "street": { "type": "string" },
+        "city": { "type": "string" }
+      }
+    },
+    "billing": {
+      "type": "object",
+      "properties": { "vat_id": { "type": "string" } }
+    }
+  }
+}`)
+
+// nestedRequiredFlow builds a login flow whose profile step collects the
+// given fields, so cases vary only by what the step declares.
+func nestedRequiredFlow(fields []domain.Field) domain.FlowDefinition {
+	return domain.FlowDefinition{
+		ProjectID: "p", Name: "f", SchemaVersion: "1",
+		UserSchema: "https://tenant.com/schemas/nested-user.json",
+		Purposes:   map[domain.FlowDefinitionPurpose]string{domain.FlowDefinitionPurposeLogin: "identifier"},
+		Steps: []domain.FlowDefinitionStep{
+			{
+				Name: "identifier", Fields: []domain.Field{"email"},
+				Actions: []domain.FlowStepAction{
+					{Name: "submit", Kind: domain.FlowActionKindSubmit, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{"submit": {Target: "profile"}},
+			},
+			{
+				Name: "profile", Fields: fields,
+				Actions: []domain.FlowStepAction{
+					{Name: "submit", Kind: domain.FlowActionKindSubmit, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{"submit": {Target: "done"}},
+			},
+			{Name: "done", Complete: new(domain.FlowStepCompleteShow)},
+		},
+	}
+}
+
+func TestValidator_RequiredNestedUserSchemaFields(t *testing.T) {
+	schema := mustSchema(t, userSchemaRequiredNested)
+
+	t.Run("nested required leaf satisfies coverage", func(t *testing.T) {
+		_, err := domain.ValidateFlowDefinition(schema, nestedRequiredFlow(
+			[]domain.Field{"address.street", "billing.vat_id"},
+		))
+		require.NoError(t, err)
+	})
+
+	t.Run("missing nested required leaf is reported by its path", func(t *testing.T) {
+		_, err := domain.ValidateFlowDefinition(schema, nestedRequiredFlow(
+			[]domain.Field{"address.city", "billing.vat_id"},
+		))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrFlowDefinitionInvalid(
+			`required fields [address.street] in user schema are missing in the flow definition steps`, nil))
+	})
+
+	t.Run("required object without its own required is covered by any leaf", func(t *testing.T) {
+		_, err := domain.ValidateFlowDefinition(schema, nestedRequiredFlow(
+			[]domain.Field{"address.street"},
+		))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrFlowDefinitionInvalid(
+			`required fields [billing] in user schema are missing in the flow definition steps`, nil))
+	})
+
+	// Naming the object itself used to resolve as a text input and only
+	// fail once the user submitted it, at create_user.
+	t.Run("naming the object itself is rejected at definition time", func(t *testing.T) {
+		_, err := domain.ValidateFlowDefinition(schema, nestedRequiredFlow(
+			[]domain.Field{"address", "address.street", "billing.vat_id"},
+		))
+		require.Error(t, err)
+		assert.Contains(t, errorDetails(t, err), domain.ErrFlowFieldNotScalar.Error())
+	})
+}
+
 // ---- Passkey action enablement ----
 
 // passkeyActionFlow builds a minimal login flow whose entry step offers

--- a/internal/domain/flow_field_resolver.go
+++ b/internal/domain/flow_field_resolver.go
@@ -50,7 +50,8 @@ type FlowResolvedFields struct {
 
 // FlowField is the resolved per-field metadata.
 type FlowField struct {
-	// Name is the user-schema property name this field collects.
+	// Name is the user-schema property this field collects, as a dotted
+	// path for a nested property (`address.street`).
 	Name string
 
 	// Type is the UI input kind the client should render. It is
@@ -64,7 +65,10 @@ type FlowField struct {
 	// `field.email`). Resolved client-side via the `| t` filter.
 	TextKey string
 
-	// Required reflects membership in the schema's top-level `required` array.
+	// Required reflects membership in the schema's `required` array at
+	// every level of the field's path: a nested leaf is required only
+	// when each of its ancestors is required too, matching what schema
+	// validation accepts for the document as a whole.
 	Required bool
 
 	// Value is an optional pre-fill (e.g. an identifier carried over
@@ -268,3 +272,9 @@ var ErrFlowFieldUnknown = errors.New("flow field: not a property in the user sch
 // reduced to X and does not trigger this error; any other multi-entry
 // union does.
 var ErrFlowFieldUnsupportedType = errors.New("flow field: unsupported JSON type")
+
+// ErrFlowFieldNotScalar is returned by [FlowFieldResolver.Resolve] when a
+// field names an object- or array-typed property. An object is collected
+// one leaf at a time through its dotted path (`address.street`); an array
+// has no field-shaped input.
+var ErrFlowFieldNotScalar = errors.New("flow field: not a scalar property, name a nested leaf instead")

--- a/internal/domain/flow_field_resolver_schema.go
+++ b/internal/domain/flow_field_resolver_schema.go
@@ -26,7 +26,8 @@ type SchemaResolver interface {
 // Translation map (user meta-schema → [FlowField]):
 //
 //   - `type` + `format` → [FlowFieldType]
-//   - top-level `required` membership → [FlowField.Required]
+//   - `required` membership at every level of the field's path →
+//     [FlowField.Required]
 //   - `minLength`, `maxLength`, `format` → [FlowFieldValidation]
 //   - `x-unique` (non-empty) → [FlowFieldChallengeIdentifier] +
 //     [FlowImplicitOutcomeUserNotFound] + [FlowField.Unique]
@@ -43,8 +44,6 @@ var _ FlowFieldResolver = (*SchemaFieldResolver)(nil)
 
 func (r *SchemaFieldResolver) Resolve(schema *jsonschema.Schema, stepName string, fieldNames []Field) (FlowResolvedFields, error) {
 	root := newSchemaReader(schema)
-	properties := root.Properties()
-	required := root.RequiredSet()
 	authMethods, err := root.AuthMethods()
 	if err != nil {
 		return FlowResolvedFields{}, fmt.Errorf("flow field resolver: read x-auth-methods: %w", err)
@@ -62,7 +61,7 @@ func (r *SchemaFieldResolver) Resolve(schema *jsonschema.Schema, stepName string
 		case field.IsAuthMethod():
 			ff, err = resolveAuthMethodField(authMethods, field, stepName)
 		default:
-			ff, err = resolveUserPropertyField(properties, required, field, stepName)
+			ff, err = resolveUserPropertyField(root, field, stepName)
 		}
 		if err != nil {
 			return FlowResolvedFields{}, err
@@ -79,17 +78,19 @@ func (r *SchemaFieldResolver) Resolve(schema *jsonschema.Schema, stepName string
 	}, nil
 }
 
-// resolveUserPropertyField builds a [FlowField] from a top-level
-// property of the user schema. Returns [ErrFlowFieldUnknown] when the
-// property is absent, [ErrFlowFieldUnsupportedType] when the JSON
-// `type` keyword is an ambiguous union.
-func resolveUserPropertyField(properties map[string]schemaReader, required map[string]struct{}, field Field, stepName string) (FlowField, error) {
-	prop, ok := properties[field.String()]
-	if !ok {
-		return FlowField{}, fmt.Errorf("%w: %q", ErrFlowFieldUnknown, field.String())
+// resolveUserPropertyField builds a [FlowField] from a property of the
+// user schema, addressed by its dotted path. Returns
+// [ErrFlowFieldUnknown] when the path does not resolve,
+// [ErrFlowFieldNotScalar] when it lands on an object or array, and
+// [ErrFlowFieldUnsupportedType] when the JSON `type` keyword is an
+// ambiguous union.
+func resolveUserPropertyField(root schemaReader, field Field, stepName string) (FlowField, error) {
+	prop, required, err := walkUserProperty(root, field)
+	if err != nil {
+		return FlowField{}, err
 	}
 
-	fieldType, err := deriveUserPropertyType(prop)
+	fieldType, err := deriveUserPropertyType(prop, field)
 	if err != nil {
 		return FlowField{}, err
 	}
@@ -102,14 +103,37 @@ func resolveUserPropertyField(properties map[string]schemaReader, required map[s
 		Type:      fieldType,
 		Challenge: deriveIdentifierChallenge(unique),
 		Unique:    unique,
-	}
-	if _, ok := required[field.String()]; ok {
-		ff.Required = true
+		Required:  required,
 	}
 	if v := buildValidation(prop); v != nil {
 		ff.Validation = v
 	}
 	return ff, nil
+}
+
+// walkUserProperty resolves a field's dotted path against the user
+// schema, descending one `properties` level per segment, and reports
+// whether every segment is listed in its own level's `required`. A
+// missing segment — or an intermediate one that holds no `properties`,
+// so the path cannot continue through it — yields
+// [ErrFlowFieldUnknown] naming the whole path.
+func walkUserProperty(root schemaReader, field Field) (schemaReader, bool, error) {
+	segments := AttributeKey(field.String()).Nodes()
+	parent, required := root, true
+	for i, segment := range segments {
+		prop, ok := parent.Properties()[segment]
+		if !ok {
+			return schemaReader{}, false, fmt.Errorf("%w: %q", ErrFlowFieldUnknown, field.String())
+		}
+		if _, ok := parent.RequiredSet()[segment]; !ok {
+			required = false
+		}
+		if i < len(segments)-1 && prop.Properties() == nil {
+			return schemaReader{}, false, fmt.Errorf("%w: %q", ErrFlowFieldUnknown, field.String())
+		}
+		parent = prop
+	}
+	return parent, required, nil
 }
 
 // resolveAuthMethodField builds a [FlowField] from an
@@ -144,11 +168,17 @@ func resolveAuthMethodField(authMethods xAuthMethodsReader, field Field, stepNam
 // JSON `type` keywords to a [FlowFieldType]. A closed `enum` surfaces
 // as `select`; JSON `type: boolean` surfaces as `checkbox`. Returns
 // [ErrFlowFieldUnsupportedType] when the JSON `type` is an ambiguous
-// union the resolver cannot reduce to a single kind.
-func deriveUserPropertyType(prop schemaReader) (FlowFieldType, error) {
+// union the resolver cannot reduce to a single kind, and
+// [ErrFlowFieldNotScalar] when the property has no field-shaped input.
+func deriveUserPropertyType(prop schemaReader, field Field) (FlowFieldType, error) {
 	jsonType, err := prop.JSONType()
 	if err != nil {
 		return "", err
+	}
+	// A property carrying `properties` is an object even when it omits
+	// the `type` keyword, which would otherwise fall through to text.
+	if jsonType == "object" || jsonType == "array" || prop.Properties() != nil {
+		return "", fmt.Errorf("%w: %q", ErrFlowFieldNotScalar, field.String())
 	}
 	if len(prop.StringEnum()) > 0 {
 		return FlowFieldTypeSelect, nil
@@ -355,7 +385,7 @@ func (r schemaReader) Properties() map[string]schemaReader {
 	return out
 }
 
-// RequiredSet returns the names listed in the top-level `required`
+// RequiredSet returns the names listed in this level's `required`
 // keyword as a set.
 func (r schemaReader) RequiredSet() map[string]struct{} {
 	out := map[string]struct{}{}
@@ -371,6 +401,30 @@ func (r schemaReader) RequiredSet() map[string]struct{} {
 		out[n] = struct{}{}
 	}
 	return out
+}
+
+// RequiredLeafPaths returns the dotted paths a document must carry:
+// every name in `required`, recursed through the nested `required` of
+// each required object. A required object that declares no `required`
+// of its own ends the descent at the object itself — any leaf beneath
+// it satisfies the coverage check.
+func (r schemaReader) RequiredLeafPaths() map[string]struct{} {
+	out := map[string]struct{}{}
+	r.collectRequiredLeafPaths("", out)
+	return out
+}
+
+func (r schemaReader) collectRequiredLeafPaths(prefix AttributeKey, out map[string]struct{}) {
+	properties := r.Properties()
+	for name := range r.RequiredSet() {
+		path := prefix.AppendNode(name)
+		prop, ok := properties[name]
+		if !ok || len(prop.RequiredSet()) == 0 {
+			out[string(path)] = struct{}{}
+			continue
+		}
+		prop.collectRequiredLeafPaths(path, out)
+	}
 }
 
 // AuthMethods returns a reader over the root schema's `x-auth-methods`

--- a/internal/domain/flow_field_resolver_schema_test.go
+++ b/internal/domain/flow_field_resolver_schema_test.go
@@ -65,6 +65,27 @@ const defaultSchemaContent string = `{
 		}
 	}`
 
+// nestedSchemaContent carries an object property whose leaves cover the
+// nested cases: a required leaf, an optional leaf, and one keyed with
+// x-unique.
+const nestedSchemaContent string = `{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type": "object",
+		"required": ["email", "address"],
+		"properties": {
+			"email": { "type": "string", "format": "email", "x-unique": "team" },
+			"address": {
+				"type": "object",
+				"required": ["street"],
+				"properties": {
+					"street": { "type": "string", "minLength": 1 },
+					"city":   { "type": "string" },
+					"zip":    { "type": "string", "x-unique": "project" }
+				}
+			}
+		}
+	}`
+
 // identifierOutcomes is what an x-unique field contributes to
 // ImplicitOutcomes — pinned here so cases stay readable.
 var identifierOutcomes = []string{
@@ -409,6 +430,110 @@ func TestSchemaFieldResolver_Resolve(t *testing.T) {
 			step:    "step",
 			fields:  []domain.Field{"either"},
 			wantErr: domain.ErrFlowFieldUnsupportedType,
+		},
+		{
+			name:   "nested leaf resolves through its dotted path",
+			schema: nestedSchemaContent,
+			step:   "profile",
+			fields: []domain.Field{"address.street"},
+			want: domain.FlowResolvedFields{
+				Fields: []domain.FlowField{
+					{
+						Name:       "address.street",
+						TextKey:    "profile.field.address.street",
+						Type:       domain.FlowFieldTypeText,
+						Required:   true,
+						Validation: &domain.FlowFieldValidation{MinLength: 1},
+					},
+				},
+				ImplicitOutcomes: map[string][]string{},
+			},
+		},
+		{
+			name:   "x-unique on a nested leaf makes it an identifier",
+			schema: nestedSchemaContent,
+			step:   "profile",
+			fields: []domain.Field{"address.zip"},
+			want: domain.FlowResolvedFields{
+				Fields: []domain.FlowField{
+					{
+						Name:      "address.zip",
+						TextKey:   "profile.field.address.zip",
+						Type:      domain.FlowFieldTypeText,
+						Challenge: domain.FlowFieldChallengeIdentifier,
+						Unique:    domain.AttributeUniquenessProject,
+					},
+				},
+				ImplicitOutcomes: map[string][]string{"address.zip": identifierOutcomes},
+			},
+		},
+		{
+			name: "nested leaf under an optional parent is not required",
+			schema: `{
+				"type": "object",
+				"properties": {
+					"address": {
+						"type": "object",
+						"required": ["street"],
+						"properties": { "street": { "type": "string" } }
+					}
+				}
+			}`,
+			step:   "profile",
+			fields: []domain.Field{"address.street"},
+			want: domain.FlowResolvedFields{
+				Fields: []domain.FlowField{
+					{
+						Name:    "address.street",
+						TextKey: "profile.field.address.street",
+						Type:    domain.FlowFieldTypeText,
+					},
+				},
+				ImplicitOutcomes: map[string][]string{},
+			},
+		},
+		{
+			name:    "object-typed property is not collectable",
+			schema:  nestedSchemaContent,
+			step:    "profile",
+			fields:  []domain.Field{"address"},
+			wantErr: domain.ErrFlowFieldNotScalar,
+		},
+		{
+			name: "property carrying properties but no type is not collectable",
+			schema: `{
+				"type": "object",
+				"properties": {
+					"address": { "properties": { "street": { "type": "string" } } }
+				}
+			}`,
+			step:    "profile",
+			fields:  []domain.Field{"address"},
+			wantErr: domain.ErrFlowFieldNotScalar,
+		},
+		{
+			name: "array-typed property is not collectable",
+			schema: `{
+				"type": "object",
+				"properties": { "tags": { "type": "array" } }
+			}`,
+			step:    "profile",
+			fields:  []domain.Field{"tags"},
+			wantErr: domain.ErrFlowFieldNotScalar,
+		},
+		{
+			name:    "unknown nested leaf returns ErrFlowFieldUnknown",
+			schema:  nestedSchemaContent,
+			step:    "profile",
+			fields:  []domain.Field{"address.country"},
+			wantErr: domain.ErrFlowFieldUnknown,
+		},
+		{
+			name:    "path through a scalar intermediate returns ErrFlowFieldUnknown",
+			schema:  nestedSchemaContent,
+			step:    "profile",
+			fields:  []domain.Field{"email.domain"},
+			wantErr: domain.ErrFlowFieldUnknown,
 		},
 	}
 

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/zitadel/nextgen/internal/maputil"
 )
 
 // Step error text keys the state machine emits when an auth-attempt
@@ -1235,7 +1237,7 @@ func prefillFromCollected(resolved *FlowResolvedFields, collected map[string]any
 		if resolved.Fields[i].Value != nil {
 			continue
 		}
-		if v, ok := collected[resolved.Fields[i].Name].(string); ok && v != "" {
+		if v, ok := maputil.GetNested[string](collected, resolved.Fields[i].Name); ok && v != "" {
 			val := v
 			resolved.Fields[i].Value = &val
 		}
@@ -1263,7 +1265,12 @@ func mergeCollected(state *FlowState, fields map[string]any) error {
 			return fmt.Errorf("unknown auth method %s", k)
 		}
 
-		state.CollectedData.UserData[k] = v
+		// Field names are dotted paths for nested properties, so the
+		// collected document keeps the shape the user schema validates
+		// and the attribute store flattens back out.
+		if err := setNested(state.CollectedData.UserData, AttributeKey(k), v); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1277,7 +1284,7 @@ func FindCollectedFieldByChallenge(resolved []FlowField, collected map[string]an
 		if f.Challenge != target {
 			continue
 		}
-		if v, present := collected[f.Name]; present {
+		if v, present := maputil.GetNested[any](collected, f.Name); present {
 			return f.Name, f, v, true
 		}
 	}

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -2768,7 +2768,13 @@ const nestedProfileSchemaContent string = `{
 			"type": "object",
 			"properties": {
 				"street": { "type": "string" },
-				"city":   { "type": "string" }
+				"city":   { "type": "string" },
+				"geo": {
+					"type": "object",
+					"properties": {
+						"label": { "type": "string" }
+					}
+				}
 			}
 		}
 	}
@@ -2786,7 +2792,7 @@ func nestedProfileDefinition() *domain.FlowDefinition {
 		Steps: []domain.FlowDefinitionStep{
 			{
 				Name:   "profile",
-				Fields: []domain.Field{"email", "address.street", "address.city"},
+				Fields: []domain.Field{"email", "address.street"},
 				Actions: []domain.FlowStepAction{
 					{Name: domain.FlowActionSubmit, Kind: domain.FlowActionKindSubmit, Primary: true},
 				},
@@ -2796,7 +2802,7 @@ func nestedProfileDefinition() *domain.FlowDefinition {
 			},
 			{
 				Name:   "confirm",
-				Fields: []domain.Field{"address.street"},
+				Fields: []domain.Field{"address.street", "address.city", "address.geo.label"},
 				Actions: []domain.FlowStepAction{
 					{Name: domain.FlowActionSubmit, Kind: domain.FlowActionKindSubmit, Primary: true},
 				},
@@ -2844,7 +2850,6 @@ func TestFlowStateMachine_CollectsNestedFieldsAsADocument(t *testing.T) {
 		Fields: map[string]any{
 			"email":          "alice@example.com",
 			"address.street": "Main Street 1",
-			"address.city":   "Zurich",
 		},
 	})
 	require.NoError(t, err)
@@ -2854,7 +2859,6 @@ func TestFlowStateMachine_CollectsNestedFieldsAsADocument(t *testing.T) {
 	address, ok := res.State.CollectedData.UserData["address"].(map[string]any)
 	require.True(t, ok, "dotted fields must merge into a nested object")
 	assert.Equal(t, "Main Street 1", address["street"])
-	assert.Equal(t, "Zurich", address["city"])
 	assert.Equal(t, "alice@example.com", res.State.CollectedData.UserData["email"])
 
 	// A later step collecting the same leaf pre-fills it from the nested
@@ -2864,6 +2868,28 @@ func TestFlowStateMachine_CollectsNestedFieldsAsADocument(t *testing.T) {
 	require.NotNil(t, confirmStreet)
 	require.NotNil(t, confirmStreet.Value, "nested leaf must prefill from collected data")
 	assert.Equal(t, "Main Street 1", *confirmStreet.Value)
+
+	// A second step writing different leaves of the same object merges into
+	// the map already in state instead of replacing it, and a leaf more than
+	// one level down builds the intermediate objects it descends through.
+	final, err := w.sm.Process(t.Context(), def, res.State, domain.FlowSubmitInput{
+		Action: domain.FlowActionSubmit,
+		Fields: map[string]any{
+			"address.street":    "Main Street 1",
+			"address.city":      "Zurich",
+			"address.geo.label": "downtown",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"email": "alice@example.com",
+		"address": map[string]any{
+			"street": "Main Street 1",
+			"city":   "Zurich",
+			"geo":    map[string]any{"label": "downtown"},
+		},
+	}, final.State.CollectedData.UserData)
 }
 
 func TestFlowStateMachine_Back_DropsPendingChallenge(t *testing.T) {

--- a/internal/domain/flow_state_machine_test.go
+++ b/internal/domain/flow_state_machine_test.go
@@ -2754,6 +2754,118 @@ func TestFlowStateMachine_Back_PreservesCollectedData(t *testing.T) {
 	}
 }
 
+// nestedProfileSchemaContent pairs with nestedProfileDefinition: a
+// required identifier plus an object property whose leaves the flow
+// collects by dotted path.
+const nestedProfileSchemaContent string = `{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"type": "object",
+	"x-auth-methods": { "password": { "enabled": true } },
+	"required": ["email"],
+	"properties": {
+		"email": { "type": "string", "format": "email", "x-unique": "team" },
+		"address": {
+			"type": "object",
+			"properties": {
+				"street": { "type": "string" },
+				"city":   { "type": "string" }
+			}
+		}
+	}
+}`
+
+func nestedProfileDefinition() *domain.FlowDefinition {
+	show := domain.FlowStepCompleteShow
+	return &domain.FlowDefinition{
+		ProjectID:  testProjectID,
+		ID:         "def-nested-profile",
+		UserSchema: defaultSchemaURL,
+		Purposes: map[domain.FlowDefinitionPurpose]string{
+			domain.FlowDefinitionPurposeRegister: "profile",
+		},
+		Steps: []domain.FlowDefinitionStep{
+			{
+				Name:   "profile",
+				Fields: []domain.Field{"email", "address.street", "address.city"},
+				Actions: []domain.FlowStepAction{
+					{Name: domain.FlowActionSubmit, Kind: domain.FlowActionKindSubmit, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{
+					domain.FlowActionSubmit: {Target: "confirm"},
+				},
+			},
+			{
+				Name:   "confirm",
+				Fields: []domain.Field{"address.street"},
+				Actions: []domain.FlowStepAction{
+					{Name: domain.FlowActionSubmit, Kind: domain.FlowActionKindSubmit, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{
+					domain.FlowActionSubmit: {Target: "done"},
+				},
+			},
+			{Name: "done", Complete: &show},
+		},
+	}
+}
+
+func TestFlowStateMachine_CollectsNestedFieldsAsADocument(t *testing.T) {
+	t.Parallel()
+	w := newFlowTestWorld(t)
+	def := nestedProfileDefinition()
+
+	w.schemaResolver.EXPECT().
+		Resolve(gomock.Any(), gomock.Any(), gomock.Any(), defaultSchemaURL, gomock.Any()).
+		Return(mustUnmarshal[jsonschema.Schema](t, nestedProfileSchemaContent), nil).
+		AnyTimes()
+	w.authAttemptService.EXPECT().Start(gomock.Any(), gomock.Any()).Return("att-1", nil)
+	// No existing user for the identifier, so registration proceeds.
+	w.authAttemptService.EXPECT().
+		SubmitIdentifier(gomock.Any(), gomock.Any()).
+		Return("", domain.ErrAuthAttemptProofRejected(nil)).
+		AnyTimes()
+
+	start, err := w.sm.Start(t.Context(), domain.FlowStartInput{
+		Definition:    def,
+		Purpose:       domain.FlowDefinitionPurposeRegister,
+		Session:       domain.FlowSessionRef{ID: "sess-1", Version: 1},
+		UserSchemaURL: defaultSchemaURL,
+	})
+	require.NoError(t, err)
+
+	// A nested leaf renders as an ordinary scalar field named by its path.
+	streetField := findFieldByName(start.Step.Fields, "address.street")
+	require.NotNil(t, streetField)
+	assert.Equal(t, domain.FlowFieldTypeText, streetField.Type)
+	assert.False(t, streetField.Required, "leaf under an optional parent is not required")
+
+	res, err := w.sm.Process(t.Context(), def, start.State, domain.FlowSubmitInput{
+		Action: domain.FlowActionSubmit,
+		Fields: map[string]any{
+			"email":          "alice@example.com",
+			"address.street": "Main Street 1",
+			"address.city":   "Zurich",
+		},
+	})
+	require.NoError(t, err)
+
+	// The collected document keeps the shape the user schema validates,
+	// so it can be handed to create_user as-is.
+	address, ok := res.State.CollectedData.UserData["address"].(map[string]any)
+	require.True(t, ok, "dotted fields must merge into a nested object")
+	assert.Equal(t, "Main Street 1", address["street"])
+	assert.Equal(t, "Zurich", address["city"])
+	assert.Equal(t, "alice@example.com", res.State.CollectedData.UserData["email"])
+
+	// A later step collecting the same leaf pre-fills it from the nested
+	// document rather than retyping.
+	require.Equal(t, "confirm", res.Step.Name)
+	confirmStreet := findFieldByName(res.Step.Fields, "address.street")
+	require.NotNil(t, confirmStreet)
+	require.NotNil(t, confirmStreet.Value, "nested leaf must prefill from collected data")
+	assert.Equal(t, "Main Street 1", *confirmStreet.Value)
+}
+
 func TestFlowStateMachine_Back_DropsPendingChallenge(t *testing.T) {
 	t.Parallel()
 	w := newFlowTestWorld(t)

--- a/internal/domain/json_schema.go
+++ b/internal/domain/json_schema.go
@@ -81,6 +81,10 @@ func NewJSONSchema(projectID string, schemabs []byte) (_ *JSONSchema, err error)
 		}
 	}
 
+	if err := rejectDottedPropertyNames(schema); err != nil {
+		return nil, err
+	}
+
 	var objectType *string
 	if ot, ok := maputil.Get[string](schema, "objectType"); ok {
 		objectType = &ot
@@ -93,6 +97,31 @@ func NewJSONSchema(projectID string, schemabs []byte) (_ *JSONSchema, err error)
 		CreatedAt:  time.Now().UTC(),
 		Schema:     schemabs,
 	}, nil
+}
+
+// rejectDottedPropertyNames walks the schema's nested `properties` and
+// rejects a name holding a dot. Nested values are keyed by their dotted
+// path in the attribute store and addressed by that same path in a flow
+// step's fields, so `{"a.b": …}` and `{"a": {"b": …}}` would be
+// indistinguishable in both places.
+func rejectDottedPropertyNames(schema map[string]any) error {
+	props, ok := maputil.Get[map[string]any](schema, "properties")
+	if !ok {
+		return nil
+	}
+	for name, prop := range props {
+		if strings.Contains(name, ".") {
+			return ErrJSONSchemaInvalid().WithMessage(fmt.Sprintf("schema property %q cannot contain a dot", name))
+		}
+		sub, ok := prop.(map[string]any)
+		if !ok {
+			continue
+		}
+		if err := rejectDottedPropertyNames(sub); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 //go:generate go tool mockgen -typed -package domainmock -destination ./mock/json_schema.mock.go . JSONSchemaStore

--- a/internal/domain/json_schema_test.go
+++ b/internal/domain/json_schema_test.go
@@ -474,6 +474,47 @@ func TestNewJSONSchema_ReservedProperties(t *testing.T) {
 		}
 	})
 
+	// A nested value is keyed by its dotted path in the attribute store and
+	// addressed by that same path in a flow step's fields, so a literal dot
+	// in a property name would be indistinguishable from nesting.
+	t.Run("dotted property names", func(t *testing.T) {
+		t.Run("rejected", func(t *testing.T) {
+			tests := []struct {
+				name    string
+				schema  string
+				message string
+			}{
+				{
+					name:    "at the top level",
+					schema:  `{"type":"object","properties":{"address.street":{"type":"string"}}}`,
+					message: `schema property "address.street" cannot contain a dot`,
+				},
+				{
+					name:    "inside a nested object",
+					schema:  `{"type":"object","properties":{"address":{"type":"object","properties":{"zip.code":{"type":"string"}}}}}`,
+					message: `schema property "zip.code" cannot contain a dot`,
+				},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					schema, err := domain.NewJSONSchema(projectID, []byte(tt.schema))
+					require.Error(t, err)
+					assert.Nil(t, schema)
+					assert.ErrorIs(t, err, domain.ErrJSONSchemaInvalid())
+					assert.EqualError(t, err, tt.message)
+				})
+			}
+		})
+
+		t.Run("an ordinary nested schema is accepted", func(t *testing.T) {
+			const content = `{"type":"object","properties":{"address":{"type":"object","properties":{"street":{"type":"string"}}}}}`
+			schema, err := domain.NewJSONSchema(projectID, []byte(content))
+			require.NoError(t, err)
+			require.NotNil(t, schema)
+		})
+	})
+
 	t.Run("a reserved key with a null value is not rejected", func(t *testing.T) {
 		// Characterisation test, not an endorsement: maputil.Get[any] reports a
 		// JSON null as absent, because a type assertion on a nil interface

--- a/internal/service/flow_create_user_for_passkey_handler_test.go
+++ b/internal/service/flow_create_user_for_passkey_handler_test.go
@@ -23,7 +23,14 @@ const passkeyHandlerTestSchema = `{
 	"properties": {
 		"email": {"type": "string", "format": "email", "x-unique": "project"},
 		"givenName": {"type": "string"},
-		"familyName": {"type": "string"}
+		"familyName": {"type": "string"},
+		"address": {
+			"type": "object",
+			"properties": {
+				"street": {"type": "string"},
+				"zipCode": {"type": "string", "x-unique": "project"}
+			}
+		}
 	}
 }`
 
@@ -145,6 +152,41 @@ func TestFlowCreateUserForPasskey_PersistsAllCollectedSchemaFields(t *testing.T)
 	familyAttr, ok := captured.Attributes.Get("familyName")
 	assert.True(t, ok, "attributes must contain familyName key")
 	assert.Equal(t, "Doe", familyAttr.Value)
+}
+
+// Spans the whole nested path: the state machine leaves UserData nested,
+// NewCreateUser validates it against the object-typed property, and the
+// attribute store flattens each leaf back to its dotted key.
+func TestFlowCreateUserForPasskey_PersistsNestedSchemaFields(t *testing.T) {
+	f := newPasskeyHandlerFixture(t)
+	expectSchemaLookup(f)
+
+	var captured *domain.CreateUser
+	expectCreateUserTx(f, func(_ context.Context, u *domain.CreateUser) error {
+		captured = u
+		return nil
+	})
+
+	state := passkeyFlowState(map[string]any{
+		"email": "alice@example.com",
+		"address": map[string]any{
+			"street":  "Main Street 1",
+			"zipCode": "8001",
+		},
+	})
+
+	err := f.handler.CreateProvisionalUser(t.Context(), "user_1", state)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	streetAttr, ok := captured.Attributes.Get("address.street")
+	assert.True(t, ok, "nested leaf must flatten to its dotted attribute key")
+	assert.Equal(t, "Main Street 1", streetAttr.Value)
+
+	zipAttr, ok := captured.Attributes.Get("address.zipCode")
+	assert.True(t, ok, "attributes must contain address.zipCode key")
+	assert.Equal(t, "8001", zipAttr.Value)
+	assert.Equal(t, domain.AttributeUniquenessProject, zipAttr.UniqueScope, "x-unique on a nested leaf must carry through")
 }
 
 func TestFlowCreateUserForPasskey_UserAlreadyExistsIsSilent(t *testing.T) {

--- a/packages/config/meta-schemas/flow-definition.json
+++ b/packages/config/meta-schemas/flow-definition.json
@@ -151,7 +151,7 @@
               "password"
             ]
           ],
-          "description": "Schema property names to collect from the user on this step. Each entry must resolve to a property in the definition's `user_schema`, or use the reserved token `x-auth-methods#<method>` (e.g. `x-auth-methods#password`) to collect a credential proof for a method enabled at the schema root. The engine reads the schema's `x-*` annotations to derive: - field type and validation (rendered into the runtime payload), - implicit transition outcomes - e.g. a property with a non-empty `x-unique` scope makes `user_not_found` a valid `transitions` key on this step."
+          "description": "Schema property names to collect from the user on this step. Each entry must resolve to a property in the definition's `user_schema` — naming a nested property by its dotted path (`address.street`), since an object- or array-typed property has no field-shaped input — or use the reserved token `x-auth-methods#<method>` (e.g. `x-auth-methods#password`) to collect a credential proof for a method enabled at the schema root. The engine reads the schema's `x-*` annotations to derive: - field type and validation (rendered into the runtime payload), - implicit transition outcomes - e.g. a property with a non-empty `x-unique` scope makes `user_not_found` a valid `transitions` key on this step."
         },
         "actions": {
           "type": "array",

--- a/packages/config/src/normalize.test.ts
+++ b/packages/config/src/normalize.test.ts
@@ -75,6 +75,34 @@ describe("normalizeSchemaBody", () => {
     });
   });
 
+  // A leaf of an object property normalizes the same way a top-level one
+  // does, or its defaults would read as a permanent diff.
+  it("strips defaults from nested properties too", () => {
+    const normalized = normalizeSchemaBody({
+      properties: {
+        address: {
+          type: "object",
+          "x-editable": true,
+          properties: {
+            street: { type: "string", "x-editable": true, "x-sensitive": false },
+            city: { type: "string", "x-sensitive": true },
+          },
+        },
+      },
+    });
+    expect(normalized).toEqual({
+      properties: {
+        address: {
+          type: "object",
+          properties: {
+            street: { type: "string" },
+            city: { type: "string", "x-sensitive": true },
+          },
+        },
+      },
+    });
+  });
+
   it("keeps non-default values, including non-boolean x-mfa", () => {
     const body = {
       properties: {

--- a/packages/config/src/normalize.ts
+++ b/packages/config/src/normalize.ts
@@ -84,10 +84,20 @@ export function normalizeFlowBody(body: object): object {
  */
 export function normalizeSchemaBody(body: object): object {
   const result = structuredClone(body) as Record<string, unknown>;
-  if (!isPlainObject(result.properties)) {
-    return result;
+  stripPropertyDefaults(result);
+  return result;
+}
+
+/**
+ * Strip {@link USER_PROPERTY_DEFAULTS} from every property of an object
+ * schema, descending into nested `properties` so a leaf of an object
+ * property normalizes the same way a top-level one does.
+ */
+function stripPropertyDefaults(schema: Record<string, unknown>): void {
+  if (!isPlainObject(schema.properties)) {
+    return;
   }
-  for (const property of Object.values(result.properties)) {
+  for (const property of Object.values(schema.properties)) {
     if (!isPlainObject(property)) {
       continue;
     }
@@ -96,6 +106,6 @@ export function normalizeSchemaBody(body: object): object {
         delete property[key];
       }
     }
+    stripPropertyDefaults(property);
   }
-  return result;
 }

--- a/packages/config/src/validate.test.ts
+++ b/packages/config/src/validate.test.ts
@@ -333,6 +333,77 @@ describe("schema-dependent rules", () => {
     );
   });
 
+  // A nested property is addressed by the same dotted path the attribute
+  // store keys it under (walkUserProperty in the Go resolver).
+  describe("nested properties", () => {
+    const nested = () => {
+      const withNested = structuredClone(schema);
+      (withNested.properties as Record<string, unknown>).address = {
+        type: "object",
+        required: ["street"],
+        properties: {
+          street: { type: "string" },
+          city: { type: "string" },
+        },
+      };
+      return withNested;
+    };
+
+    it("accepts a nested leaf addressed by its dotted path", () => {
+      const def = flow();
+      step(def, "register").fields.push("address.street");
+      expect(messages(validateFlowDefinition(def, nested()))).not.toContain(
+        'step "register": flow field: not a property in the user schema: "address.street"',
+      );
+    });
+
+    it("rejects an unknown nested leaf", () => {
+      const def = flow();
+      step(def, "register").fields.push("address.country");
+      expect(messages(validateFlowDefinition(def, nested()))).toContain(
+        'step "register": flow field: not a property in the user schema: "address.country"',
+      );
+    });
+
+    it("rejects a path through a scalar intermediate", () => {
+      const def = flow();
+      step(def, "register").fields.push("email.domain");
+      expect(messages(validateFlowDefinition(def, nested()))).toContain(
+        'step "register": flow field: not a property in the user schema: "email.domain"',
+      );
+    });
+
+    it("rejects naming the object itself", () => {
+      const def = flow();
+      step(def, "register").fields.push("address");
+      expect(messages(validateFlowDefinition(def, nested()))).toContain(
+        'step "register": flow field: not a scalar property, name a nested leaf instead: "address"',
+      );
+    });
+
+    it("demands a required object's required leaf by its path", () => {
+      const withRequired = nested();
+      withRequired.required = ["address"];
+      const def = flow();
+      step(def, "identifier").fields = ["email"];
+      step(def, "register").fields = ["email"];
+      expect(messages(validateFlowDefinition(def, withRequired))).toContain(
+        "required fields [address.street] in user schema are missing in the flow definition steps",
+      );
+    });
+
+    it("covers a required object without its own required by any leaf beneath it", () => {
+      const withRequired = nested();
+      delete (withRequired.properties as Record<string, Record<string, unknown>>).address.required;
+      withRequired.required = ["address"];
+      const def = flow();
+      step(def, "register").fields.push("address.city");
+      expect(messages(validateFlowDefinition(def, withRequired))).not.toContain(
+        "required fields [address] in user schema are missing in the flow definition steps",
+      );
+    });
+  });
+
   it("rejects an ambiguous JSON type union but accepts the nullable idiom", () => {
     const withUnions = structuredClone(schema);
     (withUnions.properties as Record<string, unknown>).mixed = { type: ["string", "number"] };

--- a/packages/config/src/validate.test.ts
+++ b/packages/config/src/validate.test.ts
@@ -393,8 +393,14 @@ describe("schema-dependent rules", () => {
     });
 
     it("covers a required object without its own required by any leaf beneath it", () => {
-      const withRequired = nested();
-      delete (withRequired.properties as Record<string, Record<string, unknown>>).address.required;
+      const withRequired = structuredClone(schema);
+      (withRequired.properties as Record<string, unknown>).address = {
+        type: "object",
+        properties: {
+          street: { type: "string" },
+          city: { type: "string" },
+        },
+      };
       withRequired.required = ["address"];
       const def = flow();
       step(def, "register").fields.push("address.city");

--- a/packages/config/src/validate.ts
+++ b/packages/config/src/validate.ts
@@ -595,8 +595,8 @@ function resolveFieldChallenge(
   const segments = field.split(".");
   let property: unknown = undefined;
   let level: Record<string, unknown> | undefined = properties;
-  for (let i = 0; i < segments.length; i++) {
-    property = level?.[segments[i]];
+  for (const [i, segment] of segments.entries()) {
+    property = level?.[segment];
     if (property === undefined) {
       return { message: `flow field: not a property in the user schema: ${q(field)}` };
     }

--- a/packages/config/src/validate.ts
+++ b/packages/config/src/validate.ts
@@ -539,6 +539,27 @@ function schemaRequired(schema: Record<string, unknown>): string[] {
   return Array.isArray(schema.required) ? schema.required.map(str).filter((n) => n !== "") : [];
 }
 
+/**
+ * Mirrors `schemaReader.RequiredLeafPaths`: every name in `required`,
+ * recursed through the nested `required` of each required object. A
+ * required object declaring no `required` of its own ends the descent at
+ * the object itself.
+ */
+function requiredLeafPaths(schema: Record<string, unknown>, prefix = ""): string[] {
+  const properties = schemaProperties(schema);
+  const out: string[] = [];
+  for (const name of schemaRequired(schema)) {
+    const path = prefix === "" ? name : `${prefix}.${name}`;
+    const property = properties?.[name];
+    if (!isPlainObject(property) || schemaRequired(property).length === 0) {
+      out.push(path);
+      continue;
+    }
+    out.push(...requiredLeafPaths(property, path));
+  }
+  return out;
+}
+
 /** Mirrors `xAuthMethodsReader.IsEnabled` in flow_field_resolver_schema.go. */
 function authMethodEnabled(schema: Record<string, unknown>, method: string): boolean {
   if (!isPlainObject(schema["x-auth-methods"])) return false;
@@ -569,12 +590,38 @@ function resolveFieldChallenge(
     return { challenge: "password" };
   }
 
-  const property = properties[field];
-  if (property === undefined) {
-    return { message: `flow field: not a property in the user schema: ${q(field)}` };
+  // Mirrors walkUserProperty: a nested property is addressed by its
+  // dotted path, descending one `properties` level per segment.
+  const segments = field.split(".");
+  let property: unknown = undefined;
+  let level: Record<string, unknown> | undefined = properties;
+  for (let i = 0; i < segments.length; i++) {
+    property = level?.[segments[i]];
+    if (property === undefined) {
+      return { message: `flow field: not a property in the user schema: ${q(field)}` };
+    }
+    const nested = isPlainObject(property) ? schemaProperties(property) : undefined;
+    if (i < segments.length - 1 && nested === undefined) {
+      return { message: `flow field: not a property in the user schema: ${q(field)}` };
+    }
+    level = nested;
   }
+
   if (!isPlainObject(property)) {
     return { challenge: null };
+  }
+
+  // Mirrors deriveUserPropertyType: an object or array has no
+  // field-shaped input. A property carrying `properties` is an object
+  // even when it omits the `type` keyword.
+  if (
+    property.type === "object" ||
+    property.type === "array" ||
+    schemaProperties(property) !== undefined
+  ) {
+    return {
+      message: `flow field: not a scalar property, name a nested leaf instead: ${q(field)}`,
+    };
   }
 
   // Mirrors schemaReader.JSONType: the nullable idiom `["null", X]`
@@ -613,8 +660,13 @@ function validateAgainstSchema(def: FlowDef, schema: object): FlowValidationIssu
       collected.add(field);
     }
   }
-  const missing = schemaRequired(raw)
-    .filter((field) => !collected.has(field))
+  // A required leaf is covered only by itself; a required object that
+  // declares no `required` of its own is covered by any field beneath it.
+  const missing = requiredLeafPaths(raw)
+    .filter(
+      (field) =>
+        !collected.has(field) && ![...collected].some((f) => f.startsWith(`${field}.`)),
+    )
     .sort();
   if (missing.length > 0) {
     issues.push(


### PR DESCRIPTION
## Summary

Flow steps can collect nested user-schema properties by dotted path:

```json
{ "name": "address", "fields": ["address.street", "address.city"], "on_success": "create_user" }
```

Schema property names may no longer contain a dot, which would be ambiguous with a nested path.
`packages/config` mirrors the validator so `zitadel plan` matches `apply`. No client changes.

## Notes

- Arrays stay opaque and are now rejected at save time rather than misrendered.


## Tests

<img width="558" height="712" alt="Screenshot 2026-08-07 at 13 50 46" src="https://github.com/user-attachments/assets/9a0c6569-44c3-4aa3-927d-a0dc1452ae4d" />

DB:

```
sqlite> SELECT * FROM user_attributes;
╭───────────────────────────────┬───────┬───────────────────────────────┬───────────────────────────────┬────────────────────────────────╮
│          project_id           │team_id│            user_id            │              key              │             value              │
╞═══════════════════════════════╪═══════╪═══════════════════════════════╪═══════════════════════════════╪════════════════════════════════╡
│proj_01KZE0GJM1G2DV4A5Q4CX9TA4A│       │user_01KZE1037KV6XNXQ08JSKDQ5YY│$schema                        │"sch_01KZE0K19QSHWK5KYH8D43Q7RQ"│
├───────────────────────────────┼───────┼───────────────────────────────┼───────────────────────────────┼────────────────────────────────┤
│proj_01KZE0GJM1G2DV4A5Q4CX9TA4A│       │user_01KZE1037KV6XNXQ08JSKDQ5YY│address.city                   │"Berlin"                        │
├───────────────────────────────┼───────┼───────────────────────────────┼───────────────────────────────┼────────────────────────────────┤
│proj_01KZE0GJM1G2DV4A5Q4CX9TA4A│       │user_01KZE1037KV6XNXQ08JSKDQ5YY│address.geo.datum.reference.   │"foo"                           │
│                               │       │                               │epsg                           │                                │
├───────────────────────────────┼───────┼───────────────────────────────┼───────────────────────────────┼────────────────────────────────┤
│proj_01KZE0GJM1G2DV4A5Q4CX9TA4A│       │user_01KZE1037KV6XNXQ08JSKDQ5YY│address.street                 │"Warsh"                         │
├───────────────────────────────┼───────┼───────────────────────────────┼───────────────────────────────┼────────────────────────────────┤
│proj_01KZE0GJM1G2DV4A5Q4CX9TA4A│       │user_01KZE1037KV6XNXQ08JSKDQ5YY│email                          │"vitor@zitadel.com"             │
╰───────────────────────────────┴───────┴───────────────────────────────┴───────────────────────────────┴────────────────────────────────╯
```