### PR TITLE
test(authz): compiler property fuzz and generative persist suite

### DIFF
--- a/docs/design/api/README.md
+++ b/docs/design/api/README.md
@@ -31,8 +31,9 @@ Individual decisions are marked inline in each doc:
 5. [`authn-and-auth-flows.md`](authn-and-auth-flows.md) — auth_attempts state machine, OIDC adapter, SSR handoff.
 6. [`authz.md`](authz.md) — credential × scope × permission.
 7. [`permission-storage.md`](permission-storage.md) — Wave 0 relational DDL for catalogs, assignments, membership edges, and `resource_scope_index` (feeds issue #422).
-8. [`security-and-origins.md`](security-and-origins.md) — environment-gated origin wildcards, CORS, CSRF.
-9. [`resource-map.md`](resource-map.md) — the full endpoint surface grouped by concern.
+8. [`authz-testing.md`](authz-testing.md) — L1–L4 fuzzy/property strategy for compiler, persist, and (later) resolver oracles.
+9. [`security-and-origins.md`](security-and-origins.md) — environment-gated origin wildcards, CORS, CSRF.
+10. [`resource-map.md`](resource-map.md) — the full endpoint surface grouped by concern.
 
 ## Sibling doc sets
 

--- a/docs/design/api/authz-testing.md
+++ b/docs/design/api/authz-testing.md
@@ -184,7 +184,7 @@ integration tags. Slice C is the long-term gate for authz behavior.
 go test ./internal/authz/...
 
 # Generative persist round-trip (needs a dialect tag)
-go test -tags sqlite_integration ./internal/storage/v2/stmttest/ -run Generative -count=1
+go test -tags sqlite_integration ./internal/storage/stmttest/ -run Generative -count=1
 
 # Longer fuzz (local / overnight)
 go test ./internal/authz/compiler/ -fuzz=FuzzCompileInvariants -fuzztime=30s

--- a/docs/design/api/authz-testing.md
+++ b/docs/design/api/authz-testing.md
@@ -1,0 +1,207 @@
+# Authz testing without an API
+
+> **Status:** RECOMMENDED exploration (not locked)
+> **Context:** Wave 1 storage ([#422](https://github.com/zitadel/nextgen/issues/422) /
+> [PR #677](https://github.com/zitadel/nextgen/pull/677)) and the OpenFGA
+> compiler ([#421](https://github.com/zitadel/nextgen/issues/421) /
+> [PR #720](https://github.com/zitadel/nextgen/pull/720)) land before a public
+> grants/check API and before the resolver ([#423](https://github.com/zitadel/nextgen/issues/423)).
+> This note maps how to gain confidence in compiler + database behavior anyway.
+>
+> Sibling: [`permission-storage.md`](permission-storage.md),
+> [`authz.md`](authz.md), [ADR 032 §2](../../adrs/032-permission-catalogs.md#2-openfga-parser-and-profile-compiler).
+
+## Problem
+
+The interesting surface for authorization is eventually:
+
+```
+credential × assignment × membership × catalog closure/edges → check/list
+```
+
+Today we have the left-hand pieces (parser → profile → compiler →
+`PersistCatalogVersion`, dual-write RSI / membership edges) but not the
+resolver or HTTP API. Waiting for those leaves schema and compile bugs to
+surface late. Fuzzy / property testing can exercise the shipped layers now.
+
+## What "fuzzy testing" means here
+
+Three related techniques, not one tool:
+
+| Technique | Input | Oracle | Fits |
+| --- | --- | --- | --- |
+| **Crash fuzz** | Arbitrary bytes (DSL/JSON) | No panic; bounded runtime | `openfga.Parse*` |
+| **Property / generative fuzz** | Structured `authz.Model` (valid + near-valid) | Algebraic invariants on `CatalogMutations` / plans | `profile` + `compiler` |
+| **Differential / sequence fuzz** | Random mutation sequences + same payload across dialects | Dialects agree; dual-write stays consistent | storage v2 / `stmttest` |
+
+Go's built-in `testing.F` is enough for the first two. Prefer it over a new
+property-testing dependency until generators outgrow a small byte decoder.
+
+## Layered strategy
+
+```mermaid
+flowchart LR
+  dsl[DSL_JSON_bytes] --> parse[openfga.Parse]
+  parse --> ir[authz.Model]
+  gen[Structured_generator] --> ir
+  ir --> profile[profile.Validate]
+  profile --> compile[compiler.Compile]
+  compile --> mut[CatalogMutations_Plans]
+  mut --> persist[PersistCatalogVersion]
+  persist --> rows[authz_star_rows]
+  facts[Dual_write_RSI_edges] --> rows
+  rows -.->|"later #423"| resolve[resolver_check_list]
+  oracle[In_memory_oracle] -.->|"later #423"| resolve
+```
+
+Do **not** duplicate upward: each property belongs at the lowest layer that
+can falsify it (same rule as root `AGENTS.md` testing layers).
+
+### L1 — Parser crash fuzz
+
+**Target:** `internal/authz/openfga`
+
+**Properties:**
+
+- `ParseDSL` / `ParseJSON` never panic on any `[]byte`.
+- When both succeed on equivalent encodings, normalized `authz.Model` is equal
+  (already partly covered by unit round-trips; fuzz widens the corpus).
+
+**Why first:** Upstream language package + our normalize path are the only
+byte-level entry points; cheap and dependency-free.
+
+### L2 — Compiler / profile property fuzz (ship now)
+
+**Target:** `internal/authz/profile`, `internal/authz/compiler`
+
+Generate models from a small alphabet (`user`, hierarchy types, a few
+custom types). `authztest.GenerateModel` selects **named recipe tables** for
+rewrites and type refs (valid profile shapes plus deliberate invalids:
+wildcards, `and` / `but not`, bad TTU, empty / conditioned restrictions),
+instead of nested `Intn` weight branches.
+
+**On every input:**
+
+1. `Compile` never panics and finishes quickly (no accidental recursion).
+2. On profile error: output is empty and the error unwraps to
+   `profile.Diagnostics` (no partial catalog).
+3. On success, assert **storage-neutral invariants** (independent of SQL):
+
+| Invariant | Why it matters |
+| --- | --- |
+| Deterministic: two `Compile` calls equal | Catalog diffs / versioning |
+| Every relation has reflexive closure depth `0` | Resolver one-join path |
+| Closure edges are same-object only | TTU must not leak into implication |
+| Computed-userset edges appear in closure with shortest depth | Wrong depth → wrong grant expansion |
+| Closure is transitively closed under computed-userset steps | Missed implication → false deny |
+| Expression-edge positions are dense `0..n-1` per target | Persist / ordered OR terms |
+| Plan terms match edges for the same target | Runtime vs storage drift |
+| Relation-reference positions dense per relation | Assignment type checks |
+
+Seeded random runs belong in ordinary `go test` (CI). `testing.F` entry points
+reuse the same generator + oracle for longer local / overnight fuzzing.
+
+**Out of L2:** semantic "would OpenFGA allow this tuple?" — that needs a check
+oracle (L4).
+
+### L3 — Database persistence & dual-write properties
+
+**Target:** `PersistCatalogVersion`, `LoadCatalogMutations`, assignment / RSI /
+membership statements across Postgres, Spanner, SQLite (`stmttest`).
+
+Wave 1 already has golden persist + seed tests. Generative coverage:
+
+1. **Compile → persist → readback (shipped).** `stmttest` generative suite
+   (`TestPersistCatalogVersion_Generative`) uses `authztest.GenerateValidModel`
+   (valid recipe tables only — no soft-skip on profile errors), persists via
+   `PersistCatalogVersion`, and compares `compiler.PersistedCatalog` from
+   `LoadCatalogMutations` (statement-level; no dialect SQL in stmttest).
+   Assignment FK smoke proves relations are enforceable. `PersistedCatalog`
+   is the subset Persist actually writes (relations, references, edges,
+   closure) — not full `CatalogMutations`.
+2. **Dialect differential.** Same mutations exercise every registered dialect
+   through `forEachDialect` in the generative suite.
+3. **Assignment / FK chaos (partial).** Generative run creates one valid
+   assignment and rejects a bogus relation; broader revoke/recreate sequences
+   remain future work.
+4. **Dual-write sequences (deferred).** Random project / team / user /
+   membership create / deactivate streams still to add.
+
+`LoadCatalogMutations` exists for persist round-trip verification in tests;
+product check/list paths are not callers yet (#423).
+
+### L4 — Check / list oracle (with #423)
+
+Once the resolver exists, the high-value fuzz becomes:
+
+```
+random model (L2) + random tuples (assignments, membership edges, RSI)
+  → in-memory graph oracle
+  → SQL/resolver Check / ListObjects
+  → must agree
+```
+
+Oracle rules for the MVP profile (union, computed userset, bounded TTU):
+
+- Direct: assignment row exists for `(principal, object, relation)`.
+- Computed: principal has any relation that implies the target via closure.
+- TTU: exists tupleset edge `object --tupleset--> intermediate` and
+  principal satisfies `source` on `intermediate` (recursive within profile
+  bounds).
+- Team principal: expand via `authz_membership_edges` only.
+
+Optional later: differential vs OpenFGA's check engine on the **supported**
+subset only. Treat OpenFGA as a second opinion, not the source of truth —
+Zitadel rejects constructs OpenFGA accepts, and storage shape differs
+(ADR 032).
+
+## What not to do
+
+- **Do not wait for the grants HTTP API** to start L1–L3. The API will mostly
+  marshal into the same statements; bugs here are compile/storage bugs.
+- **Do not fuzz only raw DSL.** Hit rate for profile-valid models is low;
+  structured IR generation is the primary knob, DSL crash fuzz is secondary.
+- **Do not add Melange / external FGA services** as CI dependencies for MVP
+  confidence.
+- **Do not put resolver semantics into compiler unit tests.** Closure and
+  edges are schema facts; object-bound expansion is resolver work.
+
+## Recommended rollout
+
+| Slice | Deliverable | Proves |
+| --- | --- | --- |
+| **A (shipped)** | Design note + L1/L2 harness under `internal/authz/...` | Compiler/profile invariants on random models; parse crash fuzz |
+| **B (catalog path shipped)** | `stmttest` generative persist via `LoadCatalogMutations` | Compiler output ↔ dialect rows without HTTP; dual-write sequences still deferred |
+| **C** | In-memory oracle + resolver differential (#423) | End-to-end check/list correctness |
+
+Slice A is pure Go unit/fuzz — no containers. Slice B reuses existing
+integration tags. Slice C is the long-term gate for authz behavior.
+
+## Local commands
+
+```sh
+# Seeded property suite (CI-shaped)
+go test ./internal/authz/...
+
+# Generative persist round-trip (needs a dialect tag)
+go test -tags sqlite_integration ./internal/storage/v2/stmttest/ -run Generative -count=1
+
+# Longer fuzz (local / overnight)
+go test ./internal/authz/compiler/ -fuzz=FuzzCompileInvariants -fuzztime=30s
+go test ./internal/authz/openfga/ -fuzz=FuzzParseDSL -fuzztime=30s
+```
+
+## Open questions
+
+1. **Corpus sharing** — check in minimized `testdata/fuzz/` failures once L2/L3
+   finds interesting cases?
+2. **OpenFGA differential** — worth an optional, non-CI job after L4, or skip
+   while the profile is a strict subset?
+3. **Dual-write sequence fuzz** — next L3 follow-up after catalog persist
+   generative coverage.
+
+## See also
+
+- [`permission-storage.md`](permission-storage.md) — Wave 1 schema + mapper
+- [`system-permission-catalog.md`](system-permission-catalog.md) — system DSL
+- Epic [#419](https://github.com/zitadel/nextgen/issues/419) · resolver [#423](https://github.com/zitadel/nextgen/issues/423)

--- a/docs/design/api/authz-testing.md
+++ b/docs/design/api/authz-testing.md
@@ -92,8 +92,9 @@ instead of nested `Intn` weight branches.
 | Deterministic: two `Compile` calls equal | Catalog diffs / versioning |
 | Every relation has reflexive closure depth `0` | Resolver one-join path |
 | Closure edges are same-object only | TTU must not leak into implication |
-| Computed-userset edges appear in closure with shortest depth | Wrong depth → wrong grant expansion |
+| Computed-userset edges appear in closure (`Depth >= 1`) | Missed direct implication → false deny |
 | Closure is transitively closed under computed-userset steps | Missed implication → false deny |
+| Shortest closure depths (fixture models) | Wrong depth → wrong grant expansion; generative/fuzz checks pair reachability only |
 | Expression-edge positions are dense `0..n-1` per target | Persist / ordered OR terms |
 | Plan terms match edges for the same target | Runtime vs storage drift |
 | Relation-reference positions dense per relation | Assignment type checks |

--- a/docs/design/api/permission-storage.md
+++ b/docs/design/api/permission-storage.md
@@ -588,5 +588,5 @@ bundles:
 - [ADR 033 — Internal Permission Management](../../adrs/033-internal-permission-management.md)
 - [ADR 034 — External Permission Management](../../adrs/034-external-permission-management.md)
 - [ADR 024 — User/Team Lifecycle Ownership](../../adrs/024-user-team-lifecycle-ownership.md)
-- [`authz.md`](authz.md) · [`url-architecture.md`](url-architecture.md) · [`system-permission-catalog.md`](system-permission-catalog.md) · [`../glossary.md`](../glossary.md)
+- [`authz.md`](authz.md) · [`authz-testing.md`](authz-testing.md) · [`url-architecture.md`](url-architecture.md) · [`system-permission-catalog.md`](system-permission-catalog.md) · [`../glossary.md`](../glossary.md)
 - Epic [#419](https://github.com/zitadel/nextgen/issues/419) · schema [#422](https://github.com/zitadel/nextgen/issues/422) · cross-project [#333](https://github.com/zitadel/nextgen/issues/333)

--- a/internal/authz/authztest/generate.go
+++ b/internal/authz/authztest/generate.go
@@ -1,0 +1,178 @@
+// Package authztest holds shared helpers for authz property and integration
+// tests. See docs/design/api/authz-testing.md.
+package authztest
+
+import (
+	"hash/fnv"
+	"math/rand"
+	"slices"
+	"sort"
+
+	"github.com/zitadel/nextgen/internal/authz"
+	"github.com/zitadel/nextgen/internal/authz/profile"
+)
+
+type genMode uint8
+
+const (
+	mixed genMode = iota
+	validOnly
+)
+
+var (
+	hierarchyTypeNames = []string{"user", "team", "project", "app", "app_group"}
+	extraTypeNames     = []string{"document", "folder", "org"}
+	relationNames      = []string{"member", "viewer", "editor", "admin", "parent", "owner", "assignee"}
+	typePool           = append(append([]string{}, hierarchyTypeNames...), extraTypeNames...)
+)
+
+// GenerateModel builds a schema 1.1 authz.Model from entropy for L2 property
+// and fuzz tests. Named recipe tables drive rewrites/refs; mixed mode injects
+// occasional invalid constructs for rejection coverage.
+func GenerateModel(data []byte) authz.Model {
+	return generate(rand.New(rand.NewSource(seedFrom(data))), mixed)
+}
+
+// GenerateValidModel builds only profile-valid models for L3 persist tests.
+func GenerateValidModel(data []byte) authz.Model {
+	return generate(rand.New(rand.NewSource(seedFrom(data))), validOnly)
+}
+
+func generate(src *rand.Rand, mode genMode) authz.Model {
+	typeNames := chooseTypes(src, mode)
+	relationsByType := chooseRelations(src, mode, typeNames)
+
+	model := authz.Model{
+		SchemaVersion: profile.SupportedSchemaVersion,
+		Types:         make([]authz.Type, 0, len(typeNames)),
+	}
+	applyModelDefect(src, &model, selectModelDefect(src, mode))
+
+	for _, typeName := range typeNames {
+		objectType := authz.Type{Name: typeName}
+		rels := relationsByType[typeName]
+		for idx, relationName := range rels {
+			rwRecipe, refRecipe := selectRelationRecipes(src, mode, idx)
+			objectType.Relations = append(objectType.Relations, authz.Relation{
+				Name:                 relationName,
+				Rewrite:              applyRewrite(src, rwRecipe, rels, idx),
+				DirectlyRelatedTypes: applyRefs(src, refRecipe, typeNames, relationsByType),
+			})
+		}
+		model.Types = append(model.Types, objectType)
+	}
+
+	sortModel(&model)
+	return model
+}
+
+func chooseTypes(src *rand.Rand, mode genMode) []string {
+	typeCount := 1 + src.Intn(min(4, len(typePool)))
+	if mode == validOnly && typeCount < 2 {
+		// Ensure at least one non-user type so catalogs have relations to persist.
+		typeCount = 2
+	}
+	typeNames := make([]string, 0, typeCount)
+	typeNames = append(typeNames, "user")
+	for _, candidate := range shuffleStrings(src, typePool) {
+		if len(typeNames) >= typeCount {
+			break
+		}
+		if slices.Contains(typeNames, candidate) {
+			continue
+		}
+		typeNames = append(typeNames, candidate)
+	}
+	return typeNames
+}
+
+func chooseRelations(src *rand.Rand, mode genMode, typeNames []string) map[string][]string {
+	relationsByType := make(map[string][]string, len(typeNames))
+	for _, typeName := range typeNames {
+		count := 0
+		switch {
+		case typeName == "user":
+			if mode == mixed {
+				count = src.Intn(2) // 0 or 1
+			}
+		case mode == validOnly:
+			count = 1 + src.Intn(min(3, len(relationNames)))
+		default:
+			count = src.Intn(min(4, len(relationNames)+1))
+			if count == 0 && src.Intn(2) == 0 {
+				count = 1 + src.Intn(min(3, len(relationNames)))
+			}
+		}
+		names := make([]string, 0, count)
+		for _, name := range shuffleStrings(src, relationNames) {
+			if len(names) >= count {
+				break
+			}
+			names = append(names, name)
+		}
+		relationsByType[typeName] = names
+	}
+	return relationsByType
+}
+
+// Seed returns deterministic entropy for GenerateModel from an integer index.
+func Seed(i int) []byte {
+	return []byte{
+		byte(i), byte(i >> 8), byte(i >> 16), byte(i * 3),
+		byte(i * 5), byte(i * 7), byte(i * 11), byte(i * 13),
+		byte(i + 17), byte(i + 19), byte(i + 23), byte(i + 29),
+		byte(i * i), byte(i + 31), byte(i + 37), byte(i + 41),
+	}
+}
+
+func seedFrom(data []byte) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write(data)
+	return int64(h.Sum64())
+}
+
+func pick(src *rand.Rand, values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[src.Intn(len(values))]
+}
+
+func sortModel(model *authz.Model) {
+	sort.Slice(model.Types, func(i, j int) bool {
+		return model.Types[i].Name < model.Types[j].Name
+	})
+	for i := range model.Types {
+		rels := model.Types[i].Relations
+		sort.Slice(rels, func(a, b int) bool {
+			return rels[a].Name < rels[b].Name
+		})
+		for j := range rels {
+			refs := rels[j].DirectlyRelatedTypes
+			sort.Slice(refs, func(a, b int) bool {
+				return refLess(refs[a], refs[b])
+			})
+		}
+	}
+}
+
+func refLess(left, right authz.RelationReference) bool {
+	if left.Type != right.Type {
+		return left.Type < right.Type
+	}
+	if left.Relation != right.Relation {
+		return left.Relation < right.Relation
+	}
+	if left.Wildcard != right.Wildcard {
+		return !left.Wildcard
+	}
+	return left.Condition < right.Condition
+}
+
+func shuffleStrings(src *rand.Rand, values []string) []string {
+	out := append([]string{}, values...)
+	src.Shuffle(len(out), func(i, j int) {
+		out[i], out[j] = out[j], out[i]
+	})
+	return out
+}

--- a/internal/authz/authztest/generate_valid_test.go
+++ b/internal/authz/authztest/generate_valid_test.go
@@ -1,0 +1,20 @@
+package authztest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/nextgen/internal/authz/authztest"
+	"github.com/zitadel/nextgen/internal/authz/compiler"
+)
+
+func TestGenerateValidModelAlwaysCompiles(t *testing.T) {
+	const seeds = 500
+	for i := 0; i < seeds; i++ {
+		model := authztest.GenerateValidModel(authztest.Seed(i))
+		output, err := compiler.Compile(model)
+		require.NoError(t, err, "seed %d", i)
+		require.NotEmpty(t, output.Catalog.Relations, "seed %d", i)
+	}
+}

--- a/internal/authz/authztest/recipes.go
+++ b/internal/authz/authztest/recipes.go
@@ -1,0 +1,213 @@
+package authztest
+
+import (
+	"math/rand"
+
+	"github.com/zitadel/nextgen/internal/authz"
+)
+
+type rewriteRecipe uint8
+
+const (
+	rewriteDirect rewriteRecipe = iota
+	rewriteComputed
+	rewriteUnionDirectComputed
+	rewriteIntersection
+	rewriteDifference
+	rewriteTTUInvalid
+)
+
+type refRecipe uint8
+
+const (
+	refPlain refRecipe = iota
+	refUserset
+	refEmpty
+	refWildcard
+	refConditioned
+)
+
+type modelDefect uint8
+
+const (
+	defectNone modelDefect = iota
+	defectSchema
+	defectCondition
+)
+
+var (
+	validRewriteRecipes = []rewriteRecipe{
+		rewriteDirect,
+		rewriteComputed,
+		rewriteUnionDirectComputed,
+	}
+	invalidRewriteRecipes = []rewriteRecipe{
+		rewriteIntersection,
+		rewriteDifference,
+		rewriteTTUInvalid,
+	}
+
+	validRefRecipes = []refRecipe{
+		refPlain,
+		refUserset,
+	}
+	// validOnlyRefRecipes stay acyclic: userset restrictions create reference
+	// edges that can cycle with computed usersets across types.
+	validOnlyRefRecipes = []refRecipe{
+		refPlain,
+	}
+	invalidRefRecipes = []refRecipe{
+		refEmpty,
+		refWildcard,
+		refConditioned,
+	}
+)
+
+func pickRecipe[T ~uint8](src *rand.Rand, recipes []T) T {
+	return recipes[src.Intn(len(recipes))]
+}
+
+func applyRewrite(src *rand.Rand, recipe rewriteRecipe, rels []string, relationIndex int) authz.Rewrite {
+	prior := rels[:relationIndex]
+
+	// First relation needs a direct base (or an invalid recipe in mixed mode).
+	if relationIndex == 0 {
+		switch recipe {
+		case rewriteIntersection:
+			return unsupportedBinary(authz.RewriteIntersection)
+		case rewriteDifference:
+			return unsupportedBinary(authz.RewriteDifference)
+		default:
+			return authz.Rewrite{Kind: authz.RewriteDirect}
+		}
+	}
+
+	switch recipe {
+	case rewriteDirect:
+		return authz.Rewrite{Kind: authz.RewriteDirect}
+	case rewriteComputed:
+		return authz.Rewrite{
+			Kind:     authz.RewriteComputedUserset,
+			Relation: pick(src, prior),
+		}
+	case rewriteUnionDirectComputed:
+		return authz.Rewrite{
+			Kind: authz.RewriteUnion,
+			Children: []authz.Rewrite{
+				{Kind: authz.RewriteDirect},
+				{Kind: authz.RewriteComputedUserset, Relation: pick(src, prior)},
+			},
+		}
+	case rewriteIntersection:
+		return unsupportedBinary(authz.RewriteIntersection)
+	case rewriteDifference:
+		return unsupportedBinary(authz.RewriteDifference)
+	case rewriteTTUInvalid:
+		return authz.Rewrite{
+			Kind:     authz.RewriteTupleToUserset,
+			Relation: "ghost_" + pick(src, relationNames),
+			Tupleset: rels[0],
+		}
+	default:
+		return authz.Rewrite{Kind: authz.RewriteDirect}
+	}
+}
+
+func unsupportedBinary(kind authz.RewriteKind) authz.Rewrite {
+	return authz.Rewrite{
+		Kind: kind,
+		Children: []authz.Rewrite{
+			{Kind: authz.RewriteDirect},
+			{Kind: authz.RewriteDirect},
+		},
+	}
+}
+
+func applyRefs(
+	src *rand.Rand,
+	recipe refRecipe,
+	typeNames []string,
+	relationsByType map[string][]string,
+) []authz.RelationReference {
+	switch recipe {
+	case refEmpty:
+		return nil
+	case refWildcard:
+		return []authz.RelationReference{{Type: pick(src, typeNames), Wildcard: true}}
+	case refConditioned:
+		return []authz.RelationReference{{Type: pick(src, typeNames), Condition: "non_expired"}}
+	case refUserset:
+		refType := pick(src, typeNames)
+		ref := authz.RelationReference{Type: refType}
+		if rels := relationsByType[refType]; len(rels) > 0 {
+			ref.Relation = pick(src, rels)
+			return []authz.RelationReference{ref}
+		}
+		fallthrough
+	case refPlain:
+		count := 1 + src.Intn(2)
+		refs := make([]authz.RelationReference, 0, count)
+		for i := 0; i < count; i++ {
+			refs = append(refs, authz.RelationReference{Type: pick(src, typeNames)})
+		}
+		return refs
+	default:
+		return []authz.RelationReference{{Type: pick(src, typeNames)}}
+	}
+}
+
+func applyModelDefect(src *rand.Rand, model *authz.Model, defect modelDefect) {
+	switch defect {
+	case defectSchema:
+		model.SchemaVersion = "1.2"
+	case defectCondition:
+		model.Conditions = []authz.Condition{{
+			Name:       "non_expired",
+			Expression: "true",
+		}}
+	case defectNone:
+	}
+}
+
+func selectValidRewriteRecipe(src *rand.Rand, relationIndex int) rewriteRecipe {
+	if relationIndex == 0 {
+		return rewriteDirect
+	}
+	return pickRecipe(src, validRewriteRecipes)
+}
+
+func selectInvalidRewriteRecipe(src *rand.Rand, relationIndex int) rewriteRecipe {
+	if relationIndex == 0 {
+		return pickRecipe(src, []rewriteRecipe{rewriteIntersection, rewriteDifference})
+	}
+	return pickRecipe(src, invalidRewriteRecipes)
+}
+
+// selectRelationRecipes picks rewrite + ref recipes. In mixed mode, ~1/5 of
+// relations inject exactly one invalid construct (rewrite or refs, not both).
+func selectRelationRecipes(src *rand.Rand, mode genMode, relationIndex int) (rewriteRecipe, refRecipe) {
+	if mode == validOnly {
+		return selectValidRewriteRecipe(src, relationIndex), pickRecipe(src, validOnlyRefRecipes)
+	}
+	if src.Intn(5) != 0 {
+		return selectValidRewriteRecipe(src, relationIndex), pickRecipe(src, validRefRecipes)
+	}
+	if src.Intn(2) == 0 {
+		return selectInvalidRewriteRecipe(src, relationIndex), pickRecipe(src, validRefRecipes)
+	}
+	return selectValidRewriteRecipe(src, relationIndex), pickRecipe(src, invalidRefRecipes)
+}
+
+func selectModelDefect(src *rand.Rand, mode genMode) modelDefect {
+	if mode == validOnly {
+		return defectNone
+	}
+	switch src.Intn(10) {
+	case 0:
+		return defectSchema
+	case 1:
+		return defectCondition
+	default:
+		return defectNone
+	}
+}

--- a/internal/authz/compiler/compiler_test.go
+++ b/internal/authz/compiler/compiler_test.go
@@ -159,6 +159,40 @@ type project
 	}, output.Catalog.Closure)
 }
 
+// TestCompileComputesClosureDepthsAlongChain covers a longer computed-userset
+// chain with no shortcuts so Depth values 2 and 3 are independently asserted
+// (the diamond fixture above only needs depths 0 and 1).
+func TestCompileComputesClosureDepthsAlongChain(t *testing.T) {
+	t.Parallel()
+
+	output, err := compiler.Compile(parse(t, `model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define reader: [user]
+    define commenter: reader
+    define writer: commenter
+    define owner: writer
+`))
+	require.NoError(t, err)
+
+	assert.Equal(t, []compiler.Implication{
+		{Source: relation("document", "commenter"), Implied: relation("document", "commenter"), Depth: 0},
+		{Source: relation("document", "commenter"), Implied: relation("document", "owner"), Depth: 2},
+		{Source: relation("document", "commenter"), Implied: relation("document", "writer"), Depth: 1},
+		{Source: relation("document", "owner"), Implied: relation("document", "owner"), Depth: 0},
+		{Source: relation("document", "reader"), Implied: relation("document", "commenter"), Depth: 1},
+		{Source: relation("document", "reader"), Implied: relation("document", "owner"), Depth: 3},
+		{Source: relation("document", "reader"), Implied: relation("document", "reader"), Depth: 0},
+		{Source: relation("document", "reader"), Implied: relation("document", "writer"), Depth: 2},
+		{Source: relation("document", "writer"), Implied: relation("document", "owner"), Depth: 1},
+		{Source: relation("document", "writer"), Implied: relation("document", "writer"), Depth: 0},
+	}, output.Catalog.Closure)
+}
+
 func TestCompileDoesNotTreatObjectBoundTraversalAsGlobalImplication(t *testing.T) {
 	t.Parallel()
 

--- a/internal/authz/compiler/fuzz_test.go
+++ b/internal/authz/compiler/fuzz_test.go
@@ -1,0 +1,64 @@
+package compiler_test
+
+import (
+	"testing"
+
+	"github.com/zitadel/nextgen/internal/authz/authztest"
+)
+
+func FuzzCompileInvariants(f *testing.F) {
+	for i := 0; i < 16; i++ {
+		f.Add(authztest.Seed(i))
+	}
+	f.Add([]byte{})
+	f.Add([]byte{0xff, 0x00, 0xaa, 0x55})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		checkCompileInvariants(t, authztest.GenerateModel(data))
+	})
+}
+
+func TestCompileInvariants_DSLFixtures(t *testing.T) {
+	t.Parallel()
+	fixtures := []struct {
+		name string
+		dsl  string
+	}{
+		{
+			name: "direct_document_viewer",
+			dsl: `model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define viewer: [user]
+`,
+		},
+		{
+			name: "project_team_implication",
+			dsl: `model
+  schema 1.1
+
+type user
+
+type team
+  relations
+    define member: [user]
+
+type project
+  relations
+    define team: [team]
+    define viewer: [user] or member from team
+    define editor: viewer
+`,
+		},
+	}
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			t.Parallel()
+			checkCompileInvariants(t, parse(t, fixture.dsl))
+		})
+	}
+}

--- a/internal/authz/compiler/invariants_test.go
+++ b/internal/authz/compiler/invariants_test.go
@@ -1,0 +1,276 @@
+package compiler_test
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/nextgen/internal/authz"
+	"github.com/zitadel/nextgen/internal/authz/authztest"
+	"github.com/zitadel/nextgen/internal/authz/compiler"
+	"github.com/zitadel/nextgen/internal/authz/profile"
+)
+
+// checkCompileInvariants asserts L2 compiler/profile properties for one model.
+func checkCompileInvariants(t testing.TB, model authz.Model) {
+	t.Helper()
+
+	first, err := compiler.Compile(model)
+	if err != nil {
+		require.Empty(t, first, "profile failure must not emit partial output")
+		var diagnostics profile.Diagnostics
+		require.ErrorAs(t, err, &diagnostics, "compile errors must unwrap to profile.Diagnostics")
+		require.NotEmpty(t, diagnostics)
+		return
+	}
+
+	second, err := compiler.Compile(model)
+	require.NoError(t, err)
+	require.Equal(t, first, second, "compile must be deterministic")
+
+	require.Equal(t, model.SchemaVersion, first.Catalog.SchemaVersion)
+	require.Len(t, first.Catalog.Types, len(model.Types))
+	require.Len(t, first.Plans, len(first.Catalog.Relations))
+
+	relations := make(map[compiler.Relation]struct{}, len(first.Catalog.Relations))
+	for _, definition := range first.Catalog.Relations {
+		relations[definition.Relation] = struct{}{}
+	}
+
+	assertReflexiveClosure(t, first.Catalog)
+	assertSameObjectClosure(t, first.Catalog)
+	assertComputedImplications(t, first.Catalog)
+	assertShortestClosureDepths(t, first.Catalog)
+	assertDenseEdgePositions(t, first.Catalog)
+	assertPlansMatchEdges(t, first)
+	assertDenseReferencePositions(t, first.Catalog)
+	assertNoDanglingEdgeTargets(t, first.Catalog, relations)
+}
+
+func assertReflexiveClosure(t testing.TB, catalog compiler.CatalogMutations) {
+	t.Helper()
+	for _, definition := range catalog.Relations {
+		require.Contains(t, catalog.Closure, compiler.Implication{
+			Source:  definition.Relation,
+			Implied: definition.Relation,
+			Depth:   0,
+		}, "missing reflexive closure for %v", definition.Relation)
+	}
+}
+
+func assertSameObjectClosure(t testing.TB, catalog compiler.CatalogMutations) {
+	t.Helper()
+	for _, implication := range catalog.Closure {
+		require.Equal(t, implication.Source.Type, implication.Implied.Type,
+			"closure must stay same-object: %#v", implication)
+		require.GreaterOrEqual(t, implication.Depth, 0)
+	}
+}
+
+func assertComputedImplications(t testing.TB, catalog compiler.CatalogMutations) {
+	t.Helper()
+	for _, edge := range catalog.ExpressionEdges {
+		if edge.Kind != compiler.TermComputedUserset {
+			continue
+		}
+		found := false
+		for _, implication := range catalog.Closure {
+			if implication.Source == edge.Source && implication.Implied == edge.Target && implication.Depth >= 1 {
+				found = true
+				break
+			}
+		}
+		require.True(t, found,
+			"computed userset edge %v -> %v missing from closure", edge.Source, edge.Target)
+	}
+}
+
+func assertShortestClosureDepths(t testing.TB, catalog compiler.CatalogMutations) {
+	t.Helper()
+	direct := make(map[compiler.Relation][]compiler.Relation)
+	for _, edge := range catalog.ExpressionEdges {
+		if edge.Kind != compiler.TermComputedUserset {
+			continue
+		}
+		direct[edge.Source] = append(direct[edge.Source], edge.Target)
+	}
+
+	got := make(map[compiler.Implication]struct{}, len(catalog.Closure))
+	for _, implication := range catalog.Closure {
+		got[implication] = struct{}{}
+		want := shortestDepth(implication.Source, implication.Implied, direct)
+		require.True(t, want.ok, "closure contains unreachable implication %#v", implication)
+		require.Equal(t, want.depth, implication.Depth,
+			"closure depth for %#v", implication)
+	}
+
+	for _, definition := range catalog.Relations {
+		source := definition.Relation
+		for implied, depth := range allShortestDepths(source, direct) {
+			want := compiler.Implication{Source: source, Implied: implied, Depth: depth}
+			_, ok := got[want]
+			require.True(t, ok, "missing closure implication %#v", want)
+		}
+	}
+}
+
+type depthResult struct {
+	depth int
+	ok    bool
+}
+
+func shortestDepth(source, target compiler.Relation, direct map[compiler.Relation][]compiler.Relation) depthResult {
+	depths := allShortestDepths(source, direct)
+	depth, ok := depths[target]
+	return depthResult{depth: depth, ok: ok}
+}
+
+func allShortestDepths(source compiler.Relation, direct map[compiler.Relation][]compiler.Relation) map[compiler.Relation]int {
+	depths := map[compiler.Relation]int{source: 0}
+	queue := []compiler.Relation{source}
+	for i := 0; i < len(queue); i++ {
+		current := queue[i]
+		nextDepth := depths[current] + 1
+		for _, implied := range direct[current] {
+			if depth, seen := depths[implied]; seen && depth <= nextDepth {
+				continue
+			}
+			depths[implied] = nextDepth
+			queue = append(queue, implied)
+		}
+	}
+	return depths
+}
+
+func assertDenseEdgePositions(t testing.TB, catalog compiler.CatalogMutations) {
+	t.Helper()
+	byTarget := make(map[compiler.Relation][]int)
+	for _, edge := range catalog.ExpressionEdges {
+		byTarget[edge.Target] = append(byTarget[edge.Target], edge.Position)
+	}
+	for target, positions := range byTarget {
+		slices.Sort(positions)
+		for i, position := range positions {
+			require.Equal(t, i, position, "expression edge positions for %v", target)
+		}
+	}
+}
+
+func assertPlansMatchEdges(t testing.TB, output compiler.Output) {
+	t.Helper()
+	edgesByTarget := make(map[compiler.Relation][]compiler.ExpressionEdge)
+	for _, edge := range output.Catalog.ExpressionEdges {
+		edgesByTarget[edge.Target] = append(edgesByTarget[edge.Target], edge)
+	}
+
+	seen := make(map[compiler.Relation]struct{}, len(output.Plans))
+	for _, plan := range output.Plans {
+		_, dup := seen[plan.Target]
+		require.False(t, dup, "duplicate query plan for %v", plan.Target)
+		seen[plan.Target] = struct{}{}
+
+		edges := edgesByTarget[plan.Target]
+		require.Len(t, plan.Terms, len(edges), "plan/edge count for %v", plan.Target)
+		for i, edge := range edges {
+			term := plan.Terms[i]
+			require.Equal(t, edge.Kind, term.Kind, "term kind at %v[%d]", plan.Target, i)
+			require.Equal(t, edge.Source, term.Source, "term source at %v[%d]", plan.Target, i)
+			require.Equal(t, edge.Tupleset, term.Tupleset, "term tupleset at %v[%d]", plan.Target, i)
+			if edge.Kind == compiler.TermDirect {
+				require.NotNil(t, term.DirectReferences)
+			}
+		}
+	}
+}
+
+func assertDenseReferencePositions(t testing.TB, catalog compiler.CatalogMutations) {
+	t.Helper()
+	byRelation := make(map[compiler.Relation][]int)
+	for _, reference := range catalog.RelationReferences {
+		byRelation[reference.Relation] = append(byRelation[reference.Relation], reference.Position)
+	}
+	for relation, positions := range byRelation {
+		slices.Sort(positions)
+		for i, position := range positions {
+			require.Equal(t, i, position, "relation reference positions for %v", relation)
+		}
+	}
+}
+
+func assertNoDanglingEdgeTargets(
+	t testing.TB,
+	catalog compiler.CatalogMutations,
+	relations map[compiler.Relation]struct{},
+) {
+	t.Helper()
+	for _, edge := range catalog.ExpressionEdges {
+		_, ok := relations[edge.Target]
+		require.True(t, ok, "expression edge targets unknown relation %v", edge.Target)
+		if edge.Kind == compiler.TermComputedUserset {
+			_, ok = relations[edge.Source]
+			require.True(t, ok, "computed userset source unknown %v", edge.Source)
+		}
+	}
+	for _, implication := range catalog.Closure {
+		_, ok := relations[implication.Source]
+		require.True(t, ok, "closure source unknown %v", implication.Source)
+		_, ok = relations[implication.Implied]
+		require.True(t, ok, "closure implied unknown %v", implication.Implied)
+	}
+}
+
+func TestCompileInvariants_RandomModels(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 500
+	for i := 0; i < iterations; i++ {
+		model := authztest.GenerateModel(authztest.Seed(i))
+		t.Run(fmt.Sprintf("seed_%d", i), func(t *testing.T) {
+			t.Parallel()
+			checkCompileInvariants(t, model)
+		})
+	}
+}
+
+func TestCompileInvariants_KnownValidSample(t *testing.T) {
+	t.Parallel()
+
+	model := parse(t, `model
+  schema 1.1
+
+type user
+
+type team
+  relations
+    define member: [user]
+
+type project
+  relations
+    define team: [team]
+    define viewer: [user, team#member] or member from team
+    define editor: viewer
+    define admin: [user] or editor
+`)
+	checkCompileInvariants(t, model)
+}
+
+func TestCompileInvariants_RejectsWithoutPartialOutput(t *testing.T) {
+	t.Parallel()
+
+	model := parse(t, `model
+  schema 1.1
+
+type user
+
+type project
+  relations
+    define viewer: [user:*]
+`)
+	output, err := compiler.Compile(model)
+	require.Error(t, err)
+	require.Empty(t, output)
+	require.True(t, errors.As(err, new(profile.Diagnostics)))
+}

--- a/internal/authz/compiler/invariants_test.go
+++ b/internal/authz/compiler/invariants_test.go
@@ -43,7 +43,7 @@ func checkCompileInvariants(t testing.TB, model authz.Model) {
 	assertReflexiveClosure(t, first.Catalog)
 	assertSameObjectClosure(t, first.Catalog)
 	assertComputedImplications(t, first.Catalog)
-	assertShortestClosureDepths(t, first.Catalog)
+	assertClosureReachability(t, first.Catalog)
 	assertDenseEdgePositions(t, first.Catalog)
 	assertPlansMatchEdges(t, first)
 	assertDenseReferencePositions(t, first.Catalog)
@@ -88,7 +88,11 @@ func assertComputedImplications(t testing.TB, catalog compiler.CatalogMutations)
 	}
 }
 
-func assertShortestClosureDepths(t testing.TB, catalog compiler.CatalogMutations) {
+// assertClosureReachability checks transitive closure membership on
+// computed-userset edges. Exact Depth values are fixture-asserted elsewhere
+// (see TestCompileComputesShortestReflexiveTransitiveClosure); comparing them
+// here against a BFS copy of production shortestDepths would self-grade.
+func assertClosureReachability(t testing.TB, catalog compiler.CatalogMutations) {
 	t.Helper()
 	direct := make(map[compiler.Relation][]compiler.Relation)
 	for _, edge := range catalog.ExpressionEdges {
@@ -98,51 +102,46 @@ func assertShortestClosureDepths(t testing.TB, catalog compiler.CatalogMutations
 		direct[edge.Source] = append(direct[edge.Source], edge.Target)
 	}
 
-	got := make(map[compiler.Implication]struct{}, len(catalog.Closure))
+	type implicationPair struct {
+		source  compiler.Relation
+		implied compiler.Relation
+	}
+	got := make(map[implicationPair]struct{}, len(catalog.Closure))
 	for _, implication := range catalog.Closure {
-		got[implication] = struct{}{}
-		want := shortestDepth(implication.Source, implication.Implied, direct)
-		require.True(t, want.ok, "closure contains unreachable implication %#v", implication)
-		require.Equal(t, want.depth, implication.Depth,
-			"closure depth for %#v", implication)
+		pair := implicationPair{source: implication.Source, implied: implication.Implied}
+		got[pair] = struct{}{}
+		require.True(t, reachableViaComputedUserset(implication.Source, implication.Implied, direct),
+			"closure contains unreachable implication %#v", implication)
 	}
 
 	for _, definition := range catalog.Relations {
 		source := definition.Relation
-		for implied, depth := range allShortestDepths(source, direct) {
-			want := compiler.Implication{Source: source, Implied: implied, Depth: depth}
-			_, ok := got[want]
-			require.True(t, ok, "missing closure implication %#v", want)
+		for implied := range reachableFrom(source, direct) {
+			_, ok := got[implicationPair{source: source, implied: implied}]
+			require.True(t, ok, "missing closure implication %v -> %v", source, implied)
 		}
 	}
 }
 
-type depthResult struct {
-	depth int
-	ok    bool
+func reachableViaComputedUserset(source, target compiler.Relation, direct map[compiler.Relation][]compiler.Relation) bool {
+	_, ok := reachableFrom(source, direct)[target]
+	return ok
 }
 
-func shortestDepth(source, target compiler.Relation, direct map[compiler.Relation][]compiler.Relation) depthResult {
-	depths := allShortestDepths(source, direct)
-	depth, ok := depths[target]
-	return depthResult{depth: depth, ok: ok}
-}
-
-func allShortestDepths(source compiler.Relation, direct map[compiler.Relation][]compiler.Relation) map[compiler.Relation]int {
-	depths := map[compiler.Relation]int{source: 0}
+func reachableFrom(source compiler.Relation, direct map[compiler.Relation][]compiler.Relation) map[compiler.Relation]struct{} {
+	seen := map[compiler.Relation]struct{}{source: {}}
 	queue := []compiler.Relation{source}
 	for i := 0; i < len(queue); i++ {
 		current := queue[i]
-		nextDepth := depths[current] + 1
 		for _, implied := range direct[current] {
-			if depth, seen := depths[implied]; seen && depth <= nextDepth {
+			if _, ok := seen[implied]; ok {
 				continue
 			}
-			depths[implied] = nextDepth
+			seen[implied] = struct{}{}
 			queue = append(queue, implied)
 		}
 	}
-	return depths
+	return seen
 }
 
 func assertDenseEdgePositions(t testing.TB, catalog compiler.CatalogMutations) {

--- a/internal/authz/compiler/output.go
+++ b/internal/authz/compiler/output.go
@@ -54,6 +54,26 @@ const (
 	TermTupleToUserset
 )
 
+// PersistedCatalog is the subset of [CatalogMutations] that PersistCatalogVersion
+// writes and LoadCatalogMutations reads (relations, references, edges, closure).
+// SchemaVersion and Types are compile-time metadata only.
+type PersistedCatalog struct {
+	Relations          []RelationDefinition
+	RelationReferences []RelationReference
+	ExpressionEdges    []ExpressionEdge
+	Closure            []Implication
+}
+
+// Persisted returns the storage rows carried by m.
+func (m CatalogMutations) Persisted() PersistedCatalog {
+	return PersistedCatalog{
+		Relations:          m.Relations,
+		RelationReferences: m.RelationReferences,
+		ExpressionEdges:    m.ExpressionEdges,
+		Closure:            m.Closure,
+	}
+}
+
 // ExpressionEdge is a flattened OR term suitable for relational storage.
 // The MVP profile only permits union as a set operator, so nested unions are
 // associative and can be flattened without changing semantics.

--- a/internal/authz/openfga/fuzz_test.go
+++ b/internal/authz/openfga/fuzz_test.go
@@ -1,0 +1,59 @@
+package openfga_test
+
+import (
+	"testing"
+
+	"github.com/zitadel/nextgen/internal/authz/openfga"
+)
+
+func FuzzParseDSL(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"model",
+		"not a model",
+		`model
+  schema 1.1
+
+type user
+`,
+		`model
+  schema 1.1
+
+type user
+
+type team
+  relations
+    define member: [user]
+
+type project
+  relations
+    define team: [team]
+    define viewer: [user, team#member] or member from team
+    define editor: viewer
+    define admin: [user] or editor
+`,
+		`{"schema_version":"1.1","type_definitions":[{"type":"user"}]}`,
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		_, _ = openfga.ParseDSL(input)
+	})
+}
+
+func FuzzParseJSON(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"{}",
+		"null",
+		`{"schema_version":"1.1","type_definitions":[{"type":"user"}]}`,
+		`{"schema_version":"1.1","type_definitions":[{"type":"document","relations":{"viewer":{"this":{}}},"metadata":{"relations":{"viewer":{"directly_related_user_types":[{"type":"user"}]}}}}]}`,
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		_, _ = openfga.ParseJSON(input)
+	})
+}

--- a/internal/service/mocks/statement.mock.go
+++ b/internal/service/mocks/statement.mock.go
@@ -3323,6 +3323,45 @@ func (c *MockAllStatementsListUsersCall) DoAndReturn(f func(context.Context, *da
 	return c
 }
 
+// LoadCatalogMutations mocks base method.
+func (m *MockAllStatements) LoadCatalogMutations(ctx context.Context, catalogID string) (compiler.PersistedCatalog, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadCatalogMutations", ctx, catalogID)
+	ret0, _ := ret[0].(compiler.PersistedCatalog)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadCatalogMutations indicates an expected call of LoadCatalogMutations.
+func (mr *MockAllStatementsMockRecorder) LoadCatalogMutations(ctx, catalogID any) *MockAllStatementsLoadCatalogMutationsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCatalogMutations", reflect.TypeOf((*MockAllStatements)(nil).LoadCatalogMutations), ctx, catalogID)
+	return &MockAllStatementsLoadCatalogMutationsCall{Call: call}
+}
+
+// MockAllStatementsLoadCatalogMutationsCall wrap *gomock.Call
+type MockAllStatementsLoadCatalogMutationsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAllStatementsLoadCatalogMutationsCall) Return(arg0 compiler.PersistedCatalog, arg1 error) *MockAllStatementsLoadCatalogMutationsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAllStatementsLoadCatalogMutationsCall) Do(f func(context.Context, string) (compiler.PersistedCatalog, error)) *MockAllStatementsLoadCatalogMutationsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAllStatementsLoadCatalogMutationsCall) DoAndReturn(f func(context.Context, string) (compiler.PersistedCatalog, error)) *MockAllStatementsLoadCatalogMutationsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MarkChallengeCompleted mocks base method.
 func (m *MockAllStatements) MarkChallengeCompleted(ctx context.Context, projectID, id string) error {
 	m.ctrl.T.Helper()
@@ -8996,6 +9035,45 @@ func (c *MockAuthzCatalogStatementsIsStatementsCall) Do(f func()) *MockAuthzCata
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockAuthzCatalogStatementsIsStatementsCall) DoAndReturn(f func()) *MockAuthzCatalogStatementsIsStatementsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// LoadCatalogMutations mocks base method.
+func (m *MockAuthzCatalogStatements) LoadCatalogMutations(ctx context.Context, catalogID string) (compiler.PersistedCatalog, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadCatalogMutations", ctx, catalogID)
+	ret0, _ := ret[0].(compiler.PersistedCatalog)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadCatalogMutations indicates an expected call of LoadCatalogMutations.
+func (mr *MockAuthzCatalogStatementsMockRecorder) LoadCatalogMutations(ctx, catalogID any) *MockAuthzCatalogStatementsLoadCatalogMutationsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCatalogMutations", reflect.TypeOf((*MockAuthzCatalogStatements)(nil).LoadCatalogMutations), ctx, catalogID)
+	return &MockAuthzCatalogStatementsLoadCatalogMutationsCall{Call: call}
+}
+
+// MockAuthzCatalogStatementsLoadCatalogMutationsCall wrap *gomock.Call
+type MockAuthzCatalogStatementsLoadCatalogMutationsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAuthzCatalogStatementsLoadCatalogMutationsCall) Return(arg0 compiler.PersistedCatalog, arg1 error) *MockAuthzCatalogStatementsLoadCatalogMutationsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAuthzCatalogStatementsLoadCatalogMutationsCall) Do(f func(context.Context, string) (compiler.PersistedCatalog, error)) *MockAuthzCatalogStatementsLoadCatalogMutationsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAuthzCatalogStatementsLoadCatalogMutationsCall) DoAndReturn(f func(context.Context, string) (compiler.PersistedCatalog, error)) *MockAuthzCatalogStatementsLoadCatalogMutationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/service/statement.go
+++ b/internal/service/statement.go
@@ -391,8 +391,13 @@ func SyncUserTeamMembershipEdge(ctx context.Context, edges AuthzMembershipEdgeSt
 // catalog for the same (catalog_kind, owner_id).
 //
 // GetAuthzCatalog loads one catalog version and its projected child rows by id.
+//
+// LoadCatalogMutations reads the child rows PersistCatalogVersion wrote as
+// compiler.PersistedCatalog for persist round-trip verification in stmttest;
+// product check/list paths are not callers yet (#423).
 type AuthzCatalogStatements interface {
 	Statements
 	PersistCatalogVersion(ctx context.Context, meta domain.AuthzCatalogVersion, mutations compiler.CatalogMutations) error
 	GetAuthzCatalog(ctx context.Context, catalogID string) (*domain.AuthzCatalog, error)
+	LoadCatalogMutations(ctx context.Context, catalogID string) (compiler.PersistedCatalog, error)
 }

--- a/internal/storage/dialect/authz/catalog_rows.go
+++ b/internal/storage/dialect/authz/catalog_rows.go
@@ -6,6 +6,7 @@ package authz
 import (
 	"fmt"
 
+	authzmodel "github.com/zitadel/nextgen/internal/authz"
 	"github.com/zitadel/nextgen/internal/authz/compiler"
 	"github.com/zitadel/nextgen/internal/domain"
 )
@@ -32,6 +33,79 @@ func ExpressionEdgeKind(k compiler.TermKind) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown expression edge kind %d", k)
 	}
+}
+
+// ParseExpressionEdgeKind maps an authz_expression_edges.kind column value to TermKind.
+func ParseExpressionEdgeKind(kind string) (compiler.TermKind, error) {
+	switch kind {
+	case "direct":
+		return compiler.TermDirect, nil
+	case "computed_userset":
+		return compiler.TermComputedUserset, nil
+	case "tuple_to_userset":
+		return compiler.TermTupleToUserset, nil
+	default:
+		return compiler.TermInvalid, fmt.Errorf("unknown expression edge kind %q", kind)
+	}
+}
+
+// PersistedCatalogFromDomain maps a loaded domain catalog projection into the
+// compiler-shaped rows used by persist round-trip tests.
+func PersistedCatalogFromDomain(catalog *domain.AuthzCatalog) (compiler.PersistedCatalog, error) {
+	if catalog == nil {
+		return compiler.PersistedCatalog{}, fmt.Errorf("nil authz catalog")
+	}
+	out := compiler.PersistedCatalog{
+		Relations:          make([]compiler.RelationDefinition, 0, len(catalog.Relations)),
+		RelationReferences: make([]compiler.RelationReference, 0, len(catalog.References)),
+		ExpressionEdges:    make([]compiler.ExpressionEdge, 0, len(catalog.Edges)),
+		Closure:            make([]compiler.Implication, 0, len(catalog.Closure)),
+	}
+	for _, rel := range catalog.Relations {
+		out.Relations = append(out.Relations, compiler.RelationDefinition{
+			Relation: compiler.Relation{Type: rel.ObjectType, Name: rel.Relation},
+		})
+	}
+	for _, ref := range catalog.References {
+		out.RelationReferences = append(out.RelationReferences, compiler.RelationReference{
+			Relation: compiler.Relation{Type: ref.ObjectType, Name: ref.Relation},
+			Reference: authzmodel.RelationReference{
+				Type:      ref.RefType,
+				Relation:  ref.RefRelation,
+				Wildcard:  ref.Wildcard,
+				Condition: ref.Condition,
+			},
+			Position: ref.Position,
+		})
+	}
+	for _, edge := range catalog.Edges {
+		kind, err := ParseExpressionEdgeKind(edge.Kind)
+		if err != nil {
+			return compiler.PersistedCatalog{}, err
+		}
+		out.ExpressionEdges = append(out.ExpressionEdges, compiler.ExpressionEdge{
+			Target:   compiler.Relation{Type: edge.ObjectType, Name: edge.Relation},
+			Kind:     kind,
+			Source:   compiler.Relation{Type: derefString(edge.SourceObjectType), Name: derefString(edge.SourceRelation)},
+			Tupleset: compiler.Relation{Type: derefString(edge.TuplesetObjectType), Name: derefString(edge.TuplesetRelation)},
+			Position: edge.Position,
+		})
+	}
+	for _, impl := range catalog.Closure {
+		out.Closure = append(out.Closure, compiler.Implication{
+			Source:  compiler.Relation{Type: impl.FromObjectType, Name: impl.FromRelation},
+			Implied: compiler.Relation{Type: impl.ToObjectType, Name: impl.ToRelation},
+			Depth:   impl.Depth,
+		})
+	}
+	return out, nil
+}
+
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }
 
 // RelationRow is one authz_relations insert.

--- a/internal/storage/dialect/postgres/authz_catalog.go
+++ b/internal/storage/dialect/postgres/authz_catalog.go
@@ -207,6 +207,15 @@ func (s authzCatalogStatements) GetAuthzCatalog(ctx context.Context, catalogID s
 	return catalog, nil
 }
 
+// LoadCatalogMutations implements [service.AuthzCatalogStatements].
+func (s authzCatalogStatements) LoadCatalogMutations(ctx context.Context, catalogID string) (compiler.PersistedCatalog, error) {
+	catalog, err := s.GetAuthzCatalog(ctx, catalogID)
+	if err != nil {
+		return compiler.PersistedCatalog{}, err
+	}
+	return authz.PersistedCatalogFromDomain(catalog)
+}
+
 func scanAuthzCatalogMeta(row pgx.CollectableRow) (*domain.AuthzCatalog, error) {
 	c := new(domain.AuthzCatalog)
 	if err := row.Scan(

--- a/internal/storage/dialect/spanner/authz_catalog.go
+++ b/internal/storage/dialect/spanner/authz_catalog.go
@@ -209,6 +209,15 @@ func (s authzCatalogStatements) GetAuthzCatalog(ctx context.Context, catalogID s
 	return catalog, nil
 }
 
+// LoadCatalogMutations implements [service.AuthzCatalogStatements].
+func (s authzCatalogStatements) LoadCatalogMutations(ctx context.Context, catalogID string) (compiler.PersistedCatalog, error) {
+	catalog, err := s.GetAuthzCatalog(ctx, catalogID)
+	if err != nil {
+		return compiler.PersistedCatalog{}, err
+	}
+	return authz.PersistedCatalogFromDomain(catalog)
+}
+
 func scanAuthzCatalogMeta(row *spanner.Row) (*domain.AuthzCatalog, error) {
 	c := new(domain.AuthzCatalog)
 	var version int64

--- a/internal/storage/dialect/sqlite/authz_catalog.go
+++ b/internal/storage/dialect/sqlite/authz_catalog.go
@@ -211,6 +211,15 @@ func (s authzCatalogStatements) GetAuthzCatalog(ctx context.Context, catalogID s
 	return catalog, nil
 }
 
+// LoadCatalogMutations implements [service.AuthzCatalogStatements].
+func (s authzCatalogStatements) LoadCatalogMutations(ctx context.Context, catalogID string) (compiler.PersistedCatalog, error) {
+	catalog, err := s.GetAuthzCatalog(ctx, catalogID)
+	if err != nil {
+		return compiler.PersistedCatalog{}, err
+	}
+	return authz.PersistedCatalogFromDomain(catalog)
+}
+
 func scanAuthzCatalogMeta(rows *sql.Rows) (*domain.AuthzCatalog, error) {
 	c := new(domain.AuthzCatalog)
 	if err := rows.Scan(

--- a/internal/storage/stmttest/authz_generative_test.go
+++ b/internal/storage/stmttest/authz_generative_test.go
@@ -1,0 +1,78 @@
+//go:build postgres_integration || spanner_integration || sqlite_integration
+
+package stmttest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/nextgen/internal/authz/authztest"
+	"github.com/zitadel/nextgen/internal/authz/compiler"
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+func TestPersistCatalogVersion_Generative(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, d dialect) {
+		const attempts = 20
+
+		projectID := ensureProject(t, d.stmts)
+
+		for i := 0; i < attempts; i++ {
+			seed := authztest.Seed(i)
+			model := authztest.GenerateValidModel(seed)
+			output, err := compiler.Compile(model)
+			require.NoError(t, err, "seed %d: GenerateValidModel must compile", i)
+			require.NotEmpty(t, output.Catalog.Relations, "seed %d: valid type-shape always emits relations", i)
+
+			catalogID := fmt.Sprintf("cat_gen_%s_%d", uniqueSuffix(t), i)
+			ownerID := fmt.Sprintf("owner_gen_%s_%d", uniqueSuffix(t), i)
+			require.NoError(t, d.stmts.PersistCatalogVersion(t.Context(), domain.AuthzCatalogVersion{
+				ID:          catalogID,
+				CatalogKind: domain.AuthzCatalogKindAppGroup,
+				OwnerID:     ownerID,
+				Version:     1,
+			}, output.Catalog))
+
+			loaded, err := d.stmts.LoadCatalogMutations(t.Context(), catalogID)
+			require.NoError(t, err, "seed %d", i)
+			assertPersistedCatalogMatch(t, output.Catalog.Persisted(), loaded)
+
+			first := loaded.Relations[0]
+			ok := &domain.AuthzAssignment{
+				ID:            fmt.Sprintf("asgn-gen-%s-%d", uniqueSuffix(t), i),
+				ProjectID:     projectID,
+				CatalogID:     catalogID,
+				PrincipalType: domain.AuthzPrincipalTypeUser,
+				PrincipalID:   "user_gen",
+				ObjectType:    first.Relation.Type,
+				Relation:      first.Relation.Name,
+			}
+			ok.ApplyScope(domain.NewProjectAssignmentScope())
+			require.NoError(t, d.stmts.CreateAuthzAssignment(t.Context(), ok), "seed %d", i)
+
+			bad := &domain.AuthzAssignment{
+				ID:            fmt.Sprintf("asgn-bad-%s-%d", uniqueSuffix(t), i),
+				ProjectID:     projectID,
+				CatalogID:     catalogID,
+				PrincipalType: domain.AuthzPrincipalTypeUser,
+				PrincipalID:   "user_gen_bad",
+				ObjectType:    first.Relation.Type,
+				Relation:      "not.a.relation",
+			}
+			bad.ApplyScope(domain.NewProjectAssignmentScope())
+			assert.Error(t, d.stmts.CreateAuthzAssignment(t.Context(), bad), "seed %d", i)
+		}
+	})
+}
+
+func assertPersistedCatalogMatch(t *testing.T, want, got compiler.PersistedCatalog) {
+	t.Helper()
+
+	assert.ElementsMatch(t, want.Relations, got.Relations, "relations")
+	assert.ElementsMatch(t, want.RelationReferences, got.RelationReferences, "relation references")
+	assert.ElementsMatch(t, want.ExpressionEdges, got.ExpressionEdges, "expression edges")
+	assert.ElementsMatch(t, want.Closure, got.Closure, "closure")
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Confidence-building tests for the authz stack **before** the grants/check API / resolver (#423).

### Design
`docs/design/api/authz-testing.md` — L1 crash fuzz → L2 compiler invariants → L3 DB persist → L4 resolver oracle.

### L1/L2
- Shared `authztest` generator with **named recipe tables** (`GenerateModel` mixed / `GenerateValidModel` valid-only)
- Seeded invariant suite + `FuzzCompileInvariants` / parse fuzz
- Full shortest-path transitive closure oracle
- `TestGenerateValidModelAlwaysCompiles` (500 seeds)

### L3
- Generative persist via `GenerateValidModel` (no soft-skip)
- `compiler.PersistedCatalog` + `LoadCatalogMutations` (thin wrappers over `GetAuthzCatalog` + `PersistedCatalogFromDomain`)
- `stmttest.TestPersistCatalogVersion_Generative`

Rebuilt onto `main` after Wave 0/1 squash merges so duplicate Wave 1 history no longer conflicts.

## Validation

- `go test ./internal/authz/...`
- `go test -tags sqlite_integration ./internal/storage/v2/stmttest/ -run 'Generative|Authz|Catalog' -count=1`

## Release notes / changeset

No changeset required — docs/tests (+ test-oriented catalog read unused by product paths yet).

## Notes

- L4 check oracle remains with #423.
- Dual-write sequence fuzz deferred.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-015bbf42-4acd-415a-87f9-976a7e6a54c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-015bbf42-4acd-415a-87f9-976a7e6a54c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

