### PR TITLE
fix(api): drop the unreachable revoked session state

### DIFF
--- a/.changeset/drop-revoked-session-state.md
+++ b/.changeset/drop-revoked-session-state.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+A session's `state` is now one of `building`, `active`, or `expired`. The `revoked` state is gone from the session response and from the `state` filter of `POST /sessions/query`.

--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -24182,8 +24182,6 @@ func (s *SessionResponseState) Decode(d *jx.Decoder) error {
 		*s = SessionResponseStateActive
 	case SessionResponseStateExpired:
 		*s = SessionResponseStateExpired
-	case SessionResponseStateRevoked:
-		*s = SessionResponseStateRevoked
 	default:
 		*s = SessionResponseState(v)
 	}

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -12569,7 +12569,7 @@ func (*SessNotFoundHeaders) getMySessionRes() {}
 // Field to filter sessions by:
 // - `created_at`: RFC3339 timestamp
 // - `user_id`: user id
-// - `state`: one of `building`, `active`, `expired`, `revoked`.
+// - `state`: one of `building`, `active`, `expired`.
 // Ref: #
 type SessionFilterField string
 
@@ -12634,8 +12634,7 @@ type SessionResponse struct {
 	// - `building`: has a user factor but is still gathering authentication factors
 	// - `active`: has at least one verified authentication factor; `assurance_levels[]` may shrink as
 	// factors age
-	// - `expired`: TTL elapsed
-	// - `revoked`: explicitly revoked via DELETE.
+	// - `expired`: TTL elapsed.
 	State SessionResponseState `json:"state"`
 	// The authenticated user. Null for anonymous sessions and until the `user`
 	// factor has been verified through an `auth_attempt`.
@@ -12841,15 +12840,13 @@ func (s *SessionResponseMetadata) init() SessionResponseMetadata {
 // - `building`: has a user factor but is still gathering authentication factors
 // - `active`: has at least one verified authentication factor; `assurance_levels[]` may shrink as
 // factors age
-// - `expired`: TTL elapsed
-// - `revoked`: explicitly revoked via DELETE.
+// - `expired`: TTL elapsed.
 type SessionResponseState string
 
 const (
 	SessionResponseStateBuilding SessionResponseState = "building"
 	SessionResponseStateActive   SessionResponseState = "active"
 	SessionResponseStateExpired  SessionResponseState = "expired"
-	SessionResponseStateRevoked  SessionResponseState = "revoked"
 )
 
 // AllValues returns all SessionResponseState values.
@@ -12858,7 +12855,6 @@ func (SessionResponseState) AllValues() []SessionResponseState {
 		SessionResponseStateBuilding,
 		SessionResponseStateActive,
 		SessionResponseStateExpired,
-		SessionResponseStateRevoked,
 	}
 }
 
@@ -12870,8 +12866,6 @@ func (s SessionResponseState) MarshalText() ([]byte, error) {
 	case SessionResponseStateActive:
 		return []byte(s), nil
 	case SessionResponseStateExpired:
-		return []byte(s), nil
-	case SessionResponseStateRevoked:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -12889,9 +12883,6 @@ func (s *SessionResponseState) UnmarshalText(data []byte) error {
 		return nil
 	case SessionResponseStateExpired:
 		*s = SessionResponseStateExpired
-		return nil
-	case SessionResponseStateRevoked:
-		*s = SessionResponseStateRevoked
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/api/generated/oas_validators_gen.go
+++ b/api/generated/oas_validators_gen.go
@@ -3544,8 +3544,6 @@ func (s SessionResponseState) Validate() error {
 		return nil
 	case "expired":
 		return nil
-	case "revoked":
-		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}

--- a/api/openapi/endpoints/sessions/query/session-filter-field.yaml
+++ b/api/openapi/endpoints/sessions/query/session-filter-field.yaml
@@ -3,7 +3,7 @@ description: |
   Field to filter sessions by:
   - `created_at`: RFC3339 timestamp
   - `user_id`: user id
-  - `state`: one of `building`, `active`, `expired`, `revoked`
+  - `state`: one of `building`, `active`, `expired`
 enum:
   - created_at
   - user_id

--- a/api/openapi/endpoints/sessions/session-response.yaml
+++ b/api/openapi/endpoints/sessions/session-response.yaml
@@ -25,12 +25,10 @@ properties:
       - `building`: has a user factor but is still gathering authentication factors
       - `active`: has at least one verified authentication factor; `assurance_levels[]` may shrink as factors age
       - `expired`: TTL elapsed
-      - `revoked`: explicitly revoked via DELETE
     enum:
       - building
       - active
       - expired
-      - revoked
     example: active
   user_id:
     description: |

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -287,16 +287,13 @@ func userAgentToAPI(agent *domain.UserAgent) api.OptNilSessionResponseUserAgent 
 
 func sessionStateToAPI(state domain.SessionState) api.SessionResponseState {
 	switch state {
-	case domain.SessionStateUnspecified:
-		return api.SessionResponseStateBuilding
 	case domain.SessionStateActive:
 		return api.SessionResponseStateActive
-	case domain.SessionStateBuilding:
-		return api.SessionResponseStateBuilding
 	case domain.SessionStateExpired:
 		return api.SessionResponseStateExpired
 	default:
-		return api.SessionResponseStateRevoked // TODO: ?
+		// Building, and the zero value: no verified factor yet.
+		return api.SessionResponseStateBuilding
 	}
 }
 

--- a/internal/api/session_test.go
+++ b/internal/api/session_test.go
@@ -101,6 +101,27 @@ func TestUserAgentToAPI(t *testing.T) {
 	require.JSONEq(t, `{"fingerprint":"fp_abc123","ip":"203.0.113.42","browser":"test"}`, string(data))
 }
 
+func TestSessionStateToAPI(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		state domain.SessionState
+		want  api.SessionResponseState
+	}{
+		{"unspecified", domain.SessionStateUnspecified, api.SessionResponseStateBuilding},
+		{"building", domain.SessionStateBuilding, api.SessionResponseStateBuilding},
+		{"active", domain.SessionStateActive, api.SessionResponseStateActive},
+		{"expired", domain.SessionStateExpired, api.SessionResponseStateExpired},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, sessionStateToAPI(tt.state))
+		})
+	}
+}
+
 func TestExchangeInputFromRequest(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
Follow up for https://github.com/zitadel/nextgen/pull/757

Removes `revoked` from the session `state` enum. It was never reachable:
`domain.SessionState` has no such value, and `sessionStateToAPI` only produced
`SessionResponseStateRevoked` from an unreachable `default` branch. Revoking a
session deletes the row, so there is no state left to report.

- `session-response.yaml` — `state` is now `building | active | expired`.
- `query/session-filter-field.yaml` — the `state` filter documents the same three.
- `sessionStateToAPI` — the switch maps active and expired, and everything else
  (building, and the zero value) falls to building.

## Validation

- `moon run server:test` — pass (includes `check-generate`)
- `moon run server:generate` and `moon run api:generate` — committed output is current
- `npx @redocly/cli lint api/openapi/openapi-spec.yaml` — valid (1 pre-existing
  warning in `branding/methods.yaml`, unrelated)
- `node scripts/check-pr-title.mjs` — ok

## Release notes / changeset

`.changeset/drop-revoked-session-state.md` (`@zitadel/server: patch`) — a
session's `state` is now one of `building`, `active`, or `expired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)