### PR TITLE
refactor(api): flatten server middleware wiring with a Chain helper

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -461,10 +461,11 @@ func buildHTTPMux(cfg ServerConfig, reqIdGen middleware.RequestIDGenerator, apiH
 	}
 
 	mux.Handle("/",
-		middleware.WithRequestIdentification(reqIdGen,
-			middleware.WithLogging(
-				api.WithRequestHostMiddleware(api.WithSessionStateNoStore(apiHandler)),
-			),
+		middleware.Chain(apiHandler,
+			func(next http.Handler) http.Handler { return middleware.WithRequestIdentification(reqIdGen, next) },
+			middleware.WithLogging,
+			api.WithRequestHostMiddleware,
+			api.WithSessionStateNoStore,
 		),
 	)
 	return mux, nil

--- a/internal/api/middleware/chain.go
+++ b/internal/api/middleware/chain.go
@@ -1,0 +1,13 @@
+package middleware
+
+import "net/http"
+
+// Chain applies mws to h so the first listed runs outermost — first to see the
+// request, last to see the response — matching the top-to-bottom reading order
+// of the equivalent nested wrapping.
+func Chain(h http.Handler, mws ...func(http.Handler) http.Handler) http.Handler {
+	for i := len(mws) - 1; i >= 0; i-- {
+		h = mws[i](h)
+	}
+	return h
+}

--- a/internal/api/middleware/chain_test.go
+++ b/internal/api/middleware/chain_test.go
@@ -30,7 +30,12 @@ func TestChain_AppliesFirstListedOutermost(t *testing.T) {
 	require.Equal(t, []string{"a", "b", "c", "handler"}, order)
 }
 
-func TestChain_NoMiddlewaresReturnsHandler(t *testing.T) {
-	final := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
-	require.NotNil(t, middleware.Chain(final))
+func TestChain_NoMiddlewaresInvokesHandlerUnchanged(t *testing.T) {
+	called := false
+	final := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+
+	middleware.Chain(final).
+		ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.True(t, called, "Chain with no middlewares must invoke the original handler")
 }

--- a/internal/api/middleware/chain_test.go
+++ b/internal/api/middleware/chain_test.go
@@ -1,0 +1,36 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/nextgen/internal/api/middleware"
+)
+
+func TestChain_AppliesFirstListedOutermost(t *testing.T) {
+	var order []string
+	record := func(name string) func(http.Handler) http.Handler {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				order = append(order, name)
+				next.ServeHTTP(w, r)
+			})
+		}
+	}
+	final := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		order = append(order, "handler")
+	})
+
+	middleware.Chain(final, record("a"), record("b"), record("c")).
+		ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.Equal(t, []string{"a", "b", "c", "handler"}, order)
+}
+
+func TestChain_NoMiddlewaresReturnsHandler(t *testing.T) {
+	final := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	require.NotNil(t, middleware.Chain(final))
+}


### PR DESCRIPTION
Pure refactor of the `/` middleware wiring — **no logic or behavior change.**

**Before**
```go
middleware.WithRequestIdentification(reqIdGen,
    middleware.WithLogging(
        api.WithRequestHostMiddleware(api.WithSessionStateNoStore(apiHandler)),
    ),
)
```

**After**
```go
middleware.Chain(apiHandler,
    func(next http.Handler) http.Handler { return middleware.WithRequestIdentification(reqIdGen, next) },
    middleware.WithLogging,
    api.WithRequestHostMiddleware,
    api.WithSessionStateNoStore,
)
```
