### PR TITLE
feat: satisfy a required object by collecting one of its leaves

### DIFF
--- a/.changeset/nested-required-coverage.md
+++ b/.changeset/nested-required-coverage.md
@@ -1,0 +1,9 @@
+---
+"@zitadel/server": minor
+---
+
+A flow definition satisfies a required object in the user schema by collecting
+one of its leaves. Required coverage walks the nested `required` arrays rather
+than only the schema root, so a schema declaring `required: ["address"]` with
+`address.required: ["street"]` is satisfied by a step collecting
+`address.street`.

--- a/internal/domain/flow_definition_validator.go
+++ b/internal/domain/flow_definition_validator.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/ianlancetaylor/jsonschema"
 )
@@ -115,7 +116,7 @@ func resolveAllStepFields(schema *jsonschema.Schema, steps []FlowDefinitionStep)
 	}
 
 	// validate that all required fields in the schema are present in the flow definition
-	if err := validateRequiredUserSchemaFields(sr.RequiredSet(), steps); err != nil {
+	if err := validateRequiredUserSchemaFields(sr.RequiredLeafPaths(), steps); err != nil {
 		return nil, err
 	}
 
@@ -179,28 +180,43 @@ func validatePasskeyActionsEnabled(sr schemaReader, steps []FlowDefinitionStep) 
 
 // validateRequiredUserSchemaFields checks that all required fields in the
 // user schema are present in the flow definition.
-func validateRequiredUserSchemaFields(required map[string]struct{}, steps []FlowDefinitionStep) error {
-	if len(required) == 0 {
+func validateRequiredUserSchemaFields(requiredPaths map[string]struct{}, steps []FlowDefinitionStep) error {
+	if len(requiredPaths) == 0 {
 		return nil
 	}
-	// gather all the fields set in the flow definition steps
-	fields := make(map[string]struct{})
+
+	// Collecting `address.street` covers the leaf and every object above
+	// it, since an object materializes once one of its children is
+	// collected.
+	covered := make(map[string]struct{})
+	cover := func(path string) {
+		for {
+			covered[path] = struct{}{}
+			dot := strings.LastIndex(path, ".")
+			if dot < 0 {
+				return
+			}
+			path = path[:dot]
+		}
+	}
 	for _, step := range steps {
-		for _, f := range step.Fields {
-			fields[string(f)] = struct{}{}
+		for _, field := range step.Fields {
+			cover(string(field))
 		}
 	}
-	missingFields := make([]string, 0, len(required))
-	for requiredField := range required {
-		if _, ok := fields[requiredField]; !ok {
-			missingFields = append(missingFields, requiredField)
+
+	missing := make([]string, 0, len(requiredPaths))
+	for path := range requiredPaths {
+		if _, ok := covered[path]; !ok {
+			missing = append(missing, path)
 		}
 	}
-	if len(missingFields) > 0 {
-		slices.Sort(missingFields)
-		return ErrFlowDefinitionInvalid(fmt.Sprintf("required fields %v in user schema are missing in the flow definition steps", missingFields), nil)
+	if len(missing) == 0 {
+		return nil
 	}
-	return nil
+
+	slices.Sort(missing)
+	return ErrFlowDefinitionInvalid(fmt.Sprintf("required fields %v in user schema are missing in the flow definition steps", missing), nil)
 }
 
 // validateSteps checks the structural shape of each step (terminal vs

--- a/internal/domain/flow_definition_validator_test.go
+++ b/internal/domain/flow_definition_validator_test.go
@@ -1593,6 +1593,101 @@ func TestValidator_MissingRequiredUserSchemaFields(t *testing.T) {
 	assert.ErrorIs(t, err, domain.ErrFlowDefinitionInvalid(`required fields [first_name last_name] in user schema are missing in the flow definition steps`, nil))
 }
 
+// userSchemaRequiredNested makes `address` required and gives it a
+// required leaf of its own, so coverage has to be checked one level
+// down. `billing` is required but declares no `required`, so any leaf
+// beneath it covers the object.
+var userSchemaRequiredNested = []byte(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tenant.com/schemas/nested-user.json",
+  "type": "object",
+  "required": ["email", "address", "billing"],
+  "x-auth-methods": {
+    "password": { "enabled": true, "position": 0 }
+  },
+  "properties": {
+    "email": { "type": "string", "format": "email", "x-unique": "team" },
+    "address": {
+      "type": "object",
+      "required": ["street"],
+      "properties": {
+        "street": { "type": "string" },
+        "city": { "type": "string" }
+      }
+    },
+    "billing": {
+      "type": "object",
+      "properties": { "vat_id": { "type": "string" } }
+    }
+  }
+}`)
+
+// nestedRequiredFlow builds a login flow whose profile step collects the
+// given fields, so cases vary only by what the step declares.
+func nestedRequiredFlow(fields []domain.Field) domain.FlowDefinition {
+	return domain.FlowDefinition{
+		ProjectID: "p", Name: "f", SchemaVersion: "1",
+		UserSchema: "https://tenant.com/schemas/nested-user.json",
+		Purposes:   map[domain.FlowDefinitionPurpose]string{domain.FlowDefinitionPurposeLogin: "identifier"},
+		Steps: []domain.FlowDefinitionStep{
+			{
+				Name: "identifier", Fields: []domain.Field{"email"},
+				Actions: []domain.FlowStepAction{
+					{Name: "submit", Kind: domain.FlowActionKindSubmit, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{"submit": {Target: "profile"}},
+			},
+			{
+				Name: "profile", Fields: fields,
+				Actions: []domain.FlowStepAction{
+					{Name: "submit", Kind: domain.FlowActionKindSubmit, Primary: true},
+				},
+				Transitions: map[string]domain.FlowStepTransition{"submit": {Target: "done"}},
+			},
+			{Name: "done", Complete: new(domain.FlowStepCompleteShow)},
+		},
+	}
+}
+
+func TestValidator_RequiredNestedUserSchemaFields(t *testing.T) {
+	schema := mustSchema(t, userSchemaRequiredNested)
+
+	t.Run("nested required leaf satisfies coverage", func(t *testing.T) {
+		_, err := domain.ValidateFlowDefinition(schema, nestedRequiredFlow(
+			[]domain.Field{"address.street", "billing.vat_id"},
+		))
+		require.NoError(t, err)
+	})
+
+	t.Run("missing nested required leaf is reported by its path", func(t *testing.T) {
+		_, err := domain.ValidateFlowDefinition(schema, nestedRequiredFlow(
+			[]domain.Field{"address.city", "billing.vat_id"},
+		))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrFlowDefinitionInvalid(
+			`required fields [address.street] in user schema are missing in the flow definition steps`, nil))
+	})
+
+	t.Run("required object without its own required is covered by any leaf", func(t *testing.T) {
+		_, err := domain.ValidateFlowDefinition(schema, nestedRequiredFlow(
+			[]domain.Field{"address.street"},
+		))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrFlowDefinitionInvalid(
+			`required fields [billing] in user schema are missing in the flow definition steps`, nil))
+	})
+
+	// Naming the object itself used to resolve as a text input and only
+	// fail once the user submitted it, at create_user.
+	t.Run("naming the object itself is rejected at definition time", func(t *testing.T) {
+		_, err := domain.ValidateFlowDefinition(schema, nestedRequiredFlow(
+			[]domain.Field{"address", "address.street", "billing.vat_id"},
+		))
+		require.Error(t, err)
+		assert.Contains(t, errorDetails(t, err), domain.ErrFlowFieldNotScalar.Error())
+	})
+}
+
 // ---- Passkey action enablement ----
 
 // passkeyActionFlow builds a minimal login flow whose entry step offers

--- a/internal/domain/flow_field_resolver_schema.go
+++ b/internal/domain/flow_field_resolver_schema.go
@@ -403,6 +403,30 @@ func (r schemaReader) RequiredSet() map[string]struct{} {
 	return out
 }
 
+// RequiredLeafPaths returns the dotted paths a document must carry:
+// every name in `required`, recursed through the nested `required` of
+// each required object. A required object that declares no `required`
+// of its own ends the descent at the object itself — any leaf beneath
+// it satisfies the coverage check.
+func (r schemaReader) RequiredLeafPaths() map[string]struct{} {
+	out := map[string]struct{}{}
+	r.collectRequiredLeafPaths("", out)
+	return out
+}
+
+func (r schemaReader) collectRequiredLeafPaths(prefix AttributeKey, out map[string]struct{}) {
+	properties := r.Properties()
+	for name := range r.RequiredSet() {
+		path := prefix.AppendNode(name)
+		prop, ok := properties[name]
+		if !ok || len(prop.RequiredSet()) == 0 {
+			out[string(path)] = struct{}{}
+			continue
+		}
+		prop.collectRequiredLeafPaths(path, out)
+	}
+}
+
 // AuthMethods returns a reader over the root schema's `x-auth-methods`
 // keyword. An empty (no-op) reader is returned when the keyword is
 // absent. An error is returned only when the keyword is present but


### PR DESCRIPTION
## Summary

Stacked on #785 — review that first.

A user schema declaring `required: ["address"]` has no valid flow definition: the object itself
is not collectable, and naming `address.street` does not count as covering it. Coverage compared
the schema root's `required` names against whole field names.

The walk now descends nested `required` arrays, and a required path is covered by itself or by
anything beneath it — an object materializes once one of its children is collected.

## Validation

- `moon run server:test`
- `moon run config:test` (the CLI mirror and its drift audit still pass unchanged)

## Release notes / changeset

- Changeset: `.changeset/nested-required-coverage.md` — minor for `@zitadel/server`.

## Notes

- `RequiredLeafPaths` travels with this PR rather than #785, since nothing else calls it.
- The matching `zitadel plan` rule is in #804.