### PR TITLE
fix(console): follow the flat-by-id management API contract

### DIFF
--- a/.changeset/flat-by-id-management-calls.md
+++ b/.changeset/flat-by-id-management-calls.md
@@ -1,0 +1,6 @@
+---
+"@zitadel/server": patch
+"@zitadel/testing": patch
+---
+
+The embedded console and the test kit's `seedUser` follow the flat-by-id management contract: path-id operations (get/delete user, list passkeys, set password, get schema, get flow definition, get/update team) no longer send a `project_id` query parameter — the server resolves the scope from the resource id itself.

--- a/apps/console-e2e/moon.yml
+++ b/apps/console-e2e/moon.yml
@@ -10,6 +10,15 @@ tasks:
   lint:
     command: "corepack pnpm exec oxlint ."
 
+  # The e2e tasks themselves are opt-in (`runInCI: false`), which would leave
+  # the specs entirely outside CI's type surface — API contract drift in a
+  # spec would only surface when someone next ran the suite. Typechecking is
+  # cheap, so it runs in CI even though the suite does not.
+  typecheck:
+    command: "corepack pnpm run typecheck"
+    deps:
+      - "testing:build"
+
   e2e:
     command: "corepack pnpm exec playwright test"
     deps:

--- a/apps/console-e2e/package.json
+++ b/apps/console-e2e/package.json
@@ -2,9 +2,13 @@
   "name": "@zitadel/console-e2e",
   "version": "0.0.1",
   "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
   "devDependencies": {
     "@playwright/test": "catalog:",
     "@zitadel/testing": "workspace:*",
-    "eslint-plugin-playwright": "catalog:"
+    "eslint-plugin-playwright": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/apps/console-e2e/src-real/add-user.spec.ts
+++ b/apps/console-e2e/src-real/add-user.spec.ts
@@ -47,12 +47,13 @@ function uniqueEmail(prefix: string): string {
 
 /** The schema the console is scoped to, straight from the API. */
 async function projectSchema(zitadel: {
-  api: { getSchemaById: (id: string, params: { project_id: string }) => Promise<unknown> };
-  handle: { schemaId: string; projectId: string };
+  api: { getSchemaById: (id: string) => Promise<unknown> };
+  handle: { schemaId: string };
 }) {
-  const schema = (await zitadel.api.getSchemaById(zitadel.handle.schemaId, {
-    project_id: zitadel.handle.projectId,
-  })) as { properties?: Record<string, unknown>; required?: string[] };
+  const schema = (await zitadel.api.getSchemaById(zitadel.handle.schemaId)) as {
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
   return {
     properties: Object.keys(schema.properties ?? {}).sort(),
     required: new Set(schema.required ?? []),

--- a/apps/console-e2e/tsconfig.json
+++ b/apps/console-e2e/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
+    // Playwright specs run in Node, but `page.evaluate` callbacks execute in
+    // the browser and reference DOM globals.
+    "lib": ["ES2022", "DOM"],
     "outDir": "out-tsc/playwright",
     "sourceMap": false,
     "types": ["node"]
@@ -9,8 +12,7 @@
   "include": [
     "playwright*.config.mts",
     "scripts/**/*.mts",
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts",
-    "src-real/**/*.spec.ts"
+    "src/**/*.ts",
+    "src-real/**/*.ts"
   ]
 }

--- a/apps/console/src/components/add-user-sheet.tsx
+++ b/apps/console/src/components/add-user-sheet.tsx
@@ -129,9 +129,7 @@ function AddUserForm({
         // document — the properties this form renders — needs its own fetch.
         const options = await Promise.all(
           listed.map(async (entry) => {
-            const schema = (await api.getSchemaById(entry.id, {
-              project_id: projectId,
-            })) as UserSchema;
+            const schema = (await api.getSchemaById(entry.id)) as UserSchema;
             return {
               id: entry.id,
               schema,

--- a/apps/console/src/components/delete-user-dialog.spec.tsx
+++ b/apps/console/src/components/delete-user-dialog.spec.tsx
@@ -13,10 +13,6 @@ vi.mock("@/auth/session", async (importOriginal) => {
 });
 
 vi.stubEnv("VITE_CONSOLE_API_BASE", "http://localhost/api");
-// The build-time override `getConsoleProjectId()` prefers (Console ADR 0004 §5),
-// so the scoping assertion below has a known value to check rather than the
-// empty string runtime discovery would leave it at under test.
-vi.stubEnv("VITE_CONSOLE_PROJECT_ID", "proj_console");
 
 const USERS_URL = "http://localhost/api/users";
 const USER = { id: "user_1", givenName: "Maya", familyName: "Patel", email: "maya@acme.com" };
@@ -95,7 +91,7 @@ describe("delete user dialog", () => {
     expect(screen.getByRole("button", { name: "Delete user" })).toBeDisabled();
   });
 
-  it("deletes the user, scoped to the console project, and reports success", async () => {
+  it("deletes the user by id and reports success", async () => {
     let deleted: URL | undefined;
     server.use(
       http.get(USERS_URL, () => HttpResponse.json({ users: deleted ? [] : [USER] })),
@@ -110,11 +106,10 @@ describe("delete user dialog", () => {
     await userEvent.type(screen.getByLabelText("Type DELETE to confirm"), "DELETE");
     await userEvent.click(screen.getByRole("button", { name: "Delete user" }));
 
-    // The delete must carry the project scope: `DELETE /users/{user_id}` takes
-    // `project_id`, and without it the request is not the one the operator
-    // thinks they are making.
+    // `DELETE /users/{user_id}` is flat-by-id: the server resolves the project
+    // scope from the id itself, so the request carries no query scope.
     await waitFor(() => expect(deleted).toBeDefined());
-    expect(deleted?.searchParams.get("project_id")).toBe("proj_console");
+    expect(deleted?.search).toBe("");
 
     // Success is confirmed to the operator (design decisions log D2) and the
     // row is gone from the invalidated list.

--- a/apps/console/src/components/delete-user-dialog.tsx
+++ b/apps/console/src/components/delete-user-dialog.tsx
@@ -20,7 +20,6 @@ import { Label } from "@/components/ui/label";
 
 import { api } from "../api/zitadel";
 import { describeError } from "../lib/api-error";
-import { getConsoleProjectId } from "../runtime/runtime";
 
 /**
  * The word the operator has to type before the action unlocks. Compared
@@ -138,7 +137,7 @@ function DeleteUserForm({
     setDeleting(true);
     setError(undefined);
     try {
-      await api.deleteUserByID(userId, { project_id: getConsoleProjectId() });
+      await api.deleteUserByID(userId);
       // Raised before the dialog closes, from the root-mounted toaster, so it
       // outlives this subtree — the caller may navigate away on `onDeleted`.
       toast.success(`${name} deleted`);

--- a/apps/console/src/routes/_authed/flow-definitions/$definitionId.tsx
+++ b/apps/console/src/routes/_authed/flow-definitions/$definitionId.tsx
@@ -1,12 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { api } from "../../../api/zitadel";
-import { getConsoleProjectId } from "../../../runtime/runtime";
 import { Page } from "../../../components/layout";
 import { PageHeader } from "../../../components/resource-page";
 
 export const Route = createFileRoute("/_authed/flow-definitions/$definitionId")({
-  loader: ({ params }) => api.getFlowDefinition(params.definitionId, { project_id: getConsoleProjectId() }),
+  loader: ({ params }) => api.getFlowDefinition(params.definitionId),
   component: FlowDefinitionDetail,
 });
 

--- a/apps/console/src/routes/_authed/schemas/$schemaId.tsx
+++ b/apps/console/src/routes/_authed/schemas/$schemaId.tsx
@@ -11,13 +11,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { type UserSchema, schemaAuthMethods, schemaDisplayName } from "@/lib/schema";
 
 import { api } from "../../../api/zitadel";
-import { getConsoleProjectId } from "../../../runtime/runtime";
 
 export const Route = createFileRoute("/_authed/schemas/$schemaId")({
-  loader: ({ params }) =>
-    api.getSchemaById(params.schemaId, {
-      project_id: getConsoleProjectId(),
-    }) as Promise<UserSchema>,
+  loader: ({ params }) => api.getSchemaById(params.schemaId) as Promise<UserSchema>,
   component: SchemaDetail,
 });
 

--- a/apps/console/src/routes/_authed/schemas/index.tsx
+++ b/apps/console/src/routes/_authed/schemas/index.tsx
@@ -35,7 +35,7 @@ export const Route = createFileRoute("/_authed/schemas/")({
     const documents = await Promise.all(
       entries.map(async (entry) => {
         try {
-          return (await api.getSchemaById(entry.id, { project_id: projectId })) as UserSchema;
+          return (await api.getSchemaById(entry.id)) as UserSchema;
         } catch {
           // One unreadable document costs its row's detail, not the screen.
           return undefined;

--- a/apps/console/src/routes/_authed/teams/$teamId.tsx
+++ b/apps/console/src/routes/_authed/teams/$teamId.tsx
@@ -14,7 +14,6 @@ import { Separator } from "@/components/ui/separator";
 import { api } from "../../../api/zitadel";
 import { describeError } from "../../../lib/api-error";
 import { formatDate } from "../../../lib/date";
-import { getConsoleProjectId } from "../../../runtime/runtime";
 
 const PLATE = "flex size-9 items-center justify-center rounded-md bg-muted text-foreground";
 
@@ -29,7 +28,7 @@ const PLATE = "flex size-9 items-center justify-center rounded-md bg-muted text-
  *
  */
 export const Route = createFileRoute("/_authed/teams/$teamId")({
-  loader: ({ params }) => api.getTeam(params.teamId, { project_id: getConsoleProjectId() }),
+  loader: ({ params }) => api.getTeam(params.teamId),
   component: TeamDetail,
 });
 
@@ -60,7 +59,7 @@ function TeamDetail() {
     setSaving(true);
     setError(undefined);
     try {
-      await api.updateTeam(team.id, { name: trimmed }, { project_id: getConsoleProjectId() });
+      await api.updateTeam(team.id, { name: trimmed });
       await router.invalidate();
     } catch (cause) {
       setError(describeError(cause, "Could not save the team."));

--- a/apps/console/src/routes/_authed/users/$userId.tsx
+++ b/apps/console/src/routes/_authed/users/$userId.tsx
@@ -18,7 +18,6 @@ import { formatDate } from "../../../lib/date";
 import { displayValue, field } from "../../../lib/record";
 import { type UserSchema, schemaDisplayName, schemaFields } from "../../../lib/schema";
 import { userDisplayName } from "../../../lib/user";
-import { getConsoleProjectId } from "../../../runtime/runtime";
 
 /**
  * User detail (Figma `467:44362`, `Filled` and `Authentication` variants).
@@ -39,8 +38,7 @@ import { getConsoleProjectId } from "../../../runtime/runtime";
  */
 export const Route = createFileRoute("/_authed/users/$userId")({
   loader: async ({ params }) => {
-    const projectId = getConsoleProjectId();
-    const user = await api.getUserByID(params.userId, { project_id: projectId });
+    const user = await api.getUserByID(params.userId);
 
     // Both are chrome for the record rather than the record itself, so neither
     // is allowed to reject the loader: a failure costs a card, not the screen.
@@ -48,12 +46,12 @@ export const Route = createFileRoute("/_authed/users/$userId")({
     const [schema, passkeys] = await Promise.all([
       schemaId
         ? api
-            .getSchemaById(schemaId, { project_id: projectId })
+            .getSchemaById(schemaId)
             .then((value) => value as UserSchema)
             .catch(() => undefined)
         : Promise.resolve(undefined),
       api
-        .listUserPasskeys(params.userId, { project_id: projectId })
+        .listUserPasskeys(params.userId)
         .then((result) => result.passkeys)
         .catch(() => undefined),
     ]);

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -34,7 +34,6 @@ import { api } from "../../../api/zitadel";
 import { displayValue, field } from "../../../lib/record";
 import { type SchemaField, type UserSchema, schemaColumns } from "../../../lib/schema";
 import { userDisplayName } from "../../../lib/user";
-import { getConsoleProjectId } from "../../../runtime/runtime";
 
 export const Route = createFileRoute("/_authed/users/")({
   // `User`, not `Users`: the sidebar frame's row carries `lucide/User`, the
@@ -74,12 +73,11 @@ const RESERVED_KEYS = new Set(["id", "$schema", "metadata"]);
  * carries `$schema`, so the set is known without a second list call.
  */
 async function columnsForUsers(users: Record<string, unknown>[]): Promise<SchemaField[]> {
-  const projectId = getConsoleProjectId();
   const schemaIds = [...new Set(users.map((user) => field(user, "$schema")).filter(isPresent))];
   const schemas = await Promise.all(
     schemaIds.map(async (id) => {
       try {
-        return (await api.getSchemaById(id, { project_id: projectId })) as UserSchema;
+        return (await api.getSchemaById(id)) as UserSchema;
       } catch {
         // One unreadable schema costs its columns, not the screen. The rows
         // still render from the fallback below.

--- a/packages/testing/src/seed.ts
+++ b/packages/testing/src/seed.ts
@@ -50,11 +50,7 @@ export async function seedUser(
     { project_id: context.projectId },
   )) as Record<string, unknown>;
   const id = requireString(user.id, "user id");
-  await client.setUserPassword(
-    id,
-    { password, is_change_required: false },
-    { project_id: context.projectId },
-  );
+  await client.setUserPassword(id, { password, is_change_required: false });
   return { id, email, password };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,6 +627,9 @@ importers:
       eslint-plugin-playwright:
         specifier: 'catalog:'
         version: 2.10.2(eslint@10.2.1(jiti@2.7.0))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
 
   apps/demo-next:
     dependencies:


### PR DESCRIPTION
## Summary

`console:typecheck` was red on main (verified at 982e8853): #810 made path-id management operations flat-by-id — the server resolves project scope from the resource-scope index — so the regenerated `@zitadel/api` client dropped their `project_id` query params, while collection operations (create/list) still require them.

- Drop the stale `project_id` argument at the 11 console call sites (`getUserByID`, `deleteUserByID`, `listUserPasskeys`, `getSchemaById`, `getFlowDefinition`, `getTeam`, `updateTeam`) and the now-unused `getConsoleProjectId` imports; collection calls keep their scoping.
- Rework `delete-user-dialog.spec.tsx` to pin the new contract: the delete request carries **no** query scope (and the `VITE_CONSOLE_PROJECT_ID` stub that only served the old assertion is gone).
- Fix the same drift in `@zitadel/testing` (`seedUser`'s `setUserPassword` call) and the console-e2e schema helper. `session.ts`/`bootstrap.ts` are not drift — `exchangeHandoff`/`createSchema` still take `project_id`.
- Add a `console-e2e:typecheck` moon task (CI-enabled) so API-contract drift in the Playwright specs fails CI instead of waiting for the opt-in e2e lanes. The new gate immediately surfaced two pre-existing tsconfig gaps, fixed here: composite projects must list imported helper files (the includes were spec-glob-only, so `support.ts` was unlisted), and `page.evaluate` callbacks need `lib: DOM`.

## Validation

```sh
moon run console:typecheck console:test console:lint \
  console-e2e:typecheck console-e2e:lint \
  testing:typecheck testing:test testing:lint
```

All green: console 98/98 unit tests (was 1 failing), testing 75/75, typechecks clean (was 11 errors). A repo-wide sweep found no other caller passing `project_id` to a flat-by-id operation. The opt-in `e2e-real` suite was not run; the server-side behavior is covered by #810's own tests.

## Release notes / changeset

`.changeset/flat-by-id-management-calls.md` — patch for `@zitadel/server` (embedded console) and `@zitadel/testing`: path-id management calls no longer send a `project_id` query parameter. Verified with `changeset status --since origin/main`.

## Notes

- The other e2e projects (demo-next-e2e, demo-nuxt-e2e, cli-journey-e2e) share the no-typecheck blind spot; follow-up tracked separately.
- `pnpm-lock.yaml` moves because console-e2e gains `typescript: "catalog:"`.
