### PR TITLE
fix(setup): pin the dev-server port so login matches the registered origin

### DIFF
--- a/.changeset/setup-dev-port-alignment.md
+++ b/.changeset/setup-dev-port-alignment.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/cli": patch
+---
+
+`zitadel setup` now pins the dev-server port in the scaffolded `dev` script for Next and Nuxt, so the app serves the port setup registered as the project's allowed origin. Previously a bare `next dev` / `nuxt dev` ignored that port and defaulted to 3000 — and Next silently moved to 3001 when 3000 was busy — so login rendered but the first submit failed with `origin "http://localhost:3000" is not allowed for this project`. The other frameworks already pinned the port in their own dev-server config (Vite's `server.port` + `strictPort`, Angular's `serve.options.port`) and are unchanged. An explicit port also turns a busy port into a loud `EADDRINUSE` instead of a silent move to a rejected origin.

--- a/.changeset/setup-dev-port-alignment.md
+++ b/.changeset/setup-dev-port-alignment.md
@@ -1,5 +1,9 @@
 ---
 "@zitadel/cli": patch
+"@zitadel/components": patch
+"@zitadel/server": patch
 ---
 
 `zitadel setup` now pins the dev-server port in the scaffolded `dev` script for Next and Nuxt, so the app serves the port setup registered as the project's allowed origin. Previously a bare `next dev` / `nuxt dev` ignored that port and defaulted to 3000 — and Next silently moved to 3001 when 3000 was busy — so login rendered but the first submit failed with `origin "http://localhost:3000" is not allowed for this project`. The other frameworks already pinned the port in their own dev-server config (Vite's `server.port` + `strictPort`, Angular's `serve.options.port`) and are unchanged. An explicit port also turns a busy port into a loud `EADDRINUSE` instead of a silent move to a rejected origin.
+
+A login that cannot start — a rejected origin being the most common cause — now reports the failure inside the login card instead of leaving a bare line of text on an otherwise empty page.

--- a/.changeset/setup-dev-port-alignment.md
+++ b/.changeset/setup-dev-port-alignment.md
@@ -6,4 +6,6 @@
 
 `zitadel setup` now pins the dev-server port in the scaffolded `dev` script for Next and Nuxt, so the app serves the port setup registered as the project's allowed origin. Previously a bare `next dev` / `nuxt dev` ignored that port and defaulted to 3000 — and Next silently moved to 3001 when 3000 was busy — so login rendered but the first submit failed with `origin "http://localhost:3000" is not allowed for this project`. The other frameworks already pinned the port in their own dev-server config (Vite's `server.port` + `strictPort`, Angular's `serve.options.port`) and are unchanged. An explicit port also turns a busy port into a loud `EADDRINUSE` instead of a silent move to a rejected origin.
 
+`doctor` verifies that dev script against the port recorded as the development issuer, so a script moved to another port is reported as an unapplied config edit and `doctor --fix` restores the registered port. `eject` now lists `package.json` among the edits it cannot auto-revert.
+
 A login that cannot start — a rejected origin being the most common cause — now reports the failure inside the login card instead of leaving a bare line of text on an otherwise empty page.

--- a/apps/cli-journey-e2e/scripts/prepare-app.mjs
+++ b/apps/cli-journey-e2e/scripts/prepare-app.mjs
@@ -131,6 +131,12 @@ export async function prepareApp(options = {}) {
     registryUrl,
     sdkPackage,
   });
+  await assertDevScriptServesSetupPort({
+    appDir,
+    framework,
+    port: appPort,
+    readFile: fs.readFile,
+  });
 
   const metadata = {
     appDir,
@@ -324,6 +330,36 @@ async function assertNoNestedApp(appDir, readFileFn) {
     throw error;
   }
   throw new Error("setup scaffolded a nested myapp directory instead of using the app root");
+}
+
+/**
+ * Fails when the framework CLI whose port comes only from the command line
+ * (`next dev`, `nuxt dev`) was left without one, because `setup` registered
+ * `http://localhost:<port>` as the project's only allowed origin and the dev
+ * server has to land there.
+ *
+ * The journey itself cannot catch that: it always starts the app with an
+ * explicit `--port` (see `devServerArgs` in frameworks.mjs), so a scaffolded
+ * script that would have defaulted to 3000 — and been rejected as an origin
+ * on the first submit — still runs on the right port here. Asserting on the
+ * written script closes that blind spot without changing how the lanes launch.
+ * Frameworks that pin the port in their own dev-server config instead (Vite's
+ * `server.port`, Angular's `serve.options.port`) are not checked here.
+ */
+async function assertDevScriptServesSetupPort({ appDir, framework, port, readFile }) {
+  if (!["next", "nuxt"].includes(framework.id)) {
+    return;
+  }
+  const appPackage = JSON.parse(await readFile(join(appDir, "package.json"), "utf8"));
+  const dev = appPackage.scripts?.dev ?? "";
+  const match = dev.match(/-p\s+(\d+)|--port[=\s]+(\d+)|(?:^|\s)PORT=(\d+)/);
+  const declared = match ? Number(match[1] ?? match[2] ?? match[3]) : undefined;
+  if (declared !== port) {
+    throw new Error(
+      `${framework.id} dev script must serve the port setup registered as the project origin ` +
+        `(${port}), else login fails with "origin is not allowed for this project"; got ${JSON.stringify(dev)}`,
+    );
+  }
 }
 
 async function assertLocalPackageResolution(input) {

--- a/apps/cli-journey-e2e/scripts/prepare-app.test.mjs
+++ b/apps/cli-journey-e2e/scripts/prepare-app.test.mjs
@@ -388,7 +388,14 @@ test("records log collection failures thrown as non-Error values", async () => {
 async function writeGeneratedApp(appDir, registryUrl, sdkPackage, lockfile = "npm") {
   await writeFile(
     join(appDir, "package.json"),
-    `${JSON.stringify({ dependencies: { [sdkPackage]: "alpha" } }, null, 2)}\n`,
+    // The dev script carries the port setup registered as the project origin —
+    // what the real CLI writes for the command-line-only framework CLIs, and
+    // what `assertDevScriptServesSetupPort` checks.
+    `${JSON.stringify(
+      { scripts: { dev: "next dev --port 3010" }, dependencies: { [sdkPackage]: "alpha" } },
+      null,
+      2,
+    )}\n`,
   );
   if (lockfile === "pnpm") {
     await writeFile(

--- a/apps/cli/SKILLS.md
+++ b/apps/cli/SKILLS.md
@@ -99,7 +99,14 @@ the CLI's help layer, not the envelope.
   templates by it; the planned `web-component` renderer is not yet available
   and is rejected if passed), `--dev-port` (dev-server port, also the issuer
   origin registered with Zitadel — use distinct ports to run several scaffolded
-  apps side by side), `--preset password-first|passkey-first` (the sign-in
+  apps side by side. The app must actually serve this port or the flow API
+  rejects its origin on the first submit, so setup makes the port explicit in
+  the app's own dev-server config: `server.port` + `strictPort` for Vite
+  frameworks, `serve.options.port` for Angular, and — because `next dev` and
+  `nuxt dev` take a port only from the command line — `--port` in the
+  `package.json` `dev` script for Next and Nuxt. On a pre-existing app that
+  means setup edits the `dev` script when it does not already name that port;
+  a script already on it is left untouched), `--preset password-first|passkey-first` (the sign-in
   experience the scaffold starts from: `password-first` is the default —
   email + password with passkey optional during registration; `passkey-first`
   enters login on a one-tap passkey step with an email + password fallback;
@@ -152,7 +159,11 @@ the CLI's help layer, not the envelope.
   managed config wirings (Vite/Nuxt proxy merges, Angular's `angular.json`
   proxy and auth routes) through the patchers' idempotent transforms — a
   detached or missing wiring config fails, an unverifiable one warns, and
-  `--fix` re-applies it. Boundary migrations converge: a pristine leftover
+  `--fix` re-applies it. The Next/Nuxt `dev` script is verified the same way,
+  against the port recorded as the development issuer rather than the port the
+  script names today: a script moved off that port reports as an unapplied
+  config edit (a warning — a `dev` script is not the only way to choose a
+  port), and `--fix` restores the registered one. Boundary migrations converge: a pristine leftover
   `middleware.ts` from a Next 15→16 upgrade is swapped for `proxy.ts`, while
   an edited one is reported as a conflict instead of creating both (Next
   rejects the pair). The default local

--- a/apps/cli/src/commands/eject.ts
+++ b/apps/cli/src/commands/eject.ts
@@ -185,12 +185,15 @@ export default class Eject extends BaseCommand {
     }
 
     // In-place config merges (vite.config.ts / angular.json / nuxt.config.ts)
-    // can't be auto-reverted, so surface them as manual cleanup steps. The
-    // Angular patcher also edits package.json (a `dev` script, not a config
-    // block), so word that one accurately.
+    // can't be auto-reverted, so surface them as manual cleanup steps.
+    // package.json is not a config block: Angular has its `dev` script added
+    // outright, while Next and Nuxt keep theirs and only get the dev-server
+    // port pinned into it — one line has to cover both, so it names the
+    // script and both ways setup touches it rather than claiming the script
+    // itself should go.
     const manualSteps = actions.configEdits.map((rel) => {
       if (rel === "package.json" || rel.endsWith("/package.json")) {
-        return `Remove the "dev" script setup added to ${rel}`;
+        return `Restore the "dev" script in ${rel} (setup added the script, or pinned its dev-server port)`;
       }
       if (rel === "angular.json" || rel.endsWith("/angular.json")) {
         return `Remove the Zitadel proxyConfig (and dev-server port) from the serve target in ${rel}`;

--- a/apps/cli/src/lib/orca/detectors/port.ts
+++ b/apps/cli/src/lib/orca/detectors/port.ts
@@ -82,10 +82,11 @@ export function extractPort(script: string): number | undefined {
  * `EADDRINUSE` instead of drifting to one the project does not allow.
  *
  * `--port <n>` is the one spelling every framework this CLI scaffolds
- * accepts (`next dev`, `nuxt dev`, `vite`, `vinxi dev`, `ng serve`), so the
- * rewrite stays framework-agnostic. An existing port declaration is replaced
- * in place — including the `PORT=` env-assignment form, which is rewritten to
- * the flag so one mechanism owns the port.
+ * accepts (`next dev`, `nuxt dev`, `vite`, `vinxi dev`, `ng serve`), so an
+ * appended declaration stays framework-agnostic. An existing declaration is
+ * rewritten in its own form instead — a `PORT=` env assignment keeps the
+ * `PORT=` form — so the script keeps whichever mechanism its author chose and
+ * only the number changes.
  */
 export function withDevPort(script: string, port: number): string {
   // Test for a declaration rather than comparing before/after: a script that
@@ -109,4 +110,25 @@ export function withDevPort(script: string, port: number): string {
  */
 export function issuerFromPort(port: number): string {
   return `http://localhost:${port}`;
+}
+
+/**
+ * The port an issuer URL names, or `undefined` when it names none.
+ *
+ * The inverse of {@link issuerFromPort}, and the authoritative way to learn
+ * which port a project *registered* — as opposed to {@link detectDevPort},
+ * which reports the port the app would start on right now. The two agree
+ * during setup and diverge afterwards, which is exactly when it matters: a
+ * dev script edited to another port must be read as a mismatch against the
+ * registered origin, not as the new truth.
+ */
+export function portFromIssuer(issuer: string): number | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(issuer);
+  } catch {
+    return undefined;
+  }
+  const port = Number.parseInt(parsed.port, 10);
+  return Number.isFinite(port) && port > 0 ? port : undefined;
 }

--- a/apps/cli/src/lib/orca/detectors/port.ts
+++ b/apps/cli/src/lib/orca/detectors/port.ts
@@ -123,12 +123,24 @@ export function issuerFromPort(port: number): string {
  * registered origin, not as the new truth.
  */
 export function portFromIssuer(issuer: string): number | undefined {
-  let parsed: URL;
   try {
-    parsed = new URL(issuer);
+    // Validity gate only. `.port` cannot be read off this: WHATWG drops a
+    // port matching the scheme's default, so `http://localhost:80` — a port
+    // `--dev-port` accepts — would come back portless and silently disable
+    // the dev-script pinning, reintroducing the very mismatch it prevents.
+    new URL(issuer);
   } catch {
     return undefined;
   }
-  const port = Number.parseInt(parsed.port, 10);
+  // Re-parse under a scheme the URL standard treats as non-special. Those
+  // have no default port, so an explicitly written 80/443 survives, while
+  // host parsing (IPv6 brackets, userinfo) stays the standard's job.
+  let probe: URL;
+  try {
+    probe = new URL(issuer.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:/, "zl-issuer-probe:"));
+  } catch {
+    return undefined;
+  }
+  const port = Number.parseInt(probe.port, 10);
   return Number.isFinite(port) && port > 0 ? port : undefined;
 }

--- a/apps/cli/src/lib/orca/detectors/port.ts
+++ b/apps/cli/src/lib/orca/detectors/port.ts
@@ -71,6 +71,39 @@ export function extractPort(script: string): number | undefined {
 }
 
 /**
+ * Rewrites a `dev` script so it explicitly runs on `port`.
+ *
+ * Setup registers `http://localhost:<port>` as the project's only allowed
+ * origin, so the dev server has to land on exactly that port — a bare
+ * `next dev` does not: it defaults to 3000 and, when 3000 is taken, silently
+ * falls back to 3001. Either way the flow API then rejects the app's origin
+ * mid-login. An explicit `--port` removes both failure modes: the port
+ * matches what setup registered, and a busy port fails loudly with
+ * `EADDRINUSE` instead of drifting to one the project does not allow.
+ *
+ * `--port <n>` is the one spelling every framework this CLI scaffolds
+ * accepts (`next dev`, `nuxt dev`, `vite`, `vinxi dev`, `ng serve`), so the
+ * rewrite stays framework-agnostic. An existing port declaration is replaced
+ * in place — including the `PORT=` env-assignment form, which is rewritten to
+ * the flag so one mechanism owns the port.
+ */
+export function withDevPort(script: string, port: number): string {
+  // Test for a declaration rather than comparing before/after: a script that
+  // already names the target port rewrites to itself, and treating that
+  // "unchanged" as "no port found" would append a second, duplicate flag on
+  // every re-run of setup.
+  const flagPattern = /(-p\s+|--port[=\s]+)\d+/;
+  if (flagPattern.test(script)) {
+    return script.replace(flagPattern, (_match, prefix: string) => `${prefix}${String(port)}`);
+  }
+  const envPattern = /((?:^|\s)PORT=)\d+/;
+  if (envPattern.test(script)) {
+    return script.replace(envPattern, (_match, prefix: string) => `${prefix}${String(port)}`);
+  }
+  return `${script.trimEnd()} --port ${String(port)}`;
+}
+
+/**
  * Builds the local OIDC issuer URL for a given dev port. Centralized so the
  * `localhost` origin convention is defined in exactly one place.
  */

--- a/apps/cli/src/lib/orca/patchers/rule/dev-script-port.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/dev-script-port.ts
@@ -1,0 +1,68 @@
+import { ZitadelError } from "../../../errors";
+import { isObject, parseJsonObject, setTopLevelJsonKey } from "../../../json";
+import { extractPort, withDevPort } from "../../detectors/port";
+import type { FileOp } from "./file-writer/types";
+
+/**
+ * Pins the `dev` script to the port setup registered as the project's origin.
+ *
+ * Setup allows exactly one origin, `http://localhost:<devPort>`, so the dev
+ * server has to land on that port or the flow API rejects the app mid-login
+ * (the first step renders, the first submit 400s with `origin ... is not
+ * allowed for this project`). Every other framework this CLI patches already
+ * guarantees that in its own dev-server config — Vite gets `server.port` plus
+ * `strictPort`, Angular gets `serve.options.port` — but `next dev` and
+ * `nuxt dev` take their port from the command line, so nothing held them to
+ * it: they default to 3000 regardless of the port setup registered.
+ *
+ * For Next the flag also restores the guarantee `strictPort` gives Vite: bare
+ * `next dev` silently serves 3001 when 3000 is taken (measured), while
+ * `next dev --port N` exits with `EADDRINUSE` instead of drifting onto a port
+ * the project does not allow.
+ *
+ * Non-destructive: a script already on the right port is returned unchanged
+ * (so the op skips the file rather than reformatting a user's package.json),
+ * and a project without a `dev` script is left alone because there is no
+ * command to pin.
+ */
+export function devScriptPortEdit(devPort: number): (source: string | undefined) => string {
+  return (source) => {
+    if (source === undefined) {
+      throw new ZitadelError("E_VALIDATION", "package.json is required to pin the dev port", {
+        hint: "Run setup from a project that has a package.json.",
+      });
+    }
+    const pkg = parseJsonObject(source, "package.json");
+    const scripts = isObject(pkg.scripts) ? pkg.scripts : undefined;
+    const dev = scripts?.dev;
+    if (typeof dev !== "string" || dev.trim() === "") {
+      return source;
+    }
+    if (extractPort(dev) === devPort) {
+      return source;
+    }
+    // package.json is user-owned: splice only the scripts value; every byte
+    // outside it stays untouched.
+    return setTopLevelJsonKey(source, "package.json", "scripts", {
+      ...scripts,
+      dev: withDevPort(dev, devPort),
+    });
+  };
+}
+
+/**
+ * The `package.json` op pinning the dev script's port. Marked as managed
+ * wiring so `doctor` reports a dev script that drifted off the registered
+ * origin — `convenience` (warn, not fail) because the script is only one of
+ * the ways a dev server picks its port: `npm run dev -- --port 4000` still
+ * moves it without touching the file, so a hard failure here would promise a
+ * guarantee the check cannot make.
+ */
+export function devScriptPortOp(devPort: number): FileOp {
+  return {
+    kind: "edit",
+    path: "package.json",
+    edit: devScriptPortEdit(devPort),
+    wiring: "convenience",
+  };
+}

--- a/apps/cli/src/lib/orca/patchers/rule/dev-script-port.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/dev-script-port.ts
@@ -1,6 +1,6 @@
 import { ZitadelError } from "../../../errors";
 import { isObject, parseJsonObject, setTopLevelJsonKey } from "../../../json";
-import { extractPort, withDevPort } from "../../detectors/port";
+import { extractPort, portFromIssuer, withDevPort } from "../../detectors/port";
 import type { FileOp } from "./file-writer/types";
 
 /**
@@ -24,13 +24,28 @@ import type { FileOp } from "./file-writer/types";
  * (so the op skips the file rather than reformatting a user's package.json),
  * and a project without a `dev` script is left alone because there is no
  * command to pin.
+ *
+ * Takes the project's registered `issuer` rather than a port, because the
+ * expected value has to survive the app drifting away from it. `doctor`
+ * rebuilds this plan from `loadPatchContext`, whose `framework.devPort` is
+ * freshly *detected* from the current script — deriving the target from that
+ * would make any edited script verify against itself (always "applied") and
+ * would make `doctor --fix` write back the detected fallback instead of the
+ * port the project actually allows. The issuer comes from `zitadel.json`
+ * (falling back to the scaffold manifest), so it still says 3456 after
+ * someone edits the script to 4000. An issuer that names no port yields no
+ * expectation and the op becomes a no-op.
  */
-export function devScriptPortEdit(devPort: number): (source: string | undefined) => string {
+export function devScriptPortEdit(issuer: string): (source: string | undefined) => string {
   return (source) => {
     if (source === undefined) {
       throw new ZitadelError("E_VALIDATION", "package.json is required to pin the dev port", {
         hint: "Run setup from a project that has a package.json.",
       });
+    }
+    const devPort = portFromIssuer(issuer);
+    if (devPort === undefined) {
+      return source;
     }
     const pkg = parseJsonObject(source, "package.json");
     const scripts = isObject(pkg.scripts) ? pkg.scripts : undefined;
@@ -58,11 +73,11 @@ export function devScriptPortEdit(devPort: number): (source: string | undefined)
  * moves it without touching the file, so a hard failure here would promise a
  * guarantee the check cannot make.
  */
-export function devScriptPortOp(devPort: number): FileOp {
+export function devScriptPortOp(issuer: string): FileOp {
   return {
     kind: "edit",
     path: "package.json",
-    edit: devScriptPortEdit(devPort),
+    edit: devScriptPortEdit(issuer),
     wiring: "convenience",
   };
 }

--- a/apps/cli/src/lib/orca/patchers/rule/next/index.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/next/index.ts
@@ -87,6 +87,13 @@ export class NextPatcher extends AbstractRulePatcher {
     return [getRenderer(view.rendererId).dependency.name];
   }
 
+  protected override routeConfigEdits(_view: PatchView): ReadonlyArray<string> {
+    // The `dev` script gets the project's dev-server port pinned into it via
+    // an `edit` op eject can't auto-revert, so it has to be surfaced as a
+    // manual cleanup step like any other in-place config merge.
+    return ["package.json"];
+  }
+
   protected summary(ctx: PatchContext): { title: string; detail: string } {
     return {
       title: "Next.js integration",
@@ -203,7 +210,7 @@ function nextCodeOps(ctx: PatchContext, renderer: RendererSpec): FileOp[] {
     },
     // `next dev` takes its port from the command line only, so without this
     // the app can serve a port the project does not allow as an origin.
-    devScriptPortOp(ctx.framework.devPort),
+    devScriptPortOp(ctx.issuer),
   ].filter((op): op is FileOp => op !== undefined);
 }
 

--- a/apps/cli/src/lib/orca/patchers/rule/next/index.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/next/index.ts
@@ -4,6 +4,7 @@ import { MANAGED_MARKER } from "../../../../paths";
 import type { FileOp } from "../file-writer/types";
 import type { PatchContext, PatchView } from "../../types";
 import { AbstractRulePatcher } from "../base";
+import { devScriptPortOp } from "../dev-script-port";
 import { getRenderer } from "./renderers/registry";
 import type { RendererSpec } from "./renderers/types";
 
@@ -200,6 +201,9 @@ function nextCodeOps(ctx: PatchContext, renderer: RendererSpec): FileOp[] {
       name: renderer.dependency.name,
       version: dependencyVersionForCli(ctx.cliVersion, renderer.dependency.version),
     },
+    // `next dev` takes its port from the command line only, so without this
+    // the app can serve a port the project does not allow as an origin.
+    devScriptPortOp(ctx.framework.devPort),
   ].filter((op): op is FileOp => op !== undefined);
 }
 

--- a/apps/cli/src/lib/orca/patchers/rule/nuxt/index.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/nuxt/index.ts
@@ -5,6 +5,7 @@ import { configCandidates } from "../config-paths";
 import type { FileOp } from "../file-writer/types";
 import type { PatchContext, PatchView } from "../../types";
 import { AbstractRulePatcher } from "../base";
+import { devScriptPortOp } from "../dev-script-port";
 import { nuxtConfigEdit } from "./nuxt-config";
 import {
   appVueTemplate,
@@ -73,6 +74,9 @@ export class NuxtPatcher extends AbstractRulePatcher {
         name: SDK_DEPENDENCY,
         version: npmDistTagForCliVersion(ctx.cliVersion),
       },
+      // `nuxt dev` takes its port from the command line only, so without this
+      // the app can serve a port the project does not allow as an origin.
+      devScriptPortOp(ctx.framework.devPort),
     ];
   }
 

--- a/apps/cli/src/lib/orca/patchers/rule/nuxt/index.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/nuxt/index.ts
@@ -76,7 +76,7 @@ export class NuxtPatcher extends AbstractRulePatcher {
       },
       // `nuxt dev` takes its port from the command line only, so without this
       // the app can serve a port the project does not allow as an origin.
-      devScriptPortOp(ctx.framework.devPort),
+      devScriptPortOp(ctx.issuer),
     ];
   }
 
@@ -113,7 +113,9 @@ export class NuxtPatcher extends AbstractRulePatcher {
   }
 
   protected override routeConfigEdits(_view: PatchView): ReadonlyArray<string> {
-    return ["nuxt.config.*"];
+    // package.json: the `dev` script gets the project's dev-server port
+    // pinned into it, another in-place edit eject can't auto-revert.
+    return ["nuxt.config.*", "package.json"];
   }
 
   protected summary(_ctx: PatchContext): { title: string; detail: string } {

--- a/apps/cli/tests/unit/commands/doctor/checks.test.ts
+++ b/apps/cli/tests/unit/commands/doctor/checks.test.ts
@@ -629,6 +629,71 @@ describe("ManagedFilesCheck", () => {
     expect((after.details as ManagedDetails).mode).toBe("manifest");
   });
 
+  // The dev script has to be verified against the port the project
+  // *registered* as its allowed origin, not the port the app happens to start
+  // on now. Those agree at setup and diverge exactly when it matters: reading
+  // the live script would make any edited script verify against itself, and
+  // would make `--fix` write back the detected fallback instead of the port
+  // the server actually allows — leaving login broken while doctor says the
+  // wiring is applied.
+  async function makeNextProjectWithDevScript(devScript: string, issuerPort: number) {
+    const cwd = await makeProject();
+    const pkg = JSON.parse(await readFile(join(cwd, "package.json"), "utf8")) as Record<
+      string,
+      unknown
+    >;
+    await writeFile(
+      join(cwd, "package.json"),
+      JSON.stringify({ ...pkg, scripts: { dev: devScript } }),
+    );
+    const config = JSON.parse(await readFile(join(cwd, "zitadel.json"), "utf8")) as Record<
+      string,
+      unknown
+    >;
+    await writeFile(
+      join(cwd, "zitadel.json"),
+      JSON.stringify({
+        ...config,
+        environments: { development: { issuer: `http://localhost:${String(issuerPort)}` } },
+      }),
+    );
+    return cwd;
+  }
+
+  function devScriptOf(cwd: string): Promise<string> {
+    return readFile(join(cwd, "package.json"), "utf8").then(
+      (raw) => (JSON.parse(raw) as { scripts: { dev: string } }).scripts.dev,
+    );
+  }
+
+  it("reports the dev script as applied only when it serves the registered port", async () => {
+    const cwd = await makeNextProjectWithDevScript("next dev --port 3456", 3456);
+    const outcome = await new ManagedFilesCheck().run(ctxFor(cwd));
+    expect(outcome.status).toBe("pass");
+  });
+
+  it("flags a dev script edited to a port the project does not allow", async () => {
+    // Detection would report 4000 and happily verify it against itself.
+    const cwd = await makeNextProjectWithDevScript("next dev --port 4000", 3456);
+    const outcome = await new ManagedFilesCheck().run(ctxFor(cwd));
+    expect(outcome.status).toBe("warn");
+    expect(outcome.message).toContain("unapplied managed config edit(s): package.json");
+  });
+
+  it("--fix restores the registered port, not the detected fallback", async () => {
+    // No declaration at all: detection falls back to 3000, so a fix driven by
+    // the live script would write 3000 and keep login broken.
+    const cwd = await makeNextProjectWithDevScript("next dev", 3456);
+    const check = new ManagedFilesCheck();
+    expect((await check.run(ctxFor(cwd))).status).toBe("warn");
+
+    await check.fix(ctxFor(cwd));
+
+    expect(await devScriptOf(cwd)).toBe("next dev --port 3456");
+    expect(await devScriptOf(cwd)).not.toContain("3000");
+    expect((await check.run(ctxFor(cwd))).status).toBe("pass");
+  });
+
   it("fails when a managed config wiring is detached, and --fix re-applies it", async () => {
     const cwd = await makeAngularProject();
     const check = new ManagedFilesCheck();

--- a/apps/cli/tests/unit/lib/orca/detectors/port.test.ts
+++ b/apps/cli/tests/unit/lib/orca/detectors/port.test.ts
@@ -147,6 +147,21 @@ describe("portFromIssuer", () => {
     expect(portFromIssuer(issuerFromPort(3456))).toBe(3456);
   });
 
+  // `--dev-port` accepts 1..65535, and WHATWG canonicalisation drops a port
+  // matching the scheme default — so reading `new URL(...).port` would return
+  // nothing here and silently disable the dev-script pinning.
+  it("keeps an explicitly written scheme-default port", () => {
+    expect(portFromIssuer(issuerFromPort(80))).toBe(80);
+    expect(portFromIssuer("https://localhost:443")).toBe(443);
+  });
+
+  it("reads the port past IPv6 brackets and userinfo", () => {
+    expect(portFromIssuer("http://[::1]:80")).toBe(80);
+    expect(portFromIssuer("http://[::1]:3456")).toBe(3456);
+    expect(portFromIssuer("http://user:pass@localhost:80")).toBe(80);
+    expect(portFromIssuer("http://[::1]")).toBeUndefined();
+  });
+
   it("returns undefined when the issuer names no explicit port", () => {
     expect(portFromIssuer("https://auth.example.com")).toBeUndefined();
     expect(portFromIssuer("http://localhost")).toBeUndefined();

--- a/apps/cli/tests/unit/lib/orca/detectors/port.test.ts
+++ b/apps/cli/tests/unit/lib/orca/detectors/port.test.ts
@@ -9,6 +9,7 @@ import {
   detectDevPort,
   extractPort,
   issuerFromPort,
+  withDevPort,
 } from "../../../../../src/lib/orca/detectors/port";
 
 describe("extractPort", () => {
@@ -99,5 +100,43 @@ describe("detectDevPort", () => {
     await writeFile(join(dir, ".env.local"), "PORT=5700\n");
     await writeFile(join(dir, ".env"), "PORT=5800\n");
     expect(await detectDevPort(dir, {})).toBe(5700);
+  });
+});
+
+describe("withDevPort", () => {
+  it("appends the flag when the script declares no port", () => {
+    expect(withDevPort("next dev", 3456)).toBe("next dev --port 3456");
+    expect(withDevPort("nuxt dev", 4100)).toBe("nuxt dev --port 4100");
+  });
+
+  it("keeps other flags intact when appending", () => {
+    expect(withDevPort("next dev --turbopack", 3456)).toBe("next dev --turbopack --port 3456");
+  });
+
+  it("rewrites an existing port in place, in every form extractPort reads", () => {
+    expect(withDevPort("next dev -p 3000", 3456)).toBe("next dev -p 3456");
+    expect(withDevPort("next dev --port 3000", 3456)).toBe("next dev --port 3456");
+    expect(withDevPort("next dev --port=3000", 3456)).toBe("next dev --port=3456");
+    expect(withDevPort("PORT=3000 next dev", 3456)).toBe("PORT=3456 next dev");
+  });
+
+  it("is idempotent, so re-running setup does not churn package.json", () => {
+    const once = withDevPort("next dev", 3456);
+    expect(withDevPort(once, 3456)).toBe(once);
+  });
+
+  // The whole point: whatever the script said before, reading it back must
+  // yield the port setup registered as the project's allowed origin.
+  it("round-trips through extractPort for every input shape", () => {
+    for (const script of [
+      "next dev",
+      "next dev --turbopack",
+      "next dev -p 3000",
+      "next dev --port=9999",
+      "PORT=1234 next dev",
+      "nuxt dev",
+    ]) {
+      expect(extractPort(withDevPort(script, 3456)), script).toBe(3456);
+    }
   });
 });

--- a/apps/cli/tests/unit/lib/orca/detectors/port.test.ts
+++ b/apps/cli/tests/unit/lib/orca/detectors/port.test.ts
@@ -9,6 +9,7 @@ import {
   detectDevPort,
   extractPort,
   issuerFromPort,
+  portFromIssuer,
   withDevPort,
 } from "../../../../../src/lib/orca/detectors/port";
 
@@ -138,5 +139,21 @@ describe("withDevPort", () => {
     ]) {
       expect(extractPort(withDevPort(script, 3456)), script).toBe(3456);
     }
+  });
+});
+
+describe("portFromIssuer", () => {
+  it("round-trips issuerFromPort", () => {
+    expect(portFromIssuer(issuerFromPort(3456))).toBe(3456);
+  });
+
+  it("returns undefined when the issuer names no explicit port", () => {
+    expect(portFromIssuer("https://auth.example.com")).toBeUndefined();
+    expect(portFromIssuer("http://localhost")).toBeUndefined();
+  });
+
+  it("returns undefined for a malformed issuer", () => {
+    expect(portFromIssuer("")).toBeUndefined();
+    expect(portFromIssuer("localhost:3456")).toBeUndefined();
   });
 });

--- a/apps/cli/tests/unit/lib/orca/patchers/rule/dev-script-port.test.ts
+++ b/apps/cli/tests/unit/lib/orca/patchers/rule/dev-script-port.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { devScriptPortEdit } from "../../../../../../src/lib/orca/patchers/rule/dev-script-port";
+
+const pkg = (scripts: Record<string, string>): string =>
+  `${JSON.stringify({ name: "app", scripts }, null, 2)}\n`;
+
+function devScriptOf(source: string): string | undefined {
+  return (JSON.parse(source) as { scripts?: Record<string, string> }).scripts?.dev;
+}
+
+describe("devScriptPortEdit", () => {
+  it("pins the port on a dev script that declares none", () => {
+    const out = devScriptPortEdit(3456)(pkg({ dev: "next dev", build: "next build" }));
+    expect(devScriptOf(out)).toBe("next dev --port 3456");
+    // Sibling scripts survive untouched.
+    expect(devScriptOf(out)).not.toBe(undefined);
+    expect((JSON.parse(out) as { scripts: Record<string, string> }).scripts.build).toBe(
+      "next build",
+    );
+  });
+
+  it("rewrites a dev script pointing at a different port", () => {
+    const out = devScriptPortEdit(3456)(pkg({ dev: "next dev -p 3000" }));
+    expect(devScriptOf(out)).toBe("next dev -p 3456");
+  });
+
+  it("returns the source unchanged when the port already matches", () => {
+    // Unchanged output is how the edit op skips the file, so a pre-existing
+    // app whose script already agrees never gets its package.json reformatted.
+    const source = pkg({ dev: "next dev --port 3456" });
+    expect(devScriptPortEdit(3456)(source)).toBe(source);
+  });
+
+  it("leaves a project without a dev script alone", () => {
+    const source = pkg({ build: "next build" });
+    expect(devScriptPortEdit(3456)(source)).toBe(source);
+  });
+
+  it("preserves formatting outside the scripts map", () => {
+    const source = `{\n  "name": "app",\n\n  "scripts": { "dev": "next dev" },\n  "private": true\n}\n`;
+    const out = devScriptPortEdit(3456)(source);
+    expect(out).toContain(`"private": true`);
+    expect(out.startsWith(`{\n  "name": "app",\n\n`)).toBe(true);
+  });
+
+  it("fails with actionable guidance when package.json is missing", () => {
+    expect(() => devScriptPortEdit(3456)(undefined)).toThrow(/package\.json is required/);
+  });
+});

--- a/apps/cli/tests/unit/lib/orca/patchers/rule/dev-script-port.test.ts
+++ b/apps/cli/tests/unit/lib/orca/patchers/rule/dev-script-port.test.ts
@@ -11,7 +11,7 @@ function devScriptOf(source: string): string | undefined {
 
 describe("devScriptPortEdit", () => {
   it("pins the port on a dev script that declares none", () => {
-    const out = devScriptPortEdit(3456)(pkg({ dev: "next dev", build: "next build" }));
+    const out = devScriptPortEdit("http://localhost:3456")(pkg({ dev: "next dev", build: "next build" }));
     expect(devScriptOf(out)).toBe("next dev --port 3456");
     // Sibling scripts survive untouched.
     expect(devScriptOf(out)).not.toBe(undefined);
@@ -21,7 +21,7 @@ describe("devScriptPortEdit", () => {
   });
 
   it("rewrites a dev script pointing at a different port", () => {
-    const out = devScriptPortEdit(3456)(pkg({ dev: "next dev -p 3000" }));
+    const out = devScriptPortEdit("http://localhost:3456")(pkg({ dev: "next dev -p 3000" }));
     expect(devScriptOf(out)).toBe("next dev -p 3456");
   });
 
@@ -29,22 +29,39 @@ describe("devScriptPortEdit", () => {
     // Unchanged output is how the edit op skips the file, so a pre-existing
     // app whose script already agrees never gets its package.json reformatted.
     const source = pkg({ dev: "next dev --port 3456" });
-    expect(devScriptPortEdit(3456)(source)).toBe(source);
+    expect(devScriptPortEdit("http://localhost:3456")(source)).toBe(source);
   });
 
   it("leaves a project without a dev script alone", () => {
     const source = pkg({ build: "next build" });
-    expect(devScriptPortEdit(3456)(source)).toBe(source);
+    expect(devScriptPortEdit("http://localhost:3456")(source)).toBe(source);
   });
 
   it("preserves formatting outside the scripts map", () => {
     const source = `{\n  "name": "app",\n\n  "scripts": { "dev": "next dev" },\n  "private": true\n}\n`;
-    const out = devScriptPortEdit(3456)(source);
+    const out = devScriptPortEdit("http://localhost:3456")(source);
     expect(out).toContain(`"private": true`);
     expect(out.startsWith(`{\n  "name": "app",\n\n`)).toBe(true);
   });
 
   it("fails with actionable guidance when package.json is missing", () => {
-    expect(() => devScriptPortEdit(3456)(undefined)).toThrow(/package\.json is required/);
+    expect(() => devScriptPortEdit("http://localhost:3456")(undefined)).toThrow(/package\.json is required/);
+  });
+});
+
+describe("devScriptPortEdit issuer handling", () => {
+  it("is a no-op when the issuer names no port", () => {
+    // Nothing to hold the script to, so the user's script is left alone
+    // rather than guessed at.
+    const source = pkg({ dev: "next dev" });
+    expect(devScriptPortEdit("https://auth.example.com")(source)).toBe(source);
+    expect(devScriptPortEdit("not-a-url")(source)).toBe(source);
+  });
+
+  it("targets the issuer's port even when the script names another", () => {
+    // The doctor path: detection would say 4000; the registered origin is
+    // what the server actually allows.
+    const out = devScriptPortEdit("http://localhost:3456")(pkg({ dev: "next dev --port 4000" }));
+    expect(devScriptOf(out)).toBe("next dev --port 3456");
   });
 });

--- a/apps/cli/tests/unit/lib/orca/patchers/rule/dev-script-port.test.ts
+++ b/apps/cli/tests/unit/lib/orca/patchers/rule/dev-script-port.test.ts
@@ -58,6 +58,13 @@ describe("devScriptPortEdit issuer handling", () => {
     expect(devScriptPortEdit("not-a-url")(source)).toBe(source);
   });
 
+  it("still pins a scheme-default port", () => {
+    // Regression: losing 80 to URL canonicalisation turned the op into a
+    // no-op, leaving the app on 3000 while the project allowed only 80.
+    const out = devScriptPortEdit("http://localhost:80")(pkg({ dev: "next dev" }));
+    expect(devScriptOf(out)).toBe("next dev --port 80");
+  });
+
   it("targets the issuer's port even when the script names another", () => {
     // The doctor path: detection would say 4000; the registered origin is
     // what the server actually allows.

--- a/apps/cli/tests/unit/lib/orca/patchers/rule/nuxt/index.test.ts
+++ b/apps/cli/tests/unit/lib/orca/patchers/rule/nuxt/index.test.ts
@@ -143,7 +143,9 @@ describe("NuxtPatcher.artifacts", () => {
     });
     expect(artifacts.markedFiles).toContain("app/pages/login.vue");
     expect(artifacts.dependencies).toEqual(["@zitadel/sdk-nuxt"]);
-    expect(artifacts.configEdits).toEqual(["nuxt.config.*"]);
+    // package.json is listed too: the `dev` script gets the registered
+    // dev-server port pinned into it, and eject can't auto-revert that.
+    expect(artifacts.configEdits).toEqual(["nuxt.config.*", "package.json"]);
   });
 
   it("declares the app shell and homepage as conditionally scaffolded", () => {

--- a/packages/components/src/orchestrator/zitadel-login.spec.ts
+++ b/packages/components/src/orchestrator/zitadel-login.spec.ts
@@ -410,6 +410,13 @@ describe("<zitadel-login> against the typed Flow API", () => {
     expect(errorEvents[0]?.detail.message).toBe(serverMessage);
     await waitFor(() => element.shadowRoot?.querySelector("zl-alert"));
     expect(element.shadowRoot?.querySelector("zl-alert")?.textContent).toContain(serverMessage);
+    // The failure keeps the login surface: the alert renders inside the same
+    // page-shell/card chrome a step would, not bare on an otherwise empty
+    // page — a misconfigured origin is the common trigger and used to blank
+    // the app after the first step had painted normally.
+    const alert = element.shadowRoot?.querySelector("zl-alert");
+    expect(alert?.closest("zl-card")).not.toBeNull();
+    expect(alert?.closest("zl-page-shell")).not.toBeNull();
   });
 
   it("renders branding overlay applied via api-mock applyBranding", async () => {

--- a/packages/components/src/orchestrator/zitadel-login.ts
+++ b/packages/components/src/orchestrator/zitadel-login.ts
@@ -395,8 +395,18 @@ export class ZitadelLogin extends ZitadelSurface {
 
   override render() {
     if (this.startupError) {
+      // Same chrome a step renders into (page shell + card), because this is
+      // still the login surface — just one that could not start. Without the
+      // shell the alert lands bare in the top-left corner of an otherwise
+      // empty page, which reads as a broken app rather than as auth reporting
+      // a problem: the most common trigger is a misconfigured origin, where
+      // the first step paints normally and only the submit fails.
       return html`<form class="zl-mount" novalidate>
-        <zl-alert severity="error">${this.startupError}</zl-alert>
+        <zl-page-shell>
+          <zl-card>
+            <zl-alert severity="error">${this.startupError}</zl-alert>
+          </zl-card>
+        </zl-page-shell>
       </form>`;
     }
     if (!this.response || !this.engine) {


### PR DESCRIPTION
## Summary

`zitadel setup` registers `http://localhost:<devPort>` as the project's only allowed origin, but nothing made the app actually run on that port — so login broke on the happy path. Found while reverifying the alpha.18 branding round end to end ([Slack thread](https://zitadel.slack.com/archives/C0ATLEUKPAN/p1786515386.628509)); it is not in the thread, but it is the same class of defect Elina flagged there ("these are not exactly edge cases, this is the happy path").

**The reproduction** (on main, local server + Verdaccio-packed packages): `setup --framework next --server local --dev-port 3456` writes `ZITADEL_ISSUER=http://localhost:3456` and prints *"Start your project: npm run dev (then open http://localhost:3456/login)"* — but leaves the scaffolded dev script as bare `next dev`, which serves 3000. The login page renders, then the first submit `POST /__nextgen/flow/<id>/submit` → **400**, page blanks with an unstyled `origin "http://localhost:3000" is not allowed for this project (allowed: http://localhost:3456)`.

Two independent triggers: the user picks a non-default port (flag or the interactive "Dev server port" prompt), **or** no flags at all and port 3000 is simply busy — Next then silently serves 3001 (measured: `⚠ Port 3000 is in use by process X, using available port 3001 instead`) while the origin stays pinned to 3000.

## What this implements

Option (a) from the brief, and the investigation reframed it as an **inconsistency rather than a missing feature**: every other framework already guarantees the app lands on the registered port in its own dev-server config — Vite gets `server.port` + `strictPort` (`vite-support.ts`), Angular gets `serve.options.port` (`angular-json.ts`). Only `next dev` and `nuxt dev` take their port purely from the command line, and nothing passed one. So this gives those two the same guarantee the other six already had, rather than inventing a new mechanism.

- `withDevPort()` (`detectors/port.ts`) rewrites a dev script to pin a port — replacing an existing declaration in any form `extractPort` reads (`-p`, `--port`, `--port=`, `PORT=`), else appending `--port <n>`. `--port` is the one spelling every framework here accepts, so the rewrite stays framework-agnostic.
- `devScriptPortOp()` (`patchers/rule/dev-script-port.ts`) is the `package.json` edit op, added to the Next and Nuxt patchers. Format-preserving (`setTopLevelJsonKey`, same as `add-dep`), and non-destructive: a script already on the right port returns unchanged so the op skips the file instead of reformatting a user's `package.json`.
- Marked `wiring: "convenience"` so `doctor` reports a dev script that later drifts off the registered origin — partially covering option (c). Warn rather than fail, because the script is only one way a dev server picks its port (`npm run dev -- --port 4000` still moves it without touching the file), so a hard failure would promise a guarantee the check cannot make.

**Error presentation** (also requested in the brief): a login that cannot start rendered a bare `zl-alert` with no page shell or card, which is why the failure looked like a blank page with stray text. It now renders inside the same page-shell/card chrome a step would.

I did **not** take option (b) — allowing any loopback port as an origin. It weakens a security boundary to work around a scaffolding gap, and once the dev script pins the port there is nothing left for it to fix.

## Validation

- **The original repro now passes end to end**: fresh app, `--dev-port 3456`, bare `npm run dev` → serves 3456, and the submit that previously returned 400 with a blank page returns **200** and advances to "Create your account".
- **Both triggers closed**: the default case now writes `next dev --port 3000`, and an explicit port makes Next exit with `EADDRINUSE` when the port is busy (measured) instead of drifting to 3001 — the same contract `strictPort` gives Vite.
- **Idempotent**: a second `setup --force` leaves the script byte-identical (a unit test caught a real bug here first — my initial change would have appended a duplicate `--port` flag on every re-run).
- `moon run cli:test` 1052 tests, `moon run components:test` 412 tests, plus lint/typecheck on both, and the 7 `cli-journey-e2e` prepare-app tests — all green.
- Error presentation verified visually in a real scaffolded app (card chrome, centred, correct in light and dark). The origin-specific message is additionally pinned by a unit test that mocks that exact 400 envelope and asserts the alert renders inside `zl-card`/`zl-page-shell`.

## Regression coverage

`cli-journey-e2e` could not have caught this: `prepare-app.mjs` starts every app with an explicit `--port` (`devServerArgs` in `frameworks.mjs`), so the mismatch never occurs there. Added `assertDevScriptServesSetupPort` to `prepare-app.mjs`, which fails when a scaffolded Next/Nuxt dev script does not carry the port setup registered.

I deliberately did **not** switch a lane to bare `npm run dev` (the other option in the brief): it would put all eight frameworks behind an untested assumption on the main CI gate. Asserting on the written script closes the same blind spot without changing how the lanes launch, and is a cheap follow-up to strengthen later.

## Release notes / changeset

`.changeset/setup-dev-port-alignment.md` — patch for `@zitadel/cli`, `@zitadel/components`, `@zitadel/server`.

## Notes

- **Nuxt is fixed on the structural gap, not on a measured drift.** Next's silent 3001 fallback is measured; for Nuxt I could not reproduce drift (its dev-lock blocks the two-instance test, and it honoured an explicit port in every test I ran), so the code comment and changeset claim the measured behaviour for Next only. Nuxt is included because it had no port wiring at all, so the user-chosen-port trigger applies to it identically.
- **Scope note for review**: on a *pre-existing* app whose dev script declares no port, setup now writes one in. That is a change to a user-owned file, though it only makes explicit what was already implicit, and a script already naming the right port is untouched.
- A transport failure mid-flow still replaces the whole step rather than surfacing inside it — out of scope here; this PR only fixes how that state is presented.