### PR TITLE
fix: surface unreachable branding asset URLs instead of failing silently

### DIFF
--- a/.changeset/branding-asset-reachability.md
+++ b/.changeset/branding-asset-reachability.md
@@ -17,12 +17,15 @@ Three changes close that hole:
   the machine planning is not necessarily the machine rendering the login
   page — so it never fails a run. Set `ZITADEL_SKIP_ASSET_PROBE` to turn it
   off (offline, air-gapped CI, a CDN that only resolves from production) and
-  `ZITADEL_ASSET_PROBE_TIMEOUT_MS` to retune the per-URL budget.
-- The login UI hides an asset that fails to load and restores the split
-  designs' decorative placeholder when that empties the brand pane, so a
-  broken asset degrades to the same result as no asset instead of a blank
-  pane. Templates could not do this themselves: they are DOMPurify-sanitised
-  and inline `onerror` is stripped.
+  `ZITADEL_ASSET_PROBE_TIMEOUT_MS` to retune the per-URL budget. Only public
+  HTTPS destinations are contacted and redirects are re-validated;
+  loopback/private/internal targets remain inconclusive rather than becoming
+  network requests from the machine running the plan.
+- The login UI hides an asset that fails to load and restores either the split
+  designs' decorative placeholder or the shipped design's authored no-logo
+  content, so a broken asset degrades to the same result as no asset instead
+  of a blank pane or missing compact brand. Templates could not do this
+  themselves: they are DOMPurify-sanitised and inline `onerror` is stripped.
 - Branding revisions can now carry plan warnings at all; previously only
   create/update actions could, and branding is revisioned.
 

--- a/.changeset/branding-asset-reachability.md
+++ b/.changeset/branding-asset-reachability.md
@@ -1,0 +1,36 @@
+---
+"@zitadel/components": patch
+"@zitadel/config": patch
+"@zitadel/cli": patch
+---
+
+A branding asset URL that is well-formed but unreachable no longer fails
+silently. `logo_url` / `hero_url` cleared every gate — the CLI's shape check
+and the server's save gate — published a revision, and then rendered as a 0×0
+`<img>`: no plan output, no apply output, no console error.
+
+Three changes close that hole:
+
+- `plan` and `apply` probe each asset URL (HEAD, 2.5s budget, in parallel) and
+  emit a non-blocking warning when it is unreachable, returns a non-2xx
+  status, or answers with something that is not an image. Advisory by design —
+  the machine planning is not necessarily the machine rendering the login
+  page — so it never fails a run. Set `ZITADEL_SKIP_ASSET_PROBE` to turn it
+  off (offline, air-gapped CI, a CDN that only resolves from production) and
+  `ZITADEL_ASSET_PROBE_TIMEOUT_MS` to retune the per-URL budget.
+- The login UI hides an asset that fails to load and restores the split
+  designs' decorative placeholder when that empties the brand pane, so a
+  broken asset degrades to the same result as no asset instead of a blank
+  pane. Templates could not do this themselves: they are DOMPurify-sanitised
+  and inline `onerror` is stripped.
+- Branding revisions can now carry plan warnings at all; previously only
+  create/update actions could, and branding is revisioned.
+
+Two readability fixes ride along. A branding `plan` no longer dumps the whole
+inlined Liquid template as one escaped line: an unchanged multi-line field
+renders as `(<n> lines, sha256:…)` and a changed one as a real line diff. And
+the branding dialect file scaffolded into `.zitadel/meta/` now spells its
+command mentions the way the generated app can run them
+(`npx @zitadel/cli@<version> apply`), matching the READMEs — the bare
+`zitadel apply` in the editor tooltip named a command that does not exist
+there.

--- a/apps/cli/SKILLS.md
+++ b/apps/cli/SKILLS.md
@@ -139,6 +139,23 @@ the CLI's help layer, not the envelope.
   or `split-right`.
 - `plan` — validate config and preview the sync diff without mutating anything.
 - `apply` — validate and upload repo config to the platform.
+- `plan` and `apply --dry-run` also emit `data.warnings`: non-blocking
+  findings as `{path, rule, message}`, the same text the human plan prints as
+  `# warning:` lines and `apply` prints through stderr. They never fail a run.
+  Two families exist today: flow-definition rules (`warn/…`, mirrored from the
+  server's validator) and branding asset reachability. `warn/asset-unreachable`
+  and `warn/asset-content-type` come from a bounded HEAD probe of
+  `logo_url` / `hero_url` — a URL that is well-formed but dead passes every
+  gate and then renders as a 0×0 image with nothing in the console, so the
+  probe is the only place it can be caught. It is advisory by design: the
+  machine planning is not necessarily the machine that renders the login page.
+  Set `ZITADEL_SKIP_ASSET_PROBE` to turn it off (offline, air-gapped CI, or a
+  CDN that only resolves from production) and `ZITADEL_ASSET_PROBE_TIMEOUT_MS`
+  to retune the per-URL budget (default 2500).
+- In the human-readable plan, a multi-line field (branding's inlined
+  `liquid_template`) renders as `(<n> lines, sha256:…)` when it is created or
+  unchanged, and as a changed-line diff when it moved — not as one escaped
+  line. Read the file itself for full content.
 - `schemas list` — inspect the revision history of a user-schema, filtered by
   `--object-type` (e.g. `human-user`). Non-interactive/`--json` prints one row
   per revision (newest first); interactive adds a picker that fetches and

--- a/apps/cli/SKILLS.md
+++ b/apps/cli/SKILLS.md
@@ -156,6 +156,9 @@ the CLI's help layer, not the envelope.
   gate and then renders as a 0×0 image with nothing in the console, so the
   probe is the only place it can be caught. It is advisory by design: the
   machine planning is not necessarily the machine that renders the login page.
+  The probe only contacts public HTTPS destinations and re-checks every
+  redirect; loopback/private/internal targets stay inconclusive instead of
+  turning repo config into a network request from the planning host.
   Set `ZITADEL_SKIP_ASSET_PROBE` to turn it off (offline, air-gapped CI, or a
   CDN that only resolves from production) and `ZITADEL_ASSET_PROBE_TIMEOUT_MS`
   to retune the per-URL budget (default 2500).

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -70,6 +70,7 @@
     "mixpanel": "^0.18.1",
     "safe-stable-stringify": "catalog:",
     "semver": "catalog:",
+    "undici": "^7.24.7",
     "zod": "catalog:",
     "picocolors": "^1.1.1"
   },

--- a/apps/cli/src/commands/branding/eject.ts
+++ b/apps/cli/src/commands/branding/eject.ts
@@ -21,7 +21,11 @@ import { ZitadelError } from "../../lib/errors";
 import { stableStringify } from "../../lib/json";
 import { BaseCommand, type JsonEnvelope } from "../../lib/oclif";
 import { hasZitadelConfig } from "../../lib/project";
-import { normalizePublicCliProse, publicCliCommand } from "../../lib/public-cli";
+import {
+  normalizePublicCliJson,
+  normalizePublicCliProse,
+  publicCliCommand,
+} from "../../lib/public-cli";
 
 /**
  * The `branding eject` command — take ownership of the login template.
@@ -95,7 +99,7 @@ export default class BrandingEject extends BaseCommand {
     if (brandingMeta) {
       await write(
         join(META_SCHEMA_DIR, brandingMeta.name),
-        `${stableStringify(brandingMeta.body)}\n`,
+        `${stableStringify(normalizePublicCliJson(brandingMeta.body, this.meta.cliVersion))}\n`,
         false,
       ).catch(swallowConflict);
     }

--- a/apps/cli/src/lib/orca/patchers/rule/base.ts
+++ b/apps/cli/src/lib/orca/patchers/rule/base.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { metaSchemaFiles, META_SCHEMA_DIR } from "@zitadel/config/meta-schemas";
 
 import { stableStringify } from "../../../json";
+import { normalizePublicCliJson } from "../../../public-cli";
 import { DEFAULT_SERVER } from "../../../server";
 import { scaffold } from "./file-writer";
 import type { FileOp, ScaffoldPlan } from "./file-writer/types";
@@ -261,13 +262,16 @@ export abstract class AbstractRulePatcher implements Patcher {
       },
       // The dialect meta-schemas, committed with the project so flow files'
       // relative `$schema` pointers resolve offline (editor validation) and
-      // agents can read the flow/schema dialect without the docs site.
+      // agents can read the flow/schema dialect without the docs site. Their
+      // descriptions become editor tooltips inside the generated app, so the
+      // `zitadel …` mentions are rewritten to the runnable public form on the
+      // way out — the shared source keeps the bare spelling the server wants.
       { kind: "mkdir", path: META_SCHEMA_DIR },
       ...metaSchemaFiles().map(
         (file): FileOp => ({
           kind: "write",
           path: `${META_SCHEMA_DIR}/${file.name}`,
-          contents: `${JSON.stringify(file.body, null, 2)}\n`,
+          contents: `${JSON.stringify(normalizePublicCliJson(file.body, ctx.cliVersion), null, 2)}\n`,
         }),
       ),
       // Guidance for humans (README) and agents (AGENTS.md): the golden

--- a/apps/cli/src/lib/public-cli.ts
+++ b/apps/cli/src/lib/public-cli.ts
@@ -51,11 +51,50 @@ export function normalizePublicCliCommands(
  */
 export function normalizePublicCliProse(content: string, cliVersion: string): string {
   const prefix = publicCliCommand("", cliVersion);
-  return content
-    .replace(/`zitadel( [^`\n]*)?`/g, (_match, args: string | undefined) => {
-      return `\`${prefix}${args ?? ""}\``;
-    })
-    .replace(/^(\s*)zitadel (.*)$/gm, (_match, indent: string, rest: string) => {
-      return `${indent}${prefix} ${rest}`;
-    });
+  return rewriteCliCodeSpans(content, cliVersion).replace(
+    /^(\s*)zitadel (.*)$/gm,
+    (_match, indent: string, rest: string) => `${indent}${prefix} ${rest}`,
+  );
+}
+
+/** The inline-code-span half of {@link normalizePublicCliProse}. */
+function rewriteCliCodeSpans(content: string, cliVersion: string): string {
+  const prefix = publicCliCommand("", cliVersion);
+  return content.replace(
+    /`zitadel( [^`\n]*)?`/g,
+    (_match, args: string | undefined) => `\`${prefix}${args ?? ""}\``,
+  );
+}
+
+/**
+ * Rewrites `zitadel …` command mentions inside every string of a scaffolded
+ * JSON document — today the `.zitadel/meta/*.json` dialect files — returning
+ * a rewritten copy. The input is never mutated: the meta-schema bodies are
+ * imported JSON modules shared across calls.
+ *
+ * Those files are byte-copies of the meta-schemas the server embeds
+ * (`api/openapi/endpoints/schemas/*.json`), where the bare `zitadel` spelling
+ * is the correct one — the server documents the product command, not one
+ * project's install. Their `description` strings surface as editor tooltips
+ * on the scaffolded `.zitadel/**` files, where the bare command does not
+ * exist on the user's PATH, so the copy is normalized on the way out instead
+ * of the shared source being edited (same fix PR #872 made for the READMEs).
+ *
+ * Unlike {@link normalizePublicCliProse} this rewrites inline code spans
+ * only: a JSON `description` is prose, so a value that merely begins with
+ * the word `zitadel` is a sentence, not a command line.
+ */
+export function normalizePublicCliJson<T>(value: T, cliVersion: string): T {
+  if (typeof value === "string") {
+    return rewriteCliCodeSpans(value, cliVersion) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizePublicCliJson(item, cliVersion)) as T;
+  }
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, normalizePublicCliJson(item, cliVersion)]),
+    ) as T;
+  }
+  return value;
 }

--- a/apps/cli/src/lib/sync/asset-probe.ts
+++ b/apps/cli/src/lib/sync/asset-probe.ts
@@ -1,4 +1,10 @@
+import type { LookupAddress } from "node:dns";
+import { lookup } from "node:dns/promises";
+import type { RequestOptions } from "node:https";
+import { BlockList, isIP } from "node:net";
+
 import { consola } from "consola";
+import { Agent } from "undici";
 
 import type { SyncAction, SyncActionWarning } from "./types.js";
 
@@ -16,6 +22,51 @@ const ASSET_FIELDS = ["logo_url", "hero_url"] as const;
  */
 const DEFAULT_TIMEOUT_MS = 2500;
 
+/** Keep redirect chains bounded and re-validate every destination ourselves. */
+const MAX_REDIRECTS = 5;
+
+/**
+ * Addresses an untrusted descriptor must never make the planning host contact.
+ * The browser-side render gate still supports canonical loopback HTTP for local
+ * development; the CLI probe deliberately leaves those URLs inconclusive
+ * instead of turning `plan` over repo content into a localhost/network scanner.
+ */
+const UNSAFE_IPV4_ADDRESSES = new BlockList();
+for (const [network, prefix] of [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.88.99.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+] as const) {
+  UNSAFE_IPV4_ADDRESSES.addSubnet(network, prefix, "ipv4");
+}
+const UNSAFE_IPV6_ADDRESSES = new BlockList();
+for (const [network, prefix] of [
+  // Global unicast currently lives in 2000::/3. Excluding everything outside
+  // it also covers mapped IPv4, translation, ULA, link-local, and multicast.
+  ["::", 3],
+  ["4000::", 2],
+  ["8000::", 1],
+  // Special-purpose ranges inside 2000::/3 are not public asset hosts.
+  ["2001::", 23],
+  ["2001:db8::", 32],
+  ["2002::", 16],
+  ["3fff::", 20],
+] as const) {
+  UNSAFE_IPV6_ADDRESSES.addSubnet(network, prefix, "ipv6");
+}
+
 /** Content types that are images despite not being `image/*`. */
 const EXTRA_IMAGE_TYPES = new Set(["application/octet-stream"]);
 
@@ -25,6 +76,7 @@ export type AssetProbeVerdict =
   | { kind: "inconclusive" }
   | { kind: "unreachable"; detail: string }
   | { kind: "status"; status: number }
+  | { kind: "empty"; status: number }
   | { kind: "content-type"; contentType: string };
 
 /**
@@ -42,7 +94,10 @@ export type AssetProbeVerdict =
  * warning, never a failed plan — the machine running `plan` is not
  * necessarily the machine that renders the login page. Set
  * `ZITADEL_SKIP_ASSET_PROBE` to turn it off entirely, and
- * `ZITADEL_ASSET_PROBE_TIMEOUT_MS` to retune the per-URL budget.
+ * `ZITADEL_ASSET_PROBE_TIMEOUT_MS` to retune the per-URL budget. Only public
+ * HTTPS destinations are contacted: loopback/private/internal targets and
+ * redirects to them stay inconclusive so repo config cannot scan the planning
+ * host's network.
  *
  * Mutates `actions` in place, like {@link validatePlannedFlows} — the caller
  * (`buildSyncPlan`) owns the array it just built.
@@ -77,7 +132,10 @@ export async function annotateAssetWarnings(actions: SyncAction[]): Promise<void
   const verdicts = new Map(
     await Promise.all(
       [...urls].map(
-        async (url): Promise<[string, AssetProbeVerdict]> => [url, await probeAsset(url, timeoutMs)],
+        async (url): Promise<[string, AssetProbeVerdict]> => [
+          url,
+          await probeAsset(url, timeoutMs),
+        ],
       ),
     ),
   );
@@ -102,46 +160,193 @@ export async function annotateAssetWarnings(actions: SyncAction[]): Promise<void
  * the content type.
  */
 export async function probeAsset(url: string, timeoutMs: number): Promise<AssetProbeVerdict> {
-  let parsed: URL;
+  let current: URL;
   try {
-    parsed = new URL(url);
+    current = new URL(url);
   } catch {
     // Shape is the schema's job; an unparseable URL never reaches here.
     return { kind: "inconclusive" };
   }
-  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-    return { kind: "inconclusive" };
-  }
-
-  let response: Response;
+  const signal = AbortSignal.timeout(timeoutMs);
   try {
-    response = await fetch(url, {
-      method: "HEAD",
-      redirect: "follow",
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    for (let redirects = 0; ; redirects += 1) {
+      if (!isSafeProbeUrl(current)) {
+        consola.debug(`asset probe ${url} skipped unsafe/private target: ${current.href}`);
+        return { kind: "inconclusive" };
+      }
+
+      const response = await requestHead(current, signal);
+
+      if (isRedirect(response.status)) {
+        const location = response.location;
+        if (!location) {
+          return { kind: "status", status: response.status };
+        }
+        if (redirects >= MAX_REDIRECTS) {
+          return { kind: "unreachable", detail: `more than ${MAX_REDIRECTS} redirects` };
+        }
+        current = new URL(location, current);
+        continue;
+      }
+
+      // Some origins refuse HEAD outright. That says nothing about the asset,
+      // and a false "your logo is broken" is worse than staying quiet.
+      if (response.status === 405 || response.status === 501) {
+        return { kind: "inconclusive" };
+      }
+      if (response.status < 200 || response.status >= 300) {
+        return { kind: "status", status: response.status };
+      }
+      // These successful statuses are explicitly bodyless. Treating them as
+      // healthy because they also omit Content-Type recreates the exact
+      // "well-formed URL that serves nothing" failure this probe exists for.
+      if (response.status === 204 || response.status === 205) {
+        return { kind: "empty", status: response.status };
+      }
+
+      const contentType = response.contentType?.split(";")[0]?.trim().toLowerCase();
+      if (!contentType) {
+        return { kind: "ok" };
+      }
+      if (contentType.startsWith("image/") || EXTRA_IMAGE_TYPES.has(contentType)) {
+        return { kind: "ok" };
+      }
+      return { kind: "content-type", contentType };
+    }
   } catch (error) {
+    if (isUnsafeProbeTargetError(error)) {
+      consola.debug(`asset probe ${url} skipped unsafe/private target`);
+      return { kind: "inconclusive" };
+    }
     consola.debug(`asset probe ${url} failed:`, error);
-    return { kind: "unreachable", detail: describeFetchError(error, timeoutMs) };
+    return { kind: "unreachable", detail: describeProbeError(error, timeoutMs) };
+  }
+}
+
+function isRedirect(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+/**
+ * Reject targets whose URL alone proves they are unsafe. Hostname resolution
+ * happens inside the connector lookup below so validation and connection use
+ * the same DNS answer, without a rebinding window.
+ */
+function isSafeProbeUrl(url: URL): boolean {
+  if (url.protocol !== "https:" || url.username !== "" || url.password !== "") {
+    return false;
   }
 
-  // Some origins refuse HEAD outright. That says nothing about the asset, and
-  // a false "your logo is broken" is worse than staying quiet.
-  if (response.status === 405 || response.status === 501) {
-    return { kind: "inconclusive" };
-  }
-  if (!response.ok) {
-    return { kind: "status", status: response.status };
+  const hostname = url.hostname
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.$/, "")
+    .toLowerCase();
+  if (
+    hostname === "localhost" ||
+    !hostname.includes(".") ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".internal") ||
+    hostname.endsWith(".lan") ||
+    hostname.endsWith(".home.arpa")
+  ) {
+    return false;
   }
 
-  const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
-  if (!contentType) {
-    return { kind: "ok" };
+  const literalFamily = isIP(hostname);
+  return literalFamily === 0 || !isUnsafeAddress(hostname, literalFamily);
+}
+
+/** Resolve once and accept the answer only when every address is public. */
+export async function resolvePublicAddresses(
+  hostname: string,
+): Promise<LookupAddress[] | undefined> {
+  const addresses = await lookup(hostname, { all: true, verbatim: true });
+  return addresses.length > 0 &&
+    addresses.every(({ address, family }) => !isUnsafeAddress(address, family))
+    ? addresses
+    : undefined;
+}
+
+function isUnsafeAddress(address: string, family: number): boolean {
+  return family === 6
+    ? UNSAFE_IPV6_ADDRESSES.check(address, "ipv6")
+    : UNSAFE_IPV4_ADDRESSES.check(address, "ipv4");
+}
+
+interface HeadResponse {
+  status: number;
+  location?: string;
+  contentType?: string;
+}
+
+const UNSAFE_PROBE_TARGET_CODE = "ERR_ZITADEL_UNSAFE_ASSET_TARGET";
+
+function unsafeProbeTargetError(hostname: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`asset target ${hostname} resolves to a non-public address`), {
+    code: UNSAFE_PROBE_TARGET_CODE,
+  });
+}
+
+/**
+ * Validate DNS in the connector's own lookup and return only approved
+ * addresses. The socket cannot perform a second lookup, which closes the DNS
+ * rebinding gap while preserving the hostname for TLS SNI/certificate checks.
+ */
+async function requestHead(url: URL, signal: AbortSignal): Promise<HeadResponse> {
+  const safeLookup: NonNullable<RequestOptions["lookup"]> = (hostname, options, callback) => {
+    resolvePublicAddresses(hostname).then(
+      (addresses) => {
+        if (!addresses) {
+          callback(unsafeProbeTargetError(hostname), "", 0);
+          return;
+        }
+        const candidates =
+          options.family === 4 || options.family === 6
+            ? addresses.filter(({ family }) => family === options.family)
+            : addresses;
+        const candidate = candidates[0];
+        if (!candidate) {
+          callback(unsafeProbeTargetError(hostname), "", 0);
+          return;
+        }
+        if (options.all) {
+          callback(null, candidates);
+          return;
+        }
+        callback(null, candidate.address, candidate.family);
+      },
+      (error: NodeJS.ErrnoException) => callback(error, "", 0),
+    );
+  };
+
+  const dispatcher = new Agent({ connect: { lookup: safeLookup } });
+  try {
+    const response = await fetch(url, {
+      method: "HEAD",
+      redirect: "manual",
+      signal,
+      dispatcher,
+    } as RequestInit & { dispatcher: Agent });
+    return {
+      status: response.status,
+      location: response.headers.get("location") ?? undefined,
+      contentType: response.headers.get("content-type") ?? undefined,
+    };
+  } finally {
+    await dispatcher.destroy();
   }
-  if (contentType.startsWith("image/") || EXTRA_IMAGE_TYPES.has(contentType)) {
-    return { kind: "ok" };
+}
+
+function isUnsafeProbeTargetError(error: unknown): boolean {
+  let current = error;
+  for (let depth = 0; depth < 4 && current instanceof Error; depth += 1) {
+    if ((current as NodeJS.ErrnoException).code === UNSAFE_PROBE_TARGET_CODE) {
+      return true;
+    }
+    current = current.cause;
   }
-  return { kind: "content-type", contentType };
+  return false;
 }
 
 function describeVerdict(
@@ -159,6 +364,13 @@ function describeVerdict(
         message:
           `${field} ${url} returned HTTP ${verdict.status} — the login page renders a ` +
           `well-formed URL that serves nothing as a 0×0 image, with no error anywhere.`,
+      };
+    case "empty":
+      return {
+        rule: "warn/asset-unreachable",
+        message:
+          `${field} ${url} returned HTTP ${verdict.status} with no representation — the login ` +
+          `page has no image bytes to render.`,
       };
     case "unreachable":
       return {
@@ -196,13 +408,15 @@ function probeTimeoutMs(): number {
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MS;
 }
 
-function describeFetchError(error: unknown, timeoutMs: number): string {
-  if (error instanceof Error && error.name === "TimeoutError") {
+function describeProbeError(error: unknown, timeoutMs: number): string {
+  if (
+    error instanceof Error &&
+    (error.name === "TimeoutError" ||
+      (error.cause instanceof Error && error.cause.name === "TimeoutError"))
+  ) {
     return `no response within ${timeoutMs}ms`;
   }
   if (error instanceof Error) {
-    // `fetch` wraps DNS/TLS/connection failures in a bare "fetch failed";
-    // the cause carries the sentence a human can act on.
     const cause = error.cause;
     const detail = cause instanceof Error ? cause.message : error.message;
     return detail || error.name;

--- a/apps/cli/src/lib/sync/asset-probe.ts
+++ b/apps/cli/src/lib/sync/asset-probe.ts
@@ -1,0 +1,211 @@
+import { consola } from "consola";
+
+import type { SyncAction, SyncActionWarning } from "./types.js";
+
+/**
+ * Branding descriptor fields whose value is a URL the login page fetches as
+ * an image. Both are optional and both fail the same invisible way when the
+ * URL is well-formed but dead.
+ */
+const ASSET_FIELDS = ["logo_url", "hero_url"] as const;
+
+/**
+ * Per-URL probe budget. Short on purpose: this runs on the critical path of
+ * every `plan` and `apply`, and a dead host that never answers must cost a
+ * couple of seconds, not a hung command.
+ */
+const DEFAULT_TIMEOUT_MS = 2500;
+
+/** Content types that are images despite not being `image/*`. */
+const EXTRA_IMAGE_TYPES = new Set(["application/octet-stream"]);
+
+export type AssetProbeVerdict =
+  | { kind: "ok" }
+  /** The probe could not decide — no warning is worth a false alarm. */
+  | { kind: "inconclusive" }
+  | { kind: "unreachable"; detail: string }
+  | { kind: "status"; status: number }
+  | { kind: "content-type"; contentType: string };
+
+/**
+ * Annotate every branding action in a plan with warnings for asset URLs that
+ * are well-formed but will not render: an unreachable host, a non-2xx status,
+ * or a response that is not an image.
+ *
+ * Why the CLI probes at all: a bad `logo_url` clears every gate on the way in
+ * (the CLI's Zod shape check, the server's save gate) and then fails silently
+ * in the browser as a 0×0 `<img>` — no plan output, no apply output, no
+ * console error. The probe is the only place in the pipeline that can see it.
+ *
+ * Deliberately non-fatal and best-effort. A developer on a plane, behind a
+ * proxy, or pointing at a CDN that only resolves from production gets a
+ * warning, never a failed plan — the machine running `plan` is not
+ * necessarily the machine that renders the login page. Set
+ * `ZITADEL_SKIP_ASSET_PROBE` to turn it off entirely, and
+ * `ZITADEL_ASSET_PROBE_TIMEOUT_MS` to retune the per-URL budget.
+ *
+ * Mutates `actions` in place, like {@link validatePlannedFlows} — the caller
+ * (`buildSyncPlan`) owns the array it just built.
+ */
+export async function annotateAssetWarnings(actions: SyncAction[]): Promise<void> {
+  if (process.env.ZITADEL_SKIP_ASSET_PROBE) {
+    consola.debug("Branding asset probe skipped (ZITADEL_SKIP_ASSET_PROBE is set)");
+    return;
+  }
+
+  const targets = actions.filter(
+    (action): action is Extract<SyncAction, { kind: "create" | "update" | "revise" }> =>
+      (action.kind === "create" || action.kind === "update" || action.kind === "revise") &&
+      action.syncer.kind === "branding",
+  );
+  if (targets.length === 0) {
+    return;
+  }
+
+  // One probe per distinct URL: the same logo referenced twice is one request.
+  const urls = new Set<string>();
+  for (const action of targets) {
+    for (const { url } of assetUrlsOf(action.content)) {
+      urls.add(url);
+    }
+  }
+  if (urls.size === 0) {
+    return;
+  }
+
+  const timeoutMs = probeTimeoutMs();
+  const verdicts = new Map(
+    await Promise.all(
+      [...urls].map(
+        async (url): Promise<[string, AssetProbeVerdict]> => [url, await probeAsset(url, timeoutMs)],
+      ),
+    ),
+  );
+
+  for (const action of targets) {
+    const warnings: SyncActionWarning[] = [];
+    for (const { field, url } of assetUrlsOf(action.content)) {
+      const warning = describeVerdict(field, url, verdicts.get(url) ?? { kind: "inconclusive" });
+      if (warning) {
+        warnings.push(warning);
+      }
+    }
+    if (warnings.length > 0) {
+      action.warnings = [...(action.warnings ?? []), ...warnings];
+    }
+  }
+}
+
+/**
+ * The probe itself: a HEAD request bounded by an abort timeout. HEAD keeps a
+ * multi-megabyte hero image off the wire — we only need the status line and
+ * the content type.
+ */
+export async function probeAsset(url: string, timeoutMs: number): Promise<AssetProbeVerdict> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // Shape is the schema's job; an unparseable URL never reaches here.
+    return { kind: "inconclusive" };
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return { kind: "inconclusive" };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "HEAD",
+      redirect: "follow",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    consola.debug(`asset probe ${url} failed:`, error);
+    return { kind: "unreachable", detail: describeFetchError(error, timeoutMs) };
+  }
+
+  // Some origins refuse HEAD outright. That says nothing about the asset, and
+  // a false "your logo is broken" is worse than staying quiet.
+  if (response.status === 405 || response.status === 501) {
+    return { kind: "inconclusive" };
+  }
+  if (!response.ok) {
+    return { kind: "status", status: response.status };
+  }
+
+  const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
+  if (!contentType) {
+    return { kind: "ok" };
+  }
+  if (contentType.startsWith("image/") || EXTRA_IMAGE_TYPES.has(contentType)) {
+    return { kind: "ok" };
+  }
+  return { kind: "content-type", contentType };
+}
+
+function describeVerdict(
+  field: string,
+  url: string,
+  verdict: AssetProbeVerdict,
+): SyncActionWarning | undefined {
+  switch (verdict.kind) {
+    case "ok":
+    case "inconclusive":
+      return undefined;
+    case "status":
+      return {
+        rule: "warn/asset-unreachable",
+        message:
+          `${field} ${url} returned HTTP ${verdict.status} — the login page renders a ` +
+          `well-formed URL that serves nothing as a 0×0 image, with no error anywhere.`,
+      };
+    case "unreachable":
+      return {
+        rule: "warn/asset-unreachable",
+        message:
+          `${field} ${url} could not be reached (${verdict.detail}) — the login page renders ` +
+          `an unreachable URL as a 0×0 image. Ignore this if the host is only reachable from ` +
+          `where the login page renders; set ZITADEL_SKIP_ASSET_PROBE to stop checking.`,
+      };
+    case "content-type":
+      return {
+        rule: "warn/asset-content-type",
+        message:
+          `${field} ${url} responded with content-type "${verdict.contentType}", not an image — ` +
+          `the login page renders a non-image response as a 0×0 image.`,
+      };
+  }
+}
+
+/** The `logo_url` / `hero_url` values a descriptor actually sets. */
+function assetUrlsOf(content: object): Array<{ field: string; url: string }> {
+  const body = content as Record<string, unknown>;
+  const out: Array<{ field: string; url: string }> = [];
+  for (const field of ASSET_FIELDS) {
+    const value = body[field];
+    if (typeof value === "string" && value !== "") {
+      out.push({ field, url: value });
+    }
+  }
+  return out;
+}
+
+function probeTimeoutMs(): number {
+  const raw = Number(process.env.ZITADEL_ASSET_PROBE_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MS;
+}
+
+function describeFetchError(error: unknown, timeoutMs: number): string {
+  if (error instanceof Error && error.name === "TimeoutError") {
+    return `no response within ${timeoutMs}ms`;
+  }
+  if (error instanceof Error) {
+    // `fetch` wraps DNS/TLS/connection failures in a bare "fetch failed";
+    // the cause carries the sentence a human can act on.
+    const cause = error.cause;
+    const detail = cause instanceof Error ? cause.message : error.message;
+    return detail || error.name;
+  }
+  return String(error);
+}

--- a/apps/cli/src/lib/sync/loop.ts
+++ b/apps/cli/src/lib/sync/loop.ts
@@ -7,6 +7,7 @@ import { consola } from "consola";
 import { ZitadelError } from "../errors";
 import { FLOWS_DIR } from "../flows";
 import { stableStringify } from "../json";
+import { annotateAssetWarnings } from "./asset-probe.js";
 import { validatePlannedFlows } from "./flow-validation.js";
 import type { PlanResourceChange } from "./plan-renderer.js";
 import { readState, removeFromState, updateState } from "./state.js";
@@ -205,6 +206,11 @@ export async function buildSyncPlan(
   // already published. Throws E_VALIDATION before any mutation.
   validatePlannedFlows({ actions, scannedContents, stateResources: state.resources });
 
+  // Reachability pre-flight for branding asset URLs. Annotates warnings only:
+  // the machine planning is not necessarily the machine rendering the login
+  // page, so a URL this host cannot fetch is never a reason to fail.
+  await annotateAssetWarnings(actions);
+
   return actions;
 }
 
@@ -246,7 +252,7 @@ export async function runSyncLoop(
 ): Promise<SyncLoopResult> {
   const actions = await buildSyncPlan(cwd, syncers);
   for (const action of actions) {
-    if (action.kind === "create" || action.kind === "update") {
+    if (action.kind === "create" || action.kind === "update" || action.kind === "revise") {
       for (const warning of action.warnings ?? []) {
         consola.warn(`${action.path}: ${warning.message}`);
       }

--- a/apps/cli/src/lib/sync/plan-renderer.ts
+++ b/apps/cli/src/lib/sync/plan-renderer.ts
@@ -1,5 +1,12 @@
+import { createHash } from "node:crypto";
+
 import { stableStringify } from "../json";
-import type { ResourceSyncer, SyncAction, SyncPlanSummary } from "./types.js";
+import type {
+  ResourceSyncer,
+  SyncAction,
+  SyncActionWarning,
+  SyncPlanSummary,
+} from "./types.js";
 
 /**
  * Count the non-`skip` actions in a {@link buildSyncPlan} result. Pure; the
@@ -27,14 +34,21 @@ export function collectPlanWarnings(
 ): Array<{ path: string; rule: string; message: string }> {
   const out: Array<{ path: string; rule: string; message: string }> = [];
   for (const action of actions) {
-    if (action.kind !== "create" && action.kind !== "update") {
-      continue;
-    }
-    for (const warning of action.warnings ?? []) {
+    for (const warning of warningsOf(action)) {
       out.push({ path: action.path, rule: warning.rule, message: warning.message });
     }
   }
   return out;
+}
+
+/**
+ * The warnings an action carries. Only the three kinds that upload a body can
+ * have any: a `delete` has no content to judge, and a `skip` was never judged.
+ */
+function warningsOf(action: SyncAction): ReadonlyArray<SyncActionWarning> {
+  return action.kind === "create" || action.kind === "update" || action.kind === "revise"
+    ? (action.warnings ?? [])
+    : [];
 }
 
 /**
@@ -136,14 +150,7 @@ export function renderPlan(actions: ReadonlyArray<SyncAction>, tty: boolean): st
 
   out.push(paint(`Plan: ${parts.join(", ")}.`, A.bold, tty));
 
-  const warningCount = active.reduce(
-    (count, action) =>
-      count +
-      ((action.kind === "create" || action.kind === "update") && action.warnings
-        ? action.warnings.length
-        : 0),
-    0,
-  );
+  const warningCount = active.reduce((count, action) => count + warningsOf(action).length, 0);
   if (warningCount > 0) {
     out.push(
       paint(
@@ -202,6 +209,44 @@ function fmtPrimitive(v: string | number | boolean | null): string {
 }
 
 /**
+ * A multi-line string is a document, not a scalar: branding inlines a whole
+ * `login.liquid` into `liquid_template`, and escaping 200 lines onto one
+ * `"…\n…\n…"` line buries every real change in the same block. Such values
+ * render as a summary (and, when they changed, as a line diff) instead.
+ */
+function isBlockString(v: unknown): v is string {
+  return typeof v === "string" && v !== KNOWN_AFTER_APPLY && v.includes("\n");
+}
+
+/** Trailing-newline-insensitive line count: `"a\nb\n"` is two lines, not three. */
+function lineCount(value: string): number {
+  const lines = value.split("\n");
+  return lines.length > 1 && lines[lines.length - 1] === "" ? lines.length - 1 : lines.length;
+}
+
+/** Short content fingerprint, so two summarised blocks can be told apart. */
+function shortHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 8);
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function blockSummary(value: string): string {
+  return `(${plural(lineCount(value), "line")}, sha256:${shortHash(value)})`;
+}
+
+function unchangedBlockSummary(value: string): string {
+  return `(unchanged, ${plural(lineCount(value), "line")}, sha256:${shortHash(value)})`;
+}
+
+/** {@link fmtPrimitive}, with multi-line strings summarised. */
+function fmtScalar(v: string | number | boolean | null): string {
+  return isBlockString(v) ? blockSummary(v) : fmtPrimitive(v);
+}
+
+/**
  * Indentation contract (matches Terraform exactly):
  *   prefixCol = column index of the +/-/~ character
  *   field content starts at prefixCol + 2  (one space gap after prefix)
@@ -247,7 +292,7 @@ function renderFields(
     const pk = key.padEnd(maxLen);
 
     if (isPrimitive(val)) {
-      const formatted = fmtPrimitive(val);
+      const formatted = fmtScalar(val);
       const suffix = ctx.deleteMode ? " -> null" : "";
       lines.push(col(`${pad}${prefix} ${pk} = ${formatted}${suffix}`));
     } else if (Array.isArray(val)) {
@@ -289,7 +334,7 @@ function renderArrayItems(
 
   for (const item of arr) {
     if (isPrimitive(item)) {
-      const formatted = fmtPrimitive(item);
+      const formatted = fmtScalar(item);
       lines.push(col(`${pad}${prefix} ${formatted},`));
     } else if (Array.isArray(item)) {
       if (item.length === 0) {
@@ -308,6 +353,134 @@ function renderArrayItems(
         lines.push(col(`${" ".repeat(prefixCol + 2)}},`));
       }
     }
+  }
+}
+
+/** Changed-line budget for one block-string diff, before the "more" trailer. */
+const MAX_BLOCK_DIFF_LINES = 20;
+
+/**
+ * LCS cell budget (500 × 500 changed lines). Above it the middle section
+ * renders as one remove/add block instead — quadratic DP over a pathological
+ * template is not worth the memory, and a whole-block replace is still an
+ * honest rendering. The shipped designs are under 200 lines *before* the
+ * prefix/suffix trim, so real templates never come close.
+ */
+const MAX_LCS_CELLS = 250_000;
+
+type LineOp = { kind: "same" | "del" | "add"; line: string };
+
+function asLines(v: string | number | boolean | null): string[] {
+  return typeof v === "string" ? v.split("\n") : [fmtPrimitive(v)];
+}
+
+/**
+ * Line-level diff of two block strings. Common prefix and suffix are trimmed
+ * first — a template edit touches one region, so this alone usually reduces
+ * the problem to a handful of lines — and the remaining middle goes through
+ * an LCS pass (or, past {@link MAX_LCS_CELLS}, renders as a wholesale
+ * replacement).
+ */
+function diffLines(oldLines: readonly string[], newLines: readonly string[]): LineOp[] {
+  let start = 0;
+  while (
+    start < oldLines.length &&
+    start < newLines.length &&
+    oldLines[start] === newLines[start]
+  ) {
+    start += 1;
+  }
+  let endOld = oldLines.length;
+  let endNew = newLines.length;
+  while (endOld > start && endNew > start && oldLines[endOld - 1] === newLines[endNew - 1]) {
+    endOld -= 1;
+    endNew -= 1;
+  }
+
+  const midOld = oldLines.slice(start, endOld);
+  const midNew = newLines.slice(start, endNew);
+  if (midOld.length * midNew.length > MAX_LCS_CELLS) {
+    return [
+      ...midOld.map((line): LineOp => ({ kind: "del", line })),
+      ...midNew.map((line): LineOp => ({ kind: "add", line })),
+    ];
+  }
+  return lcsDiff(midOld, midNew);
+}
+
+/** Classic LCS-length DP, walked back into an op list. */
+function lcsDiff(a: readonly string[], b: readonly string[]): LineOp[] {
+  const table: number[][] = Array.from({ length: a.length + 1 }, () =>
+    new Array<number>(b.length + 1).fill(0),
+  );
+  for (let i = a.length - 1; i >= 0; i -= 1) {
+    for (let j = b.length - 1; j >= 0; j -= 1) {
+      table[i][j] =
+        a[i] === b[j] ? table[i + 1][j + 1] + 1 : Math.max(table[i + 1][j], table[i][j + 1]);
+    }
+  }
+
+  const ops: LineOp[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      ops.push({ kind: "same", line: a[i] });
+      i += 1;
+      j += 1;
+    } else if (table[i + 1][j] >= table[i][j + 1]) {
+      ops.push({ kind: "del", line: a[i] });
+      i += 1;
+    } else {
+      ops.push({ kind: "add", line: b[j] });
+      j += 1;
+    }
+  }
+  for (; i < a.length; i += 1) {
+    ops.push({ kind: "del", line: a[i] });
+  }
+  for (; j < b.length; j += 1) {
+    ops.push({ kind: "add", line: b[j] });
+  }
+  return ops;
+}
+
+/**
+ * Render a changed block string as a header plus its changed lines. Context
+ * lines are deliberately omitted: the file is on disk, and the plan's job is
+ * to name what moved, not to reproduce the template.
+ */
+function renderBlockStringDiff(
+  paddedKey: string,
+  oldVal: string | number | boolean | null,
+  newVal: string | number | boolean | null,
+  prefixCol: number,
+  tty: boolean,
+  lines: string[],
+): void {
+  const pad = " ".repeat(prefixCol);
+  const bodyPad = " ".repeat(prefixCol + 4);
+  const changed = diffLines(asLines(oldVal), asLines(newVal)).filter((op) => op.kind !== "same");
+  const total = typeof newVal === "string" ? lineCount(newVal) : 1;
+  const fingerprints =
+    typeof oldVal === "string" && typeof newVal === "string"
+      ? `, sha256:${shortHash(oldVal)} -> sha256:${shortHash(newVal)}`
+      : "";
+
+  lines.push(
+    paint(
+      `${pad}~ ${paddedKey} = (${plural(changed.length, "line")} changed of ${total}${fingerprints})`,
+      A.yellow,
+      tty,
+    ),
+  );
+  for (const op of changed.slice(0, MAX_BLOCK_DIFF_LINES)) {
+    const del = op.kind === "del";
+    lines.push(paint(`${bodyPad}${del ? "-" : "+"} ${op.line}`, del ? A.red : A.green, tty));
+  }
+  const omitted = changed.length - MAX_BLOCK_DIFF_LINES;
+  if (omitted > 0) {
+    lines.push(`${bodyPad}  # (${plural(omitted, "more changed line")} not shown)`);
   }
 }
 
@@ -345,7 +518,7 @@ function renderDiff(
       hasChanges = true;
       const col = (s: string) => paint(s, A.green, tty);
       if (isPrimitive(newVal)) {
-        lines.push(col(`${pad}+ ${pk} = ${fmtPrimitive(newVal)}`));
+        lines.push(col(`${pad}+ ${pk} = ${fmtScalar(newVal)}`));
       } else if (Array.isArray(newVal)) {
         lines.push(col(`${pad}+ ${pk} = [`));
         renderArrayItems(newVal, "+", prefixCol + 4, { tty, deleteMode: false }, lines);
@@ -359,7 +532,7 @@ function renderDiff(
       hasChanges = true;
       const col = (s: string) => paint(s, A.red, tty);
       if (isPrimitive(oldVal)) {
-        lines.push(col(`${pad}- ${pk} = ${fmtPrimitive(oldVal)} -> null`));
+        lines.push(col(`${pad}- ${pk} = ${fmtScalar(oldVal)} -> null`));
       } else if (Array.isArray(oldVal)) {
         lines.push(col(`${pad}- ${pk} = [`));
         renderArrayItems(oldVal, "-", prefixCol + 4, { tty, deleteMode: false }, lines);
@@ -371,7 +544,14 @@ function renderDiff(
       }
     } else if (isPrimitive(oldVal) && isPrimitive(newVal)) {
       if (oldVal === newVal) {
-        lines.push(`${pad}  ${pk} = ${fmtPrimitive(newVal)}`);
+        lines.push(
+          isBlockString(newVal)
+            ? `${pad}  ${pk} = ${unchangedBlockSummary(newVal)}`
+            : `${pad}  ${pk} = ${fmtPrimitive(newVal)}`,
+        );
+      } else if (isBlockString(oldVal) || isBlockString(newVal)) {
+        hasChanges = true;
+        renderBlockStringDiff(pk, oldVal, newVal, prefixCol, tty, lines);
       } else {
         hasChanges = true;
         const col = (s: string) => paint(s, A.yellow, tty);
@@ -429,10 +609,10 @@ function renderDiff(
       const colR = (s: string) => paint(s, A.red, tty);
       const colA = (s: string) => paint(s, A.green, tty);
       if (isPrimitive(oldVal)) {
-        lines.push(colR(`${pad}- ${pk} = ${fmtPrimitive(oldVal)} -> null`));
+        lines.push(colR(`${pad}- ${pk} = ${fmtScalar(oldVal)} -> null`));
       }
       if (isPrimitive(newVal)) {
-        lines.push(colA(`${pad}+ ${pk} = ${fmtPrimitive(newVal)}`));
+        lines.push(colA(`${pad}+ ${pk} = ${fmtScalar(newVal)}`));
       }
     }
   }
@@ -584,6 +764,7 @@ function renderBlock(action: SyncAction, tty: boolean): string[] {
         );
       }
       lines.push(`${closePad}}`);
+      renderWarnings(action.warnings, blkPad, tty, lines);
       if (action.affectedPaths.length > 0) {
         lines.push(
           paint(

--- a/apps/cli/src/lib/sync/types.ts
+++ b/apps/cli/src/lib/sync/types.ts
@@ -171,8 +171,9 @@ export type SyncPlanSummary = {
 export type FlowRepin = { previousId: string; schemaPath: string; newId?: string };
 
 /**
- * A non-blocking finding from plan-time flow validation (severity
- * `warning` in `@zitadel/config/validate`). Rendered as `# warning:`
+ * A non-blocking plan-time finding: a flow-validation issue of severity
+ * `warning` (`@zitadel/config/validate`), or a branding asset URL the
+ * probe could not fetch (`asset-probe.ts`). Rendered as `# warning:`
  * comment lines in the plan and `consola.warn`ed during apply; never
  * fails the run.
  */
@@ -208,6 +209,7 @@ export type SyncAction =
       previousId: string;
       oldContent: object | null;
       affectedPaths: ReadonlyArray<string>;
+      warnings?: ReadonlyArray<SyncActionWarning>;
     }
   | { kind: "delete"; path: string; syncer: ResourceSyncer; id: string; oldContent: object | null }
   | { kind: "skip"; path: string; reason: "immutable" | "no-change" };

--- a/apps/cli/tests/unit/commands/branding-eject.test.ts
+++ b/apps/cli/tests/unit/commands/branding-eject.test.ts
@@ -68,6 +68,13 @@ describe("branding eject", () => {
     const readme = await readFile(join(cwd, ".zitadel/branding/README.md"), "utf8");
     expect(readme).toContain("npx @zitadel/cli@");
     expect(readme).not.toMatch(/`zitadel /);
+
+    // Same rule for the dialect file: its `description` strings are the
+    // editor tooltip on branding.json, so a bare `zitadel apply` there reads
+    // as a command the generated app doesn't have.
+    const meta = await readFile(join(cwd, ".zitadel/meta/branding.json"), "utf8");
+    expect(meta).toContain("npx @zitadel/cli@");
+    expect(meta).not.toMatch(/`zitadel /);
   });
 
   it("--design split writes the split template and layout", async () => {

--- a/apps/cli/tests/unit/lib/public-cli.test.ts
+++ b/apps/cli/tests/unit/lib/public-cli.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   normalizePublicCliCommand,
+  normalizePublicCliJson,
   normalizePublicCliProse,
   npmDistTagForCliVersion,
   npmSelectorForCliVersion,
@@ -73,5 +74,48 @@ describe("normalizePublicCliProse", () => {
     expect(normalizePublicCliProse("`npm install` then `git push`", "0.1.0-alpha.1")).toBe(
       "`npm install` then `git push`",
     );
+  });
+});
+
+describe("normalizePublicCliJson", () => {
+  it("rewrites command spans in nested strings without mutating the input", () => {
+    const body = {
+      description: "`zitadel apply` publishes this as a revision.",
+      properties: { layout: { examples: ["run `zitadel branding eject --design split`"] } },
+    };
+    const before = JSON.stringify(body);
+
+    const out = normalizePublicCliJson(body, "0.1.0-alpha.1");
+
+    expect(out.description).toBe(
+      "`npx @zitadel/cli@0.1.0-alpha.1 apply` publishes this as a revision.",
+    );
+    expect(out.properties.layout.examples[0]).toBe(
+      "run `npx @zitadel/cli@0.1.0-alpha.1 branding eject --design split`",
+    );
+    expect(JSON.stringify(body)).toBe(before);
+  });
+
+  it("leaves non-string leaves and unspanned prose alone", () => {
+    const out = normalizePublicCliJson(
+      {
+        // A description is prose, not a command line: the fenced-block rule
+        // `normalizePublicCliProse` applies must not fire here.
+        description: "zitadel resolves the latest revision per project.",
+        maxLength: 131072,
+        additionalProperties: false,
+        pattern: "^https://",
+        nothing: null,
+      },
+      "0.1.0-alpha.1",
+    );
+
+    expect(out).toEqual({
+      description: "zitadel resolves the latest revision per project.",
+      maxLength: 131072,
+      additionalProperties: false,
+      pattern: "^https://",
+      nothing: null,
+    });
   });
 });

--- a/apps/cli/tests/unit/lib/sync/asset-probe.test.ts
+++ b/apps/cli/tests/unit/lib/sync/asset-probe.test.ts
@@ -1,0 +1,239 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+
+import { annotateAssetWarnings } from "../../../../src/lib/sync/asset-probe";
+import { buildSyncPlan } from "../../../../src/lib/sync/loop";
+import { collectPlanWarnings } from "../../../../src/lib/sync/plan-renderer";
+import type { ResourceSyncer, SyncAction } from "../../../../src/lib/sync/types";
+
+/**
+ * Every outbound request the probe makes is intercepted: a sandboxed vitest
+ * worker freezes its event loop for ~10s on an unresolvable host, and a JS
+ * timeout cannot rescue it. No test here may reach a real network.
+ */
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+afterEach(() => {
+  server.resetHandlers();
+  delete process.env.ZITADEL_SKIP_ASSET_PROBE;
+});
+
+function makeSyncer(kind: string): ResourceSyncer {
+  return {
+    kind,
+    directory: `.zitadel/${kind}`,
+    mutable: false,
+    revisioned: true,
+    validate() { /* no-op: probe tests do not exercise validation */ },
+    async create() { return { id: "id" }; },
+    async update() { return {}; },
+    async delete() { /* no-op: probe tests do not exercise delete */ },
+  };
+}
+
+const branding = makeSyncer("branding");
+
+function reviseBranding(content: object): SyncAction[] {
+  return [
+    {
+      kind: "revise",
+      path: ".zitadel/branding/branding.json",
+      syncer: branding,
+      content,
+      hash: "h",
+      previousId: "brd_1",
+      oldContent: null,
+      affectedPaths: [],
+    },
+  ];
+}
+
+function warningsOf(actions: SyncAction[]): ReadonlyArray<{ rule: string; message: string }> {
+  const action = actions[0];
+  return action.kind === "revise" ? (action.warnings ?? []) : [];
+}
+
+describe("annotateAssetWarnings", () => {
+  it("stays quiet when the asset serves an image", async () => {
+    server.use(
+      http.head("https://cdn.example.com/logo.svg", () =>
+        HttpResponse.text("", { headers: { "content-type": "image/svg+xml" } }),
+      ),
+    );
+    const actions = reviseBranding({ logo_url: "https://cdn.example.com/logo.svg" });
+
+    await annotateAssetWarnings(actions);
+
+    expect(warningsOf(actions)).toEqual([]);
+  });
+
+  // The Elina case: the URL clears the CLI's zod gate and the server's save
+  // gate, then renders as a 0×0 <img> with nothing logged anywhere.
+  it("warns when the asset 404s", async () => {
+    server.use(
+      http.head("https://cdn.example.com/logo.svg", () => new HttpResponse(null, { status: 404 })),
+    );
+    const actions = reviseBranding({ logo_url: "https://cdn.example.com/logo.svg" });
+
+    await annotateAssetWarnings(actions);
+
+    expect(warningsOf(actions)).toHaveLength(1);
+    expect(warningsOf(actions)[0].rule).toBe("warn/asset-unreachable");
+    expect(warningsOf(actions)[0].message).toContain("logo_url https://cdn.example.com/logo.svg");
+    expect(warningsOf(actions)[0].message).toContain("HTTP 404");
+  });
+
+  it("warns when the host cannot be reached at all", async () => {
+    server.use(http.head("https://gone.example.com/hero.png", () => HttpResponse.error()));
+    const actions = reviseBranding({ hero_url: "https://gone.example.com/hero.png" });
+
+    await annotateAssetWarnings(actions);
+
+    expect(warningsOf(actions)[0].rule).toBe("warn/asset-unreachable");
+    expect(warningsOf(actions)[0].message).toContain("could not be reached");
+    // The probe host is not necessarily the render host, so the warning has
+    // to name its own escape hatch.
+    expect(warningsOf(actions)[0].message).toContain("ZITADEL_SKIP_ASSET_PROBE");
+  });
+
+  it("warns when the URL serves a page instead of an image", async () => {
+    server.use(
+      http.head("https://cdn.example.com/logo.svg", () =>
+        HttpResponse.text("", { headers: { "content-type": "text/html; charset=utf-8" } }),
+      ),
+    );
+    const actions = reviseBranding({ logo_url: "https://cdn.example.com/logo.svg" });
+
+    await annotateAssetWarnings(actions);
+
+    expect(warningsOf(actions)[0].rule).toBe("warn/asset-content-type");
+    expect(warningsOf(actions)[0].message).toContain('content-type "text/html"');
+  });
+
+  it("stays quiet when the origin refuses HEAD — that says nothing about the asset", async () => {
+    server.use(
+      http.head("https://cdn.example.com/logo.svg", () => new HttpResponse(null, { status: 405 })),
+    );
+    const actions = reviseBranding({ logo_url: "https://cdn.example.com/logo.svg" });
+
+    await annotateAssetWarnings(actions);
+
+    expect(warningsOf(actions)).toEqual([]);
+  });
+
+  it("warns per field and probes each distinct URL once", async () => {
+    let hits = 0;
+    server.use(
+      http.head("https://cdn.example.com/brand.png", () => {
+        hits += 1;
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+    const actions = reviseBranding({
+      logo_url: "https://cdn.example.com/brand.png",
+      hero_url: "https://cdn.example.com/brand.png",
+    });
+
+    await annotateAssetWarnings(actions);
+
+    expect(hits).toBe(1);
+    expect(warningsOf(actions).map((w) => w.message.split(" ")[0])).toEqual([
+      "logo_url",
+      "hero_url",
+    ]);
+  });
+
+  it("makes no request at all when ZITADEL_SKIP_ASSET_PROBE is set", async () => {
+    process.env.ZITADEL_SKIP_ASSET_PROBE = "1";
+    // No handler registered: an outbound request would fail the suite under
+    // `onUnhandledRequest: "error"`.
+    const actions = reviseBranding({ logo_url: "https://cdn.example.com/logo.svg" });
+
+    await annotateAssetWarnings(actions);
+
+    expect(warningsOf(actions)).toEqual([]);
+  });
+
+  it("ignores descriptors without asset URLs and non-branding resources", async () => {
+    const actions: SyncAction[] = [
+      ...reviseBranding({ layout: "split", liquid_template_file: "./login.liquid" }),
+      {
+        kind: "create",
+        path: ".zitadel/flows/default.json",
+        syncer: makeSyncer("flow"),
+        content: { logo_url: "https://cdn.example.com/not-branding.svg" },
+        hash: "h",
+      },
+    ];
+
+    await annotateAssetWarnings(actions);
+
+    expect(warningsOf(actions)).toEqual([]);
+    expect(actions[1].kind === "create" && actions[1].warnings).toBeUndefined();
+  });
+
+  it("keeps warnings an earlier pass already attached", async () => {
+    server.use(
+      http.head("https://cdn.example.com/logo.svg", () => new HttpResponse(null, { status: 404 })),
+    );
+    const actions = reviseBranding({ logo_url: "https://cdn.example.com/logo.svg" });
+    (actions[0] as { warnings?: unknown }).warnings = [{ rule: "warn/other", message: "earlier" }];
+
+    await annotateAssetWarnings(actions);
+
+    expect(warningsOf(actions).map((w) => w.rule)).toEqual(["warn/other", "warn/asset-unreachable"]);
+  });
+});
+
+describe("buildSyncPlan wiring", () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    while (dirs.length > 0) {
+      const dir = dirs.pop();
+      if (dir) await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * The plan path, not the probe: a branding edit plans a `revise`, which is
+   * the action kind that had nowhere to carry a warning before.
+   */
+  it("surfaces a dead asset URL as a plan warning on the branding revision", async () => {
+    server.use(
+      http.head("https://cdn.example.com/logo.svg", () => new HttpResponse(null, { status: 404 })),
+    );
+    const cwd = await mkdtemp(join(tmpdir(), "zitadel-asset-plan-"));
+    dirs.push(cwd);
+    await mkdir(join(cwd, ".zitadel/branding"), { recursive: true });
+    await writeFile(
+      join(cwd, ".zitadel/state.json"),
+      JSON.stringify({
+        framework: "next",
+        resources: { ".zitadel/branding/branding.json": { id: "brd_1", hash: "stale" } },
+      }),
+    );
+    await writeFile(
+      join(cwd, ".zitadel/branding/branding.json"),
+      JSON.stringify({ layout: "split", logo_url: "https://cdn.example.com/logo.svg" }),
+    );
+
+    const actions = await buildSyncPlan(cwd, [branding]);
+
+    expect(actions.map((a) => a.kind)).toEqual(["revise"]);
+    expect(collectPlanWarnings(actions)).toEqual([
+      {
+        path: ".zitadel/branding/branding.json",
+        rule: "warn/asset-unreachable",
+        message: expect.stringContaining("HTTP 404"),
+      },
+    ]);
+  });
+});

--- a/apps/cli/tests/unit/lib/sync/asset-probe.test.ts
+++ b/apps/cli/tests/unit/lib/sync/asset-probe.test.ts
@@ -2,14 +2,20 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { annotateAssetWarnings } from "../../../../src/lib/sync/asset-probe";
+import {
+  annotateAssetWarnings,
+  resolvePublicAddresses,
+} from "../../../../src/lib/sync/asset-probe";
 import { buildSyncPlan } from "../../../../src/lib/sync/loop";
 import { collectPlanWarnings } from "../../../../src/lib/sync/plan-renderer";
 import type { ResourceSyncer, SyncAction } from "../../../../src/lib/sync/types";
+
+const { lookupMock } = vi.hoisted(() => ({ lookupMock: vi.fn() }));
+vi.mock("node:dns/promises", () => ({ lookup: lookupMock }));
 
 /**
  * Every outbound request the probe makes is intercepted: a sandboxed vitest
@@ -20,6 +26,10 @@ const server = setupServer();
 
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterAll(() => server.close());
+beforeEach(() => {
+  lookupMock.mockReset();
+  lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
 afterEach(() => {
   server.resetHandlers();
   delete process.env.ZITADEL_SKIP_ASSET_PROBE;
@@ -31,10 +41,18 @@ function makeSyncer(kind: string): ResourceSyncer {
     directory: `.zitadel/${kind}`,
     mutable: false,
     revisioned: true,
-    validate() { /* no-op: probe tests do not exercise validation */ },
-    async create() { return { id: "id" }; },
-    async update() { return {}; },
-    async delete() { /* no-op: probe tests do not exercise delete */ },
+    validate() {
+      /* no-op: probe tests do not exercise validation */
+    },
+    async create() {
+      return { id: "id" };
+    },
+    async update() {
+      return {};
+    },
+    async delete() {
+      /* no-op: probe tests do not exercise delete */
+    },
   };
 }
 
@@ -117,6 +135,18 @@ describe("annotateAssetWarnings", () => {
     expect(warningsOf(actions)[0].message).toContain('content-type "text/html"');
   });
 
+  it("warns when a successful response is explicitly bodyless", async () => {
+    server.use(
+      http.head("https://cdn.example.com/logo.svg", () => new HttpResponse(null, { status: 204 })),
+    );
+    const actions = reviseBranding({ logo_url: "https://cdn.example.com/logo.svg" });
+
+    await annotateAssetWarnings(actions);
+
+    expect(warningsOf(actions)[0].rule).toBe("warn/asset-unreachable");
+    expect(warningsOf(actions)[0].message).toContain("HTTP 204 with no representation");
+  });
+
   it("stays quiet when the origin refuses HEAD — that says nothing about the asset", async () => {
     server.use(
       http.head("https://cdn.example.com/logo.svg", () => new HttpResponse(null, { status: 405 })),
@@ -125,6 +155,54 @@ describe("annotateAssetWarnings", () => {
 
     await annotateAssetWarnings(actions);
 
+    expect(warningsOf(actions)).toEqual([]);
+  });
+
+  it("does not probe literal private destinations and rejects private DNS answers", async () => {
+    lookupMock.mockResolvedValueOnce([{ address: "10.0.0.7", family: 4 }]);
+    const loopback = reviseBranding({ logo_url: "http://127.0.0.1:8080/logo.svg" });
+    const privateLiteral = reviseBranding({ logo_url: "https://10.0.0.7/logo.svg" });
+
+    await annotateAssetWarnings(loopback);
+    await annotateAssetWarnings(privateLiteral);
+    const privateAddresses = await resolvePublicAddresses("assets.internal.example");
+
+    expect(warningsOf(loopback)).toEqual([]);
+    expect(warningsOf(privateLiteral)).toEqual([]);
+    expect(privateAddresses).toBeUndefined();
+    expect(lookupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects IPv6 translation addresses that could tunnel to a private IPv4 host", async () => {
+    lookupMock.mockResolvedValueOnce([
+      { address: "::ffff:10.0.0.7", family: 6 },
+      { address: "64:ff9b::a00:7", family: 6 },
+    ]);
+
+    await expect(resolvePublicAddresses("translated.example.com")).resolves.toBeUndefined();
+  });
+
+  it("re-validates redirects instead of following them into a private network", async () => {
+    let privateHits = 0;
+    server.use(
+      http.head(
+        "https://cdn.example.com/logo.svg",
+        () =>
+          new HttpResponse(null, {
+            status: 302,
+            headers: { location: "https://10.0.0.7/internal-logo.svg" },
+          }),
+      ),
+      http.head("https://10.0.0.7/internal-logo.svg", () => {
+        privateHits += 1;
+        return new HttpResponse(null, { headers: { "content-type": "image/svg+xml" } });
+      }),
+    );
+    const actions = reviseBranding({ logo_url: "https://cdn.example.com/logo.svg" });
+
+    await annotateAssetWarnings(actions);
+
+    expect(privateHits).toBe(0);
     expect(warningsOf(actions)).toEqual([]);
   });
 
@@ -188,7 +266,10 @@ describe("annotateAssetWarnings", () => {
 
     await annotateAssetWarnings(actions);
 
-    expect(warningsOf(actions).map((w) => w.rule)).toEqual(["warn/other", "warn/asset-unreachable"]);
+    expect(warningsOf(actions).map((w) => w.rule)).toEqual([
+      "warn/other",
+      "warn/asset-unreachable",
+    ]);
   });
 });
 

--- a/apps/cli/tests/unit/lib/sync/plan-renderer.test.ts
+++ b/apps/cli/tests/unit/lib/sync/plan-renderer.test.ts
@@ -386,7 +386,23 @@ describe("renderPlan — string escaping", () => {
     expect(renderPlan(actions, false)).toContain('"say \\"hello\\""');
   });
 
-  it("escapes newlines inside string values", () => {
+  it("escapes tabs and carriage returns inside single-line string values", () => {
+    const actions: SyncAction[] = [
+      {
+        kind: "create",
+        path: ".zitadel/schemas/user.json",
+        syncer: schema,
+        content: { text: "col1\tcol2\r" },
+        hash: "a",
+      },
+    ];
+    expect(renderPlan(actions, false)).toContain('"col1\\tcol2\\r"');
+  });
+
+  // Multi-line strings are documents, not scalars — see the block-string
+  // suite below. Escaping one onto a single line is what made a branding
+  // plan unreadable.
+  it("summarises a multi-line string instead of escaping it", () => {
     const actions: SyncAction[] = [
       {
         kind: "create",
@@ -396,7 +412,9 @@ describe("renderPlan — string escaping", () => {
         hash: "a",
       },
     ];
-    expect(renderPlan(actions, false)).toContain('"line1\\nline2"');
+    const out = renderPlan(actions, false);
+    expect(out).not.toContain('"line1\\nline2"');
+    expect(out).toMatch(/\+ text = \(2 lines, sha256:[0-9a-f]{8}\)/);
   });
 });
 
@@ -566,10 +584,120 @@ describe("renderPlan — validation warnings", () => {
     expect(renderPlan(actions, false)).toContain(`# warning: ${warning.message}`);
   });
 
+  // Branding is revisioned, so a broken logo_url can only ever surface on a
+  // `revise` — the kind that used to have nowhere to put a warning.
+  it("renders warnings under a revise block and counts them in the summary", () => {
+    const assetWarning = {
+      rule: "warn/asset-unreachable",
+      message: "logo_url https://cdn.example.com/logo.svg returned HTTP 404",
+    };
+    const actions: SyncAction[] = [
+      {
+        kind: "revise",
+        path: ".zitadel/branding/branding.json",
+        syncer: makeSyncer("branding", ".zitadel/branding", { revisioned: true }),
+        content: { logo_url: "https://cdn.example.com/logo.svg" },
+        hash: "h",
+        previousId: "brd_1",
+        oldContent: { logo_url: "https://cdn.example.com/old.svg" },
+        affectedPaths: [],
+        warnings: [assetWarning],
+      },
+    ];
+
+    const out = renderPlan(actions, false);
+    expect(out).toContain(`# warning: ${assetWarning.message}`);
+    expect(out).toContain("Warnings: 1 (non-blocking");
+  });
+
   it("emits no warning summary when the plan is warning-free", () => {
     const actions: SyncAction[] = [
       { kind: "create", path: "a", syncer: flow, content: {}, hash: "h" },
     ];
     expect(renderPlan(actions, false)).not.toContain("Warnings:");
+  });
+});
+
+describe("renderPlan — block strings (liquid_template)", () => {
+  const branding = makeSyncer("branding", ".zitadel/branding", { revisioned: true });
+  const template = [
+    "<zl-page-shell>",
+    "  <aside class=\"zl-split__brand\">",
+    "    {% if branding.logo_url %}",
+    "      <img class=\"zl-split__logo\" src=\"{{ branding.logo_url }}\" alt=\"\" />",
+    "    {% endif %}",
+    "  </aside>",
+    "</zl-page-shell>",
+    "",
+  ].join("\n");
+
+  function revise(content: object, oldContent: object): SyncAction[] {
+    return [
+      {
+        kind: "revise",
+        path: ".zitadel/branding/branding.json",
+        syncer: branding,
+        content,
+        hash: "h",
+        previousId: "brd_1",
+        oldContent,
+        affectedPaths: [],
+      },
+    ];
+  }
+
+  it("summarises an unchanged template instead of dumping it on one line", () => {
+    const out = renderPlan(
+      revise({ layout: "split", liquid_template: template }, { layout: "centered", liquid_template: template }),
+      false,
+    );
+
+    expect(out).toMatch(/liquid_template = \(unchanged, 7 lines, sha256:[0-9a-f]{8}\)/);
+    expect(out).not.toContain("zl-split__brand");
+    // The field that really moved stays visible.
+    expect(out).toContain('~ layout          = "centered" -> "split"');
+  });
+
+  it("renders a changed template as a line diff, not two escaped blobs", () => {
+    const edited = template.replace('alt=""', 'alt="Acme"');
+
+    const out = renderPlan(
+      revise({ liquid_template: edited }, { liquid_template: template }),
+      false,
+    );
+
+    expect(out).toMatch(/~ liquid_template = \(2 lines changed of 7, sha256:[0-9a-f]{8} -> sha256:[0-9a-f]{8}\)/);
+    expect(out).toContain('- ' + '      <img class="zl-split__logo" src="{{ branding.logo_url }}" alt="" />');
+    expect(out).toContain('+ ' + '      <img class="zl-split__logo" src="{{ branding.logo_url }}" alt="Acme" />');
+    // Untouched lines never reach the output.
+    expect(out).not.toContain("<zl-page-shell>");
+  });
+
+  it("caps the changed-line body and says how much it dropped", () => {
+    const long = Array.from({ length: 40 }, (_, i) => `line ${i}`).join("\n");
+    const rewritten = Array.from({ length: 40 }, (_, i) => `LINE ${i}`).join("\n");
+
+    const out = renderPlan(revise({ liquid_template: rewritten }, { liquid_template: long }), false);
+
+    expect(out).toContain("(80 lines changed of 40");
+    expect(out).toContain("# (60 more changed lines not shown)");
+  });
+
+  it("summarises the template on a first-revision create", () => {
+    const out = renderPlan(
+      [
+        {
+          kind: "create",
+          path: ".zitadel/branding/branding.json",
+          syncer: branding,
+          content: { layout: "split", liquid_template: template },
+          hash: "h",
+        },
+      ],
+      false,
+    );
+
+    expect(out).toMatch(/\+ liquid_template = \(7 lines, sha256:[0-9a-f]{8}\)/);
+    expect(out).not.toContain("zl-split__brand");
   });
 });

--- a/docs/design/branding/schema.md
+++ b/docs/design/branding/schema.md
@@ -122,11 +122,14 @@ Shape validation cannot tell a live asset from a dead one, and a well-formed
 URL that serves nothing renders as a 0×0 `<img>` — invisible in the design and
 silent in the console. Two layers cover that gap, neither of them a gate:
 `zitadel plan` / `apply` probe each URL and warn (`apps/cli/src/lib/sync/asset-probe.ts`),
-and the component hides an asset whose load fails, restoring the split designs'
-decorative placeholder when that empties the brand pane
+and the component hides an asset whose load fails, restoring either the split
+designs' decorative placeholder or a shipped design's authored no-asset content
 (`packages/components/src/orchestrator/asset-fallback.ts`). Templates cannot do
 the latter themselves: DOMPurify strips inline `onerror` along with every other
-event handler, so the listener has to be orchestrator-side.
+event handler, so the listener has to be orchestrator-side. The CLI side only
+contacts public HTTPS destinations and validates every redirect; loopback,
+private, and internal targets remain inconclusive so repo config cannot make
+the planning host scan its own network.
 
 `font_url` is **read-only in v1**: because the component must inject it at document level (shadow-scoped `@font-face` never registers faces), a writable value would give `branding.write` page-wide CSS control over the embedding application. `POST /branding` rejects it and the local config dialect omits it; safe delivery is an [ADR 040](../../adrs/040-tenant-login-templates-editable-config.md) follow-up. Until then, load fonts from the embedding page.
 

--- a/docs/design/branding/schema.md
+++ b/docs/design/branding/schema.md
@@ -118,6 +118,16 @@ document also runs on loopback HTTP. `font_url` remains HTTPS-only and is
 injected as a `<link rel="stylesheet">` before the widget paints. `hero_url` is
 consumed by the `split` layout.
 
+Shape validation cannot tell a live asset from a dead one, and a well-formed
+URL that serves nothing renders as a 0×0 `<img>` — invisible in the design and
+silent in the console. Two layers cover that gap, neither of them a gate:
+`zitadel plan` / `apply` probe each URL and warn (`apps/cli/src/lib/sync/asset-probe.ts`),
+and the component hides an asset whose load fails, restoring the split designs'
+decorative placeholder when that empties the brand pane
+(`packages/components/src/orchestrator/asset-fallback.ts`). Templates cannot do
+the latter themselves: DOMPurify strips inline `onerror` along with every other
+event handler, so the listener has to be orchestrator-side.
+
 `font_url` is **read-only in v1**: because the component must inject it at document level (shadow-scoped `@font-face` never registers faces), a writable value would give `branding.write` page-wide CSS control over the embedding application. `POST /branding` rejects it and the local config dialect omits it; safe delivery is an [ADR 040](../../adrs/040-tenant-login-templates-editable-config.md) follow-up. Until then, load fonts from the embedding page.
 
 ### Proposed extensions
@@ -183,6 +193,7 @@ Every branding payload the component receives passes through:
 1. **Shape validation**: types, enums, URLs, invariants. Every paint, cheap.
 2. **Template validation**: if `liquid_template` is set, structural AST pass vs flow ([`validator.md`](validator.md)). Once per load, cached.
 3. **Runtime safety net**: `{% mandatory_gates %}` appends missing required UI so a bad template still yields a submittable step.
+4. **Asset degradation**: an `<img>` that fails to load is hidden and, in the split designs, replaced by the decorative brand-pane placeholder. Armed per commit; a failure is warned about once on the console.
 
 Stages 1 and 2 run in the component. Stage 3 runs as part of Liquid rendering. The security pipeline in [`../flowengine/template-security.md`](../flowengine/template-security.md) runs on save server-side; this doc assumes it. The widget does not re-check security at paint time.
 

--- a/packages/components/src/orchestrator/__fixtures__/asset.svg
+++ b/packages/components/src/orchestrator/__fixtures__/asset.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="test asset"><rect width="64" height="64" rx="8" fill="#bba5e4"/></svg>

--- a/packages/components/src/orchestrator/asset-fallback.spec.ts
+++ b/packages/components/src/orchestrator/asset-fallback.spec.ts
@@ -103,23 +103,31 @@ describe("armAssetFallbacks", () => {
     fail(pane.querySelector("img.zl-split__logo") as Element);
 
     expect(pane.querySelector(".zl-split__placeholder")).toBeNull();
-    expect((pane.querySelector("img.zl-split__hero") as Element).hasAttribute(
-      "data-zl-asset-broken",
-    )).toBe(false);
+    expect(
+      (pane.querySelector("img.zl-split__hero") as Element).hasAttribute("data-zl-asset-broken"),
+    ).toBe(false);
   });
 
-  it("does not decorate a brand pane whose non-image content still renders", () => {
+  it("reveals the hero design's authored fallbacks without decorating its brand pane", () => {
     // The hero design fills the pane with a landing mock; a dead logo inside
     // it is a missing wordmark, not an empty pane.
     const root = render("hero", { logo_url: "https://cdn.example.com/gone.svg" });
     const pane = root.querySelector(".zl-split__brand") as HTMLElement;
+    const authoredFallbacks = root.querySelectorAll("[data-zl-asset-fallback-content]");
+    expect(authoredFallbacks).toHaveLength(2);
+    for (const fallback of authoredFallbacks) {
+      expect(fallback.hasAttribute("hidden")).toBe(true);
+    }
 
     armAssetFallbacks(root);
-    for (const img of pane.querySelectorAll("img")) {
+    for (const img of root.querySelectorAll("img")) {
       fail(img);
     }
 
     expect(pane.querySelector(".zl-split__placeholder")).toBeNull();
+    for (const fallback of authoredFallbacks) {
+      expect(fallback.hasAttribute("hidden")).toBe(false);
+    }
   });
 
   it("adds exactly one placeholder however often it is called", () => {

--- a/packages/components/src/orchestrator/asset-fallback.spec.ts
+++ b/packages/components/src/orchestrator/asset-fallback.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Broken-branding-asset degradation, exercised over the *shipped* split
+ * template rather than hand-written markup: the regression this guards is
+ * that `.zl-split__placeholder` is keyed on "no asset configured", so a
+ * configured-but-dead asset used to leave the brand pane empty (a 0×0 img,
+ * no console error, nothing in plan output).
+ *
+ * jsdom never loads images, so failure is injected the way the browser
+ * reports it — an `error` event on the element.
+ */
+import type { CreateFlow201Step } from "@zitadel/api/generated/model";
+import { getDefaultBrandingConfig } from "@zitadel/config/defaults";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { armAssetFallbacks } from "./asset-fallback.js";
+import { createLiquidEngine } from "./liquid.js";
+import { createSanitiser } from "./sanitiser.js";
+
+const locale: Record<string, string> = {
+  "identifier.title": "Sign in",
+  "identifier.field.email": "Work email",
+  "submit.continue": "Continue",
+};
+
+const step: CreateFlow201Step = {
+  name: "identifier",
+  fields: [{ name: "email", type: "email", text_key: "identifier.field.email", required: true }],
+  actions: [{ name: "submit", kind: "submit", text_key: "submit.continue", primary: true }],
+  gates: {},
+};
+
+function render(design: string, branding: Record<string, string>): HTMLElement {
+  const { template } = getDefaultBrandingConfig(design);
+  const html = createLiquidEngine({ locale }).parseAndRenderSync(template, {
+    step: { name: step.name, texts: { title_key: "identifier.title" } },
+    fields: step.fields,
+    actions: step.actions,
+    gates: [],
+    messages: [],
+    errors: [],
+    identity: null,
+    branding,
+    loading: false,
+    challenge: null,
+  });
+  const root = document.createElement("div");
+  root.innerHTML = createSanitiser()(html);
+  document.body.append(root);
+  return root;
+}
+
+function fail(img: Element): void {
+  img.dispatchEvent(new Event("error"));
+}
+
+beforeEach(() => {
+  // Silenced, not asserted away: one test below checks it was called.
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("armAssetFallbacks", () => {
+  it("hides a broken logo and restores the split placeholder", () => {
+    const root = render("split", { logo_url: "https://cdn.example.com/gone.svg" });
+    const pane = root.querySelector(".zl-split__brand") as HTMLElement;
+    expect(pane.querySelector(".zl-split__placeholder")).toBeNull();
+
+    armAssetFallbacks(root);
+    for (const img of root.querySelectorAll("img")) {
+      fail(img);
+    }
+
+    const logo = pane.querySelector("img.zl-split__logo") as HTMLElement;
+    expect(logo.hasAttribute("data-zl-asset-broken")).toBe(true);
+    const placeholder = pane.querySelector(".zl-split__placeholder");
+    expect(placeholder).not.toBeNull();
+    expect(placeholder?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("says out loud what it hid — the failure is silent everywhere else", () => {
+    const root = render("split", { logo_url: "https://cdn.example.com/gone.svg" });
+    armAssetFallbacks(root);
+
+    fail(root.querySelector("img.zl-split__logo") as Element);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("https://cdn.example.com/gone.svg"),
+    );
+  });
+
+  it("leaves the pane alone while one asset still renders", () => {
+    const root = render("split", {
+      logo_url: "https://cdn.example.com/gone.svg",
+      hero_url: "https://cdn.example.com/hero.png",
+    });
+    const pane = root.querySelector(".zl-split__brand") as HTMLElement;
+
+    armAssetFallbacks(root);
+    fail(pane.querySelector("img.zl-split__logo") as Element);
+
+    expect(pane.querySelector(".zl-split__placeholder")).toBeNull();
+    expect((pane.querySelector("img.zl-split__hero") as Element).hasAttribute(
+      "data-zl-asset-broken",
+    )).toBe(false);
+  });
+
+  it("does not decorate a brand pane whose non-image content still renders", () => {
+    // The hero design fills the pane with a landing mock; a dead logo inside
+    // it is a missing wordmark, not an empty pane.
+    const root = render("hero", { logo_url: "https://cdn.example.com/gone.svg" });
+    const pane = root.querySelector(".zl-split__brand") as HTMLElement;
+
+    armAssetFallbacks(root);
+    for (const img of pane.querySelectorAll("img")) {
+      fail(img);
+    }
+
+    expect(pane.querySelector(".zl-split__placeholder")).toBeNull();
+  });
+
+  it("adds exactly one placeholder however often it is called", () => {
+    const root = render("split-right", { hero_url: "https://cdn.example.com/gone.png" });
+    const pane = root.querySelector(".zl-split__brand") as HTMLElement;
+
+    armAssetFallbacks(root);
+    fail(pane.querySelector("img.zl-split__hero") as Element);
+    armAssetFallbacks(root);
+    armAssetFallbacks(root);
+
+    expect(pane.querySelectorAll(".zl-split__placeholder")).toHaveLength(1);
+  });
+
+  it("arms each image once, so a re-commit does not stack listeners", () => {
+    const root = render("split", { logo_url: "https://cdn.example.com/gone.svg" });
+    const img = root.querySelector("img.zl-split__logo") as HTMLImageElement;
+    const addListener = vi.spyOn(img, "addEventListener");
+
+    armAssetFallbacks(root);
+    armAssetFallbacks(root);
+
+    expect(addListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("catches an image that already failed before it was armed", () => {
+    const root = render("split", { logo_url: "https://cdn.example.com/gone.svg" });
+    const img = root.querySelector("img.zl-split__logo") as HTMLImageElement;
+    // jsdom never loads, so `complete`/`naturalWidth` are stubbed to the
+    // shape a browser reports for an image whose error already fired.
+    Object.defineProperty(img, "complete", { value: true });
+    Object.defineProperty(img, "naturalWidth", { value: 0 });
+
+    armAssetFallbacks(root);
+
+    expect(img.hasAttribute("data-zl-asset-broken")).toBe(true);
+    expect(root.querySelector(".zl-split__placeholder")).not.toBeNull();
+  });
+
+  it("leaves a healthy design untouched", () => {
+    const root = render("split", { logo_url: "https://cdn.example.com/logo.svg" });
+
+    armAssetFallbacks(root);
+
+    expect(root.querySelector("[data-zl-asset-broken]")).toBeNull();
+    expect(root.querySelector(".zl-split__placeholder")).toBeNull();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/components/src/orchestrator/asset-fallback.ts
+++ b/packages/components/src/orchestrator/asset-fallback.ts
@@ -1,0 +1,102 @@
+/**
+ * Broken-branding-asset degradation.
+ *
+ * A `logo_url` / `hero_url` that is well-formed but unreachable clears every
+ * gate on the way in — the CLI's zod shape check, the server's save gate —
+ * and then renders as a 0×0 `<img>`: a silent hole where the brand should
+ * be, with nothing in the console and nothing in `plan` output. The split
+ * designs are the worst case, because their `.zl-split__placeholder` is
+ * keyed on *no asset being configured*, so a configured-but-dead asset
+ * leaves the whole brand pane blank.
+ *
+ * The templates cannot fix this themselves. They go through DOMPurify
+ * (`sanitiser.ts`), which strips `onerror` along with every other inline
+ * handler, so the recovery has to be orchestrator-side: arm a real `error`
+ * listener on each rendered image after every commit, hide what fails, and
+ * put the placeholder back when that empties a brand pane.
+ */
+
+/** Marks an image whose `error` listener is already attached. */
+const ARMED_ATTR = "data-zl-asset-armed";
+
+/** Marks an image that failed to load; `layout-chrome.css` hides it. */
+const BROKEN_ATTR = "data-zl-asset-broken";
+
+const BRAND_PANE_SELECTOR = ".zl-split__brand";
+const PLACEHOLDER_CLASS = "zl-split__placeholder";
+
+/**
+ * Arm every not-yet-armed `<img>` under `root`, and repair anything already
+ * broken. Idempotent: safe to call on every Lit commit, since `unsafeHTML`
+ * only re-parses when the rendered string actually changes and re-parsed
+ * nodes arrive without the marker attribute.
+ */
+export function armAssetFallbacks(root: ParentNode): void {
+  let repairNeeded = false;
+
+  for (const img of root.querySelectorAll("img")) {
+    if (img.hasAttribute(ARMED_ATTR)) {
+      continue;
+    }
+    img.setAttribute(ARMED_ATTR, "");
+
+    // An image that finished loading before we got here reports its verdict
+    // through `complete` + `naturalWidth`, not through an event we can still
+    // catch — the error already fired.
+    if (img.getAttribute("src") && img.complete && img.naturalWidth === 0) {
+      markBroken(img);
+      repairNeeded = true;
+      continue;
+    }
+    img.addEventListener(
+      "error",
+      () => {
+        markBroken(img);
+        repairBrandPanes(root);
+      },
+      { once: true },
+    );
+  }
+
+  if (repairNeeded) {
+    repairBrandPanes(root);
+  }
+}
+
+function markBroken(img: HTMLImageElement): void {
+  img.setAttribute(BROKEN_ATTR, "");
+  // The failure is invisible by construction — say so once, out loud.
+  console.warn(
+    `[zitadel-login] branding asset failed to load, hiding it: ${img.getAttribute("src") ?? ""}`,
+  );
+}
+
+/**
+ * Restore `.zl-split__placeholder` in any split brand pane whose only content
+ * was assets that all failed. Deliberately narrow: a pane is only repaired
+ * when it actually holds a broken image, so a pane an author left empty on
+ * purpose — or a hero design whose landing copy still renders — is never
+ * given decoration it did not ask for.
+ */
+function repairBrandPanes(root: ParentNode): void {
+  for (const pane of root.querySelectorAll(BRAND_PANE_SELECTOR)) {
+    if (pane.querySelector(`.${PLACEHOLDER_CLASS}`)) {
+      continue;
+    }
+    const children = Array.from(pane.children);
+    if (!children.some(isBrokenImage)) {
+      continue;
+    }
+    if (children.some((child) => !isBrokenImage(child))) {
+      continue;
+    }
+    const placeholder = pane.ownerDocument.createElement("div");
+    placeholder.className = PLACEHOLDER_CLASS;
+    placeholder.setAttribute("aria-hidden", "true");
+    pane.append(placeholder);
+  }
+}
+
+function isBrokenImage(node: Element): boolean {
+  return node.tagName === "IMG" && node.hasAttribute(BROKEN_ATTR);
+}

--- a/packages/components/src/orchestrator/asset-fallback.ts
+++ b/packages/components/src/orchestrator/asset-fallback.ts
@@ -24,6 +24,8 @@ const BROKEN_ATTR = "data-zl-asset-broken";
 
 const BRAND_PANE_SELECTOR = ".zl-split__brand";
 const PLACEHOLDER_CLASS = "zl-split__placeholder";
+const AUTHORED_FALLBACK_ATTR = "data-zl-asset-fallback";
+const AUTHORED_FALLBACK_CONTENT_ATTR = "data-zl-asset-fallback-content";
 
 /**
  * Arm every not-yet-armed `<img>` under `root`, and repair anything already
@@ -65,10 +67,28 @@ export function armAssetFallbacks(root: ParentNode): void {
 
 function markBroken(img: HTMLImageElement): void {
   img.setAttribute(BROKEN_ATTR, "");
+  revealAuthoredFallback(img);
   // The failure is invisible by construction — say so once, out loud.
   console.warn(
     `[zitadel-login] branding asset failed to load, hiding it: ${img.getAttribute("src") ?? ""}`,
   );
+}
+
+/**
+ * Some shipped templates have a richer no-asset branch than the generic split
+ * placeholder (the hero design's brand mark and compact text). They render that
+ * branch hidden beside the image and opt in with data attributes, so the
+ * orchestrator can reveal the exact authored fallback without knowing template
+ * copy or structure.
+ */
+function revealAuthoredFallback(img: HTMLImageElement): void {
+  if (!img.hasAttribute(AUTHORED_FALLBACK_ATTR)) {
+    return;
+  }
+  const fallback = img.nextElementSibling;
+  if (fallback?.hasAttribute(AUTHORED_FALLBACK_CONTENT_ATTR)) {
+    fallback.removeAttribute("hidden");
+  }
 }
 
 /**

--- a/packages/components/src/orchestrator/embedding.browser.spec.ts
+++ b/packages/components/src/orchestrator/embedding.browser.spec.ts
@@ -1,16 +1,16 @@
-import type { CreateFlow201 } from "@zitadel/api/generated/model";
 import { configureZitadel, _resetConfigForTesting } from "@zitadel/api/config";
 import type { ZitadelProject } from "@zitadel/api/config";
+import type { CreateFlow201 } from "@zitadel/api/generated/model";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import "./zitadel-login.js";
-import type { ZitadelLogin } from "./zitadel-login.js";
+import heroTemplate from "../../../config/defaults/branding/hero/login.liquid";
+import minimalTemplate from "../../../config/defaults/branding/minimal/login.liquid";
+import splitRightTemplate from "../../../config/defaults/branding/split-right/login.liquid";
 // Raw import via the liquidRaw Vite plugin — @zitadel/config/defaults reads
 // files with node:fs at call time, which cannot run inside Chromium.
 import splitTemplate from "../../../config/defaults/branding/split/login.liquid";
-import splitRightTemplate from "../../../config/defaults/branding/split-right/login.liquid";
-import heroTemplate from "../../../config/defaults/branding/hero/login.liquid";
-import minimalTemplate from "../../../config/defaults/branding/minimal/login.liquid";
+import type { ZitadelLogin } from "./zitadel-login.js";
 
 /**
  * Real-browser checks for the widget-first embedding contract.
@@ -35,9 +35,7 @@ const identifierStep: CreateFlow201 = {
   step: {
     name: "identifier",
     texts: { title_key: "identifier.title" },
-    fields: [
-      { name: "email", type: "email", text_key: "identifier.field.email", required: true },
-    ],
+    fields: [{ name: "email", type: "email", text_key: "identifier.field.email", required: true }],
     actions: [{ name: "submit", kind: "submit", text_key: "submit.continue", primary: true }],
     gates: {},
   },
@@ -87,6 +85,7 @@ const fieldlessStep: CreateFlow201 = {
  * layout tests below want to measure.
  */
 const LOADABLE_ASSET = `${location.origin}/src/orchestrator/__fixtures__/asset.svg`;
+const BROKEN_ASSET = `${location.origin}/src/orchestrator/__fixtures__/does-not-exist.svg`;
 
 /** The shipped split design carried as tenant branding, logo-less. */
 const splitHeroOnlyStep: CreateFlow201 = {
@@ -114,7 +113,7 @@ const splitBrokenLogoStep: CreateFlow201 = {
   branding: {
     layout: "split",
     liquid_template: splitTemplate,
-    logo_url: `${location.origin}/src/orchestrator/__fixtures__/does-not-exist.svg`,
+    logo_url: BROKEN_ASSET,
   },
 } as unknown as CreateFlow201;
 
@@ -152,6 +151,16 @@ const heroNoLogoStep: CreateFlow201 = {
   branding: {
     layout: "split",
     liquid_template: heroTemplate,
+  },
+} as unknown as CreateFlow201;
+
+/** A configured hero logo whose request fails must recover both authored fallbacks. */
+const heroBrokenLogoStep: CreateFlow201 = {
+  ...identifierStep,
+  branding: {
+    layout: "split",
+    liquid_template: heroTemplate,
+    logo_url: BROKEN_ASSET,
   },
 } as unknown as CreateFlow201;
 
@@ -297,9 +306,7 @@ describe("<zitadel-login> widget-first embedding (chromium)", () => {
       el.variant = "page";
     });
     const mountNode = element.shadowRoot?.querySelector(".zl-mount") as HTMLElement;
-    expect(mountNode.getBoundingClientRect().height).toBeGreaterThanOrEqual(
-      window.innerHeight - 1,
-    );
+    expect(mountNode.getBoundingClientRect().height).toBeGreaterThanOrEqual(window.innerHeight - 1);
     expect(getComputedStyle(element).backgroundColor).not.toBe(TRANSPARENT);
     expect(document.getElementById("zl-default-font-link")).not.toBeNull();
     const field = element.shadowRoot?.querySelector("zl-field");
@@ -486,5 +493,21 @@ describe("<zitadel-login> widget-first embedding (chromium)", () => {
       element.shadowRoot?.querySelector(".zl-split__placeholder"),
     );
     expect(placeholder.getBoundingClientRect().width).toBeGreaterThan(0);
+  });
+
+  it("a broken hero logo restores the compact text fallback at narrow widths", async () => {
+    const element = await mount(heroBrokenLogoStep);
+    await waitFor(() =>
+      element.shadowRoot?.querySelector("img.zl-split__compact[data-zl-asset-broken]"),
+    );
+
+    const brandPane = element.shadowRoot?.querySelector(".zl-split__brand") as HTMLElement;
+    expect(getComputedStyle(brandPane).display).toBe("none");
+
+    const fallback = await waitFor(() =>
+      element.shadowRoot?.querySelector(".zl-split__form > .zl-hero__compact-brand:not([hidden])"),
+    );
+    expect(getComputedStyle(fallback).display).not.toBe("none");
+    expect(fallback.textContent).toContain("Your brand");
   });
 });

--- a/packages/components/src/orchestrator/embedding.browser.spec.ts
+++ b/packages/components/src/orchestrator/embedding.browser.spec.ts
@@ -78,13 +78,23 @@ const fieldlessStep: CreateFlow201 = {
   },
 };
 
+/**
+ * A branding asset URL that genuinely loads in the test browser. It has to
+ * be same-origin (the vitest server is loopback http, which
+ * `validateBranding` allows for assets, unlike a `data:` URI) and it has to
+ * decode: an unreachable host now degrades to a hidden image plus the split
+ * placeholder (`asset-fallback.ts`), which is the opposite of what the
+ * layout tests below want to measure.
+ */
+const LOADABLE_ASSET = `${location.origin}/src/orchestrator/__fixtures__/asset.svg`;
+
 /** The shipped split design carried as tenant branding, logo-less. */
 const splitHeroOnlyStep: CreateFlow201 = {
   ...identifierStep,
   branding: {
     layout: "split",
     liquid_template: splitTemplate,
-    hero_url: "https://cdn.example.com/hero.png",
+    hero_url: LOADABLE_ASSET,
   },
 } as unknown as CreateFlow201;
 
@@ -94,7 +104,17 @@ const splitLogoStep: CreateFlow201 = {
   branding: {
     layout: "split",
     liquid_template: splitTemplate,
-    logo_url: "https://cdn.example.com/logo.png",
+    logo_url: LOADABLE_ASSET,
+  },
+} as unknown as CreateFlow201;
+
+/** Same design, pointed at a host that does not resolve. */
+const splitBrokenLogoStep: CreateFlow201 = {
+  ...identifierStep,
+  branding: {
+    layout: "split",
+    liquid_template: splitTemplate,
+    logo_url: `${location.origin}/src/orchestrator/__fixtures__/does-not-exist.svg`,
   },
 } as unknown as CreateFlow201;
 
@@ -443,5 +463,28 @@ describe("<zitadel-login> widget-first embedding (chromium)", () => {
     const banner = withHero.shadowRoot?.querySelector(".zl-split__compact") as HTMLElement;
     expect(banner.tagName).toBe("IMG");
     expect(getComputedStyle(banner).maxHeight).toBe("96px");
+  });
+
+  it("a branding asset that fails to load degrades to the split placeholder", async () => {
+    // The reported failure: a well-formed but dead logo_url clears the CLI
+    // gate and the server gate, then renders as a 0×0 img — the templates'
+    // own placeholder is keyed on "no asset configured", so the brand pane
+    // was left blank with nothing in the console.
+    host.style.width = "1200px";
+    const element = await mount(splitBrokenLogoStep, (el) => {
+      el.variant = "page";
+    });
+
+    const logo = await waitFor(() =>
+      element.shadowRoot?.querySelector("img.zl-split__logo[data-zl-asset-broken]"),
+    );
+    // The recovery has to be scripted: DOMPurify strips inline `onerror`, so
+    // no template could do this for itself.
+    expect(getComputedStyle(logo).display).toBe("none");
+
+    const placeholder = await waitFor(() =>
+      element.shadowRoot?.querySelector(".zl-split__placeholder"),
+    );
+    expect(placeholder.getBoundingClientRect().width).toBeGreaterThan(0);
   });
 });

--- a/packages/components/src/orchestrator/templates/layout-chrome.css
+++ b/packages/components/src/orchestrator/templates/layout-chrome.css
@@ -23,6 +23,16 @@
   min-height: 100%;
   background: var(--zl-color-surface-default-black, #0f0f11);
 }
+/* A branding asset whose URL is well-formed but dead otherwise renders as a
+   0×0 <img> — a silent hole in the design. `asset-fallback.ts` stamps this
+   attribute from a real `error` listener (templates are DOMPurify-sanitised,
+   so inline `onerror` is not available to them) and the element leaves the
+   layout, degrading to the same result as "no asset configured". Qualified
+   on `img` so it outranks the `.zl-split__compact` display rules below
+   regardless of source order. */
+img[data-zl-asset-broken] {
+  display: none;
+}
 .zl-mount {
   display: flex;
   flex-direction: column;

--- a/packages/components/src/orchestrator/zitadel-login.ts
+++ b/packages/components/src/orchestrator/zitadel-login.ts
@@ -25,6 +25,7 @@ import {
   startFlow as apiStartFlow,
   submitStep as apiSubmitStep,
 } from "./api-client.js";
+import { armAssetFallbacks } from "./asset-fallback.js";
 import { validateBranding } from "./branding-validator.js";
 import type { Branding } from "./branding.js";
 import { stampExportparts } from "./exportparts.js";
@@ -343,6 +344,9 @@ export class ZitadelLogin extends ZitadelSurface {
     // `:host([variant])` selector.
     if (this.shadowRoot) {
       stampExportparts(this.shadowRoot);
+      // A configured-but-dead logo_url/hero_url is invisible everywhere else
+      // in the pipeline; this is the only layer that can see the image fail.
+      armAssetFallbacks(this.shadowRoot);
       const widget = this.variant !== "page";
       for (const shell of this.shadowRoot.querySelectorAll("zl-page-shell")) {
         shell.toggleAttribute("data-widget", widget);

--- a/packages/config/defaults/README-branding.md
+++ b/packages/config/defaults/README-branding.md
@@ -44,6 +44,15 @@ by re-applying an earlier template.
   }
   ```
 
+  A well-formed URL that serves nothing is the one branding mistake nothing
+  else catches — it passes validation, publishes a revision, and then renders
+  as an invisible image. So `zitadel plan` fetches each asset URL and warns
+  (never fails) when it is unreachable or does not answer with an image, and
+  the login UI hides an asset that fails to load, falling back to the split
+  designs' decorative panel rather than leaving a gap. If the host is only
+  reachable from where the login page renders — or you are offline — set
+  `ZITADEL_SKIP_ASSET_PROBE=1` to skip the check.
+
   `layout` is the degrade preset (`centered` or `split`), **not** the complete
   design catalog. All named designs (`centered`, `split`, `split-right`, `hero`,
   `minimal`) are delivered as templates and map onto those two values. Switch

--- a/packages/config/defaults/README-branding.md
+++ b/packages/config/defaults/README-branding.md
@@ -46,12 +46,15 @@ by re-applying an earlier template.
 
   A well-formed URL that serves nothing is the one branding mistake nothing
   else catches — it passes validation, publishes a revision, and then renders
-  as an invisible image. So `zitadel plan` fetches each asset URL and warns
-  (never fails) when it is unreachable or does not answer with an image, and
-  the login UI hides an asset that fails to load, falling back to the split
-  designs' decorative panel rather than leaving a gap. If the host is only
+  as an invisible image. So `zitadel plan` probes each asset URL and warns
+  (never fails) when it is unreachable, bodyless, or not an image, and the
+  login UI hides an asset that fails to load, restoring the shipped design's
+  no-asset content rather than leaving a gap. If the host is only
   reachable from where the login page renders — or you are offline — set
-  `ZITADEL_SKIP_ASSET_PROBE=1` to skip the check.
+  `ZITADEL_SKIP_ASSET_PROBE=1` to skip the check. The probe contacts public
+  HTTPS destinations only and re-checks redirects; loopback/private/internal
+  targets are left to the browser-side fallback instead of being requested by
+  the machine running `plan`.
 
   `layout` is the degrade preset (`centered` or `split`), **not** the complete
   design catalog. All named designs (`centered`, `split`, `split-right`, `hero`,

--- a/packages/config/defaults/branding/hero/login.liquid
+++ b/packages/config/defaults/branding/hero/login.liquid
@@ -19,7 +19,8 @@
         <nav class="zl-hero__nav">
           <span class="zl-hero__brand">
             {% if branding.logo_url %}
-              <img class="zl-hero__brand-logo" src="{{ branding.logo_url }}" alt="" />
+              <img class="zl-hero__brand-logo" src="{{ branding.logo_url }}" alt="" data-zl-asset-fallback />
+              <span class="zl-hero__brand-mark" aria-hidden="true" hidden data-zl-asset-fallback-content></span>
             {% else %}
               <span class="zl-hero__brand-mark" aria-hidden="true"></span>
             {% endif %}
@@ -54,7 +55,8 @@
     </aside>
     <section class="zl-split__form">
     {% if branding.logo_url %}
-      <img class="zl-split__compact" src="{{ branding.logo_url }}" alt="" />
+      <img class="zl-split__compact" src="{{ branding.logo_url }}" alt="" data-zl-asset-fallback />
+      <p class="zl-split__compact zl-hero__compact-brand" hidden data-zl-asset-fallback-content>Your brand</p>
     {% else %}
       <p class="zl-split__compact zl-hero__compact-brand">Your brand</p>
     {% endif %}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,9 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.8.5
+      undici:
+        specifier: ^7.24.7
+        version: 7.24.7
       zod:
         specifier: 'catalog:'
         version: 4.4.3


### PR DESCRIPTION
## Summary

- Warn during `zitadel plan` and `zitadel apply` when configured branding assets are unreachable, return a non-image response, or return an empty `204`/`205` response. Probes remain advisory and deduplicated.
- Restrict probes to public HTTPS destinations. Redirects are revalidated, credentials and local/private/reserved targets are skipped as inconclusive, and the DNS result approved by the validator is pinned to the connection to prevent rebinding.
- Preserve branding warnings on revision actions and in JSON output, while rendering large Liquid template changes as bounded line diffs instead of escaped one-line blobs.
- Hide broken runtime branding images and reveal template-authored fallback content. The shipped hero template now falls back to the wide brand mark or compact `Your brand` text instead of leaving an empty pane.
- Normalize scaffolded branding meta-schema CLI guidance to `zitadel apply`, and document the probe and fallback contracts.

## Validation

- `moon run cli:test` — 111 files, 1062 tests passed before the final rebase; the post-rebase focused probe suite passed 14/14.
- `moon run components:test --force` — 33 files, 420 tests passed post-rebase.
- `corepack pnpm --filter @zitadel/components exec vitest run --project browser src/orchestrator/embedding.browser.spec.ts` — 18/18 Chromium tests passed post-rebase.
- `moon run cli:lint cli:typecheck` — passed post-rebase (existing warning-only lint output, no errors).
- `moon run config:test` — 151 tests passed.
- `moon run workspace:check -- --only release` — passed.
- `node scripts/check-pr-title.mjs --title "fix: surface unreachable branding asset URLs instead of failing silently"` — passed.
- `corepack pnpm exec changeset status --since origin/main` — passed.
- `git diff --check` — passed.

## Release notes / changeset

- Changeset: `.changeset/branding-asset-reachability.md` — patch releases for `@zitadel/cli`, `@zitadel/components`, and `@zitadel/config`. This fixes customer-visible silent failures for configured branding assets.

## Notes

- Asset probing is intentionally non-blocking because the planning machine may not have the same network reachability as the browser rendering the login page. `ZITADEL_SKIP_ASSET_PROBE` disables it, and `ZITADEL_ASSET_PROBE_TIMEOUT_MS` bounds the complete redirect chain.
- Warnings attach to branding revisions that a run uploads; unchanged branding is not re-probed on every plan.
- The probe tests intercept all outbound requests. Browser fallback tests use same-origin fixtures and make no external network requests.
