### PR TITLE
fix(setup): describe the split brand pane's real container-width contract

### DIFF
--- a/.changeset/setup-split-design-warning-wording.md
+++ b/.changeset/setup-split-design-warning-wording.md
@@ -1,0 +1,9 @@
+---
+"@zitadel/cli": patch
+---
+
+`zitadel setup` no longer claims a split design's brand pane is collapsed in
+your app. The pane follows the login's own container width — the page setup
+scaffolds renders it in full — so the warning now describes when it does
+collapse (a card-width embed or a phone-width viewport) and why setting
+`logo_url` or `hero_url` in `.zitadel/branding/branding.json` matters there.

--- a/.changeset/setup-split-design-warning-wording.md
+++ b/.changeset/setup-split-design-warning-wording.md
@@ -3,7 +3,9 @@
 ---
 
 `zitadel setup` no longer claims a split design's brand pane is collapsed in
-your app. The pane follows the login's own container width — the page setup
-scaffolds renders it in full — so the warning now describes when it does
-collapse (a card-width embed or a phone-width viewport) and why setting
-`logo_url` or `hero_url` in `.zitadel/branding/branding.json` matters there.
+your app. The pane follows the login's own container width, so the warning now
+describes when it actually collapses — a card-width embed, or any phone-width
+viewport — and why setting `logo_url` or `hero_url` in
+`.zitadel/branding/branding.json` matters there. Full-page setups get the
+warning too: without one of those assets, a `split` or `split-right` login
+loses its branding entirely at narrow widths.

--- a/apps/cli/src/commands/setup/index.ts
+++ b/apps/cli/src/commands/setup/index.ts
@@ -423,11 +423,12 @@ export default class Setup extends BaseCommand {
     // envelope returned from `this.emit(...)` be the sole stdout
     // payload (oclif requires single-doc JSON).
     // The split-family brand pane collapses to the compact brand mark once the
-    // login's container is narrow — and that mark is empty until branding.json
-    // names an asset. Say so at setup time instead of letting the pane's
-    // absence read as a rendering bug once the card moves into a layout we
-    // don't own (see `designWarnings` for the scoping rationale).
-    const warnings = designWarnings({ design: answers.design, posture });
+    // login's container is narrow — and the template only emits that mark when
+    // branding.json names an asset. Say so at setup time instead of letting the
+    // branding's absence read as a rendering bug. Keyed to the design alone:
+    // the collapse is a container query, so posture doesn't decide it (see
+    // `designWarnings`).
+    const warnings = designWarnings(answers.design);
     if (!this.jsonEnabled()) {
       const projectFacts = await detectProjectFacts(cwd, framework.id);
       const sections = buildSummary({

--- a/apps/cli/src/commands/setup/index.ts
+++ b/apps/cli/src/commands/setup/index.ts
@@ -46,6 +46,7 @@ import {
 import { installDependenciesForSetup } from "./install";
 import { PickFrameworkPrompt, SETUP_PROMPTS, type SetupAnswers } from "./prompts";
 import {
+  designWarnings,
   detectProjectFacts,
   dim as styleDim,
   fileNameOf,
@@ -421,18 +422,12 @@ export default class Setup extends BaseCommand {
     // The structured report is human-only. Under `--json` we let the
     // envelope returned from `this.emit(...)` be the sole stdout
     // payload (oclif requires single-doc JSON).
-    // Widget-posture embeds render at card width, where the split-family
-    // brand pane is collapsed to the compact brand mark — which is empty
-    // until branding.json names an asset. Say so at setup time instead of
-    // letting the pane's absence read as a rendering bug. Scoped to the
-    // designs whose wide layout is mostly brand pane; `hero` keeps its
-    // editable text fallback and stays quiet.
-    const designWarnings =
-      posture === "widget" && (answers.design === "split" || answers.design === "split-right")
-        ? [
-            `The ${answers.design} design renders its brand pane only at wide container widths; this app embeds the login as a card, which shows the compact brand mark instead. Set logo_url (or hero_url) in .zitadel/branding/branding.json so the mark isn't empty.`,
-          ]
-        : [];
+    // The split-family brand pane collapses to the compact brand mark once the
+    // login's container is narrow — and that mark is empty until branding.json
+    // names an asset. Say so at setup time instead of letting the pane's
+    // absence read as a rendering bug once the card moves into a layout we
+    // don't own (see `designWarnings` for the scoping rationale).
+    const warnings = designWarnings({ design: answers.design, posture });
     if (!this.jsonEnabled()) {
       const projectFacts = await detectProjectFacts(cwd, framework.id);
       const sections = buildSummary({
@@ -459,14 +454,14 @@ export default class Setup extends BaseCommand {
       });
       // The envelope's `warnings` never render in non-JSON mode (setup
       // passes `pretty: ""`), so surface them to humans here.
-      for (const warning of designWarnings) {
+      for (const warning of warnings) {
         consola.warn(warning);
       }
     }
 
     return this.emit({
       status: "ok",
-      warnings: designWarnings,
+      warnings,
       // Human-facing output was already shown via consola (box + per-step
       // narration). Pass an empty `pretty` so the base command's fallback
       // renderer doesn't duplicate the summary on stdout. The JSON envelope

--- a/apps/cli/src/commands/setup/summary.ts
+++ b/apps/cli/src/commands/setup/summary.ts
@@ -1,9 +1,11 @@
 import { readFile, stat } from "node:fs/promises";
 import { basename, join } from "node:path";
 
+import type { BrandingDesign } from "@zitadel/config/defaults";
 import pc from "picocolors";
 
 import { detectPackageManager, type PackageManager } from "../../lib/package-manager";
+import type { ScaffoldPosture } from "../../lib/sync/types";
 
 /**
  * Structured end-of-command summary, modelled on the report layout the
@@ -165,4 +167,35 @@ function stripRange(range: string): string {
 /** Returns just the file name from a relative path, for the `→ filename` secondary detail in PACKAGE rows. */
 export function fileNameOf(p: string): string {
   return basename(p);
+}
+
+/**
+ * Layout caveats for the chosen login design, shown to humans after the
+ * summary box and carried in the JSON envelope's `warnings`.
+ *
+ * The split family's brand pane is keyed to the **login's own container**
+ * width — a `@container (max-width: 48rem)` query on the widget's mount, not
+ * a viewport media query. Above that the pane renders; below it the pane
+ * collapses and the compact brand mark takes over, and that mark is empty
+ * until `branding.json` names an asset. So the warning describes the
+ * contract, not a prediction about the container this app happens to give
+ * it: the wrapper we scaffold is full-width, and the pane does render there.
+ *
+ * Scoped to widget posture because that is where container width becomes the
+ * host app's choice — the card is meant to move into a layout we do not own,
+ * and a sidebar or modal is exactly the narrow case. `hero` stays quiet: its
+ * compact fallback is editable text, so a narrow container never leaves it
+ * blank.
+ */
+export function designWarnings(input: {
+  design?: BrandingDesign;
+  posture: ScaffoldPosture;
+}): string[] {
+  const { design, posture } = input;
+  if (posture !== "widget" || (design !== "split" && design !== "split-right")) {
+    return [];
+  }
+  return [
+    `The ${design} design shows its brand pane only when the login's container is wide; a narrow container — a card-width embed, or any phone-width viewport — collapses it to the compact brand mark. Set logo_url (or hero_url) in .zitadel/branding/branding.json so that mark isn't empty.`,
+  ];
 }

--- a/apps/cli/src/commands/setup/summary.ts
+++ b/apps/cli/src/commands/setup/summary.ts
@@ -5,7 +5,6 @@ import type { BrandingDesign } from "@zitadel/config/defaults";
 import pc from "picocolors";
 
 import { detectPackageManager, type PackageManager } from "../../lib/package-manager";
-import type { ScaffoldPosture } from "../../lib/sync/types";
 
 /**
  * Structured end-of-command summary, modelled on the report layout the
@@ -175,24 +174,21 @@ export function fileNameOf(p: string): string {
  *
  * The split family's brand pane is keyed to the **login's own container**
  * width — a `@container (max-width: 48rem)` query on the widget's mount, not
- * a viewport media query. Above that the pane renders; below it the pane
- * collapses and the compact brand mark takes over, and that mark is empty
- * until `branding.json` names an asset. So the warning describes the
- * contract, not a prediction about the container this app happens to give
- * it: the wrapper we scaffold is full-width, and the pane does render there.
+ * a viewport media query. Above that the pane renders; below it the pane is
+ * `display: none` and the compact brand mark takes its place — and the split
+ * template only emits that mark when `branding.json` names `logo_url` or
+ * `hero_url`, so without one the narrow layout loses the branding entirely.
  *
- * Scoped to widget posture because that is where container width becomes the
- * host app's choice — the card is meant to move into a layout we do not own,
- * and a sidebar or modal is exactly the narrow case. `hero` stays quiet: its
- * compact fallback is editable text, so a narrow container never leaves it
- * blank.
+ * Independent of posture, because the container query is: a full-page login
+ * hits the same collapse on a phone that an embedded card hits in a sidebar.
+ * Gating on `widget` would have been a guess about the container, and a wrong
+ * one in both directions — the wrapper setup scaffolds for a widget is
+ * full-width (the pane renders there), and a page-posture login on a phone is
+ * exactly the narrow case the advice is for. `hero` stays quiet: its compact
+ * fallback is editable text, so a narrow container never leaves it blank.
  */
-export function designWarnings(input: {
-  design?: BrandingDesign;
-  posture: ScaffoldPosture;
-}): string[] {
-  const { design, posture } = input;
-  if (posture !== "widget" || (design !== "split" && design !== "split-right")) {
+export function designWarnings(design?: BrandingDesign): string[] {
+  if (design !== "split" && design !== "split-right") {
     return [];
   }
   return [

--- a/apps/cli/tests/unit/commands/setup/index.test.ts
+++ b/apps/cli/tests/unit/commands/setup/index.test.ts
@@ -284,6 +284,44 @@ describe("setup command pre-flight", () => {
     }
     expect(projectName.trim().length).toBeGreaterThan(0);
   });
+
+  it("warns about the split brand pane's narrow-container fallback, not about this app", async () => {
+    const cwd = await makeTempDir();
+    // A pre-existing Next app — the posture that embeds `variant="widget"`
+    // cards (ADR 044), which is what scopes the warning.
+    await mkdir(join(cwd, "app"), { recursive: true });
+    await writeFile(
+      join(cwd, "package.json"),
+      JSON.stringify({ name: "demo", dependencies: { next: "^16" } }),
+    );
+    const capture = await startCreateProjectCaptureServer();
+
+    const res = await runCliForTest([
+      "setup",
+      "--cwd",
+      cwd,
+      "--design",
+      "split-right",
+      "--server",
+      capture.url,
+      "--non-interactive",
+      "--json",
+      "--skip-install",
+    ]);
+
+    expect(res.exitCode).toBe(0);
+    const json = parseJson(res.stdout) as { status: string; warnings: string[] };
+    expect(json.status).toBe("ok");
+    expect(json.warnings).toHaveLength(1);
+    // The wrapper setup scaffolds around the widget is full-width, so the
+    // brand pane does render in the page we just wrote. Telling the user it
+    // shows the compact mark "instead" sends them hunting a rendering bug
+    // that isn't happening — the warning states the container-width contract
+    // and the branding.json fix for the narrow case.
+    expect(json.warnings[0]).not.toMatch(/this app/i);
+    expect(json.warnings[0]).toContain("container is wide");
+    expect(json.warnings[0]).toContain(".zitadel/branding/branding.json");
+  });
 });
 
 describe("setup --renderer surface", () => {
@@ -395,6 +433,16 @@ async function startCreateProjectCaptureServer(): Promise<{
       res.writeHead(201, { "content-type": "application/json" }).end(
         JSON.stringify({
           id: "flow_test",
+          created_at: "2026-06-01T00:00:00.000Z",
+        }),
+      );
+      return;
+    }
+    if (req.method === "POST" && path === "/branding") {
+      res.writeHead(201, { "content-type": "application/json" }).end(
+        JSON.stringify({
+          id: "brand_test",
+          revision: 1,
           created_at: "2026-06-01T00:00:00.000Z",
         }),
       );

--- a/apps/cli/tests/unit/commands/setup/index.test.ts
+++ b/apps/cli/tests/unit/commands/setup/index.test.ts
@@ -287,8 +287,9 @@ describe("setup command pre-flight", () => {
 
   it("warns about the split brand pane's narrow-container fallback, not about this app", async () => {
     const cwd = await makeTempDir();
-    // A pre-existing Next app — the posture that embeds `variant="widget"`
-    // cards (ADR 044), which is what scopes the warning.
+    // Widget posture (a pre-existing Next app, ADR 044): the card is meant to
+    // move into a layout the CLI doesn't own, so a narrow container is the
+    // likely end state.
     await mkdir(join(cwd, "app"), { recursive: true });
     await writeFile(
       join(cwd, "package.json"),
@@ -320,6 +321,47 @@ describe("setup command pre-flight", () => {
     // and the branding.json fix for the narrow case.
     expect(json.warnings[0]).not.toMatch(/this app/i);
     expect(json.warnings[0]).toContain("container is wide");
+    expect(json.warnings[0]).toContain(".zitadel/branding/branding.json");
+  });
+
+  it("warns in page posture too — the collapse is a container query, not a posture", async () => {
+    const cwd = await makeTempDir();
+    // A pre-existing React app: not route-based, so `derivePosture` returns
+    // "page" without a scaffold (ADR 044). A full-page split login hits the
+    // same collapse on a phone that an embedded card hits in a sidebar, and
+    // the template emits no compact mark without logo_url/hero_url — so
+    // suppressing the advice here would leave that dead state unexplained.
+    await mkdir(join(cwd, "src"), { recursive: true });
+    await writeFile(
+      join(cwd, "package.json"),
+      JSON.stringify({ name: "demo", dependencies: { react: "^19", vite: "^7" } }),
+    );
+    // The React patcher merges the /__nextgen dev proxy into the Vite config
+    // and fails loudly without one.
+    await writeFile(
+      join(cwd, "vite.config.ts"),
+      'import { defineConfig } from "vite";\n\nexport default defineConfig({});\n',
+    );
+    const capture = await startCreateProjectCaptureServer();
+
+    const res = await runCliForTest([
+      "setup",
+      "--cwd",
+      cwd,
+      "--design",
+      "split",
+      "--server",
+      capture.url,
+      "--non-interactive",
+      "--json",
+      "--skip-install",
+    ]);
+
+    expect(res.exitCode).toBe(0);
+    const json = parseJson(res.stdout) as { status: string; warnings: string[] };
+    expect(json.status).toBe("ok");
+    expect(json.warnings).toHaveLength(1);
+    expect(json.warnings[0]).toContain("The split design");
     expect(json.warnings[0]).toContain(".zitadel/branding/branding.json");
   });
 });

--- a/apps/cli/tests/unit/commands/setup/summary.test.ts
+++ b/apps/cli/tests/unit/commands/setup/summary.test.ts
@@ -22,7 +22,7 @@ describe("relativeDisplayPath", () => {
 
 describe("designWarnings", () => {
   it("describes the container-width contract without claiming the pane is already collapsed", () => {
-    const [warning, ...rest] = designWarnings({ design: "split-right", posture: "widget" });
+    const [warning, ...rest] = designWarnings("split-right");
 
     expect(rest).toEqual([]);
     expect(warning).toBeDefined();
@@ -40,20 +40,15 @@ describe("designWarnings", () => {
   });
 
   it("names the chosen design", () => {
-    expect(designWarnings({ design: "split", posture: "widget" })[0]).toContain("The split design");
+    expect(designWarnings("split")[0]).toContain("The split design");
   });
 
   it("stays quiet for designs that survive a narrow container", () => {
     // `hero`'s compact fallback is editable text, and the non-split designs
     // have no brand pane to collapse.
-    expect(designWarnings({ design: "hero", posture: "widget" })).toEqual([]);
-    expect(designWarnings({ design: "centered", posture: "widget" })).toEqual([]);
-    expect(designWarnings({ design: "minimal", posture: "widget" })).toEqual([]);
-    expect(designWarnings({ posture: "widget" })).toEqual([]);
-  });
-
-  it("stays quiet in page posture, where the login owns the container", () => {
-    expect(designWarnings({ design: "split", posture: "page" })).toEqual([]);
-    expect(designWarnings({ design: "split-right", posture: "page" })).toEqual([]);
+    expect(designWarnings("hero")).toEqual([]);
+    expect(designWarnings("centered")).toEqual([]);
+    expect(designWarnings("minimal")).toEqual([]);
+    expect(designWarnings()).toEqual([]);
   });
 });

--- a/apps/cli/tests/unit/commands/setup/summary.test.ts
+++ b/apps/cli/tests/unit/commands/setup/summary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { relativeDisplayPath } from "../../../../src/commands/setup/summary";
+import { designWarnings, relativeDisplayPath } from "../../../../src/commands/setup/summary";
 
 describe("relativeDisplayPath", () => {
   it("normalizes Windows paths for repository-style suffix matching", () => {
@@ -17,5 +17,43 @@ describe("relativeDisplayPath", () => {
     expect(relativeDisplayPath("C:\\repo", "C:\\repository\\file.json")).toBe(
       "C:/repository/file.json",
     );
+  });
+});
+
+describe("designWarnings", () => {
+  it("describes the container-width contract without claiming the pane is already collapsed", () => {
+    const [warning, ...rest] = designWarnings({ design: "split-right", posture: "widget" });
+
+    expect(rest).toEqual([]);
+    expect(warning).toBeDefined();
+    // The pane is keyed to the login's container width, and the wrapper the
+    // CLI scaffolds does not constrain it — the pane renders there. Claiming
+    // "this app shows the compact mark instead" sends users hunting for a
+    // rendering bug that isn't happening.
+    expect(warning).not.toMatch(/this app/i);
+    expect(warning).toContain("container is wide");
+    expect(warning).toContain("collapses it to the compact brand mark");
+    // The actionable half has to survive any rewording.
+    expect(warning).toContain("logo_url");
+    expect(warning).toContain("hero_url");
+    expect(warning).toContain(".zitadel/branding/branding.json");
+  });
+
+  it("names the chosen design", () => {
+    expect(designWarnings({ design: "split", posture: "widget" })[0]).toContain("The split design");
+  });
+
+  it("stays quiet for designs that survive a narrow container", () => {
+    // `hero`'s compact fallback is editable text, and the non-split designs
+    // have no brand pane to collapse.
+    expect(designWarnings({ design: "hero", posture: "widget" })).toEqual([]);
+    expect(designWarnings({ design: "centered", posture: "widget" })).toEqual([]);
+    expect(designWarnings({ design: "minimal", posture: "widget" })).toEqual([]);
+    expect(designWarnings({ posture: "widget" })).toEqual([]);
+  });
+
+  it("stays quiet in page posture, where the login owns the container", () => {
+    expect(designWarnings({ design: "split", posture: "page" })).toEqual([]);
+    expect(designWarnings({ design: "split-right", posture: "page" })).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- `zitadel setup`'s split-family design warning claimed **"this app embeds the login as a card, which shows the compact brand mark instead"**. That is false for the page the CLI itself scaffolds: the widget-posture wrapper is `<div style={{display:"flex", justifyContent:"center", padding:"4rem 1rem"}}>` (Next and Nuxt alike), so the widget's container spans the viewport. Verified end-to-end on main (61a0eee0) with a fresh create-next-app + `setup --design split-right`: at a 1440px viewport `.zl-split__brand` measured 688px and rendered the gradient placeholder — the compact mark was never used. It only collapses below the container-query breakpoint (`@container (max-width: 48rem)` on the widget's mount, confirmed at 420px: `.zl-split__brand` `display:none`).
- So `variant="widget"` is not the same thing as card width. The warning now states the contract instead of predicting this app's layout: the pane renders when the login's container is wide and collapses to the compact mark in a narrow one — a card-width embed, or any phone-width viewport — which is why `logo_url`/`hero_url` matter. The actionable half is unchanged.
- **The warning now fires in page posture too.** The collapse is a container query, so it isn't posture-dependent, and `packages/config/defaults/branding/split/login.liquid` emits the compact mark only when `logo_url` or `hero_url` is set — a fresh full-page `--design split` setup therefore loses its branding entirely on a phone. Gating on `widget` was a guess about container width, wrong in both directions. `designWarnings` is keyed on the design alone; the posture argument is gone.
- Text extracted from an inline ternary into `designWarnings(design)` in `apps/cli/src/commands/setup/summary.ts` so it is unit-testable. `hero` still stays quiet — its compact fallback is editable text, so a narrow container never leaves it blank.

## Validation

- `moon run cli:test` — 1090 passed (112 files), including the new suites.
- `moon run cli:typecheck cli:lint` — clean; `oxlint` reports 0 warnings on the touched files.
- `corepack pnpm exec changeset status --since origin/main` — `@zitadel/cli` patch.
- Manual runs against a stub server, confirming the human-facing `WARN` line: `--design split-right` into a pre-existing Next app (widget posture, and the generated `app/login/page.tsx` carries the unconstrained flex wrapper), and `--design split` into a pre-existing React app (page posture).

New tests:

- `tests/unit/commands/setup/summary.test.ts` — the helper: contract wording, no "this app" claim, the `logo_url`/`hero_url`/`branding.json` half survives any rewording, design named, quiet for `hero`/`centered`/`minimal`/none.
- `tests/unit/commands/setup/index.test.ts` — two real setup runs asserting the JSON envelope carries exactly one warning with the new text: a pre-existing Next app (widget posture) and a pre-existing React app (page posture — `derivePosture` reports "page" for non-route-based frameworks without a scaffold, so the page path is reachable without running create-next-app). These cover the wiring the pure-function test cannot. The capture server gained a `POST /branding` handler for the design path.

## Release notes / changeset

- Changeset: `.changeset/setup-split-design-warning-wording.md` — `@zitadel/cli` patch. The warning no longer claims the pane is collapsed in your app, describes when it actually collapses, and now also covers full-page setups. Customer-visible CLI output changed, so this is a real changeset and a `fix` title.

## Notes

- The same conflation survives in the `--design` flag help (`apps/cli/src/commands/setup/index.ts:132`): "narrow containers — including widget-posture embeds at card width", which reads as *widget-posture embeds are card width*. Left out of this PR to keep the diff to the reviewed scope, and because changing it forces a `moon run cli:readme` regeneration that also touches `apps/cli/README.md:522`. Happy to fold it in if you'd rather fix both at once.
- Behavior change worth a second opinion: fresh `--design split` / `--design split-right` scaffolds now emit one warning they previously didn't. It is accurate and actionable, but if you'd rather keep the fresh-scaffold path quiet, the alternative is narrowing the copy to embed-specific wording and keeping the widget gate.
- Unrelated to the diff, for anyone reproducing locally: a worktree missing `undici` makes every spawned-CLI test fail with exit 127. `pnpm install` fixes it.
