### PR TITLE
fix(login): bound branding asset height in the split brand pane

### DIFF
--- a/.changeset/split-hero-height-cap.md
+++ b/.changeset/split-hero-height-cap.md
@@ -1,0 +1,13 @@
+---
+"@zitadel/components": patch
+---
+
+A `hero_url` no longer decides how tall the sign-in page is. In the `split` and
+`split-right` designs the brand pane took its height from the image, so an asset
+that is tall, square, or an SVG with no width/height of its own — the kind every
+framework scaffold ships in `public/` — stretched the pane past the viewport and
+pushed the "Secured with Zitadel" attribution below the fold. The hero now spans
+the brand pane's width with a capped height: a conventional wide banner renders
+exactly as before, and a taller asset is cropped to fit instead of growing the
+page. Set `--zl-split-hero-max-height` on the template root to raise or lower the
+cap for a design that wants a taller pane.

--- a/.changeset/split-logo-height-cap.md
+++ b/.changeset/split-logo-height-cap.md
@@ -1,0 +1,11 @@
+---
+"@zitadel/components": patch
+---
+
+A tall `logo_url` no longer stretches the `split` / `split-right` brand pane. The
+logo was capped in width but not in height, so a portrait lockup — a mark stacked
+above a wordmark, say — kept the height its own proportions asked for and grew the
+pane past the viewport. It is now capped in both directions and scales down whole,
+never cropped: a logo that already fit is untouched, and a small one is still shown
+at its own size rather than blown up to fill the pane. Set
+`--zl-split-logo-max-height` on the template root if your lockup wants more room.

--- a/.changeset/split-logo-height-cap.md
+++ b/.changeset/split-logo-height-cap.md
@@ -7,5 +7,7 @@ logo was capped in width but not in height, so a portrait lockup — a mark stac
 above a wordmark, say — kept the height its own proportions asked for and grew the
 pane past the viewport. It is now capped in both directions and scales down whole,
 never cropped: a logo that already fit is untouched, and a small one is still shown
-at its own size rather than blown up to fill the pane. Set
-`--zl-split-logo-max-height` on the template root if your lockup wants more room.
+at its own size rather than blown up to fill the pane. When a logo and a hero share
+the pane the logo takes the smaller header-mark cap, so the two together still leave
+the "Secured with Zitadel" badge on screen. Set `--zl-split-logo-max-height` on the
+template root if your lockup wants more room.

--- a/packages/components/src/orchestrator/__fixtures__/square-unsized-asset.svg
+++ b/packages/components/src/orchestrator/__fixtures__/square-unsized-asset.svg
@@ -1,0 +1,5 @@
+<!-- A square SVG with a viewBox and no width/height: it has an intrinsic ratio
+     but no intrinsic size, so `width: auto` resolves to the containing block's
+     width and the ratio squares it. Every framework scaffold ships one of these
+     (Next's `public/globe.svg`), which is how it reached a brand pane. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="square test asset"><rect width="64" height="64" rx="8" fill="#bba5e4"/></svg>

--- a/packages/components/src/orchestrator/__fixtures__/tall-logo-asset.svg
+++ b/packages/components/src/orchestrator/__fixtures__/tall-logo-asset.svg
@@ -1,0 +1,4 @@
+<!-- A portrait lockup with a real intrinsic size and a 1:4 ratio. Unlike
+     `square-unsized-asset.svg` this one is not bounded by the brand pane's
+     width cap: clamped to 16rem wide it still resolves to 1024px tall. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="2000" viewBox="0 0 500 2000" role="img" aria-label="tall test asset"><rect width="500" height="2000" rx="24" fill="#bba5e4"/></svg>

--- a/packages/components/src/orchestrator/__fixtures__/wide-banner-asset.svg
+++ b/packages/components/src/orchestrator/__fixtures__/wide-banner-asset.svg
@@ -1,0 +1,4 @@
+<!-- A conventional landscape banner: intrinsic size, ratio far wider than the
+     hero's height cap. The counterpart to `square-unsized-asset.svg` — it must
+     stay uncropped, which is what keeps the cap a cap and not a hard slot. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="300" viewBox="0 0 1200 300" role="img" aria-label="wide test asset"><rect width="1200" height="300" rx="8" fill="#f48aa0"/></svg>

--- a/packages/components/src/orchestrator/embedding.browser.spec.ts
+++ b/packages/components/src/orchestrator/embedding.browser.spec.ts
@@ -222,6 +222,14 @@ const minimalStep: CreateFlow201 = {
 
 const TRANSPARENT = "rgba(0, 0, 0, 0)";
 
+/**
+ * Captured before any test runs, because a test that resizes the viewport has
+ * to hand back what it borrowed. Vitest's own default is 414×896 — restoring a
+ * hardcoded desktop size instead would silently re-house every test declared
+ * after the resizing one.
+ */
+const DEFAULT_VIEWPORT = { width: window.innerWidth, height: window.innerHeight };
+
 function installFlowFetchStub(responses: readonly CreateFlow201[]): { restore: () => void } {
   let cursor = 0;
   const fetchStub = vi.fn(async (): Promise<Response> => {
@@ -290,7 +298,7 @@ describe("<zitadel-login> widget-first embedding (chromium)", () => {
     document.getElementById("zl-font-link")?.remove();
     if (resetViewport) {
       resetViewport = false;
-      await page.viewport(1440, 900);
+      await page.viewport(DEFAULT_VIEWPORT.width, DEFAULT_VIEWPORT.height);
     }
   });
 
@@ -646,6 +654,24 @@ describe("<zitadel-login> widget-first embedding (chromium)", () => {
     // The user-visible invariant behind the whole budget: the badge is on screen.
     const pill = element.shadowRoot?.querySelector(".zl-attribution > *") as HTMLElement;
     expect(pill.getBoundingClientRect().bottom).toBeLessThanOrEqual(window.innerHeight);
+  });
+
+  it("a viewport too short for the budget shrinks the hero, it does not erase it", async () => {
+    // The budget subtraction goes negative below ~420px of viewport height.
+    // Floored at 0 the hero silently vanished while the pane kept the logo —
+    // and it bought nothing, because at those heights the form card is already
+    // taller than the brand pane and sets the page height by itself. The floor
+    // is the compact banner's 6rem so the asset degrades instead of dropping.
+    resetViewport = true;
+    await page.viewport(1200, 420);
+    host.style.width = "1200px";
+    const element = await mount(splitBothAssetsStep, (el) => {
+      el.variant = "page";
+    });
+
+    const hero = await loadedImage(element, "img.zl-split__hero");
+    expect(hero.getBoundingClientRect().height).toBeGreaterThanOrEqual(96);
+    expect(getComputedStyle(hero).display).not.toBe("none");
   });
 
   it("the logo cap never stretches a small logo to the pane", async () => {

--- a/packages/components/src/orchestrator/embedding.browser.spec.ts
+++ b/packages/components/src/orchestrator/embedding.browser.spec.ts
@@ -130,6 +130,17 @@ const splitTallLogoStep: CreateFlow201 = {
   },
 } as unknown as CreateFlow201;
 
+/** Both assets at once — the pane stacks them, so the caps share one budget. */
+const splitBothAssetsStep: CreateFlow201 = {
+  ...identifierStep,
+  branding: {
+    layout: "split",
+    liquid_template: splitTemplate,
+    logo_url: TALL_ASSET,
+    hero_url: SQUARE_ASSET,
+  },
+} as unknown as CreateFlow201;
+
 /** The shipped split design with a logo: the compact fallback is a capped <img>. */
 const splitLogoStep: CreateFlow201 = {
   ...identifierStep,
@@ -597,6 +608,33 @@ describe("<zitadel-login> widget-first embedding (chromium)", () => {
     // Deliberately unlike the hero: no pinned width, so the cap shrinks both
     // axes and the mark keeps its whole shape. Cropping a logo loses brand.
     expect(rect.width / rect.height).toBeCloseTo(logo.naturalWidth / logo.naturalHeight, 1);
+  });
+
+  it("a logo and a hero together stay inside the whole page shell's budget", async () => {
+    // Capping each image on its own is not enough. The templates render both
+    // when a tenant sets both, and the brand pane's padding and gap are only
+    // half the chrome they compete with: the shell adds 3.25rem of block
+    // padding, a region gap, and the attribution row. At their solo caps the
+    // pair measured an 824px pane inside a 976px document at 1440×900 — the
+    // attribution back below the fold, which is what the caps exist to stop.
+    host.style.width = "1200px";
+    const element = await mount(splitBothAssetsStep, (el) => {
+      el.variant = "page";
+    });
+
+    // Both are really rendering — a budget met by dropping one asset is no fix.
+    const logo = await loadedImage(element, "img.zl-split__logo");
+    const hero = await loadedImage(element, "img.zl-split__hero");
+    expect(logo.getBoundingClientRect().height).toBeGreaterThan(0);
+    expect(hero.getBoundingClientRect().height).toBeGreaterThan(0);
+
+    const brand = element.shadowRoot?.querySelector(".zl-split__brand") as HTMLElement;
+    expect(brand.getBoundingClientRect().height).toBeLessThanOrEqual(window.innerHeight);
+    const mountNode = element.shadowRoot?.querySelector(".zl-mount") as HTMLElement;
+    expect(mountNode.getBoundingClientRect().height).toBeLessThanOrEqual(window.innerHeight + 1);
+    // The user-visible invariant behind the whole budget: the badge is on screen.
+    const pill = element.shadowRoot?.querySelector(".zl-attribution > *") as HTMLElement;
+    expect(pill.getBoundingClientRect().bottom).toBeLessThanOrEqual(window.innerHeight);
   });
 
   it("the logo cap never stretches a small logo to the pane", async () => {

--- a/packages/components/src/orchestrator/embedding.browser.spec.ts
+++ b/packages/components/src/orchestrator/embedding.browser.spec.ts
@@ -86,6 +86,11 @@ const fieldlessStep: CreateFlow201 = {
  */
 const LOADABLE_ASSET = `${location.origin}/src/orchestrator/__fixtures__/asset.svg`;
 const BROKEN_ASSET = `${location.origin}/src/orchestrator/__fixtures__/does-not-exist.svg`;
+/** Square, and carrying a viewBox but no width/height — see the fixture. */
+const SQUARE_ASSET = `${location.origin}/src/orchestrator/__fixtures__/square-unsized-asset.svg`;
+const WIDE_ASSET = `${location.origin}/src/orchestrator/__fixtures__/wide-banner-asset.svg`;
+/** Sized, 1:4 — the shape the brand pane's width cap does *not* bound. */
+const TALL_ASSET = `${location.origin}/src/orchestrator/__fixtures__/tall-logo-asset.svg`;
 
 /** The shipped split design carried as tenant branding, logo-less. */
 const splitHeroOnlyStep: CreateFlow201 = {
@@ -94,6 +99,34 @@ const splitHeroOnlyStep: CreateFlow201 = {
     layout: "split",
     liquid_template: splitTemplate,
     hero_url: LOADABLE_ASSET,
+  },
+} as unknown as CreateFlow201;
+
+/** Same design, pointed at the two hero shapes the height cap has to separate. */
+const splitSquareHeroStep: CreateFlow201 = {
+  ...identifierStep,
+  branding: {
+    layout: "split",
+    liquid_template: splitTemplate,
+    hero_url: SQUARE_ASSET,
+  },
+} as unknown as CreateFlow201;
+
+const splitWideHeroStep: CreateFlow201 = {
+  ...identifierStep,
+  branding: {
+    layout: "split",
+    liquid_template: splitTemplate,
+    hero_url: WIDE_ASSET,
+  },
+} as unknown as CreateFlow201;
+
+const splitTallLogoStep: CreateFlow201 = {
+  ...identifierStep,
+  branding: {
+    layout: "split",
+    liquid_template: splitTemplate,
+    logo_url: TALL_ASSET,
   },
 } as unknown as CreateFlow201;
 
@@ -205,6 +238,17 @@ async function waitFor<T>(probe: () => T | null | undefined, timeout = 3000): Pr
     await new Promise((resolve) => setTimeout(resolve, 16));
   }
   throw new Error("waitFor timed out");
+}
+
+/**
+ * Asset-sizing assertions are meaningless against a pending `<img>`: the
+ * intrinsic dimensions the layout derives from only exist once it has decoded.
+ */
+async function loadedImage(element: ZitadelLogin, selector: string): Promise<HTMLImageElement> {
+  return waitFor(() => {
+    const img = element.shadowRoot?.querySelector(selector) as HTMLImageElement | null;
+    return img?.complete && img.naturalWidth > 0 ? img : null;
+  });
 }
 
 describe("<zitadel-login> widget-first embedding (chromium)", () => {
@@ -470,6 +514,104 @@ describe("<zitadel-login> widget-first embedding (chromium)", () => {
     const banner = withHero.shadowRoot?.querySelector(".zl-split__compact") as HTMLElement;
     expect(banner.tagName).toBe("IMG");
     expect(getComputedStyle(banner).maxHeight).toBe("96px");
+  });
+
+  it("a square hero asset cannot grow the brand pane past the viewport", async () => {
+    // The reported failure: `hero_url` pointed at a framework scaffold's own
+    // `public/globe.svg` — square, and with no intrinsic size, so it laid out
+    // at the brand pane's width and squared itself (656×656). The pane is
+    // content-sized, so that became the page height (1028px at a 900px
+    // viewport) and pushed the attribution below the fold.
+    host.style.width = "1200px";
+    const element = await mount(splitSquareHeroStep, (el) => {
+      el.variant = "page";
+    });
+
+    const hero = await loadedImage(element, "img.zl-split__hero");
+    const heroRect = hero.getBoundingClientRect();
+    // Still a pane-filling hero, not a stamp — the cap bounds height only.
+    expect(heroRect.width).toBeGreaterThan(400);
+    expect(heroRect.height).toBeLessThan(heroRect.width);
+
+    const brand = element.shadowRoot?.querySelector(".zl-split__brand") as HTMLElement;
+    expect(brand.getBoundingClientRect().height).toBeLessThanOrEqual(window.innerHeight);
+    // Page mode floors the mount at 100vh; it must not have grown past it.
+    const mountNode = element.shadowRoot?.querySelector(".zl-mount") as HTMLElement;
+    expect(mountNode.getBoundingClientRect().height).toBeLessThanOrEqual(window.innerHeight + 1);
+
+    const cap = parseFloat(getComputedStyle(hero).maxHeight);
+    expect(cap).toBeGreaterThan(0);
+    expect(heroRect.height).toBeLessThanOrEqual(cap + 1);
+    // The cap crops rather than distorts; `contain` here would letterbox the
+    // asset back into the same square footprint the cap just removed.
+    expect(getComputedStyle(hero).objectFit).toBe("cover");
+  });
+
+  it("the hero height cap leaves a conventional wide banner uncropped", async () => {
+    // The other half of the cap: it may not turn into a fixed slot. A landscape
+    // banner's height never reaches the cap, so it keeps its own ratio and
+    // `object-fit` stays a no-op — the tenant sees the whole asset.
+    host.style.width = "1200px";
+    const element = await mount(splitWideHeroStep, (el) => {
+      el.variant = "page";
+    });
+
+    const hero = await loadedImage(element, "img.zl-split__hero");
+    const heroRect = hero.getBoundingClientRect();
+    const intrinsicRatio = hero.naturalWidth / hero.naturalHeight;
+    expect(heroRect.width / heroRect.height).toBeCloseTo(intrinsicRatio, 1);
+  });
+
+  it("the collapsed compact banner caps the same square asset", async () => {
+    // Narrow container: the brand pane is gone and the hero rides in the form
+    // pane instead. Its `width: 100%` is what makes the 6rem cap bite — without
+    // it the same asset would square itself off the form pane's width and wall
+    // off the card.
+    const element = await mount(splitSquareHeroStep);
+    const banner = await loadedImage(element, "img.zl-split__compact--hero");
+    const rect = banner.getBoundingClientRect();
+    expect(rect.width).toBeGreaterThan(100);
+    expect(rect.height).toBeLessThanOrEqual(96 + 1);
+  });
+
+  it("a tall logo asset cannot grow the brand pane past the viewport", async () => {
+    // The hero's sibling defect. `max-width: min(16rem, 60%)` bounds one axis
+    // only, so a 1:4 portrait lockup clamped to 256px wide still resolved to
+    // 1024px tall and handed that to the content-sized pane. A square asset
+    // does not reproduce this — the width cap already squares it off at 256.
+    host.style.width = "1200px";
+    const element = await mount(splitTallLogoStep, (el) => {
+      el.variant = "page";
+    });
+
+    const logo = await loadedImage(element, "img.zl-split__logo");
+    const brand = element.shadowRoot?.querySelector(".zl-split__brand") as HTMLElement;
+    expect(brand.getBoundingClientRect().height).toBeLessThanOrEqual(window.innerHeight);
+    const mountNode = element.shadowRoot?.querySelector(".zl-mount") as HTMLElement;
+    expect(mountNode.getBoundingClientRect().height).toBeLessThanOrEqual(window.innerHeight + 1);
+
+    const rect = logo.getBoundingClientRect();
+    const cap = parseFloat(getComputedStyle(logo).maxHeight);
+    expect(cap).toBeGreaterThan(0);
+    expect(rect.height).toBeLessThanOrEqual(cap + 1);
+    // Deliberately unlike the hero: no pinned width, so the cap shrinks both
+    // axes and the mark keeps its whole shape. Cropping a logo loses brand.
+    expect(rect.width / rect.height).toBeCloseTo(logo.naturalWidth / logo.naturalHeight, 1);
+  });
+
+  it("the logo cap never stretches a small logo to the pane", async () => {
+    // The other direction of the same rule. `.zl-split__hero` pins `width:
+    // 100%`, which upscales a small asset; the logo must not inherit that —
+    // a 64px brand mark blown up to a 536px pane is a blurry mess.
+    host.style.width = "1200px";
+    const element = await mount(splitLogoStep, (el) => {
+      el.variant = "page";
+    });
+
+    const logo = await loadedImage(element, "img.zl-split__logo");
+    const rect = logo.getBoundingClientRect();
+    expect(rect.width).toBeCloseTo(logo.naturalWidth, 0);
+    expect(rect.height).toBeCloseTo(logo.naturalHeight, 0);
   });
 
   it("a branding asset that fails to load degrades to the split placeholder", async () => {

--- a/packages/components/src/orchestrator/embedding.browser.spec.ts
+++ b/packages/components/src/orchestrator/embedding.browser.spec.ts
@@ -2,6 +2,7 @@ import { configureZitadel, _resetConfigForTesting } from "@zitadel/api/config";
 import type { ZitadelProject } from "@zitadel/api/config";
 import type { CreateFlow201 } from "@zitadel/api/generated/model";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { page } from "vitest/browser";
 
 import "./zitadel-login.js";
 import heroTemplate from "../../../config/defaults/branding/hero/login.liquid";
@@ -266,6 +267,7 @@ describe("<zitadel-login> widget-first embedding (chromium)", () => {
   let host: HTMLDivElement;
   let stub: ReturnType<typeof installFlowFetchStub> | undefined;
   let project: ZitadelProject;
+  let resetViewport = false;
 
   beforeEach(() => {
     _resetConfigForTesting();
@@ -279,13 +281,17 @@ describe("<zitadel-login> widget-first embedding (chromium)", () => {
     document.body.appendChild(host);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     host.remove();
     stub?.restore();
     // The font links are document-level state the orchestrator manages on
     // update; isolate tests from each other.
     document.getElementById("zl-default-font-link")?.remove();
     document.getElementById("zl-font-link")?.remove();
+    if (resetViewport) {
+      resetViewport = false;
+      await page.viewport(1440, 900);
+    }
   });
 
   async function mount(
@@ -617,6 +623,11 @@ describe("<zitadel-login> widget-first embedding (chromium)", () => {
     // padding, a region gap, and the attribution row. At their solo caps the
     // pair measured an 824px pane inside a 976px document at 1440×900 — the
     // attribution back below the fold, which is what the caps exist to stop.
+    // This is still a desktop-width split pane, but its 800px height exposed
+    // the stale arithmetic in the first combined cap (864px mount).
+    resetViewport = true;
+    await page.viewport(1200, 800);
+    expect(window.innerHeight).toBe(800);
     host.style.width = "1200px";
     const element = await mount(splitBothAssetsStep, (el) => {
       el.variant = "page";

--- a/packages/components/src/orchestrator/templates/layout-chrome.css
+++ b/packages/components/src/orchestrator/templates/layout-chrome.css
@@ -180,11 +180,37 @@ img[data-zl-asset-broken] {
   gap: var(--zl-spacing-04, 1.5rem);
   padding: 52px 16px;
 }
+/* A width cap alone leaves the height open: a portrait lockup clamped to 16rem
+   wide still resolves whatever height its ratio asks for (a 500×2000 mark
+   renders 256×1024), and the content-sized brand pane hands that straight to
+   the page. `max-height` only, deliberately unlike `.zl-split__hero` below: a
+   logo is a mark, not a pane-filling image, so it shrinks proportionally and
+   keeps its whole shape rather than being cropped to a slot — and it is never
+   stretched to the pane, which is what `width: 100%` there would do. 16rem
+   squares off the existing width cap, and it is also the budget: logo and hero
+   stack in this pane, so 16rem + the hero's 27.5rem + the gap and padding is
+   what still fits a laptop viewport when a tenant sets both. Raise
+   `--zl-split-logo-max-height` from the template root for a taller lockup. */
 .zl-split__logo {
   max-width: min(16rem, 60%);
+  max-height: var(--zl-split-logo-max-height, 16rem);
 }
+/* Pinned width and a capped height, not a bare `max-width`. The brand pane is
+   content-sized — the grid centres it, nothing above the image constrains it —
+   so an unbounded hero *is* the page height. That bites hardest on an asset
+   with no intrinsic size (an SVG carrying only a viewBox, which every
+   framework scaffold ships): `width: auto` resolves to the pane's width and
+   the ratio squares it, so the pane grows past the viewport and pushes the
+   attribution below the fold. Pinning the width hands the excess to
+   `object-fit` instead of the layout: a wide banner is untouched (its height
+   never reaches the cap) and a tall or square one is cropped. The cap is the
+   `.zl-split__placeholder` footprint (22rem at 4 / 5), so a hero never claims
+   more vertical space than the panel it replaces, with a viewport term for
+   short screens. Tenants whose design wants a taller pane raise
+   `--zl-split-hero-max-height` from the template root. */
 .zl-split__hero {
-  max-width: 100%;
+  width: 100%;
+  max-height: var(--zl-split-hero-max-height, min(27.5rem, 60vh));
   border-radius: var(--zl-radius-m, 0.75rem);
   object-fit: cover;
 }
@@ -233,7 +259,10 @@ img.zl-split__compact {
   max-height: 2.5rem;
 }
 /* hero_url-only tenants: the compact fallback renders the hero image as a
-   modest banner instead of vanishing with the brand pane. */
+   modest banner instead of vanishing with the brand pane. Same pinned-width +
+   capped-height shape as `.zl-split__hero`, and load-bearing for the same
+   reason — drop the `width` and an intrinsic-size-less asset sizes itself off
+   the form pane instead, squaring a banner slot into a wall above the card. */
 img.zl-split__compact--hero {
   max-height: 6rem;
   max-width: 100%;

--- a/packages/components/src/orchestrator/templates/layout-chrome.css
+++ b/packages/components/src/orchestrator/templates/layout-chrome.css
@@ -187,13 +187,25 @@ img[data-zl-asset-broken] {
    logo is a mark, not a pane-filling image, so it shrinks proportionally and
    keeps its whole shape rather than being cropped to a slot — and it is never
    stretched to the pane, which is what `width: 100%` there would do. 16rem
-   squares off the existing width cap, and it is also the budget: logo and hero
-   stack in this pane, so 16rem + the hero's 27.5rem + the gap and padding is
-   what still fits a laptop viewport when a tenant sets both. Raise
-   `--zl-split-logo-max-height` from the template root for a taller lockup. */
+   squares off the existing width cap, so the logo fits a 16rem box either way.
+   That is the cap for a logo that has the pane to itself — when a hero shares
+   it, the rule below takes over. Raise `--zl-split-logo-max-height` from the
+   template root for a taller lockup. */
 .zl-split__logo {
   max-width: min(16rem, 60%);
   max-height: var(--zl-split-logo-max-height, 16rem);
+}
+/* A tenant who sets both assets stacks them in this one pane, so the two solo
+   caps stop being independent — and the pane's own gap and padding are only
+   half the chrome they compete with. The shell around it adds 3.25rem of block
+   padding, a region gap, and the attribution row: 16rem + 27.5rem + all of that
+   measures an 824px pane inside a 976px document at 1440×900, which is the same
+   below-the-fold attribution these caps exist to prevent. The logo yields
+   rather than the hero — above a hero image a logo reads as a header mark, and
+   shrinking the hero would tax the far more common hero-only pane for a
+   combination it never uses. */
+.zl-split__logo:has(+ .zl-split__hero) {
+  max-height: var(--zl-split-logo-max-height, 8rem);
 }
 /* Pinned width and a capped height, not a bare `max-width`. The brand pane is
    content-sized — the grid centres it, nothing above the image constrains it —

--- a/packages/components/src/orchestrator/templates/layout-chrome.css
+++ b/packages/components/src/orchestrator/templates/layout-chrome.css
@@ -201,7 +201,14 @@ img[data-zl-asset-broken] {
    padding, a region gap, and the 2.5rem attribution pill. The logo first yields
    to a header-mark cap; the hero then takes only the viewport height left after
    that whole fixed budget, so the pair also fits short, wide laptop viewports.
-   Hero-only panes keep the larger cap below. */
+   Hero-only panes keep the larger cap below.
+
+   The floor is 6rem — the compact banner's cap — not 0. Below roughly a 420px
+   viewport the subtraction goes negative, and floored at 0 the hero silently
+   disappeared while the pane kept the logo. That bought nothing: at those
+   heights the form card is already taller than the brand pane, so it, not the
+   hero, sets the page height. A visible-but-small hero is the honest
+   degradation. */
 .zl-split__logo:has(+ .zl-split__hero) {
   max-height: var(--zl-split-logo-max-height, 8rem);
 }
@@ -209,7 +216,7 @@ img[data-zl-asset-broken] {
   max-height: min(
     var(--zl-split-hero-max-height, 27.5rem),
     max(
-      0px,
+      6rem,
       calc(
         100vh - 104px - 6.5rem - 2.5rem - var(--zl-spacing-04, 1.5rem) -
           var(--zl-spacing-04, 1.5rem) - var(--zl-split-logo-max-height, 8rem)

--- a/packages/components/src/orchestrator/templates/layout-chrome.css
+++ b/packages/components/src/orchestrator/templates/layout-chrome.css
@@ -198,14 +198,24 @@ img[data-zl-asset-broken] {
 /* A tenant who sets both assets stacks them in this one pane, so the two solo
    caps stop being independent — and the pane's own gap and padding are only
    half the chrome they compete with. The shell around it adds 3.25rem of block
-   padding, a region gap, and the attribution row: 16rem + 27.5rem + all of that
-   measures an 824px pane inside a 976px document at 1440×900, which is the same
-   below-the-fold attribution these caps exist to prevent. The logo yields
-   rather than the hero — above a hero image a logo reads as a header mark, and
-   shrinking the hero would tax the far more common hero-only pane for a
-   combination it never uses. */
+   padding, a region gap, and the 2.5rem attribution pill. The logo first yields
+   to a header-mark cap; the hero then takes only the viewport height left after
+   that whole fixed budget, so the pair also fits short, wide laptop viewports.
+   Hero-only panes keep the larger cap below. */
 .zl-split__logo:has(+ .zl-split__hero) {
   max-height: var(--zl-split-logo-max-height, 8rem);
+}
+.zl-split__logo:has(+ .zl-split__hero) + .zl-split__hero {
+  max-height: min(
+    var(--zl-split-hero-max-height, 27.5rem),
+    max(
+      0px,
+      calc(
+        100vh - 104px - 6.5rem - 2.5rem - var(--zl-spacing-04, 1.5rem) -
+          var(--zl-spacing-04, 1.5rem) - var(--zl-split-logo-max-height, 8rem)
+      )
+    )
+  );
 }
 /* Pinned width and a capped height, not a bare `max-width`. The brand pane is
    content-sized — the grid centres it, nothing above the image constrains it —


### PR DESCRIPTION
## Summary

- The `split` / `split-right` brand pane is content-sized — the grid centres it and nothing above the images constrains them — so an unbounded asset **is** the page height. Neither of the pane's two images had a height cap.
- `.zl-split__hero` had `max-width: 100%` and `max-height: none`. That bites hardest on an asset with no intrinsic size: an SVG carrying only a viewBox (the kind every framework scaffold ships in `public/`) lays out at the pane's width and squares itself. Reproduced on main @ 61a0eee0 with a fresh `create-next-app` scaffolded via `setup --design split-right` and `hero_url` pointing at Next's own `public/globe.svg`: hero **656×656**, brand pane **836px**, document **1028px** at a 1440×900 viewport, "Secured with Zitadel" pushed below the fold.
- `.zl-split__logo` had `max-width: min(16rem, 60%)` and no height cap, which bounds one axis only: a 1:4 portrait lockup clamped to 256px wide still resolved to **1024px** tall and handed the pane **1128px**. A square or intrinsic-size-less asset does *not* reproduce this one — the width cap already squares it off at 256px — so only a genuinely tall sized asset blows out.

The two fixes take **deliberately opposite shapes**, which is the part worth reviewing:

| | `.zl-split__hero` | `.zl-split__logo` |
| --- | --- | --- |
| width | pinned `100%` | untouched (`max-width` only) |
| height | `max-height: var(--zl-split-hero-max-height, min(27.5rem, 60vh))` | `max-height: var(--zl-split-logo-max-height, 16rem)` |
| over-tall asset | cropped by `object-fit: cover` | shrunk proportionally, whole mark kept |

Pinning the hero's width is what hands the excess to `object-fit` instead of the layout. Measured in Chromium: a `max-height` on a replaced element whose `width` is `auto` shrinks **both** axes proportionally, so `object-fit` stays a no-op and never crops — cropping requires a determined width. A wide banner is untouched (its height never reaches the cap); a tall or square one is cropped.

The logo does not get that treatment on purpose: a logo is a mark, not a pane-filling image, so it shrinks whole rather than being cropped to a slot (cropping a logo loses brand), and a small mark is never blown up to the pane.

**Where the two cap values come from**, since either would otherwise be a magic number:

- Hero `27.5rem` = the `.zl-split__placeholder` footprint (`22rem` at `4 / 5`). The asset and no-asset states then claim the same vertical slot. The `60vh` term covers short screens.
- Logo `16rem` squares off the existing width cap, so the logo fits a 16rem box either way. That is its cap when it has the pane to itself.
- **When a logo and a hero share the pane** the logo drops to an `8rem` header-mark cap, then the hero takes only the viewport height left after that logo and all pane, shell, gap, and attribution chrome. This keeps the stacked pair inside a 1200×800 short-wide viewport without reducing the far more common hero-only pane.

Both caps are tunable from the template root (`--zl-split-hero-max-height`, `--zl-split-logo-max-height`), following the file's existing `--zl-split-columns` / `--zl-split-align` idiom, so a design that wants a taller pane is not stuck with a hard regression.

`.zl-split__compact--hero` needed no change — it already had the pinned-width + capped-height shape. Its comment now records why the `width` there is load-bearing, so a future tidy-up doesn't strip it.

## Validation

```sh
moon run components:test-browser components:test components:lint components:typecheck
```

- 95 browser tests, 420 unit tests, 0 lint errors, typecheck clean.
- Six new browser tests in `embedding.browser.spec.ts` with three same-origin fixtures. **All three blowout tests were confirmed failing against the pre-fix CSS**, by reverting each rule and re-running:
  - hero — `AssertionError: expected 536 to be less than 536` (the square blowout at a 536px pane)
  - logo — `AssertionError: expected 1128 to be less than or equal to 896` (brand pane vs viewport)
  - logo + hero together — `AssertionError: expected 952 to be less than or equal to 897` (mount vs viewport)
- The other three tests are guards on the deliberate halves: a conventional wide banner stays uncropped, the compact fallback caps the same square asset, and a small logo is not stretched to the pane.
- CSS constraint behaviour was measured in headless Chromium before choosing the rules, not inferred from the spec: `max-width:100%` → 656×656; `max-width:100% + max-height:300` → 300×300 (bounded but *not* cropped); `width:100% + max-height:300` → 656×300 (cropped); a 32:9 banner under the same rule → 656×185, untouched.

## Release notes / changeset

Changeset: `.changeset/split-hero-height-cap.md` — a `hero_url` no longer decides how tall the sign-in page is; the hero spans the brand pane's width with a capped height, wide banners render as before, taller assets are cropped to fit.

Changeset: `.changeset/split-logo-height-cap.md` — a tall `logo_url` no longer stretches the brand pane; the logo is capped in both directions and scales down whole, never cropped, and takes a smaller cap when it shares the pane with a hero.

Kept as two files so the fixes stay independently splittable; both are `@zitadel/components` patch. Verified with `corepack pnpm exec changeset status --since origin/main`.

## Notes

- **Behaviour changes for existing tenants**, both narrow but real:
  - A hero *smaller* than the brand pane is now upscaled to the pane width instead of sitting at its natural size. `.zl-split__compact--hero` already did exactly this, so it is consistent, but it is a change.
  - A logo *taller than square* shrinks. A 1:1 or landscape mark is untouched; a 3:4 vertical lockup that rendered 256×341 now renders 192×256. Sharing the pane with a hero lowers that cap further, to `8rem`.
- **Short-wide coverage:** the combined case is pinned at 1200×800 in Chromium and asserts the pane, mount, and attribution badge against the viewport while both images remain rendered. With the default values, the preserved 8rem logo plus fixed pane/shell/attribution chrome still consume about 424px before any hero is shown; below that extreme height the page posture itself must collapse or scroll. The brand pane already collapses below a 48rem *container* width.
- Every remaining `img` rule in `layout-chrome.css` is now bounded (`img.zl-split__compact` 2.5rem, `--hero` 6rem, `.zl-hero__brand-logo` 1.75rem), so this closes the defect class rather than one more instance of it.
- Drive-by: the repeated "wait for a decoded `<img>`" block in the spec is now a `loadedImage` helper — it had four call sites before this PR added a fifth.
- Both defects came out of the 2026-08-13 alpha.18 branding test round, downstream of #872 / #873 / #874 / #875 / #885 / #886.
