### PR TITLE
fix(authz): constrain sk_team checks to the token team

### DIFF
--- a/.changeset/authz-sk-team-scope.md
+++ b/.changeset/authz-sk-team-scope.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+Team service principals (`sk_team_`) can no longer act on users or teams outside the token's team, even if a project-wide grant exists. Project-scoped team-bound grants are rejected at mint time.

--- a/.changeset/authz-sk-team-scope.md
+++ b/.changeset/authz-sk-team-scope.md
@@ -2,4 +2,4 @@
 "@zitadel/server": patch
 ---
 
-Team service principals (`sk_team_`) can no longer act on users or teams outside the token's team, even if a project-wide grant exists. Project-scoped team-bound grants are rejected at mint time.
+Team service principals (`sk_team_`) can no longer act on users or teams outside the token's team, even if a project-wide grant exists. Project-scoped team-bound grants are rejected at mint time. HTTP wiring for the constraint lands in the stacked follow-ups (#893–#895).

--- a/docs/design/api/credentials.md
+++ b/docs/design/api/credentials.md
@@ -84,11 +84,13 @@ permission string (old `team.users.*` did). Compensating requirement: every
 `sk_team_` grant must carry a resolver-enforced team scope, and the deny-list
 suite must include "team token reads/writes a user outside its team".
 
-> **LOCKED / deferred:** Wave 3 (#423) ships the flat permission-name allowlist
-> only (`internal/authz/resolver/sk_team.go`). Resolver-enforced team scope and
-> the outside-team deny suite are **not** implemented yet — tracked in
-> [#831](https://github.com/zitadel/nextgen/issues/831). `sk_team_` is not
-> production-safe for `user.*` / `team_membership.*` until that lands.
+> **LOCKED:** Wave 3 (#423) shipped the flat permission-name allowlist
+> (`internal/authz/resolver/sk_team.go`). Resolver-enforced team scope
+> (`Request.TeamID` → `ConstraintTeamID`) and the outside-team deny suite
+> landed in [#831](https://github.com/zitadel/nextgen/issues/831). Grant
+> minting rejects project-scoped `sk_team_` grants for team-bound object
+> types. There is still no HTTP `sk_team_` token type — tests inject
+> `ScopeContext` / `resolver.Request` directly.
 
 SCIM sync (`scim.sync`) is not listed yet — SCIM is a hosted interop surface
 (`/scim/v2/Users`, `/scim/v2/Groups` in [`resource-map.md`](resource-map.md))

--- a/docs/design/api/permission-storage.md
+++ b/docs/design/api/permission-storage.md
@@ -80,7 +80,8 @@ Authz statement interfaces in `internal/service/statement.go` stay table-shaped
   materialization helper, foothold smoke helper, active system catalog) plus
   `internal/authz/resolver` orchestration (`sk_team_` permission-name
   allowlist, decision kinds). Resolver-enforced `sk_team_` **team scope**
-  (token `team_id` + outside-team deny suite) is deferred —
+  (`Request.TeamID` → `ConstraintTeamID`, outside-team deny suite, grant
+  minting reject of project-scoped team-bound grants) landed in
   [#831](https://github.com/zitadel/nextgen/issues/831). In-project
   management handlers call `resolver.Check` (coarse
   `project.{viewer,editor,admin}` until #420) after credential resolution.

--- a/internal/api/security.go
+++ b/internal/api/security.go
@@ -187,6 +187,8 @@ type ScopeContext struct {
 	// OAuth2 project secrets are sk_proj with PrincipalID == ProjectID.
 	PrincipalType domain.AuthzPrincipalType
 	PrincipalID   string
+	// TeamID is the token team for sk_team_ principals (resolver ConstraintTeamID).
+	TeamID string
 }
 
 func WithScopeContext(ctx context.Context, scopeCtx ScopeContext) context.Context {

--- a/internal/authz/resolver/check_test.go
+++ b/internal/authz/resolver/check_test.go
@@ -76,6 +76,7 @@ func TestCheck_Orchestration(t *testing.T) {
 			ProjectID:     "proj_1",
 			ObjectType:    "project",
 			Relation:      "write",
+			TeamID:        "team_1",
 		})
 		require.NoError(t, err)
 		assert.Equal(t, resolver.DecisionNotFound, d)
@@ -85,7 +86,17 @@ func TestCheck_Orchestration(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		stmts := mocks.NewMockAuthzResolverStatements(ctrl)
 		stmts.EXPECT().ActiveSystemCatalogID(gomock.Any()).Return(domain.SystemCatalogID, nil)
-		stmts.EXPECT().CheckAuthz(gomock.Any(), gomock.Any()).Return(true, true, nil)
+		stmts.EXPECT().CheckAuthz(gomock.Any(), domain.AuthzCheckParams{
+			CatalogID:              domain.SystemCatalogID,
+			ProjectID:              "proj_1",
+			PrincipalHomeProjectID: "proj_1",
+			PrincipalType:          domain.AuthzPrincipalTypeSKTeam,
+			PrincipalID:            "sk_team_1",
+			ObjectType:             "user",
+			Relation:               "read",
+			ConstraintTeamID:       "team_1",
+			ResourceID:             "usr_in",
+		}).Return(true, true, nil)
 
 		d, err := resolver.New().Check(context.Background(), stmts, resolver.Request{
 			PrincipalType: domain.AuthzPrincipalTypeSKTeam,
@@ -93,9 +104,25 @@ func TestCheck_Orchestration(t *testing.T) {
 			ProjectID:     "proj_1",
 			ObjectType:    "user",
 			Relation:      "read",
+			TeamID:        "team_1",
+			ResourceID:    "usr_in",
 		})
 		require.NoError(t, err)
 		assert.Equal(t, resolver.DecisionAllow, d)
+	})
+
+	t.Run("sk_team missing team id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stmts := mocks.NewMockAuthzResolverStatements(ctrl)
+		_, err := resolver.New().Check(context.Background(), stmts, resolver.Request{
+			PrincipalType: domain.AuthzPrincipalTypeSKTeam,
+			PrincipalID:   "sk_team_1",
+			ProjectID:     "proj_1",
+			ObjectType:    "user",
+			Relation:      "read",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "team id is required")
 	})
 
 	t.Run("invalid input", func(t *testing.T) {
@@ -170,6 +197,7 @@ func TestListObjects_SKTeamDeny(t *testing.T) {
 			ProjectID:     "proj_1",
 			ObjectType:    "project",
 			Relation:      "viewer",
+			TeamID:        "team_1",
 		},
 		ResourceKind: domain.ResourceKindUser,
 	})

--- a/internal/authz/resolver/check_test.go
+++ b/internal/authz/resolver/check_test.go
@@ -125,6 +125,21 @@ func TestCheck_Orchestration(t *testing.T) {
 		assert.Contains(t, err.Error(), "team id is required")
 	})
 
+	t.Run("sk_team team-bound check requires resource id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stmts := mocks.NewMockAuthzResolverStatements(ctrl)
+		_, err := resolver.New().Check(context.Background(), stmts, resolver.Request{
+			PrincipalType: domain.AuthzPrincipalTypeSKTeam,
+			PrincipalID:   "sk_team_1",
+			ProjectID:     "proj_1",
+			ObjectType:    "user",
+			Relation:      "read",
+			TeamID:        "team_1",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resource id is required")
+	})
+
 	t.Run("invalid input", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		stmts := mocks.NewMockAuthzResolverStatements(ctrl)
@@ -203,4 +218,37 @@ func TestListObjects_SKTeamDeny(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, ids)
+}
+
+func TestListObjects_SKTeamTeamBoundDoesNotRequireResourceID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stmts := mocks.NewMockAuthzResolverStatements(ctrl)
+	stmts.EXPECT().ActiveSystemCatalogID(gomock.Any()).Return(domain.SystemCatalogID, nil)
+	stmts.EXPECT().ListAuthzObjectIDs(gomock.Any(), domain.AuthzListObjectsParams{
+		AuthzCheckParams: domain.AuthzCheckParams{
+			CatalogID:              domain.SystemCatalogID,
+			ProjectID:              "proj_1",
+			PrincipalHomeProjectID: "proj_1",
+			PrincipalType:          domain.AuthzPrincipalTypeSKTeam,
+			PrincipalID:            "sk",
+			ObjectType:             "user",
+			Relation:               "read",
+			ConstraintTeamID:       "team_1",
+		},
+		ResourceKind: domain.ResourceKindUser,
+	}).Return([]string{"usr_in"}, nil)
+
+	ids, err := resolver.New().ListObjects(context.Background(), stmts, resolver.ListRequest{
+		Request: resolver.Request{
+			PrincipalType: domain.AuthzPrincipalTypeSKTeam,
+			PrincipalID:   "sk",
+			ProjectID:     "proj_1",
+			ObjectType:    "user",
+			Relation:      "read",
+			TeamID:        "team_1",
+		},
+		ResourceKind: domain.ResourceKindUser,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"usr_in"}, ids)
 }

--- a/internal/authz/resolver/oracle.go
+++ b/internal/authz/resolver/oracle.go
@@ -83,6 +83,9 @@ func (g *Graph) constraintTeamAllows(p domain.AuthzCheckParams) bool {
 	if p.ResourceID == p.ConstraintTeamID {
 		return true
 	}
+	if p.ResourceTeamID != "" && p.ResourceTeamID == p.ConstraintTeamID {
+		return true
+	}
 	return g.isMember(p.ProjectID, p.ConstraintTeamID, p.ResourceID)
 }
 
@@ -93,9 +96,6 @@ func (g *Graph) listedObjectInConstraintTeam(p domain.AuthzListObjectsParams, id
 	case domain.ResourceKindTeam:
 		return id == p.ConstraintTeamID
 	default:
-		if id == p.ConstraintTeamID {
-			return true
-		}
 		for _, r := range g.Resources {
 			if r.ResourceID == id && r.TeamID != nil && *r.TeamID == p.ConstraintTeamID {
 				return true

--- a/internal/authz/resolver/oracle.go
+++ b/internal/authz/resolver/oracle.go
@@ -26,6 +26,14 @@ func (g *Graph) OracleCheck(projectID, principalHomeProjectID string, principalT
 	return g.ttuAllows(projectID, home, principalType, principalID, objectType, relation, now)
 }
 
+// OracleCheckParams applies OracleCheck then the sk_team_ team constraint.
+func (g *Graph) OracleCheckParams(p domain.AuthzCheckParams) bool {
+	if !g.OracleCheck(p.ProjectID, p.HomeProjectID(), p.PrincipalType, p.PrincipalID, p.ObjectType, p.Relation) {
+		return false
+	}
+	return g.constraintTeamAllows(p)
+}
+
 // OracleList returns resource ids of kind authorized under project / team / resource scopes.
 func (g *Graph) OracleList(projectID, principalHomeProjectID string, principalType domain.AuthzPrincipalType, principalID string, kind domain.ResourceKind, objectType, relation string) []string {
 	home := principalHomeOrProject(principalHomeProjectID, projectID)
@@ -51,6 +59,50 @@ func (g *Graph) OracleList(projectID, principalHomeProjectID string, principalTy
 		out = append(out, r.ResourceID)
 	}
 	return out
+}
+
+// OracleListParams applies OracleList then the sk_team_ team constraint.
+func (g *Graph) OracleListParams(p domain.AuthzListObjectsParams) []string {
+	ids := g.OracleList(p.ProjectID, p.HomeProjectID(), p.PrincipalType, p.PrincipalID, p.ResourceKind, p.ObjectType, p.Relation)
+	if p.ConstraintTeamID == "" {
+		return ids
+	}
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if g.listedObjectInConstraintTeam(p, id) {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func (g *Graph) constraintTeamAllows(p domain.AuthzCheckParams) bool {
+	if p.ConstraintTeamID == "" || p.ResourceID == "" {
+		return true
+	}
+	if p.ResourceID == p.ConstraintTeamID {
+		return true
+	}
+	return g.isMember(p.ProjectID, p.ConstraintTeamID, p.ResourceID)
+}
+
+func (g *Graph) listedObjectInConstraintTeam(p domain.AuthzListObjectsParams, id string) bool {
+	switch p.ResourceKind {
+	case domain.ResourceKindUser:
+		return g.isMember(p.ProjectID, p.ConstraintTeamID, id)
+	case domain.ResourceKindTeam:
+		return id == p.ConstraintTeamID
+	default:
+		if id == p.ConstraintTeamID {
+			return true
+		}
+		for _, r := range g.Resources {
+			if r.ResourceID == id && r.TeamID != nil && *r.TeamID == p.ConstraintTeamID {
+				return true
+			}
+		}
+		return false
+	}
 }
 
 // OracleFoothold mirrors HasAuthzProjectFoothold.

--- a/internal/authz/resolver/oracle_test.go
+++ b/internal/authz/resolver/oracle_test.go
@@ -135,4 +135,36 @@ func TestOracle_HandBuilt(t *testing.T) {
 		assert.True(t, g.OracleFoothold("p1", domain.AuthzPrincipalTypeUser, "alice"))
 		assert.False(t, g.OracleFoothold("p1", domain.AuthzPrincipalTypeUser, "bob"))
 	})
+
+	t.Run("sk_team constraint", func(t *testing.T) {
+		g := Graph{
+			Closure: closure,
+			Assignments: []*domain.AuthzAssignment{{
+				ProjectID: "p1", CatalogID: "c1",
+				PrincipalType: domain.AuthzPrincipalTypeSKTeam, PrincipalID: "sk",
+				ObjectType: "project", Relation: "viewer",
+				ScopeKind: domain.AuthzScopeKindProject,
+			}},
+			Memberships: []*domain.AuthzMembershipEdge{
+				domain.NewUserTeamMembershipEdge("p1", "eng", "alice"),
+			},
+			Resources: []*domain.ResourceScope{
+				domain.NewUserResourceScope("p1", "alice"),
+				domain.NewUserResourceScope("p1", "bob"),
+			},
+		}
+		in := domain.AuthzCheckParams{
+			ProjectID: "p1", PrincipalType: domain.AuthzPrincipalTypeSKTeam, PrincipalID: "sk",
+			ObjectType: "project", Relation: "viewer",
+			ConstraintTeamID: "eng", ResourceID: "alice",
+		}
+		out := in
+		out.ResourceID = "bob"
+		assert.True(t, g.OracleCheckParams(in))
+		assert.False(t, g.OracleCheckParams(out))
+		assert.Equal(t, []string{"alice"}, g.OracleListParams(domain.AuthzListObjectsParams{
+			AuthzCheckParams: in,
+			ResourceKind:     domain.ResourceKindUser,
+		}))
+	})
 }

--- a/internal/authz/resolver/oracle_test.go
+++ b/internal/authz/resolver/oracle_test.go
@@ -167,4 +167,37 @@ func TestOracle_HandBuilt(t *testing.T) {
 			ResourceKind:     domain.ResourceKindUser,
 		}))
 	})
+
+	t.Run("sk_team constraint non-user rsi", func(t *testing.T) {
+		eng := "eng"
+		other := "other"
+		g := Graph{
+			Closure: closure,
+			Assignments: []*domain.AuthzAssignment{{
+				ProjectID: "p1", CatalogID: "c1",
+				PrincipalType: domain.AuthzPrincipalTypeSKTeam, PrincipalID: "sk",
+				ObjectType: "project", Relation: "viewer",
+				ScopeKind: domain.AuthzScopeKindProject,
+			}},
+			Resources: []*domain.ResourceScope{
+				{ResourceID: "brand_in", ResourceKind: domain.ResourceKindBranding, ProjectID: "p1", TeamID: &eng},
+				{ResourceID: "brand_out", ResourceKind: domain.ResourceKindBranding, ProjectID: "p1", TeamID: &other},
+				{ResourceID: eng, ResourceKind: domain.ResourceKindBranding, ProjectID: "p1", TeamID: &other},
+			},
+		}
+		in := domain.AuthzCheckParams{
+			ProjectID: "p1", PrincipalType: domain.AuthzPrincipalTypeSKTeam, PrincipalID: "sk",
+			ObjectType: "project", Relation: "viewer",
+			ConstraintTeamID: eng, ResourceID: "brand_in", ResourceTeamID: eng,
+		}
+		out := in
+		out.ResourceID = "brand_out"
+		out.ResourceTeamID = other
+		assert.True(t, g.OracleCheckParams(in))
+		assert.False(t, g.OracleCheckParams(out))
+		assert.Equal(t, []string{"brand_in"}, g.OracleListParams(domain.AuthzListObjectsParams{
+			AuthzCheckParams: in,
+			ResourceKind:     domain.ResourceKindBranding,
+		}))
+	})
 }

--- a/internal/authz/resolver/resolver.go
+++ b/internal/authz/resolver/resolver.go
@@ -16,6 +16,12 @@ type Request struct {
 	ProjectID     string
 	ObjectType    string
 	Relation      string
+	// TeamID is required for sk_team_ principals (token team). Copied to
+	// AuthzCheckParams.ConstraintTeamID so SQL can constrain the object.
+	TeamID string
+	// ResourceID is the object being checked (user id, team id). Optional for
+	// permission-level Check; required for per-object sk_team_ deny.
+	ResourceID string
 }
 
 // ListRequest is the public ListObjects input (L4 / oracle helper).
@@ -32,6 +38,8 @@ type memoKey struct {
 	ProjectID     string
 	ObjectType    string
 	Relation      string
+	TeamID        string
+	ResourceID    string
 }
 
 // Resolver evaluates checks with optional request-scoped memoization.
@@ -67,6 +75,8 @@ func (r *Resolver) Check(ctx context.Context, stmts service.AuthzResolverStateme
 		ProjectID:     req.ProjectID,
 		ObjectType:    req.ObjectType,
 		Relation:      req.Relation,
+		TeamID:        req.TeamID,
+		ResourceID:    req.ResourceID,
 	}
 	if d, ok := r.memo[key]; ok {
 		return d, nil
@@ -77,15 +87,7 @@ func (r *Resolver) Check(ctx context.Context, stmts service.AuthzResolverStateme
 		return DecisionUnspecified, err
 	}
 
-	allowed, foothold, err := stmts.CheckAuthz(ctx, domain.AuthzCheckParams{
-		CatalogID:              catalogID,
-		ProjectID:              req.ProjectID,
-		PrincipalHomeProjectID: req.ProjectID,
-		PrincipalType:          req.PrincipalType,
-		PrincipalID:            req.PrincipalID,
-		ObjectType:             req.ObjectType,
-		Relation:               req.Relation,
-	})
+	allowed, foothold, err := stmts.CheckAuthz(ctx, checkParams(catalogID, req))
 	if err != nil {
 		return DecisionUnspecified, err
 	}
@@ -117,17 +119,26 @@ func (r *Resolver) ListObjects(ctx context.Context, stmts service.AuthzResolverS
 		return nil, err
 	}
 	return stmts.ListAuthzObjectIDs(ctx, domain.AuthzListObjectsParams{
-		AuthzCheckParams: domain.AuthzCheckParams{
-			CatalogID:              catalogID,
-			ProjectID:              req.ProjectID,
-			PrincipalHomeProjectID: req.ProjectID,
-			PrincipalType:          req.PrincipalType,
-			PrincipalID:            req.PrincipalID,
-			ObjectType:             req.ObjectType,
-			Relation:               req.Relation,
-		},
-		ResourceKind: req.ResourceKind,
+		AuthzCheckParams: checkParams(catalogID, req.Request),
+		ResourceKind:     req.ResourceKind,
 	})
+}
+
+func checkParams(catalogID string, req Request) domain.AuthzCheckParams {
+	p := domain.AuthzCheckParams{
+		CatalogID:              catalogID,
+		ProjectID:              req.ProjectID,
+		PrincipalHomeProjectID: req.ProjectID,
+		PrincipalType:          req.PrincipalType,
+		PrincipalID:            req.PrincipalID,
+		ObjectType:             req.ObjectType,
+		Relation:               req.Relation,
+		ResourceID:             req.ResourceID,
+	}
+	if req.PrincipalType == domain.AuthzPrincipalTypeSKTeam {
+		p.ConstraintTeamID = req.TeamID
+	}
+	return p
 }
 
 func (r *Resolver) activeCatalogID(ctx context.Context, stmts service.AuthzResolverStatements) (string, error) {
@@ -154,6 +165,8 @@ func validateCheckRequest(req Request) error {
 		return fmt.Errorf("resolver: object type is required")
 	case req.Relation == "":
 		return fmt.Errorf("resolver: relation is required")
+	case req.PrincipalType == domain.AuthzPrincipalTypeSKTeam && req.TeamID == "":
+		return fmt.Errorf("resolver: team id is required for sk_team")
 	default:
 		return nil
 	}

--- a/internal/authz/resolver/resolver.go
+++ b/internal/authz/resolver/resolver.go
@@ -20,8 +20,14 @@ type Request struct {
 	// AuthzCheckParams.ConstraintTeamID so SQL can constrain the object.
 	TeamID string
 	// ResourceID is the object being checked (user id, team id). Optional for
-	// permission-level Check; required for per-object sk_team_ deny.
+	// permission-level Check of non-team-bound types; required for sk_team
+	// checks of team-bound object types so the compensating team constraint
+	// cannot be skipped. Empty ResourceID does not skip the grant Check — it
+	// only skips the extra "object is in the token team" AND — so omission
+	// would look like a create-style Check. Missing id is an error, not Allow.
 	ResourceID string
+	// ResourceTeamID is RSI.team_id after a by-id lookup (team-scoped grant arm).
+	ResourceTeamID string
 }
 
 // ListRequest is the public ListObjects input (L4 / oracle helper).
@@ -33,13 +39,14 @@ type ListRequest struct {
 // memoKey is the request-scoped Check cache key. A struct key avoids
 // delimiter aliasing that string joins can introduce.
 type memoKey struct {
-	PrincipalType domain.AuthzPrincipalType
-	PrincipalID   string
-	ProjectID     string
-	ObjectType    string
-	Relation      string
-	TeamID        string
-	ResourceID    string
+	PrincipalType  domain.AuthzPrincipalType
+	PrincipalID    string
+	ProjectID      string
+	ObjectType     string
+	Relation       string
+	TeamID         string
+	ResourceID     string
+	ResourceTeamID string
 }
 
 // Resolver evaluates checks with optional request-scoped memoization.
@@ -64,19 +71,23 @@ func (r *Resolver) Check(ctx context.Context, stmts service.AuthzResolverStateme
 	if err := validateCheckRequest(req); err != nil {
 		return DecisionUnspecified, err
 	}
+	if err := requireSKTeamTeamBoundResourceID(req); err != nil {
+		return DecisionUnspecified, err
+	}
 	if req.PrincipalType == domain.AuthzPrincipalTypeSKTeam &&
 		!skTeamPermissionAllowed(PermissionName(req.ObjectType, req.Relation)) {
 		return DecisionNotFound, nil
 	}
 
 	key := memoKey{
-		PrincipalType: req.PrincipalType,
-		PrincipalID:   req.PrincipalID,
-		ProjectID:     req.ProjectID,
-		ObjectType:    req.ObjectType,
-		Relation:      req.Relation,
-		TeamID:        req.TeamID,
-		ResourceID:    req.ResourceID,
+		PrincipalType:  req.PrincipalType,
+		PrincipalID:    req.PrincipalID,
+		ProjectID:      req.ProjectID,
+		ObjectType:     req.ObjectType,
+		Relation:       req.Relation,
+		TeamID:         req.TeamID,
+		ResourceID:     req.ResourceID,
+		ResourceTeamID: req.ResourceTeamID,
 	}
 	if d, ok := r.memo[key]; ok {
 		return d, nil
@@ -134,6 +145,7 @@ func checkParams(catalogID string, req Request) domain.AuthzCheckParams {
 		ObjectType:             req.ObjectType,
 		Relation:               req.Relation,
 		ResourceID:             req.ResourceID,
+		ResourceTeamID:         req.ResourceTeamID,
 	}
 	if req.PrincipalType == domain.AuthzPrincipalTypeSKTeam {
 		p.ConstraintTeamID = req.TeamID
@@ -170,4 +182,13 @@ func validateCheckRequest(req Request) error {
 	default:
 		return nil
 	}
+}
+
+func requireSKTeamTeamBoundResourceID(req Request) error {
+	if req.PrincipalType == domain.AuthzPrincipalTypeSKTeam &&
+		domain.TeamBoundObjectType(req.ObjectType) &&
+		req.ResourceID == "" {
+		return fmt.Errorf("resolver: resource id is required for sk_team team-bound checks")
+	}
+	return nil
 }

--- a/internal/authz/resolver/sk_team_test.go
+++ b/internal/authz/resolver/sk_team_test.go
@@ -1,14 +1,20 @@
 package resolver
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/zitadel/nextgen/internal/domain"
 )
 
 func TestSKTeamAllowlist(t *testing.T) {
 	for perm := range skTeamAllowed {
 		assert.True(t, skTeamPermissionAllowed(perm), perm)
+		objectType, _, ok := strings.Cut(perm, ".")
+		assert.True(t, ok, perm)
+		assert.True(t, domain.TeamBoundObjectType(objectType), perm)
 	}
 	denies := []string{
 		"user.set_password",

--- a/internal/domain/authz.go
+++ b/internal/domain/authz.go
@@ -28,6 +28,19 @@ const (
 
 func (k ResourceKind) String() string { return string(k) }
 
+// TeamBoundObjectType reports whether objectType is always team-scoped for
+// sk_team_ principals (user, team, team_membership, event). Mint-time
+// validation and the sk_team allowlist share this set so a new allowlist
+// entry cannot silently allow project-scoped minting.
+func TeamBoundObjectType(objectType string) bool {
+	switch objectType {
+	case "user", "team", "team_membership", "event":
+		return true
+	default:
+		return false
+	}
+}
+
 // AuthzMemberType is authz_membership_edges.member_type.
 type AuthzMemberType string
 
@@ -341,8 +354,9 @@ const (
 //
 // ConstraintTeamID, when set (sk_team_ tokens), requires the checked or listed
 // object to belong to that team: users via authz_membership_edges, teams by id,
-// other kinds via resource_scope_index.team_id. ResourceID is the object being
-// checked (empty for permission-level Check / list materialization).
+// other kinds via resource_scope_index.team_id (Check binds ResourceTeamID).
+// ResourceID is the object being checked (empty for permission-level Check /
+// list materialization). ResourceTeamID is RSI.team_id for by-id Check.
 type AuthzCheckParams struct {
 	CatalogID              string
 	ProjectID              string
@@ -353,6 +367,7 @@ type AuthzCheckParams struct {
 	Relation               string
 	ConstraintTeamID       string
 	ResourceID             string
+	ResourceTeamID         string
 }
 
 // HomeProjectID returns PrincipalHomeProjectID, or ProjectID when unset.

--- a/internal/domain/authz.go
+++ b/internal/domain/authz.go
@@ -338,6 +338,11 @@ const (
 
 // AuthzCheckParams is the storage-level input for a single-resource permission check.
 // PrincipalHomeProjectID is the project used for membership-edge lookup (defaults to ProjectID).
+//
+// ConstraintTeamID, when set (sk_team_ tokens), requires the checked or listed
+// object to belong to that team: users via authz_membership_edges, teams by id,
+// other kinds via resource_scope_index.team_id. ResourceID is the object being
+// checked (empty for permission-level Check / list materialization).
 type AuthzCheckParams struct {
 	CatalogID              string
 	ProjectID              string
@@ -346,6 +351,8 @@ type AuthzCheckParams struct {
 	PrincipalID            string
 	ObjectType             string
 	Relation               string
+	ConstraintTeamID       string
+	ResourceID             string
 }
 
 // HomeProjectID returns PrincipalHomeProjectID, or ProjectID when unset.

--- a/internal/domain/authz_test.go
+++ b/internal/domain/authz_test.go
@@ -1,0 +1,19 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+func TestTeamBoundObjectType(t *testing.T) {
+	t.Parallel()
+	assert.True(t, domain.TeamBoundObjectType("user"))
+	assert.True(t, domain.TeamBoundObjectType("team"))
+	assert.True(t, domain.TeamBoundObjectType("team_membership"))
+	assert.True(t, domain.TeamBoundObjectType("event"))
+	assert.False(t, domain.TeamBoundObjectType("project"))
+	assert.False(t, domain.TeamBoundObjectType("branding"))
+	assert.False(t, domain.TeamBoundObjectType(""))
+}

--- a/internal/storage/dialect/authz/resolver_sql.go
+++ b/internal/storage/dialect/authz/resolver_sql.go
@@ -57,9 +57,18 @@ func WriteHasAuthzProjectFoothold(w ArgWriter, env Env, projectID string, princi
 // WriteCheckAuthz emits SELECT (allowed), (foothold) in one round-trip.
 func WriteCheckAuthz(w ArgWriter, env Env, params domain.AuthzCheckParams) {
 	w.WriteString("SELECT (")
-	writeProjectScopedClosureExists(w, env, params)
-	w.WriteString(" OR ")
-	writeFullTTUExists(w, env, params)
+	if params.ConstraintTeamID != "" && params.ResourceID != "" {
+		w.WriteString("(")
+		writeProjectScopedClosureExists(w, env, params)
+		w.WriteString(" OR ")
+		writeFullTTUExists(w, env, params)
+		w.WriteString(") AND ")
+		writeCheckedObjectInConstraintTeam(w, env, params)
+	} else {
+		writeProjectScopedClosureExists(w, env, params)
+		w.WriteString(" OR ")
+		writeFullTTUExists(w, env, params)
+	}
 	w.WriteString("), ")
 	writeFoothold(w, env, params.ProjectID, params.PrincipalType, params.PrincipalID)
 }
@@ -126,6 +135,67 @@ func writeListAuthzRSIMatch(w ArgWriter, env Env, params domain.AuthzListObjects
 	writeScopedClosureExists(w, env, params.AuthzCheckParams, "resource", "r.resource_id")
 	w.WriteString(`
   )`)
+	if params.ConstraintTeamID != "" {
+		w.WriteString(`
+  AND `)
+		writeListedObjectInConstraintTeam(w, env, params)
+	}
+}
+
+// writeCheckedObjectInConstraintTeam is the per-object sk_team_ compensating
+// constraint for Check: the ResourceID is a member of ConstraintTeamID or is
+// the team itself (team / team_membership reads).
+func writeCheckedObjectInConstraintTeam(w ArgWriter, env Env, params domain.AuthzCheckParams) {
+	w.WriteString("(")
+	writeUserMembershipInTeam(w, env, params.ProjectID, params.ConstraintTeamID, "", params.ResourceID)
+	w.WriteString(" OR ")
+	w.WriteArg(params.ResourceID)
+	w.WriteString(" = ")
+	w.WriteArg(params.ConstraintTeamID)
+	w.WriteString(")")
+}
+
+// writeListedObjectInConstraintTeam filters list/EXISTS rows to the token team.
+// Users are not team-keyed in RSI — membership edges are the source of truth.
+func writeListedObjectInConstraintTeam(w ArgWriter, env Env, params domain.AuthzListObjectsParams) {
+	w.WriteString("(")
+	w.WriteString("(r.resource_kind = ")
+	w.WriteArg(domain.ResourceKindUser.String())
+	w.WriteString(" AND ")
+	writeUserMembershipInTeam(w, env, params.ProjectID, params.ConstraintTeamID, "r.resource_id", "")
+	w.WriteString(") OR (r.resource_kind = ")
+	w.WriteArg(domain.ResourceKindTeam.String())
+	w.WriteString(" AND r.resource_id = ")
+	w.WriteArg(params.ConstraintTeamID)
+	w.WriteString(") OR (r.team_id IS NOT NULL AND r.team_id = ")
+	w.WriteArg(params.ConstraintTeamID)
+	w.WriteString("))")
+}
+
+// writeUserMembershipInTeam emits EXISTS on authz_membership_edges.
+// memberIDExpr is a raw SQL column (list); memberIDArg is a bound value (Check).
+func writeUserMembershipInTeam(w ArgWriter, env Env, projectID, teamID, memberIDExpr, memberIDArg string) {
+	w.WriteString(`EXISTS (
+        SELECT 1
+        FROM `)
+	writeTable(w, env, "authz_membership_edges")
+	w.WriteString(` e
+        WHERE e.project_id = `)
+	w.WriteArg(projectID)
+	w.WriteString(`
+          AND e.set_type = 'team'
+          AND e.set_id = `)
+	w.WriteArg(teamID)
+	w.WriteString(`
+          AND e.member_type = 'user'
+          AND e.member_id = `)
+	if memberIDExpr != "" {
+		w.WriteString(memberIDExpr)
+	} else {
+		w.WriteArg(memberIDArg)
+	}
+	w.WriteString(`
+    )`)
 }
 
 func writeFoothold(w ArgWriter, env Env, projectID string, principalType domain.AuthzPrincipalType, principalID string) {

--- a/internal/storage/dialect/authz/resolver_sql.go
+++ b/internal/storage/dialect/authz/resolver_sql.go
@@ -143,38 +143,52 @@ func writeListAuthzRSIMatch(w ArgWriter, env Env, params domain.AuthzListObjects
 }
 
 // writeCheckedObjectInConstraintTeam is the per-object sk_team_ compensating
-// constraint for Check: the ResourceID is a member of ConstraintTeamID or is
-// the team itself (team / team_membership reads).
+// constraint for Check: the ResourceID is a member of ConstraintTeamID, is
+// the team itself, or (non-user kinds) ResourceTeamID matches RSI.team_id.
 func writeCheckedObjectInConstraintTeam(w ArgWriter, env Env, params domain.AuthzCheckParams) {
 	w.WriteString("(")
-	writeUserMembershipInTeam(w, env, params.ProjectID, params.ConstraintTeamID, "", params.ResourceID)
+	writeUserMembershipInTeam(w, env, params.ProjectID, "", params.ConstraintTeamID, "", params.ResourceID)
 	w.WriteString(" OR ")
 	w.WriteArg(params.ResourceID)
 	w.WriteString(" = ")
 	w.WriteArg(params.ConstraintTeamID)
+	if params.ResourceTeamID != "" {
+		w.WriteString(" OR ")
+		w.WriteArg(params.ResourceTeamID)
+		w.WriteString(" = ")
+		w.WriteArg(params.ConstraintTeamID)
+	}
 	w.WriteString(")")
 }
 
 // writeListedObjectInConstraintTeam filters list/EXISTS rows to the token team.
 // Users are not team-keyed in RSI — membership edges are the source of truth.
+// The RSI.team_id disjunct is gated off user and team kinds so a stray
+// team_id on a user row cannot skip the membership edge.
 func writeListedObjectInConstraintTeam(w ArgWriter, env Env, params domain.AuthzListObjectsParams) {
 	w.WriteString("(")
 	w.WriteString("(r.resource_kind = ")
 	w.WriteArg(domain.ResourceKindUser.String())
 	w.WriteString(" AND ")
-	writeUserMembershipInTeam(w, env, params.ProjectID, params.ConstraintTeamID, "r.resource_id", "")
+	writeUserMembershipInTeam(w, env, params.ProjectID, "", params.ConstraintTeamID, "r.resource_id", "")
 	w.WriteString(") OR (r.resource_kind = ")
 	w.WriteArg(domain.ResourceKindTeam.String())
 	w.WriteString(" AND r.resource_id = ")
 	w.WriteArg(params.ConstraintTeamID)
-	w.WriteString(") OR (r.team_id IS NOT NULL AND r.team_id = ")
+	w.WriteString(") OR (r.resource_kind <> ")
+	w.WriteArg(domain.ResourceKindUser.String())
+	w.WriteString(" AND r.resource_kind <> ")
+	w.WriteArg(domain.ResourceKindTeam.String())
+	w.WriteString(" AND r.team_id IS NOT NULL AND r.team_id = ")
 	w.WriteArg(params.ConstraintTeamID)
 	w.WriteString("))")
 }
 
-// writeUserMembershipInTeam emits EXISTS on authz_membership_edges.
-// memberIDExpr is a raw SQL column (list); memberIDArg is a bound value (Check).
-func writeUserMembershipInTeam(w ArgWriter, env Env, projectID, teamID, memberIDExpr, memberIDArg string) {
+// writeUserMembershipInTeam emits EXISTS on authz_membership_edges: user is a
+// member of a team. setIDExpr / memberIDExpr are raw SQL column refs; when
+// empty, setID / memberID are bound arguments. Check, List, TTU, and
+// principal-match all use this helper so ADR 052's home-project switch is one edit.
+func writeUserMembershipInTeam(w ArgWriter, env Env, projectID, setIDExpr, setID, memberIDExpr, memberID string) {
 	w.WriteString(`EXISTS (
         SELECT 1
         FROM `)
@@ -185,17 +199,21 @@ func writeUserMembershipInTeam(w ArgWriter, env Env, projectID, teamID, memberID
 	w.WriteString(`
           AND e.set_type = 'team'
           AND e.set_id = `)
-	w.WriteArg(teamID)
+	writeExprOrArg(w, setIDExpr, setID)
 	w.WriteString(`
           AND e.member_type = 'user'
           AND e.member_id = `)
-	if memberIDExpr != "" {
-		w.WriteString(memberIDExpr)
-	} else {
-		w.WriteArg(memberIDArg)
-	}
+	writeExprOrArg(w, memberIDExpr, memberID)
 	w.WriteString(`
     )`)
+}
+
+func writeExprOrArg(w ArgWriter, expr, arg string) {
+	if expr != "" {
+		w.WriteString(expr)
+		return
+	}
+	w.WriteArg(arg)
 }
 
 func writeFoothold(w ArgWriter, env Env, projectID string, principalType domain.AuthzPrincipalType, principalID string) {
@@ -333,21 +351,9 @@ func writeFullTTUExists(w ArgWriter, env Env, params domain.AuthzCheckParams) {
                 AND `)
 	w.WriteArg(ptype)
 	w.WriteString(` = 'user'
-                AND EXISTS (
-                    SELECT 1
-                    FROM `)
-	writeTable(w, env, "authz_membership_edges")
-	w.WriteString(` e
-                    WHERE e.project_id = `)
-	w.WriteArg(home)
+                AND `)
+	writeUserMembershipInTeam(w, env, home, "ts.principal_id", "", "", params.PrincipalID)
 	w.WriteString(`
-                      AND e.set_type = 'team'
-                      AND e.set_id = ts.principal_id
-                      AND e.member_type = 'user'
-                      AND e.member_id = `)
-	w.WriteArg(params.PrincipalID)
-	w.WriteString(`
-                )
                 )
              OR EXISTS (
                     SELECT 1
@@ -403,23 +409,9 @@ func writePrincipalMatch(w ArgWriter, env Env, alias, principalType, principalID
                 AND `)
 	w.WriteString(alias)
 	w.WriteString(`.principal_type = 'team'
-                AND EXISTS (
-                    SELECT 1
-                    FROM `)
-	writeTable(w, env, "authz_membership_edges")
-	w.WriteString(` e
-                    WHERE e.project_id = `)
-	w.WriteArg(homeProjectID)
+                AND `)
+	writeUserMembershipInTeam(w, env, homeProjectID, alias+".principal_id", "", "", principalID)
 	w.WriteString(`
-                      AND e.set_type = 'team'
-                      AND e.set_id = `)
-	w.WriteString(alias)
-	w.WriteString(`.principal_id
-                      AND e.member_type = 'user'
-                      AND e.member_id = `)
-	w.WriteArg(principalID)
-	w.WriteString(`
-                )
              )
           )`)
 }

--- a/internal/storage/dialect/authz/resolver_sql_test.go
+++ b/internal/storage/dialect/authz/resolver_sql_test.go
@@ -108,6 +108,35 @@ func TestWriteActiveSystemCatalogID(t *testing.T) {
 	assert.Contains(t, w.b.String(), "zitadel_nextgen.authz_catalogs")
 }
 
+func TestWriteCheckAuthzConstraintTeam(t *testing.T) {
+	t.Parallel()
+	params := domain.AuthzCheckParams{
+		CatalogID:        "cat_sys_1",
+		ProjectID:        "proj_1",
+		PrincipalType:    domain.AuthzPrincipalTypeSKTeam,
+		PrincipalID:      "sk_team_1",
+		ObjectType:       "project",
+		Relation:         "viewer",
+		ConstraintTeamID: "team_1",
+		ResourceID:       "usr_in",
+	}
+	var w recordingWriter
+	authz.WriteCheckAuthz(&w, testEnv(&w), params)
+	assert.Contains(t, w.b.String(), "authz_membership_edges")
+	assert.Contains(t, w.args, "team_1")
+	assert.Contains(t, w.args, "usr_in")
+
+	listParams := domain.AuthzListObjectsParams{
+		AuthzCheckParams: params,
+		ResourceKind:     domain.ResourceKindUser,
+	}
+	var list recordingWriter
+	authz.WriteListAuthzObjectIDs(&list, testEnv(&list), listParams)
+	assert.Contains(t, list.b.String(), "authz_membership_edges")
+	assert.Contains(t, list.b.String(), "r.resource_kind = ?")
+	assert.Contains(t, list.args, "team_1")
+}
+
 func TestWriteHasAuthzProjectFoothold(t *testing.T) {
 	t.Parallel()
 	var w recordingWriter

--- a/internal/storage/dialect/authz/resolver_sql_test.go
+++ b/internal/storage/dialect/authz/resolver_sql_test.go
@@ -134,7 +134,15 @@ func TestWriteCheckAuthzConstraintTeam(t *testing.T) {
 	authz.WriteListAuthzObjectIDs(&list, testEnv(&list), listParams)
 	assert.Contains(t, list.b.String(), "authz_membership_edges")
 	assert.Contains(t, list.b.String(), "r.resource_kind = ?")
+	assert.Contains(t, list.b.String(), "r.resource_kind <> ?")
 	assert.Contains(t, list.args, "team_1")
+
+	withTeam := params
+	withTeam.ResourceTeamID = "team_1"
+	var checkTeam recordingWriter
+	authz.WriteCheckAuthz(&checkTeam, testEnv(&checkTeam), withTeam)
+	assert.Contains(t, checkTeam.b.String(), "authz_membership_edges")
+	assert.Contains(t, checkTeam.args, "team_1")
 }
 
 func TestWriteHasAuthzProjectFoothold(t *testing.T) {

--- a/internal/storage/dialect/authz/validate_assignment.go
+++ b/internal/storage/dialect/authz/validate_assignment.go
@@ -20,7 +20,7 @@ func ValidateAssignment(a *domain.AuthzAssignment) error {
 	if a.PrincipalType != domain.AuthzPrincipalTypeSKTeam {
 		return nil
 	}
-	if !teamBoundObjectType(a.ObjectType) {
+	if !domain.TeamBoundObjectType(a.ObjectType) {
 		return nil
 	}
 	if a.ScopeKind == domain.AuthzScopeKindProject {
@@ -30,13 +30,4 @@ func ValidateAssignment(a *domain.AuthzAssignment) error {
 		return ErrSKTeamProjectScope
 	}
 	return nil
-}
-
-func teamBoundObjectType(objectType string) bool {
-	switch objectType {
-	case "user", "team", "team_membership", "event":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/storage/dialect/authz/validate_assignment.go
+++ b/internal/storage/dialect/authz/validate_assignment.go
@@ -1,0 +1,42 @@
+package authz
+
+import (
+	"errors"
+
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+// ErrSKTeamProjectScope is returned when an sk_team_ grant for a team-bound
+// permission is minted with project scope.
+var ErrSKTeamProjectScope = errors.New("authz: sk_team grants for team-bound permissions must be team-scoped")
+
+// ValidateAssignment rejects sk_team_ + project-scope grants for team-bound
+// object types (user, team, team_membership, event). Call from every dialect's
+// CreateAuthzAssignment before INSERT.
+func ValidateAssignment(a *domain.AuthzAssignment) error {
+	if a == nil {
+		return nil
+	}
+	if a.PrincipalType != domain.AuthzPrincipalTypeSKTeam {
+		return nil
+	}
+	if !teamBoundObjectType(a.ObjectType) {
+		return nil
+	}
+	if a.ScopeKind == domain.AuthzScopeKindProject {
+		return ErrSKTeamProjectScope
+	}
+	if a.ScopeKind == domain.AuthzScopeKindTeam && (a.ScopeTeamID == nil || *a.ScopeTeamID == "") {
+		return ErrSKTeamProjectScope
+	}
+	return nil
+}
+
+func teamBoundObjectType(objectType string) bool {
+	switch objectType {
+	case "user", "team", "team_membership", "event":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/storage/dialect/authz/validate_assignment_test.go
+++ b/internal/storage/dialect/authz/validate_assignment_test.go
@@ -1,0 +1,48 @@
+package authz_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/storage/dialect/authz"
+)
+
+func TestValidateAssignment_SKTeamProjectScope(t *testing.T) {
+	t.Parallel()
+
+	teamScope := domain.NewTeamAssignmentScope("team_1")
+	ok := &domain.AuthzAssignment{
+		PrincipalType: domain.AuthzPrincipalTypeSKTeam,
+		ObjectType:    "user",
+		Relation:      "read",
+	}
+	ok.ApplyScope(teamScope)
+	require.NoError(t, authz.ValidateAssignment(ok))
+
+	bad := &domain.AuthzAssignment{
+		PrincipalType: domain.AuthzPrincipalTypeSKTeam,
+		ObjectType:    "user",
+		Relation:      "read",
+	}
+	bad.ApplyScope(domain.NewProjectAssignmentScope())
+	assert.ErrorIs(t, authz.ValidateAssignment(bad), authz.ErrSKTeamProjectScope)
+
+	projViewer := &domain.AuthzAssignment{
+		PrincipalType: domain.AuthzPrincipalTypeSKTeam,
+		ObjectType:    "project",
+		Relation:      "viewer",
+	}
+	projViewer.ApplyScope(domain.NewProjectAssignmentScope())
+	require.NoError(t, authz.ValidateAssignment(projViewer), "project.viewer is not team-bound")
+
+	userGrant := &domain.AuthzAssignment{
+		PrincipalType: domain.AuthzPrincipalTypeUser,
+		ObjectType:    "user",
+		Relation:      "read",
+	}
+	userGrant.ApplyScope(domain.NewProjectAssignmentScope())
+	require.NoError(t, authz.ValidateAssignment(userGrant))
+}

--- a/internal/storage/dialect/postgres/authz_assignment.go
+++ b/internal/storage/dialect/postgres/authz_assignment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
+	"github.com/zitadel/nextgen/internal/storage/dialect/authz"
 )
 
 const (
@@ -65,6 +66,9 @@ func newAuthzAssignmentStatements(client queryExecutor) authzAssignmentStatement
 
 // CreateAuthzAssignment implements [service.AuthzAssignmentStatements].
 func (s authzAssignmentStatements) CreateAuthzAssignment(ctx context.Context, a *domain.AuthzAssignment) error {
+	if err := authz.ValidateAssignment(a); err != nil {
+		return err
+	}
 	if err := ensureManagedID(&a.ID, domain.PrefixAuthzAssignment); err != nil {
 		return err
 	}

--- a/internal/storage/dialect/spanner/authz_assignment.go
+++ b/internal/storage/dialect/spanner/authz_assignment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
+	"github.com/zitadel/nextgen/internal/storage/dialect/authz"
 )
 
 const (
@@ -67,6 +68,9 @@ func newAuthzAssignmentStatements(db queryExecutor) authzAssignmentStatements {
 
 // CreateAuthzAssignment implements [service.AuthzAssignmentStatements].
 func (s authzAssignmentStatements) CreateAuthzAssignment(ctx context.Context, a *domain.AuthzAssignment) error {
+	if err := authz.ValidateAssignment(a); err != nil {
+		return err
+	}
 	if err := ensureManagedID(&a.ID, domain.PrefixAuthzAssignment); err != nil {
 		return err
 	}

--- a/internal/storage/dialect/sqlite/authz_assignment.go
+++ b/internal/storage/dialect/sqlite/authz_assignment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
 	"github.com/zitadel/nextgen/internal/storage/database"
+	"github.com/zitadel/nextgen/internal/storage/dialect/authz"
 )
 
 const (
@@ -60,6 +61,9 @@ func newAuthzAssignmentStatements(client queryExecutor) authzAssignmentStatement
 
 // CreateAuthzAssignment implements [service.AuthzAssignmentStatements].
 func (s authzAssignmentStatements) CreateAuthzAssignment(ctx context.Context, a *domain.AuthzAssignment) error {
+	if err := authz.ValidateAssignment(a); err != nil {
+		return err
+	}
 	if err := ensureManagedID(&a.ID, domain.PrefixAuthzAssignment); err != nil {
 		return err
 	}

--- a/internal/storage/stmttest/authz_sk_team_test.go
+++ b/internal/storage/stmttest/authz_sk_team_test.go
@@ -1,0 +1,111 @@
+//go:build postgres_integration || spanner_integration || sqlite_integration
+
+package stmttest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/nextgen/internal/authz/resolver"
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/storage/dialect/authz"
+)
+
+func TestAuthzAssignment_SKTeamProjectScopeRejected(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, d dialect) {
+		projectID := ensureProject(t, d.stmts)
+		teamID := "team_sk_mint_" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.CreateTeam(t.Context(), newTestTeam(projectID, teamID)))
+		a := newTestAssignment(projectID, "", domain.AuthzPrincipalTypeSKTeam, "sk_team_1", "user", "read", domain.NewProjectAssignmentScope())
+		assert.ErrorIs(t, d.stmts.CreateAuthzAssignment(t.Context(), a), authz.ErrSKTeamProjectScope)
+
+		ok := newTestAssignment(projectID, "", domain.AuthzPrincipalTypeSKTeam, "sk_team_1", "team", "member", domain.NewTeamAssignmentScope(teamID))
+		require.NoError(t, d.stmts.CreateAuthzAssignment(t.Context(), ok))
+	})
+}
+
+// TestAuthzSKTeam_OutsideTeamDeny is the compensating deny suite for #831.
+// MVP catalog relations are project.{viewer,editor,admin}; a project-scoped
+// project.viewer grant is the "somehow holds a project-wide grant" case.
+// ConstraintTeamID still limits Check/List to the token team via membership.
+func TestAuthzSKTeam_OutsideTeamDeny(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, d dialect) {
+		projectID := ensureProject(t, d.stmts)
+		teamIn := "team_sk_in_" + uniqueSuffix(t)
+		teamOut := "team_sk_out_" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.CreateTeam(t.Context(), newTestTeam(projectID, teamIn)))
+		require.NoError(t, d.stmts.CreateTeam(t.Context(), newTestTeam(projectID, teamOut)))
+
+		usrIn := "usr_sk_in_" + uniqueSuffix(t)
+		usrOut := "usr_sk_out_" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.UpsertResourceScope(t.Context(), domain.NewUserResourceScope(projectID, usrIn)))
+		require.NoError(t, d.stmts.UpsertResourceScope(t.Context(), domain.NewUserResourceScope(projectID, usrOut)))
+		require.NoError(t, d.stmts.UpsertAuthzMembershipEdge(t.Context(), domain.NewUserTeamMembershipEdge(projectID, teamIn, usrIn)))
+		require.NoError(t, d.stmts.UpsertAuthzMembershipEdge(t.Context(), domain.NewUserTeamMembershipEdge(projectID, teamOut, usrOut)))
+
+		sk := "sk_team_" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.CreateAuthzAssignment(t.Context(),
+			newTestAssignment(projectID, "", domain.AuthzPrincipalTypeSKTeam, sk, "project", "viewer", domain.NewProjectAssignmentScope())))
+
+		base := domain.AuthzCheckParams{
+			CatalogID:        domain.SystemCatalogID,
+			ProjectID:        projectID,
+			PrincipalType:    domain.AuthzPrincipalTypeSKTeam,
+			PrincipalID:      sk,
+			ObjectType:       "project",
+			Relation:         "viewer",
+			ConstraintTeamID: teamIn,
+		}
+
+		in := base
+		in.ResourceID = usrIn
+		allowed, foothold, err := d.stmts.CheckAuthz(t.Context(), in)
+		require.NoError(t, err)
+		assert.True(t, allowed, "in-team user must Allow")
+		assert.True(t, foothold)
+
+		out := base
+		out.ResourceID = usrOut
+		allowed, foothold, err = d.stmts.CheckAuthz(t.Context(), out)
+		require.NoError(t, err)
+		assert.False(t, allowed, "outside-team user must not Allow")
+		assert.True(t, foothold, "project-wide grant still counts as foothold")
+
+		ids, err := d.stmts.ListAuthzObjectIDs(t.Context(), domain.AuthzListObjectsParams{
+			AuthzCheckParams: base,
+			ResourceKind:     domain.ResourceKindUser,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{usrIn}, ids)
+
+		persisted, err := d.stmts.LoadCatalogMutations(t.Context(), domain.SystemCatalogID)
+		require.NoError(t, err)
+		g := resolver.GraphFromPersisted(persisted)
+		asgns, err := d.stmts.ListAuthzAssignments(t.Context(), projectID, domain.AuthzPrincipalTypeSKTeam, sk, false)
+		require.NoError(t, err)
+		g.Assignments = asgns
+		g.Memberships = []*domain.AuthzMembershipEdge{
+			domain.NewUserTeamMembershipEdge(projectID, teamIn, usrIn),
+			domain.NewUserTeamMembershipEdge(projectID, teamOut, usrOut),
+		}
+		g.Resources = []*domain.ResourceScope{
+			domain.NewUserResourceScope(projectID, usrIn),
+			domain.NewUserResourceScope(projectID, usrOut),
+		}
+		assert.Equal(t, allowedFor(t, d, in), g.OracleCheckParams(in))
+		assert.Equal(t, allowedFor(t, d, out), g.OracleCheckParams(out))
+		assert.ElementsMatch(t, ids, g.OracleListParams(domain.AuthzListObjectsParams{
+			AuthzCheckParams: base,
+			ResourceKind:     domain.ResourceKindUser,
+		}))
+	})
+}
+
+func allowedFor(t *testing.T, d dialect, p domain.AuthzCheckParams) bool {
+	t.Helper()
+	allowed, _, err := d.stmts.CheckAuthz(t.Context(), p)
+	require.NoError(t, err)
+	return allowed
+}

--- a/internal/storage/stmttest/authz_sk_team_test.go
+++ b/internal/storage/stmttest/authz_sk_team_test.go
@@ -61,17 +61,23 @@ func TestAuthzSKTeam_OutsideTeamDeny(t *testing.T) {
 
 		in := base
 		in.ResourceID = usrIn
-		allowed, foothold, err := d.stmts.CheckAuthz(t.Context(), in)
-		require.NoError(t, err)
-		assert.True(t, allowed, "in-team user must Allow")
-		assert.True(t, foothold)
-
 		out := base
 		out.ResourceID = usrOut
-		allowed, foothold, err = d.stmts.CheckAuthz(t.Context(), out)
-		require.NoError(t, err)
-		assert.False(t, allowed, "outside-team user must not Allow")
-		assert.True(t, foothold, "project-wide grant still counts as foothold")
+
+		for _, rel := range []string{"viewer", "editor", "admin"} {
+			inRel, outRel := in, out
+			inRel.Relation = rel
+			outRel.Relation = rel
+			allowed, foothold, err := d.stmts.CheckAuthz(t.Context(), inRel)
+			require.NoError(t, err)
+			assert.True(t, allowed, "in-team user must Allow %s", rel)
+			assert.True(t, foothold)
+
+			allowed, foothold, err = d.stmts.CheckAuthz(t.Context(), outRel)
+			require.NoError(t, err)
+			assert.False(t, allowed, "outside-team user must not Allow %s", rel)
+			assert.True(t, foothold, "project-wide grant still counts as foothold")
+		}
 
 		ids, err := d.stmts.ListAuthzObjectIDs(t.Context(), domain.AuthzListObjectsParams{
 			AuthzCheckParams: base,
@@ -99,6 +105,81 @@ func TestAuthzSKTeam_OutsideTeamDeny(t *testing.T) {
 		assert.ElementsMatch(t, ids, g.OracleListParams(domain.AuthzListObjectsParams{
 			AuthzCheckParams: base,
 			ResourceKind:     domain.ResourceKindUser,
+		}))
+	})
+}
+
+// TestAuthzSKTeam_NonUserResourceCheckListParity pins that Check and List
+// agree for team-scoped non-user RSI rows (RSI.team_id / ResourceTeamID).
+func TestAuthzSKTeam_NonUserResourceCheckListParity(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, d dialect) {
+		projectID := ensureProject(t, d.stmts)
+		teamIn := "team_sk_brand_in_" + uniqueSuffix(t)
+		teamOut := "team_sk_brand_out_" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.CreateTeam(t.Context(), newTestTeam(projectID, teamIn)))
+		require.NoError(t, d.stmts.CreateTeam(t.Context(), newTestTeam(projectID, teamOut)))
+
+		brandIn := "brand_sk_in_" + uniqueSuffix(t)
+		brandOut := "brand_sk_out_" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.UpsertResourceScope(t.Context(), &domain.ResourceScope{
+			ResourceID: brandIn, ResourceKind: domain.ResourceKindBranding, ProjectID: projectID, TeamID: &teamIn,
+		}))
+		require.NoError(t, d.stmts.UpsertResourceScope(t.Context(), &domain.ResourceScope{
+			ResourceID: brandOut, ResourceKind: domain.ResourceKindBranding, ProjectID: projectID, TeamID: &teamOut,
+		}))
+
+		sk := "sk_team_" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.CreateAuthzAssignment(t.Context(),
+			newTestAssignment(projectID, "", domain.AuthzPrincipalTypeSKTeam, sk, "project", "viewer", domain.NewProjectAssignmentScope())))
+
+		base := domain.AuthzCheckParams{
+			CatalogID:        domain.SystemCatalogID,
+			ProjectID:        projectID,
+			PrincipalType:    domain.AuthzPrincipalTypeSKTeam,
+			PrincipalID:      sk,
+			ObjectType:       "project",
+			Relation:         "viewer",
+			ConstraintTeamID: teamIn,
+		}
+		in := base
+		in.ResourceID = brandIn
+		in.ResourceTeamID = teamIn
+		out := base
+		out.ResourceID = brandOut
+		out.ResourceTeamID = teamOut
+
+		allowed, foothold, err := d.stmts.CheckAuthz(t.Context(), in)
+		require.NoError(t, err)
+		assert.True(t, allowed, "in-team branding must Check-allow")
+		assert.True(t, foothold)
+
+		allowed, foothold, err = d.stmts.CheckAuthz(t.Context(), out)
+		require.NoError(t, err)
+		assert.False(t, allowed, "outside-team branding must not Check-allow")
+		assert.True(t, foothold)
+
+		ids, err := d.stmts.ListAuthzObjectIDs(t.Context(), domain.AuthzListObjectsParams{
+			AuthzCheckParams: base,
+			ResourceKind:     domain.ResourceKindBranding,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{brandIn}, ids)
+
+		persisted, err := d.stmts.LoadCatalogMutations(t.Context(), domain.SystemCatalogID)
+		require.NoError(t, err)
+		g := resolver.GraphFromPersisted(persisted)
+		asgns, err := d.stmts.ListAuthzAssignments(t.Context(), projectID, domain.AuthzPrincipalTypeSKTeam, sk, false)
+		require.NoError(t, err)
+		g.Assignments = asgns
+		g.Resources = []*domain.ResourceScope{
+			{ResourceID: brandIn, ResourceKind: domain.ResourceKindBranding, ProjectID: projectID, TeamID: &teamIn},
+			{ResourceID: brandOut, ResourceKind: domain.ResourceKindBranding, ProjectID: projectID, TeamID: &teamOut},
+		}
+		assert.Equal(t, allowedFor(t, d, in), g.OracleCheckParams(in))
+		assert.Equal(t, allowedFor(t, d, out), g.OracleCheckParams(out))
+		assert.ElementsMatch(t, ids, g.OracleListParams(domain.AuthzListObjectsParams{
+			AuthzCheckParams: base,
+			ResourceKind:     domain.ResourceKindBranding,
 		}))
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `sk_team_` had a permission-name allowlist but no team-id constraint. A project-scoped grant could Allow `user.read` for the whole project.
- `resolver.Request.TeamID` is required for `sk_team_` and is copied to `AuthzCheckParams.ConstraintTeamID`. Check/List/EXISTS then require the object to belong to that team: users via `authz_membership_edges`, teams by id, other kinds via RSI `team_id` / Check `ResourceTeamID`.
- `CreateAuthzAssignment` rejects `sk_team` + project scope for team-bound object types (`user`, `team`, `team_membership`, `event`) using the shared `domain.TeamBoundObjectType` set.
- sk_team Checks of team-bound types require `ResourceID` so a forgotten by-id id cannot skip the compensating constraint (List still omits it).
- No HTTP `sk_team_` token type is added. Tests inject `Request` / statement params directly.

Closes #831.

## Validation

- `go test ./internal/domain/ ./internal/authz/resolver/ ./internal/storage/dialect/authz/ -count=1`
- `go test ./internal/storage/stmttest/ -count=1 -tags sqlite_integration -run 'TestAuthzAssignment_SKTeam|TestAuthzSKTeam_'`

## Release notes / changeset

Changeset: `.changeset/authz-sk-team-scope.md` — Team service principals (`sk_team_`) can no longer act on users or teams outside the token's team, even if a project-wide grant exists. Project-scoped team-bound grants are rejected at mint time. HTTP wiring lands in #893–#895. (`@zitadel/server`)

## Notes

- Second PR in the authz follow-up workstream. Independent of #841 (sibling of #890, not stacked under it).
- MVP catalog still uses `project.viewer`; the deny suite uses a project-scoped `project.viewer` grant as the "somehow holds a project-wide grant" case because `user.read` is not in `cat_sys_1` yet (#420). The suite now also Checks `editor`/`admin`.
- Next: #833 decision note, then by-id scoped Allow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8717a912-93c8-4c59-ae9a-e01da9e80900?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8717a912-93c8-4c59-ae9a-e01da9e80900&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

