### PR TITLE
test(authz): prove owner-from-owning_team does not resolve cross-project

### DIFF
--- a/internal/storage/stmttest/authz_owning_team_test.go
+++ b/internal/storage/stmttest/authz_owning_team_test.go
@@ -1,0 +1,191 @@
+//go:build postgres_integration || spanner_integration || sqlite_integration
+
+package stmttest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zitadel/nextgen/internal/authz/compiler"
+	"github.com/zitadel/nextgen/internal/authz/openfga"
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+// ADR 053 §3's profile fragment, minus `sk_proj` (irrelevant to the path under
+// test). `admin` derives from the *owner* relation of the owning team, while
+// the lower roles derive from `team#member` — the asymmetry this file probes.
+const owningTeamOpenFGAModel = `model
+  schema 1.1
+
+type user
+
+type team
+  relations
+    define owner: [user]
+    define member: [user]
+
+type project
+  relations
+    define owning_team: [team]
+    define admin: [user, team#member] or owner from owning_team
+    define editor: [user, team#member] or admin
+    define viewer: [user, team#member] or editor
+`
+
+// TestAuthzOwningTeamOwnerInheritsProjectAdmin pins the load-bearing rule of
+// [ADR 053] §3 — "team owners inherit; contributors do not" — against the
+// portable resolver.
+//
+// The shape under test is the one ADR 052 and 053 jointly specify:
+//
+//   - `project.owning_team` is stored on the **protected** (customer) project
+//     and names a foreign platform team (ADR 053 §2);
+//   - `team.owner` is stored at the team's **home** (platform) scope, as a
+//     distinct assignment from roster membership (ADR 053 §1);
+//   - the human is homed in the platform project and holds nothing at all in
+//     the customer project (ADR 052 §1).
+//
+// The two control subtests establish that the harness, catalog, and
+// cross-project machinery are sound, so a failure in the third isolates the
+// tuple-to-userset hop rather than the setup.
+//
+// [ADR 053]: ../../../docs/adrs/053-customer-collaboration-grants.md
+func TestAuthzOwningTeamOwnerInheritsProjectAdmin(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, d dialect) {
+		ctx := t.Context()
+
+		model, err := openfga.ParseDSL(owningTeamOpenFGAModel)
+		require.NoError(t, err)
+		output, err := compiler.Compile(model)
+		require.NoError(t, err)
+
+		catalogID := fmt.Sprintf("cat_app_%s", uniqueSuffix(t))
+		require.NoError(t, d.stmts.PersistCatalogVersion(ctx, domain.AuthzCatalogVersion{
+			ID:          catalogID,
+			CatalogKind: domain.AuthzCatalogKindAppGroup,
+			OwnerID:     fmt.Sprintf("owner_%s", uniqueSuffix(t)),
+			Version:     1,
+		}, output.Catalog))
+
+		// The platform project homes the operator identity and its teams; the
+		// customer projects are the protected resources.
+		platformProject := ensureProject(t, d.stmts)
+		grantedProject := ensureProject(t, d.stmts)
+		ownedProject := ensureProject(t, d.stmts)
+
+		acme := "team_acme_" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.CreateTeam(ctx, newTestTeam(platformProject, acme)))
+
+		// Alice is an active participant of Acme and, separately, its owner —
+		// the two facts ADR 053 §1 keeps distinct.
+		alice := "user_alice_" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.UpsertAuthzMembershipEdge(ctx,
+			domain.NewUserTeamMembershipEdge(platformProject, acme, alice)))
+		require.NoError(t, d.stmts.CreateAuthzAssignment(ctx, catalogAssignment(
+			catalogID, platformProject,
+			domain.AuthzPrincipalTypeUser, alice,
+			"team", "owner", domain.NewTeamAssignmentScope(acme))))
+
+		check := func(t *testing.T, projectID, relation string) (bool, bool) {
+			t.Helper()
+			allowed, foothold, err := d.stmts.CheckAuthz(ctx, domain.AuthzCheckParams{
+				CatalogID:              catalogID,
+				ProjectID:              projectID,
+				PrincipalHomeProjectID: platformProject,
+				PrincipalType:          domain.AuthzPrincipalTypeUser,
+				PrincipalID:            alice,
+				ObjectType:             "project",
+				Relation:               relation,
+			})
+			require.NoError(t, err)
+			return allowed, foothold
+		}
+
+		// Control 1: the identical `owner from owning_team` rule, evaluated
+		// with the owning_team row and the team.owner assignment in the *same*
+		// project. This is the finding's controlled twin — it differs in
+		// exactly one variable, whether the two rows are co-located — so it
+		// proves the catalog, the team-scoped source assignment, and the
+		// relation closure are all sound.
+		t.Run("control: owner from owning_team resolves within one project", func(t *testing.T) {
+			require.NoError(t, d.stmts.CreateAuthzAssignment(ctx, catalogAssignment(
+				catalogID, platformProject,
+				domain.AuthzPrincipalTypeTeam, acme,
+				"project", "owning_team", domain.NewProjectAssignmentScope())))
+
+			allowed, _, err := d.stmts.CheckAuthz(ctx, domain.AuthzCheckParams{
+				CatalogID:     catalogID,
+				ProjectID:     platformProject,
+				PrincipalType: domain.AuthzPrincipalTypeUser,
+				PrincipalID:   alice,
+				ObjectType:    "project",
+				Relation:      "admin",
+			})
+			require.NoError(t, err)
+			assert.True(t, allowed,
+				"owner-of-owning-team must resolve when both rows live in the same project")
+		})
+
+		// Control 2: a foreign *team* grant expands membership from the home
+		// project — ADR 052 testing obligation 2. This is the resolver's
+		// hardcoded `team#member` fast path, and it proves cross-project
+		// resolution works in general.
+		t.Run("control: cross-project team grant expands from home", func(t *testing.T) {
+			require.NoError(t, d.stmts.CreateAuthzAssignment(ctx, catalogAssignment(
+				catalogID, grantedProject,
+				domain.AuthzPrincipalTypeTeam, acme,
+				"project", "admin", domain.NewProjectAssignmentScope())))
+
+			allowed, _ := check(t, grantedProject, "admin")
+			assert.True(t, allowed,
+				"a foreign team grant must expand active membership from the principal's home project")
+		})
+
+		// The finding. Acme owns `ownedProject`; Alice owns Acme. ADR 053 §3
+		// says that makes her administrator there, and testing obligations 1
+		// and 5 require it.
+		//
+		// It does not resolve. `writeFullTTUExists` in
+		// internal/storage/dialect/authz/resolver_sql.go special-cases the
+		// source relation `member` (looking up membership edges in the
+		// principal's home project) but constrains every other source relation
+		// to an assignment on the *protected* project. `team.owner` lives in
+		// the platform project, so the second hop finds nothing: membership
+		// crosses projects, ownership does not.
+		t.Run("owning-team owner inherits project admin", func(t *testing.T) {
+			require.NoError(t, d.stmts.CreateAuthzAssignment(ctx, catalogAssignment(
+				catalogID, ownedProject,
+				domain.AuthzPrincipalTypeTeam, acme,
+				"project", "owning_team", domain.NewProjectAssignmentScope())))
+
+			allowed, foothold := check(t, ownedProject, "admin")
+			assert.True(t, allowed,
+				"an owner of the owning team must inherit project.admin on the owned project "+
+					"(ADR 053 §3; obligations 1 and 5). foothold=%v", foothold)
+		})
+	})
+}
+
+// catalogAssignment builds an assignment against an explicitly named catalog.
+// newTestAssignment pins domain.SystemCatalogID, which does not define the
+// target relations this file compiles.
+func catalogAssignment(
+	catalogID, projectID string,
+	principalType domain.AuthzPrincipalType, principalID string,
+	objectType, relation string,
+	scope domain.AuthzAssignmentScope,
+) *domain.AuthzAssignment {
+	a := &domain.AuthzAssignment{
+		ProjectID:     projectID,
+		CatalogID:     catalogID,
+		PrincipalType: principalType,
+		PrincipalID:   principalID,
+		ObjectType:    objectType,
+		Relation:      relation,
+	}
+	a.ApplyScope(scope)
+	return a
+}

--- a/internal/storage/stmttest/authz_owning_team_test.go
+++ b/internal/storage/stmttest/authz_owning_team_test.go
@@ -14,9 +14,14 @@ import (
 	"github.com/zitadel/nextgen/internal/domain"
 )
 
-// ADR 053 §3's profile fragment, minus `sk_proj` (irrelevant to the path under
-// test). `admin` derives from the *owner* relation of the owning team, while
-// the lower roles derive from `team#member` — the asymmetry this file probes.
+// ADR 053 §3's profile fragment (minus `sk_proj`, irrelevant here), plus one
+// synthetic relation.
+//
+// `admin` derives from the owning team's *owner* relation, which is the rule
+// under test. `participant` derives from the same tupleset through *member*
+// instead, and exists only so a control can vary the source relation while
+// holding every other input identical — same tupleset row, same
+// tuple-to-userset machinery, same principal. It is not part of ADR 053.
 const owningTeamOpenFGAModel = `model
   schema 1.1
 
@@ -33,24 +38,28 @@ type project
     define admin: [user, team#member] or owner from owning_team
     define editor: [user, team#member] or admin
     define viewer: [user, team#member] or editor
+    define participant: [user] or member from owning_team
 `
 
-// TestAuthzOwningTeamOwnerInheritsProjectAdmin pins the load-bearing rule of
-// [ADR 053] §3 — "team owners inherit; contributors do not" — against the
-// portable resolver.
+// TestAuthzOwningTeamOwnerInheritsProjectAdmin pins both halves of [ADR 053]
+// §3 — "team owners inherit; contributors do not" — against the portable
+// resolver, under the storage shape ADRs 052 and 053 jointly specify:
 //
-// The shape under test is the one ADR 052 and 053 jointly specify:
+//   - `project.owning_team` is stored on the **protected** project and names a
+//     foreign platform team (053 §2);
+//   - `team.owner` is stored at the team's **home** scope, as an assignment
+//     distinct from roster membership (053 §1);
+//   - the humans are platform-homed and hold nothing in the protected project
+//     (052 §1).
 //
-//   - `project.owning_team` is stored on the **protected** (customer) project
-//     and names a foreign platform team (ADR 053 §2);
-//   - `team.owner` is stored at the team's **home** (platform) scope, as a
-//     distinct assignment from roster membership (ADR 053 §1);
-//   - the human is homed in the platform project and holds nothing at all in
-//     the customer project (ADR 052 §1).
+// Alice owns the team; Bob only participates. The controls vary one input at a
+// time, so a failure localizes rather than merely reporting red:
 //
-// The two control subtests establish that the harness, catalog, and
-// cross-project machinery are sound, so a failure in the third isolates the
-// tuple-to-userset hop rather than the setup.
+//	                  source relation   projects      expected
+//	control 1         member            cross         allow
+//	control 2         owner             co-located    allow
+//	contributor       owner             cross         deny   <- must stay deny
+//	the finding       owner             cross         allow  <- fails today
 //
 // [ADR 053]: ../../../docs/adrs/053-customer-collaboration-grants.md
 func TestAuthzOwningTeamOwnerInheritsProjectAdmin(t *testing.T) {
@@ -70,101 +79,100 @@ func TestAuthzOwningTeamOwnerInheritsProjectAdmin(t *testing.T) {
 			Version:     1,
 		}, output.Catalog))
 
-		// The platform project homes the operator identity and its teams; the
-		// customer projects are the protected resources.
-		platformProject := ensureProject(t, d.stmts)
-		grantedProject := ensureProject(t, d.stmts)
+		// The platform project homes the operator identities and their teams;
+		// ownedProject is the protected resource. 052 §3 validates the foreign
+		// principal's lifecycle state, so these are real user rows, not bare
+		// membership edges.
+		platformProject, schemaURL := ensureUserTestProject(t, d.stmts)
 		ownedProject := ensureProject(t, d.stmts)
 
 		acme := "team_acme_" + uniqueSuffix(t)
 		require.NoError(t, d.stmts.CreateTeam(ctx, newTestTeam(platformProject, acme)))
 
-		// Alice is an active participant of Acme and, separately, its owner —
-		// the two facts ADR 053 §1 keeps distinct.
-		alice := "user_alice_" + uniqueSuffix(t)
-		require.NoError(t, d.stmts.UpsertAuthzMembershipEdge(ctx,
-			domain.NewUserTeamMembershipEdge(platformProject, acme, alice)))
+		alice := "usr-alice-" + uniqueSuffix(t)
+		bob := "usr-bob-" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.CreateUser(ctx,
+			newTestUser(t, platformProject, schemaURL, alice, alice+"@example.com", "Alice")))
+		require.NoError(t, d.stmts.CreateUser(ctx,
+			newTestUser(t, platformProject, schemaURL, bob, bob+"@example.com", "Bob")))
+
+		// Both participate in Acme. Only Alice additionally owns it — the two
+		// facts 053 §1 keeps separate.
+		for _, u := range []string{alice, bob} {
+			require.NoError(t, d.stmts.UpsertAuthzMembershipEdge(ctx,
+				domain.NewUserTeamMembershipEdge(platformProject, acme, u)))
+		}
 		require.NoError(t, d.stmts.CreateAuthzAssignment(ctx, catalogAssignment(
 			catalogID, platformProject,
 			domain.AuthzPrincipalTypeUser, alice,
 			"team", "owner", domain.NewTeamAssignmentScope(acme))))
 
-		check := func(t *testing.T, projectID, relation string) (bool, bool) {
+		// Acme owns ownedProject. The second row co-locates the same relation
+		// inside the platform project so control 2 can isolate cross-project
+		// lookup as the only difference.
+		for _, p := range []string{ownedProject, platformProject} {
+			require.NoError(t, d.stmts.CreateAuthzAssignment(ctx, catalogAssignment(
+				catalogID, p,
+				domain.AuthzPrincipalTypeTeam, acme,
+				"project", "owning_team", domain.NewProjectAssignmentScope())))
+		}
+
+		check := func(t *testing.T, principal, projectID, relation string) bool {
 			t.Helper()
-			allowed, foothold, err := d.stmts.CheckAuthz(ctx, domain.AuthzCheckParams{
+			allowed, _, err := d.stmts.CheckAuthz(ctx, domain.AuthzCheckParams{
 				CatalogID:              catalogID,
 				ProjectID:              projectID,
 				PrincipalHomeProjectID: platformProject,
 				PrincipalType:          domain.AuthzPrincipalTypeUser,
-				PrincipalID:            alice,
+				PrincipalID:            principal,
 				ObjectType:             "project",
 				Relation:               relation,
 			})
 			require.NoError(t, err)
-			return allowed, foothold
+			return allowed
 		}
 
-		// Control 1: the identical `owner from owning_team` rule, evaluated
-		// with the owning_team row and the team.owner assignment in the *same*
-		// project. This is the finding's controlled twin — it differs in
-		// exactly one variable, whether the two rows are co-located — so it
+		// Control 1: the tuple-to-userset hop itself works across projects when
+		// the source relation is `member` — writeFullTTUExists special-cases it
+		// and resolves membership edges in the principal's home project.
+		t.Run("control: member from owning_team resolves cross-project", func(t *testing.T) {
+			assert.True(t, check(t, bob, ownedProject, "participant"),
+				"the TTU member branch must expand the owning team's roster from the home project")
+		})
+
+		// Control 2: the same `owner from owning_team` rule resolves when the
+		// owning_team row and the team.owner assignment share a project. This
 		// proves the catalog, the team-scoped source assignment, and the
 		// relation closure are all sound.
 		t.Run("control: owner from owning_team resolves within one project", func(t *testing.T) {
-			require.NoError(t, d.stmts.CreateAuthzAssignment(ctx, catalogAssignment(
-				catalogID, platformProject,
-				domain.AuthzPrincipalTypeTeam, acme,
-				"project", "owning_team", domain.NewProjectAssignmentScope())))
-
-			allowed, _, err := d.stmts.CheckAuthz(ctx, domain.AuthzCheckParams{
-				CatalogID:     catalogID,
-				ProjectID:     platformProject,
-				PrincipalType: domain.AuthzPrincipalTypeUser,
-				PrincipalID:   alice,
-				ObjectType:    "project",
-				Relation:      "admin",
-			})
-			require.NoError(t, err)
-			assert.True(t, allowed,
+			assert.True(t, check(t, alice, platformProject, "admin"),
 				"owner-of-owning-team must resolve when both rows live in the same project")
 		})
 
-		// Control 2: a foreign *team* grant expands membership from the home
-		// project — ADR 052 testing obligation 2. This is the resolver's
-		// hardcoded `team#member` fast path, and it proves cross-project
-		// resolution works in general.
-		t.Run("control: cross-project team grant expands from home", func(t *testing.T) {
-			require.NoError(t, d.stmts.CreateAuthzAssignment(ctx, catalogAssignment(
-				catalogID, grantedProject,
-				domain.AuthzPrincipalTypeTeam, acme,
-				"project", "admin", domain.NewProjectAssignmentScope())))
-
-			allowed, _ := check(t, grantedProject, "admin")
-			assert.True(t, allowed,
-				"a foreign team grant must expand active membership from the principal's home project")
+		// The other half of 053 §3, and obligation 15: participation alone
+		// never inherits. This passes today and must keep passing — a fix that
+		// resolved the case below by treating membership as ownership would
+		// turn this red.
+		t.Run("contributor does not inherit project admin", func(t *testing.T) {
+			assert.False(t, check(t, bob, ownedProject, "admin"),
+				"an active participant who is not an owner must not inherit project.admin")
+			assert.False(t, check(t, bob, platformProject, "admin"),
+				"...including when the owning_team row is co-located")
 		})
 
-		// The finding. Acme owns `ownedProject`; Alice owns Acme. ADR 053 §3
-		// says that makes her administrator there, and testing obligations 1
-		// and 5 require it.
+		// The finding. Acme owns ownedProject and Alice owns Acme, so 053 §3
+		// and obligations 1 and 5 make her administrator there.
 		//
-		// It does not resolve. `writeFullTTUExists` in
-		// internal/storage/dialect/authz/resolver_sql.go special-cases the
-		// source relation `member` (looking up membership edges in the
-		// principal's home project) but constrains every other source relation
-		// to an assignment on the *protected* project. `team.owner` lives in
-		// the platform project, so the second hop finds nothing: membership
-		// crosses projects, ownership does not.
+		// It does not resolve. writeFullTTUExists
+		// (internal/storage/dialect/authz/resolver_sql.go) special-cases the
+		// source relation `member` — control 1 — but constrains every other
+		// source relation to an assignment on the *protected* project.
+		// `team.owner` lives in the platform project, so the second hop finds
+		// nothing: membership crosses projects, ownership does not.
 		t.Run("owning-team owner inherits project admin", func(t *testing.T) {
-			require.NoError(t, d.stmts.CreateAuthzAssignment(ctx, catalogAssignment(
-				catalogID, ownedProject,
-				domain.AuthzPrincipalTypeTeam, acme,
-				"project", "owning_team", domain.NewProjectAssignmentScope())))
-
-			allowed, foothold := check(t, ownedProject, "admin")
-			assert.True(t, allowed,
+			assert.True(t, check(t, alice, ownedProject, "admin"),
 				"an owner of the owning team must inherit project.admin on the owned project "+
-					"(ADR 053 §3; obligations 1 and 5). foothold=%v", foothold)
+					"(ADR 053 §3; obligations 1 and 5)")
 		})
 	})
 }


### PR DESCRIPTION
## Summary

A failing test demonstrating that ADR 053 §3's central rule — "team owners inherit; contributors do not" — does not resolve under the storage shape ADRs 052 and 053 specify. Raised against #876, which proposes both ADRs.

`define admin: [user, team#member, sk_proj] or owner from owning_team` needs two hops. The first resolves: `project.owning_team` is stored on the protected project (ADR 053 §2), which is where the resolver looks. The second does not: `team.owner` is stored at the team's home scope as an assignment distinct from roster membership (ADR 053 §1), but `writeFullTTUExists` constrains the source assignment to the protected project.

The asymmetry is in [`internal/storage/dialect/authz/resolver_sql.go`](https://github.com/zitadel/nextgen/blob/main/internal/storage/dialect/authz/resolver_sql.go). The tuple-to-userset path special-cases source relation `member` and looks up membership edges in the principal's **home** project. Every other source relation — `owner` included — falls to the general branch, which requires `a.project_id = <target>`. Membership crosses projects; ownership does not.

The test sets up exactly the shape the ADRs describe: a platform-homed human who owns a platform team, that team named as `project.owning_team` on a customer project, and no row of any kind for the human in the customer project.

Two controls isolate the hop, each differing from the failing case in one variable:

Alice owns the team; Bob only participates. One input varies at a time:

| Source relation | Projects | Principal | Expected | Result |
| --- | --- | --- | --- | --- |
| `member` | cross-project | Bob | allow | **passes** — the TTU hop itself works across projects |
| `owner` | co-located | Alice | allow | **passes** — catalog, team-scoped source assignment and closure are sound |
| `owner` | cross-project | Bob | deny | **passes** — and must keep passing (053 §3's second half, obligation 15) |
| `owner` | cross-project | Alice | allow | **fails** |

Bob is what stops an overbroad fix: resolving ownership by treating membership as ownership would turn the last row green and the third row red. The `member` control uses a synthetic `participant: [user] or member from owning_team` relation, present only so the control varies the source relation and nothing else — a direct team grant would have resolved through `writePrincipalMatch` instead, never touching the branch under test.

## Validation

- `go test -tags sqlite_integration -run TestAuthzOwningTeamOwnerInheritsProjectAdmin ./internal/storage/stmttest/ -v` — 2 controls pass, target case fails
- Same against PostgreSQL via `ZITADEL_TEST_POSTGRES_URL` on a local 17 instance — identical result, as expected: the resolver SQL is emitted by shared code and only the schema prefix and clock differ per dialect
- `gofmt -l` clean; `go vet -tags sqlite_integration ./internal/storage/stmttest/` clean

## Release notes / changeset

No changeset required — no shipped behavior changed.

## Notes

**This PR is expected to be red, and it reds CI.** `server:test-postgres` runs `go test -tags postgres_integration ./...` with `runInCI: true`, so the build tag alone wires this into `full-pr` — an earlier revision of this description claimed no lane picked it up, which was wrong. Nothing in the product is broken: `owning_team` is not in the checked-in catalog (ADR 053 §2 says as much), so this documents an unimplemented decision rather than a regression. It goes green as part of implementing the fix. Merging it before then would red `main`, which is why it is a draft.

**Why raise it now.** ADR 053's own testing obligations 1 and 5 require this behavior, and ADR 052 obligation 6 requires authorized-project listing to include the ownership path — the same missing edge, second surface. If 053 is accepted as written, people design against a model the engine cannot evaluate, and the correction may move where ownership is stored, which would ripple back through 052 §2, §6 and §8.

**Suggested fix.** Extend the source-assignment lookup to the principal's home project, bound to the tupleset principal. That works because ADR 052 §2 forbids cross-project team membership, so the caller's home project is the owning team's home project — and it needs that invariant stated explicitly, which is what @livio-a already asked for on #876 (making cross-project grant principals platform-homed). Same edit from two directions.

**One trap for whoever implements it.** Apply the widening only to the team- and resource-scoped branches of the source predicate. The `scope_kind = 'project'` branch is not bound to `ts.principal_id`, so widening it would let any `team.owner` in the project grant admin on any owned project.

Related: this was surfaced by Copilot on #876 but landed in a collapsed suppressed-comments block, so neither human reviewer saw it. I verified it independently rather than taking it at face value — and my first attempt at a control was itself wrong, which is documented in the commit message.

/cc @livio-a @IAM-marco

