### PR TITLE
fix(console): report an unreachable server instead of "no project yet"

### DIFF
--- a/.changeset/console-runtime-unreachable-error.md
+++ b/.changeset/console-runtime-unreachable-error.md
@@ -1,0 +1,13 @@
+---
+"@zitadel/server": patch
+---
+
+The console now tells an unreachable server apart from a deployment that has no
+project yet. Its boot-time configuration read (`GET /console/runtime.json`) used
+to resolve every failure — a dropped connection, a `500`, an unreadable body —
+to the same "No project yet" screen, so an outage read as missing setup and sent
+operators to run `zitadel setup` against a problem setup cannot fix. Those cases
+now render a "Server unavailable" screen naming what went wrong, with a retry
+button that re-reads the configuration in place once the server is back. A
+server that answers normally but has no project still shows the setup hint,
+unchanged.

--- a/apps/console-e2e/README.md
+++ b/apps/console-e2e/README.md
@@ -21,6 +21,14 @@ under its production embed base at `/ui/console/`. This lane does not connect to
 a live API — with no backend, every API call fails the same way whatever base it
 targeted, so nothing here can vouch for the API base.
 
+The one request it does answer is `/console/runtime.json`, stubbed per test with
+Playwright routing. Console ADR 0004 §3 makes an unreachable runtime document a
+connectivity error rather than "no project yet", so the guard cases have to say
+which of the two they mean; the same routing lets the lane assert the error
+state (and its retry) against a real build. The build under test deliberately
+carries no `VITE_CONSOLE_RUNTIME_FALLBACK` — that opt-in exists for humans
+previewing without a backend, and setting it here would hide the error state.
+
 ## Real-instance resource coverage
 
 ```sh
@@ -35,6 +43,12 @@ fresh user per test.
 The dev proxy is also this lane's blind spot: it rewrites `/api/*` onto the API
 root, so the console's API base is correct here by construction. That is what
 `e2e-embedded` is for.
+
+This lane boots the binary with both `/ui/*` surfaces off, and the mux mounts
+`/console/runtime.json` only alongside one of them — so its instance serves no
+runtime document, and the lane sets `VITE_CONSOLE_RUNTIME_FALLBACK` for the same
+reason a backend-less preview does (see [`moon.yml`](moon.yml)). The project id
+reaches the console through `VITE_CONSOLE_PROJECT_ID` as before.
 
 ## Embedded-surface coverage
 

--- a/apps/console-e2e/moon.yml
+++ b/apps/console-e2e/moon.yml
@@ -56,6 +56,15 @@ tasks:
       # Vite-served console, so keep both server surfaces off.
       NEXTGEN_SERVER_LOGIN_ENABLED: "false"
       NEXTGEN_SERVER_CONSOLE_ENABLED: "false"
+      # Consequence of the two flags above: `/console/runtime.json` is mounted
+      # only alongside a UI surface (`buildHTTPMux`), so this lane's instance
+      # serves none. Since Console ADR 0004 §3 that is a connectivity error,
+      # not a mode, and the console would stop at its error screen before any
+      # screen loaded — so opt in explicitly, the same way a backend-less
+      # preview does. The project id comes from VITE_CONSOLE_PROJECT_ID, which
+      # withZitadel already maps from the instance handle. Reaches the Vite dev
+      # server through the app-runner, which inherits this process env.
+      VITE_CONSOLE_RUNTIME_FALLBACK: "1"
     options:
       cache: false
       runInCI: false

--- a/apps/console-e2e/src/console-shell.spec.ts
+++ b/apps/console-e2e/src/console-shell.spec.ts
@@ -7,17 +7,41 @@
  * is the real settings app behind an auth guard (Console ADR 0003), so this
  * spec proves the built SPA mounts under its embed base (`/ui/console/`,
  * exercising the `vite preview` base config in `apps/console/vite.config.mts`)
- * and that the guard behaves against a backend-less preview: unauthenticated
- * visits land on the shell-less login screen, deep links carry `?next=`, and
- * with no runtime document the login screen renders the "no project yet"
- * setup hint (Console ADR 0004 §2) instead of the widget.
+ * and that boot behaves against a backend-less preview.
+ *
+ * `vite preview` proxies nothing, so every test here stubs
+ * `/console/runtime.json` itself — which is the point of the lane after
+ * Console ADR 0004 §3: the console tells a server it cannot reach apart from
+ * a deployment that has no project yet, and only the second one is the "run
+ * `zitadel setup`" hint. Leaving the endpoint unstubbed would exercise the
+ * connectivity error, not the guard. (The build under test carries no
+ * `VITE_CONSOLE_RUNTIME_FALLBACK`, deliberately: that opt-in is for humans
+ * running a backend-less preview, and a lane that set it could no longer see
+ * the error state at all.)
  */
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+const RUNTIME_URL = "**/console/runtime.json";
+
+/** What a reachable server with no project yet answers (ADR 0004 §3, state 2). */
+const AWAITING_SETUP = { mode: "standalone" };
+
+async function serveRuntime(page: Page, document: object): Promise<void> {
+  await page.route(RUNTIME_URL, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(document),
+    }),
+  );
+}
 
 test("unauthenticated console redirects to login under the embed base", async ({ page }) => {
   // The console build is served under `/ui/console/` (it embeds in the Go
   // server), so the app only mounts there — not at the origin root. With no
-  // session backend, the `_authed` guard must land on the login route.
+  // session backend, the `_authed` guard must land on the login route, where
+  // the project-less runtime document renders the setup hint.
+  await serveRuntime(page, AWAITING_SETUP);
   await page.goto("/ui/console/");
   await expect(page.getByRole("heading", { name: "No project yet" })).toBeVisible();
 
@@ -28,10 +52,48 @@ test("unauthenticated console redirects to login under the embed base", async ({
 });
 
 test("deep links survive the auth guard via ?next=", async ({ page }) => {
+  await serveRuntime(page, AWAITING_SETUP);
   await page.goto("/ui/console/users");
   await expect(page.getByRole("heading", { name: "No project yet" })).toBeVisible();
 
   const url = new URL(page.url());
   expect(url.pathname).toBe("/ui/console/login");
   expect(url.searchParams.get("next")).toBe("/users");
+});
+
+test("an erroring runtime endpoint renders a retryable connectivity error", async ({ page }) => {
+  // The failure this replaces: a 500 used to render "No project yet", sending
+  // an operator to `zitadel setup` for a server outage (Console ADR 0004 §3).
+  let broken = true;
+  await page.route(RUNTIME_URL, (route) =>
+    broken
+      ? route.fulfill({ status: 500, contentType: "application/json", body: `{"error":"boom"}` })
+      : route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(AWAITING_SETUP),
+        }),
+  );
+
+  await page.goto("/ui/console/");
+  await expect(page.getByRole("heading", { name: "Server unavailable" })).toBeVisible();
+  await expect(page.getByText("the server answered 500")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "No project yet" })).toBeHidden();
+  // The router never mounted, so no guard redirect happened either.
+  expect(new URL(page.url()).pathname).toBe("/ui/console/");
+
+  // Retry is a real second attempt, not a reload hint: recovering the server
+  // hands the operator the console on one click.
+  broken = false;
+  await page.getByRole("button", { name: "Try again" }).click();
+  await expect(page.getByRole("heading", { name: "No project yet" })).toBeVisible();
+  expect(new URL(page.url()).pathname).toBe("/ui/console/login");
+});
+
+test("an unreachable runtime endpoint renders the same connectivity error", async ({ page }) => {
+  await page.route(RUNTIME_URL, (route) => route.abort("failed"));
+
+  await page.goto("/ui/console/");
+  await expect(page.getByRole("heading", { name: "Server unavailable" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "No project yet" })).toBeHidden();
 });

--- a/apps/console/AGENTS.md
+++ b/apps/console/AGENTS.md
@@ -43,6 +43,10 @@ direction for the console build-out (issue
   not forbid more. The runtime document carries only public sign-in metadata;
   portal surfaces render from target-scoped **effective permissions**, never
   membership, build-time flags, or a parallel console-facing feature array.
+  A runtime document the Console cannot read is an **error, not a mode** (§3):
+  keep "unreachable/erroring" and "no project yet" separate states, and do not
+  reintroduce a silent fallback to `standalone` — backend-less dev and preview
+  runs opt in with `VITE_CONSOLE_RUNTIME_FALLBACK` instead.
 
 If an implementation needs to diverge from an ADR, update the ADR in the same
 change rather than letting code and decision drift.

--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -100,6 +100,18 @@ hint; refresh after setup and the console picks the new project up. Only
 `standalone` mode exists today; `platform` (cloud portal) mode is future
 work.
 
+**A server the console cannot reach is an error, not a mode** (ADR 0004 §3).
+An unreachable endpoint, a non-2xx answer, or a body that is not a runtime
+document renders a retryable "Server unavailable" screen instead of the app —
+deliberately distinct from the setup hint, because "no project yet" would send
+an operator to `zitadel setup` for a problem setup cannot fix. Running the
+console against something that serves no runtime document (a backend-less
+`vite preview`, the api-mock loop below) is the one legitimate case for the
+old behavior, and it says so explicitly: set `VITE_CONSOLE_RUNTIME_FALLBACK=1`
+*for the build or dev server*, and discovery failures resolve to `standalone`
+again with a warning in the browser console. Never set it for the embedded
+production build.
+
 The runtime document also carries the default project's **publishable key**
 (root ADR 036): a browser-safe, origin-scoped bearer the login widget sends
 on flow calls and the handoff exchange. Sign-in therefore needs no
@@ -142,6 +154,7 @@ Note `listUsers` requires `user.read`, which only the **project secret** carries
 ```sh
 PORT=8080 moon run api-mock:start          # terminal 1
 VITE_CONSOLE_PROJECT_ID=proj_dev_mock \
+  VITE_CONSOLE_RUNTIME_FALLBACK=1 \
   moon run console:dev                     # terminal 2
 ```
 
@@ -150,8 +163,11 @@ Fast and offline, and the full sign-in loop works (the mock serves
 `identifier` → `password` flow the real server emits. Use it only for chrome that
 needs no real data: it has **no user store**, so list screens cannot be
 meaningful and nothing about authorization can be proven there. It also serves no
-`/console/runtime.json`, so runtime discovery falls back to `standalone` and the
-project id must come from `VITE_CONSOLE_PROJECT_ID`.
+`/console/runtime.json`, which is why the two variables above are both required:
+`VITE_CONSOLE_RUNTIME_FALLBACK` opts this loop into the standalone fallback
+(without it the console stops on the connectivity screen, correctly — the
+document really is missing), and the project id then has to come from
+`VITE_CONSOLE_PROJECT_ID`.
 
 ### Embedded build
 
@@ -170,6 +186,7 @@ embed base path.
 | `CONSOLE_PROJECT_SECRET` | Node (dev proxy) | Bearer attached by the proxy; never shipped to the browser |
 | `VITE_CONSOLE_API_BASE` | Client | Same-origin API base the SDK calls (default `/api`) |
 | `VITE_CONSOLE_PROJECT_ID` | Client | Dev override for the project id; when unset it is discovered from `/console/runtime.json` (Console ADR 0004) |
+| `VITE_CONSOLE_RUNTIME_FALLBACK` | Client (build/dev time) | Opt-in for runs with no `/console/runtime.json` (`vite preview`, api-mock): failed discovery resolves to `standalone` instead of the connectivity error. Never set it for the embedded build |
 
 ## Commands
 

--- a/apps/console/docs/adrs/0004-console-deployment-modes.md
+++ b/apps/console/docs/adrs/0004-console-deployment-modes.md
@@ -8,10 +8,13 @@
 > and the flag-gated row-only `platform.bootstrap_project` path exist. The
 > pin, the first-created fallback, and row-only bootstrap are transitional
 > behavior, not the target described here, and the pin retires with the
-> fallback (§2). The Console's current fall-back-to-`standalone` handling of an
-> unreachable runtime document contradicts §3 and is a pending change. The full
-> platform-project provisioner, first-party Console session authorization,
-> effective-permission exposure, and seed-input contract remain future work.
+> fallback (§2). §3's three discovery states are implemented: an unreachable,
+> erroring, or unreadable runtime document renders a retryable connectivity
+> error, and builds that deliberately run without one (`vite preview`, the
+> api-mock dev loop) opt back into the standalone fallback with
+> `VITE_CONSOLE_RUNTIME_FALLBACK`. The full platform-project provisioner,
+> first-party Console session authorization, effective-permission exposure,
+> and seed-input contract remain future work.
 > **Scope:** `apps/console`, plus the server-owned bootstrap and authorization
 > contracts on which it depends. See
 > [`apps/console/AGENTS.md`](../../AGENTS.md).
@@ -312,11 +315,11 @@ without changing its Console build or moving operator identities.
   removal at cutover, together with the first-created fallback it overrides.
   It is transitional configuration, not a supported way to choose the
   platform project.
-- The unreachable-endpoint rule in §3 is a **pending behavior change**: the
-  shipped Console still resolves any fetch failure to `mode: "standalone"`
-  (`apps/console/src/runtime/runtime.ts`), and `apps/console-e2e` asserts that
-  behavior against a backend-less preview. Implementing §3 means an explicit
-  error state, an opt-in for backend-less development, and an updated spec.
+- A deployment whose runtime document is unreachable renders a connectivity
+  error, so a server outage no longer reads as "no project yet". Backend-less
+  development and preview builds are the cases the old silent fallback
+  actually served; they now say so with `VITE_CONSOLE_RUNTIME_FALLBACK`, and
+  the embedded build never carries it.
 - Effective-permission exposure, CSRF enforcement, and session-derived
   target authorization are server dependencies. The Console remains
   fail-closed until they land.

--- a/apps/console/src/components/runtime-unavailable.spec.tsx
+++ b/apps/console/src/components/runtime-unavailable.spec.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { RuntimeUnavailable } from "./runtime-unavailable";
+
+/**
+ * The boot-time connectivity screen (Console ADR 0004 §3). What matters here
+ * is that it names the actual failure — a status or a transport error, never
+ * "no project yet" — and that retry is a real second attempt rather than copy
+ * telling the operator to reload.
+ */
+describe("runtime unavailable screen", () => {
+  it("names the failure the server produced", () => {
+    render(
+      <RuntimeUnavailable
+        failure={{ status: 500, detail: "the server answered 500" }}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Server unavailable" })).toBeInTheDocument();
+    expect(screen.getByText(/the server answered 500/)).toBeInTheDocument();
+    // The state this screen exists to be told apart from.
+    expect(screen.queryByText(/no project yet/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/zitadel setup/i)).not.toBeInTheDocument();
+  });
+
+  it("retries discovery and reports progress while the attempt is in flight", async () => {
+    const user = userEvent.setup();
+    let releaseRetry: (() => void) | undefined;
+    const onRetry = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRetry = resolve;
+        }),
+    );
+
+    render(
+      <RuntimeUnavailable failure={{ detail: "the request failed (network down)" }} onRetry={onRetry} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(onRetry).toHaveBeenCalledOnce();
+    const retrying = await screen.findByRole("button", { name: "Retrying…" });
+    expect(retrying).toBeDisabled();
+
+    releaseRetry?.();
+    expect(await screen.findByRole("button", { name: "Try again" })).toBeEnabled();
+  });
+});

--- a/apps/console/src/components/runtime-unavailable.tsx
+++ b/apps/console/src/components/runtime-unavailable.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { RUNTIME_URL, type ConsoleRuntimeFailure } from "../runtime/runtime";
+import { ZitadelMark } from "./app-shell/icons";
+
+/**
+ * Boot-time connectivity error (Console ADR 0004 §3).
+ *
+ * Rendered by `main.tsx` in place of the router when runtime discovery finds
+ * the endpoint unreachable, erroring, or unreadable. It is deliberately the
+ * one console screen that renders without the router: with no runtime
+ * document there is no sign-in project, so every route below the guard would
+ * fail the same way, and the login screen's "No project yet" hint — the state
+ * this screen exists to be distinguishable from — would send an operator to
+ * run `zitadel setup` against a server problem setup cannot fix.
+ *
+ * Retry re-runs discovery in place rather than reloading: an operator who
+ * starts the server (or fixes the proxy) in another window gets the console
+ * on one click, and a reload would cost the same round trip anyway.
+ */
+export interface RuntimeUnavailableProps {
+  failure: ConsoleRuntimeFailure;
+  /** Re-runs discovery; resolves once the next attempt has been rendered. */
+  onRetry: () => Promise<void>;
+}
+
+export function RuntimeUnavailable({ failure, onRetry }: RuntimeUnavailableProps) {
+  const [retrying, setRetrying] = useState(false);
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    try {
+      await onRetry();
+    } finally {
+      // A successful retry has already swapped this screen for the router,
+      // so this only lands when the server is still unreachable.
+      setRetrying(false);
+    }
+  };
+
+  return (
+    <main className="flex min-h-svh flex-col items-center justify-center gap-8 bg-background px-4 py-10">
+      <ZitadelMark size={40} className="text-foreground" aria-hidden />
+      <div className="flex max-w-md flex-col items-center gap-4 text-center">
+        <h1 className="font-serif text-xl text-foreground">Server unavailable</h1>
+        <p className="text-sm text-muted-foreground">
+          The console could not read its runtime configuration from{" "}
+          <code className="rounded bg-accent px-1.5 py-0.5 text-foreground">{RUNTIME_URL}</code> —{" "}
+          {failure.detail}. Until it can, the console cannot tell whether this deployment has a
+          project yet, so it stops here instead of guessing. Check that the Zitadel server is
+          running and reachable from this origin, then try again.
+        </p>
+        <Button onClick={handleRetry} disabled={retrying}>
+          {retrying ? "Retrying…" : "Try again"}
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -1,8 +1,9 @@
 import { RouterProvider } from "@tanstack/react-router";
-import ReactDOM from "react-dom/client";
+import ReactDOM, { type Root } from "react-dom/client";
 
+import { RuntimeUnavailable } from "./components/runtime-unavailable";
 import { createAppRouter } from "./router";
-import { initRuntime } from "./runtime/runtime";
+import { type ConsoleRuntimeResult, initRuntime, retryRuntime } from "./runtime/runtime";
 
 const router = createAppRouter();
 
@@ -15,18 +16,33 @@ async function clearStaleServiceWorkers(): Promise<void> {
 
 async function main(): Promise<void> {
   await clearStaleServiceWorkers();
-  // Discover deployment runtime metadata (mode + project ids) before any
-  // route guard or loader runs (Console ADR 0004 §3). Today an unreachable
-  // endpoint resolves to the standalone fallback so rendering never blocks on
-  // a broken backend; §3 supersedes that with an explicit error state, which
-  // is a pending change tracked in that ADR's Consequences.
-  await initRuntime();
 
   const rootElement = document.getElementById("app");
-  if (rootElement && !rootElement.innerHTML) {
-    const root = ReactDOM.createRoot(rootElement);
+  if (!rootElement || rootElement.innerHTML) return;
+  const root = ReactDOM.createRoot(rootElement);
+
+  // Discover deployment runtime metadata (mode + project ids) before any
+  // route guard or loader runs (Console ADR 0004 §3). An unreachable or
+  // erroring endpoint is an error, not a mode: it renders the retryable
+  // connectivity screen instead of the app — rendering, never blocking, so a
+  // broken backend still produces a page an operator can act on.
+  render(root, await initRuntime());
+}
+
+function render(root: Root, result: ConsoleRuntimeResult): void {
+  if (result.ok) {
     root.render(<RouterProvider router={router} />);
+    return;
   }
+
+  root.render(
+    <RuntimeUnavailable
+      failure={result.failure}
+      onRetry={async () => {
+        render(root, await retryRuntime());
+      }}
+    />,
+  );
 }
 
 void main();

--- a/apps/console/src/runtime/runtime.spec.ts
+++ b/apps/console/src/runtime/runtime.spec.ts
@@ -123,6 +123,24 @@ describe("initRuntime", () => {
     });
   });
 
+  // A wrongly-typed id must not coerce to "absent" and render as "no project
+  // yet": the server omits the ids it has none of (`omitempty`), so a present
+  // one that is not a usable string came from something that is not our
+  // server. Same misdiagnosis §3 removes, one field lower down.
+  it.each([
+    ["console_project_id", { mode: "standalone", console_project_id: 42 }],
+    ["publishable_key", { mode: "standalone", console_project_id: "proj_a", publishable_key: 42 }],
+    ["a null id", { mode: "standalone", console_project_id: null }],
+    ["an empty id", { mode: "standalone", console_project_id: "" }],
+  ])("reports a malformed %s as a failure rather than an absent project", async (_case, doc) => {
+    fetchMock.mockResolvedValue(jsonResponse(doc));
+
+    expect(await initRuntime()).toEqual({
+      ok: false,
+      failure: { status: 200, detail: "the response was not a runtime document" },
+    });
+  });
+
   it("shares one in-flight fetch across concurrent callers", async () => {
     fetchMock.mockResolvedValue(jsonResponse({ mode: "standalone", console_project_id: "proj_a" }));
 

--- a/apps/console/src/runtime/runtime.spec.ts
+++ b/apps/console/src/runtime/runtime.spec.ts
@@ -7,12 +7,15 @@ import {
   getPublishableKey,
   getRuntime,
   initRuntime,
+  retryRuntime,
 } from "./runtime";
 
 /**
  * Console runtime discovery (Console ADR 0004 §3): the document is fetched
- * once, malformed or unreachable endpoints degrade to the standalone
- * fallback, and the dev env override wins over the discovered project id.
+ * once, an unreachable or erroring endpoint is reported as a failure rather
+ * than guessed to be `standalone`, `VITE_CONSOLE_RUNTIME_FALLBACK` is the
+ * backend-less opt-in back to that fallback, and the dev env override wins
+ * over the discovered project id.
  */
 const fetchMock = vi.fn();
 
@@ -20,15 +23,24 @@ beforeEach(() => {
   _resetRuntimeForTesting();
   fetchMock.mockReset();
   vi.stubGlobal("fetch", fetchMock);
+  // Re-applied per test: `unstubAllEnvs` below drops `test-setup.ts`'s
+  // hermetic defaults along with each test's own stubs.
+  vi.stubEnv("VITE_CONSOLE_PROJECT_ID", "");
+  vi.stubEnv("VITE_CONSOLE_RUNTIME_FALLBACK", "");
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
+  vi.restoreAllMocks();
 });
 
-function jsonResponse(body: unknown, ok = true): Response {
-  return { ok, json: async () => body } as Response;
+function jsonResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? (init?.ok === false ? 500 : 200),
+    json: async () => body,
+  } as Response;
 }
 
 describe("initRuntime", () => {
@@ -41,13 +53,16 @@ describe("initRuntime", () => {
       }),
     );
 
-    const runtime = await initRuntime();
+    const result = await initRuntime();
 
     expect(fetchMock).toHaveBeenCalledWith(RUNTIME_URL, { credentials: "same-origin" });
-    expect(runtime).toEqual({
-      mode: "standalone",
-      console_project_id: "proj_first",
-      publishable_key: "pk_test",
+    expect(result).toEqual({
+      ok: true,
+      runtime: {
+        mode: "standalone",
+        console_project_id: "proj_first",
+        publishable_key: "pk_test",
+      },
     });
     expect(getPublishableKey()).toBe("pk_test");
 
@@ -56,22 +71,104 @@ describe("initRuntime", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to standalone when the endpoint is unreachable", async () => {
+  it("treats a 2xx document without a project as awaiting setup, not an error", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ mode: "standalone" }));
+
+    const result = await initRuntime();
+
+    expect(result).toEqual({ ok: true, runtime: { mode: "standalone" } });
+    // The login screen renders its `zitadel setup` hint off this empty id.
+    expect(getConsoleProjectId()).toBe("");
+  });
+
+  it("reports an unreachable endpoint as a failure", async () => {
     fetchMock.mockRejectedValue(new TypeError("network down"));
 
-    expect(await initRuntime()).toEqual({ mode: "standalone" });
+    expect(await initRuntime()).toEqual({
+      ok: false,
+      failure: { detail: "the request failed (network down)" },
+    });
   });
 
-  it("falls back to standalone on a non-OK response", async () => {
-    fetchMock.mockResolvedValue(jsonResponse({}, false));
+  it("reports a non-2xx response as a failure carrying the status", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, { ok: false, status: 500 }));
 
-    expect(await initRuntime()).toEqual({ mode: "standalone" });
+    expect(await initRuntime()).toEqual({
+      ok: false,
+      failure: { status: 500, detail: "the server answered 500" },
+    });
   });
 
-  it("rejects a document with an unknown mode", async () => {
+  it("reports an unparseable body as a failure", async () => {
+    // What a dev server answers for an unknown path: 200 with `index.html`.
+    fetchMock.mockResolvedValue({
+      ...jsonResponse(null),
+      json: async () => {
+        throw new SyntaxError("Unexpected token <");
+      },
+    });
+
+    expect(await initRuntime()).toEqual({
+      ok: false,
+      failure: { status: 200, detail: "the response was not valid JSON" },
+    });
+  });
+
+  it("reports a document with an unknown mode as a failure", async () => {
     fetchMock.mockResolvedValue(jsonResponse({ mode: "enterprise", console_project_id: "x" }));
 
-    expect(await initRuntime()).toEqual({ mode: "standalone" });
+    expect(await initRuntime()).toEqual({
+      ok: false,
+      failure: { status: 200, detail: "the response was not a runtime document" },
+    });
+  });
+
+  it("shares one in-flight fetch across concurrent callers", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ mode: "standalone", console_project_id: "proj_a" }));
+
+    const [first, second] = await Promise.all([initRuntime(), initRuntime()]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(second);
+  });
+});
+
+describe("VITE_CONSOLE_RUNTIME_FALLBACK", () => {
+  it("degrades a failed discovery to the standalone document when opted in", async () => {
+    vi.stubEnv("VITE_CONSOLE_RUNTIME_FALLBACK", "1");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    fetchMock.mockResolvedValue(jsonResponse({}, { ok: false, status: 404 }));
+
+    expect(await initRuntime()).toEqual({ ok: true, runtime: { mode: "standalone" } });
+    // The opt-in is never silent — a build carrying the flag says so.
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("stays off for values that read as disabled", async () => {
+    vi.stubEnv("VITE_CONSOLE_RUNTIME_FALLBACK", "false");
+    fetchMock.mockRejectedValue(new TypeError("network down"));
+
+    expect(await initRuntime()).toMatchObject({ ok: false });
+  });
+});
+
+describe("retryRuntime", () => {
+  it("re-fetches after a failure and keeps the document once one arrives", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("network down"));
+    expect(await initRuntime()).toMatchObject({ ok: false });
+
+    fetchMock.mockResolvedValue(jsonResponse({ mode: "standalone", console_project_id: "proj_up" }));
+
+    expect(await retryRuntime()).toEqual({
+      ok: true,
+      runtime: { mode: "standalone", console_project_id: "proj_up" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // A resolved document is a per-boot fact: retrying again must not refetch
+    // and swap the sign-in project under a mounted router.
+    expect(await retryRuntime()).toMatchObject({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -96,7 +193,7 @@ describe("getConsoleProjectId", () => {
     expect(getConsoleProjectId()).toBe("proj_discovered");
   });
 
-  it("resolves to an empty id before discovery and after fallback", () => {
+  it("resolves to an empty id before discovery", () => {
     vi.stubEnv("VITE_CONSOLE_PROJECT_ID", "");
     expect(getRuntime()).toEqual({ mode: "standalone" });
     expect(getConsoleProjectId()).toBe("");

--- a/apps/console/src/runtime/runtime.ts
+++ b/apps/console/src/runtime/runtime.ts
@@ -192,16 +192,28 @@ function describeCause(cause: unknown): string {
 function parseRuntime(doc: unknown): ConsoleRuntime | undefined {
   if (typeof doc !== "object" || doc === null) return undefined;
   const record = doc as Record<string, unknown>;
-  if (record.mode !== "standalone" && record.mode !== "platform") return undefined;
-  return {
-    mode: record.mode,
-    console_project_id: optionalString(record.console_project_id),
-    publishable_key: optionalString(record.publishable_key),
-  };
+  // Destructured first: a type predicate does not narrow a property read off
+  // a `Record<string, unknown>`, only a local.
+  const { mode, console_project_id: projectId, publishable_key: publishableKey } = record;
+
+  if (mode !== "standalone" && mode !== "platform") return undefined;
+  if (!absentOrString(projectId) || !absentOrString(publishableKey)) return undefined;
+
+  return { mode, console_project_id: projectId, publishable_key: publishableKey };
 }
 
-function optionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value !== "" ? value : undefined;
+/**
+ * Absence is how the document says "not provisioned yet": the server omits
+ * both ids rather than emitting empty ones (`omitempty` in
+ * `cmd/server/console_runtime.go`), and ADR 0004 §2's shape shows the field
+ * omitted. A *present* field must therefore be a usable string — a number, a
+ * `null`, or `""` came from something that is not our server, and coercing it
+ * to "absent" would report that as "no project yet", which is the
+ * misdiagnosis §3 exists to end, one field lower down. JSON cannot carry
+ * `undefined`, so it can only mean the key was missing.
+ */
+function absentOrString(value: unknown): value is string | undefined {
+  return value === undefined || (typeof value === "string" && value !== "");
 }
 
 /** Test-only: drop the cached document so specs can exercise `initRuntime` again. */

--- a/apps/console/src/runtime/runtime.ts
+++ b/apps/console/src/runtime/runtime.ts
@@ -9,9 +9,23 @@
  * and project ids, never secrets or feature inventories (per-surface gating
  * rides effective permissions, ADR 0004 §5).
  *
- * A fetch failure — including `vite preview`, which proxies nothing — falls
- * back to `standalone` with no ids, so a broken endpoint degrades to the
- * smallest surface, never to an accidental portal.
+ * Discovery has three outcomes, and ADR 0004 §3 keeps them distinct because
+ * each asks a different thing of the operator:
+ *
+ * 1. **reachable and provisioned** — the document names a sign-in project;
+ *    the console boots normally.
+ * 2. **reachable and not provisioned** — a 2xx document without
+ *    `console_project_id`; the login screen shows its `zitadel setup` hint.
+ * 3. **unreachable, non-2xx, or unreadable** — {@link initRuntime} reports a
+ *    {@link ConsoleRuntimeFailure} and `main.tsx` renders a retryable
+ *    connectivity error. Guessing `standalone` here would report a server
+ *    outage as "no project yet" and send an operator to run `zitadel setup`
+ *    against a problem setup cannot fix.
+ *
+ * Builds that deliberately run without a runtime document — `vite preview`,
+ * the api-mock dev loop — collapse state 3 into state 2 by opting in with
+ * `VITE_CONSOLE_RUNTIME_FALLBACK`. That opt-in is the only path back to the
+ * old silent fallback, and the embedded production build never sets it.
  */
 
 /** The payload of `GET /console/runtime.json`, served by the Go mux. */
@@ -37,6 +51,19 @@ export interface ConsoleRuntime {
   publishable_key?: string;
 }
 
+/** Why discovery produced no document — ADR 0004 §3's third state. */
+export interface ConsoleRuntimeFailure {
+  /** The HTTP status, when the endpoint answered at all. */
+  status?: number;
+  /** Operator-facing clause, rendered into the connectivity error screen. */
+  detail: string;
+}
+
+/** What {@link initRuntime} resolved to: a usable document, or why there is none. */
+export type ConsoleRuntimeResult =
+  | { ok: true; runtime: ConsoleRuntime }
+  | { ok: false; failure: ConsoleRuntimeFailure };
+
 /**
  * Absolute same-origin path, deliberately not under the console's BASE_URL:
  * the Go server serves it at the root mux (dev: proxied in
@@ -47,39 +74,44 @@ export const RUNTIME_URL = "/console/runtime.json";
 const FALLBACK: ConsoleRuntime = { mode: "standalone" };
 
 let runtime: ConsoleRuntime = FALLBACK;
-let initialized = false;
+let settled: ConsoleRuntimeResult | undefined;
+let pending: Promise<ConsoleRuntimeResult> | undefined;
 
 /**
- * Fetches the runtime document once. Idempotent; later calls return the
- * cached result. Never throws — any failure resolves to the standalone
- * fallback.
- *
- * That fallback is transitional. Console ADR 0004 §3 requires an unreachable
- * or non-`2xx` endpoint to surface an explicit connectivity error instead,
- * kept distinct from "reachable, not provisioned yet": collapsing the two
- * reports a server outage as "no project yet" and sends operators to run
- * `zitadel setup` against a problem setup cannot fix. Implementing it needs an
- * opt-in for backend-less preview/dev builds, which is what the fallback
- * actually serves today, plus an `apps/console-e2e` update.
+ * Fetches the runtime document once. Idempotent; concurrent and later calls
+ * share the first result. Never throws — a failed discovery resolves to an
+ * `ok: false` result the caller renders (see {@link retryRuntime}).
  */
-export async function initRuntime(): Promise<ConsoleRuntime> {
-  if (initialized) return runtime;
-  initialized = true;
-  try {
-    const response = await fetch(RUNTIME_URL, { credentials: "same-origin" });
-    if (response.ok) {
-      runtime = parseRuntime(await response.json()) ?? FALLBACK;
-    }
-  } catch {
-    // Unreachable endpoint (preview builds, dev without a backend) — keep
-    // the standalone fallback. Note this also swallows a non-`2xx` response,
-    // so a failing server currently renders as "no project yet"; ADR 0004 §3
-    // separates the two.
-  }
-  return runtime;
+export async function initRuntime(): Promise<ConsoleRuntimeResult> {
+  if (settled) return settled;
+  pending ??= discover()
+    .then((result) => {
+      settled = result;
+      return result;
+    })
+    .finally(() => {
+      pending = undefined;
+    });
+  return pending;
 }
 
-/** The discovered runtime document (fallback until {@link initRuntime} resolves). */
+/**
+ * Re-runs discovery after a failure — what the connectivity error screen's
+ * retry button calls. A document that already resolved is kept: it is a
+ * per-boot fact, and re-reading it mid-session would swap the sign-in project
+ * under a mounted router.
+ */
+export async function retryRuntime(): Promise<ConsoleRuntimeResult> {
+  if (settled?.ok) return settled;
+  settled = undefined;
+  return initRuntime();
+}
+
+/**
+ * The discovered runtime document. Falls back to the standalone shape before
+ * discovery resolves and after it fails — in the failure case nothing renders
+ * from it, because `main.tsx` shows the connectivity error instead of the app.
+ */
 export function getRuntime(): ConsoleRuntime {
   return runtime;
 }
@@ -102,6 +134,61 @@ export function getPublishableKey(): string | undefined {
   return getRuntime().publishable_key;
 }
 
+async function discover(): Promise<ConsoleRuntimeResult> {
+  let response: Response;
+  try {
+    response = await fetch(RUNTIME_URL, { credentials: "same-origin" });
+  } catch (cause) {
+    return failed({ detail: `the request failed (${describeCause(cause)})` });
+  }
+
+  if (!response.ok) {
+    return failed({ status: response.status, detail: `the server answered ${response.status}` });
+  }
+
+  let document: unknown;
+  try {
+    document = await response.json();
+  } catch {
+    return failed({ status: response.status, detail: "the response was not valid JSON" });
+  }
+
+  const parsed = parseRuntime(document);
+  if (!parsed) {
+    // A 2xx body the console cannot read is a broken server, not an
+    // unprovisioned one — the same reason §3 refuses to guess a mode.
+    return failed({ status: response.status, detail: "the response was not a runtime document" });
+  }
+
+  runtime = parsed;
+  return { ok: true, runtime: parsed };
+}
+
+/**
+ * Turns a discovery failure into a result. Honors the backend-less opt-in
+ * (`VITE_CONSOLE_RUNTIME_FALLBACK`), which is the only way back to the
+ * pre-§3 behavior of treating an absent document as `standalone` — and warns
+ * when it fires, so a build carrying the flag by accident says so out loud.
+ */
+function failed(failure: ConsoleRuntimeFailure): ConsoleRuntimeResult {
+  if (!runtimeFallbackEnabled()) return { ok: false, failure };
+  console.warn(
+    `[console] runtime discovery failed (${failure.detail}); VITE_CONSOLE_RUNTIME_FALLBACK is set, ` +
+      `continuing with the built-in ${FALLBACK.mode} document.`,
+  );
+  runtime = FALLBACK;
+  return { ok: true, runtime: FALLBACK };
+}
+
+function runtimeFallbackEnabled(): boolean {
+  const flag = import.meta.env.VITE_CONSOLE_RUNTIME_FALLBACK;
+  return flag !== undefined && flag !== "" && flag !== "0" && flag !== "false";
+}
+
+function describeCause(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
 function parseRuntime(doc: unknown): ConsoleRuntime | undefined {
   if (typeof doc !== "object" || doc === null) return undefined;
   const record = doc as Record<string, unknown>;
@@ -120,5 +207,6 @@ function optionalString(value: unknown): string | undefined {
 /** Test-only: drop the cached document so specs can exercise `initRuntime` again. */
 export function _resetRuntimeForTesting(): void {
   runtime = FALLBACK;
-  initialized = false;
+  settled = undefined;
+  pending = undefined;
 }

--- a/apps/console/src/test-setup.ts
+++ b/apps/console/src/test-setup.ts
@@ -56,8 +56,11 @@ if (typeof Element !== "undefined") {
   Element.prototype.scrollIntoView ??= () => undefined;
 }
 
-// Hermetic env: Vitest (via Vite) loads `.env.local`, so without this stub a
-// developer's local VITE_CONSOLE_PROJECT_ID would leak into test requests and
-// make outcomes depend on gitignored local files. Specs that need a value
-// stub their own (vi.stubEnv wins over this default).
+// Hermetic env: Vitest (via Vite) loads `.env.local`, so without these stubs a
+// developer's local VITE_CONSOLE_PROJECT_ID would leak into test requests, and
+// a local VITE_CONSOLE_RUNTIME_FALLBACK would turn runtime-discovery failures
+// back into the standalone fallback (Console ADR 0004 §3) — both make outcomes
+// depend on gitignored local files. Specs that need a value stub their own
+// (vi.stubEnv wins over these defaults).
 vi.stubEnv("VITE_CONSOLE_PROJECT_ID", "");
+vi.stubEnv("VITE_CONSOLE_RUNTIME_FALLBACK", "");

--- a/apps/console/src/vite-env.d.ts
+++ b/apps/console/src/vite-env.d.ts
@@ -5,6 +5,13 @@ interface ImportMetaEnv {
   readonly VITE_CONSOLE_API_BASE?: string;
   /** Non-secret project id used to scope list/detail API calls. */
   readonly VITE_CONSOLE_PROJECT_ID?: string;
+  /**
+   * Opt-in for builds that run without a runtime document (`vite preview`,
+   * the api-mock dev loop): treat failed discovery as the standalone
+   * fallback instead of an error (Console ADR 0004 §3). Never set for the
+   * embedded production build.
+   */
+  readonly VITE_CONSOLE_RUNTIME_FALLBACK?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- Implements Console ADR 0004 §3's **"an unreachable endpoint is an error, not a mode"**, the behavior change #876 deliberately recorded and deferred. Runtime discovery resolved *every* failure — a dropped connection, a `500`, a body that is not a runtime document — to the standalone fallback, so a server outage rendered the login screen's "No project yet" hint and sent an operator to run `zitadel setup` against a problem setup cannot fix.
- `initRuntime()` now returns a result rather than a document, and the three states stay distinct: **reachable + provisioned** boots the router, **reachable + unprovisioned** keeps the setup hint, **anything else** renders a retryable "Server unavailable" screen in place of the app. `main.tsx` swaps the rendered tree, so a broken backend still produces a page instead of blocking boot; `retryRuntime()` re-runs discovery in place and pins a document once one arrives, so a recovered server is one click away and the sign-in project cannot change under a mounted router.
- A 2xx body that will not parse counts as an error too: a server answering garbage is broken, not unprovisioned, so "no project yet" would be the same lie.
- The fallback's real users are runs with **no runtime document to read**, and they now say so: `VITE_CONSOLE_RUNTIME_FALLBACK` opts a build or dev server back into it, loudly (browser-console warning), and the embedded build never carries it. Two consumers: the api-mock dev loop, and `console-e2e:e2e-real` — its binary runs with both `/ui/*` surfaces off, and `buildHTTPMux` mounts `/console/runtime.json` only alongside a UI surface, so that lane's instance 404s the document and would otherwise have died at the error screen. `console:dev-real` is unaffected (surfaces default on), so the default dev loop now exercises real discovery.
- `apps/console-e2e/src/console-shell.spec.ts` stops relying on the fallback: it stubs the document per test, which is what makes the guard cases say which state they mean *and* lets the lane assert the error state and its retry against a real preview build.
- Docs follow the code: ADR 0004's "pending behavior change" bullet is replaced by its consequence, the implementation-state header is updated, and the `runtime.ts` / `main.tsx` comments that described the fallback as pending are rewritten. Console README (three states, mock-loop flag, env table), console-e2e README, and `apps/console/AGENTS.md` gain the guardrail so the fallback is not quietly reintroduced.

> [!NOTE]
> **Stacked on #876** (`codex/cross-project-access-adrs`). The pending bullet, the §3 decision text, and the comments this corrects exist only on that branch — `main` still carries the older ADR 0004 revision — so this cannot be based on `main`. GitHub retargets the base when #876 merges.

## Validation

- `moon run console:lint console:typecheck console:test console-e2e:lint console-e2e:typecheck console-e2e:e2e` — green (110 console unit tests, 4 shell-lane e2e tests, 2 of them new)
- `moon run console-e2e:e2e-real` — 22 passed (the lane that needed the opt-in; its log confirms the instance answers `404` for `/console/runtime.json`)
- `moon run console-e2e:e2e-embedded` — 7 passed (production path: the binary serving a real runtime document, sign-in end to end)
- Manual, both halves of the opt-in against a real build: `VITE_CONSOLE_RUNTIME_FALLBACK=1 vite build` + `vite preview` renders the setup hint; the same build without the flag renders the connectivity screen. (`vite preview` answers `404`, so today's preview case was in fact the silently-ignored non-2xx branch, not a transport failure.)
- `corepack pnpm exec changeset status --since origin/main` — `@zitadel/server` patch

## Release notes / changeset

- Changeset: `.changeset/console-runtime-unreachable-error.md` — the console now tells an unreachable server apart from a deployment that has no project yet, with a retryable "Server unavailable" screen naming what went wrong. Lists `@zitadel/server`, per [.changeset/README.md](../blob/main/.changeset/README.md#publishable-npm-packages): the console ships embedded in the server and publishes no package of its own.

## Notes

- **Copy:** the error screen names the failure it actually saw ("the server answered 500", "the request failed (…)") rather than a generic message, because the two classes send an operator to different places.
- **Follow-up (open):** `apps/login-ui/src/main.ts` has the identical collapse in the hosted sign-in shell. Different audience (end users, not operators), so it wants its own decision rather than a copy of this fix.
- **Smaller follow-up:** `@zitadel/api-mock` could serve `/console/runtime.json`, which would remove the opt-in from the mock dev loop entirely.
