### PR TITLE
fix(login): report an unreachable deployment instead of "no project yet"

### DIFF
--- a/.changeset/login-shell-runtime-unreachable-error.md
+++ b/.changeset/login-shell-runtime-unreachable-error.md
@@ -1,0 +1,14 @@
+---
+"@zitadel/server": patch
+---
+
+The hosted sign-in shell at `/ui/login/` now tells a deployment it cannot reach
+apart from one that has no project yet. Its boot-time configuration read
+(`GET /console/runtime.json`) used to resolve every failure — a dropped
+connection, a `500`, an unreadable body — to the same "No project yet" screen,
+so a server whose database was down still served the sign-in page and then told
+the people trying to sign in to run `npx @zitadel/cli setup`. Those cases now
+render a "Sign-in is unavailable" screen with a retry button that re-reads the
+configuration in place, and name the underlying failure in a secondary line for
+whoever can act on it. A deployment that answers normally but has no project
+still shows the setup hint, unchanged.

--- a/apps/console-e2e/README.md
+++ b/apps/console-e2e/README.md
@@ -63,6 +63,14 @@ exercises the request path a customer gets, and the one that would have caught
 both shipped bugs: the console calling `/api/*` at a mux that never served it,
 and the login shell defaulting to the project id `"demo"`.
 
+Its instance is provisioned, so the login shell's non-happy paths stub
+`/console/runtime.json` per test the way the preview lane does — Console
+ADR 0004 §3 holds for the shell too, and the states it separates ("no project
+yet" vs. a server that cannot answer) are exactly the ones this lane's own
+deployment state cannot produce. The stubbed retry falls through to the real
+server, so recovery is asserted against a genuine document rather than a
+fixture.
+
 Keep feature coverage out of it. Management screens need `user.read`, which
 only the project secret carries — that is `e2e-real`'s job. This lane asserts
 that the surfaces reach the API at all.

--- a/apps/console-e2e/src-embedded/hosted-login.spec.ts
+++ b/apps/console-e2e/src-embedded/hosted-login.spec.ts
@@ -13,7 +13,20 @@ import { expect, test } from "@zitadel/testing/playwright";
  * The shell sets no `post-sign-in-url`, so it stops at the terminal step and
  * emits `zitadel-flow-complete` for the host to act on rather than exchanging
  * the handoff itself. These cases follow it exactly that far.
+ *
+ * The runtime document the shell discovers from is real here — this lane boots
+ * a provisioned instance — so the cases that need a *different* deployment
+ * state (no project yet, a server that cannot answer) stub the endpoint per
+ * test. Those three states are the ones Console ADR 0004 §3 keeps apart, and
+ * the shell's copy differs per state because its audience does: the setup hint
+ * addresses whoever is standing up the deployment, the connectivity error
+ * addresses someone who just wanted to sign in.
  */
+
+const RUNTIME_URL = "**/console/runtime.json";
+
+/** What a reachable server with no project yet answers (ADR 0004 §3, state 2). */
+const AWAITING_SETUP = { mode: "standalone" };
 
 interface FlowCompletion {
   behavior: string;
@@ -103,13 +116,93 @@ test("an explicit ?project_id= still wins over discovery", async ({ page, zitade
   expect(project.publishableKey).toBeUndefined();
 });
 
-// The shell's other branch — the setup hint — needs a deployment with no
-// project at all, which this suite's instance is bootstrapped past. A
-// caller-supplied id that does not resolve is a different case and keeps the
-// widget's own error, deliberately: the hint tells an operator to run
-// `zitadel setup`, which is not the answer to a bad query parameter.
+// A caller-supplied id that does not resolve is neither of the shell's own
+// screens and keeps the widget's own error, deliberately: the setup hint tells
+// an operator to run `zitadel setup`, which is not the answer to a bad query
+// parameter.
 test("a caller-supplied unknown project keeps the widget's own error", async ({ page }) => {
   await page.goto("/ui/login/?project_id=proj_does_not_exist");
   await expect(page.getByText(/not found/i)).toBeVisible();
   await expect(page.getByLabel("Email")).toHaveCount(0);
+});
+
+test("a reachable deployment with no project yet shows the setup hint", async ({ page }) => {
+  // This instance is bootstrapped past the state, so serve it directly. It is
+  // the one case whose copy is aimed at an operator: a deployment with no
+  // project has no application to send an end user here.
+  await page.route(RUNTIME_URL, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(AWAITING_SETUP),
+    }),
+  );
+
+  await page.goto("/ui/login/");
+  await expect(page.getByRole("heading", { name: "No project yet" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sign-in is unavailable" })).toBeHidden();
+});
+
+test("an erroring runtime endpoint renders a retryable error, not the setup hint", async ({
+  page,
+  zitadel,
+}) => {
+  // The failure this replaces, and the reason it is not the narrow window it
+  // sounds like: `/ui/login/` is served from the binary's embedded assets and
+  // touches no storage, while `/console/runtime.json` is resolved per request
+  // from the default project and answers 500 when that lookup fails. A healthy
+  // binary in front of an unhealthy database hit exactly this, and told the
+  // people trying to sign in that the deployment was never set up.
+  let broken = true;
+  await page.route(RUNTIME_URL, (route) =>
+    broken
+      ? route.fulfill({
+          status: 500,
+          contentType: "text/plain",
+          body: "failed to resolve console runtime metadata",
+        })
+      : route.continue(),
+  );
+
+  await page.goto("/ui/login/");
+  await expect(page.getByRole("heading", { name: "Sign-in is unavailable" })).toBeVisible();
+  await expect(page.getByText("the server answered 500")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "No project yet" })).toBeHidden();
+  await expect(page.getByLabel("Email")).toHaveCount(0);
+
+  // Retry is a real second attempt, not a reload hint: the next request goes
+  // to the actual server, so a recovered deployment is one click from the
+  // widget it should have rendered all along.
+  broken = false;
+  await page.getByRole("button", { name: "Try again" }).click();
+  await expect(page.getByLabel("Email")).toBeVisible();
+  expect((await widgetProject(page)).projectId).toBe(zitadel.handle.projectId);
+});
+
+test("an unreachable runtime endpoint renders the same error", async ({ page }) => {
+  await page.route(RUNTIME_URL, (route) => route.abort("failed"));
+
+  await page.goto("/ui/login/");
+  await expect(page.getByRole("heading", { name: "Sign-in is unavailable" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "No project yet" })).toBeHidden();
+});
+
+test("a 2xx body that is not the runtime document is an error, not a setup hint", async ({
+  page,
+}) => {
+  // What a misrouting proxy answers with, and what `vite preview` answers with
+  // for any unknown path. The shell used to tolerate it and fall through to
+  // the hint; `mode` is the field that tells a real document from this one.
+  await page.route(RUNTIME_URL, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<!doctype html><title>Zitadel sign-in</title>",
+    }),
+  );
+
+  await page.goto("/ui/login/");
+  await expect(page.getByRole("heading", { name: "Sign-in is unavailable" })).toBeVisible();
+  await expect(page.getByText("the response was not valid JSON")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "No project yet" })).toBeHidden();
 });

--- a/apps/console-e2e/src-embedded/hosted-login.spec.ts
+++ b/apps/console-e2e/src-embedded/hosted-login.spec.ts
@@ -206,3 +206,28 @@ test("a 2xx body that is not the runtime document is an error, not a setup hint"
   await expect(page.getByText("the response was not valid JSON")).toBeVisible();
   await expect(page.getByRole("heading", { name: "No project yet" })).toBeHidden();
 });
+
+// A wrongly-typed field is the same misdiagnosis one level down: `mode` is
+// valid, so the document passes, and coercing the id to "absent" renders the
+// setup hint for a document the shell could not read. Only an *omitted* id
+// means "not provisioned" — that is how the server says it.
+for (const [field, document] of [
+  ["console_project_id", { mode: "standalone", console_project_id: 42 }],
+  ["publishable_key", { mode: "standalone", console_project_id: "proj_x", publishable_key: 42 }],
+] as const) {
+  test(`a non-string ${field} is a malformed document, not "no project yet"`, async ({ page }) => {
+    await page.route(RUNTIME_URL, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(document),
+      }),
+    );
+
+    await page.goto("/ui/login/");
+    await expect(page.getByRole("heading", { name: "Sign-in is unavailable" })).toBeVisible();
+    await expect(page.getByText("the response was not a runtime document")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "No project yet" })).toBeHidden();
+    await expect(page.getByLabel("Email")).toHaveCount(0);
+  });
+}

--- a/apps/console/docs/adrs/0004-console-deployment-modes.md
+++ b/apps/console/docs/adrs/0004-console-deployment-modes.md
@@ -8,15 +8,18 @@
 > and the flag-gated row-only `platform.bootstrap_project` path exist. The
 > pin, the first-created fallback, and row-only bootstrap are transitional
 > behavior, not the target described here, and the pin retires with the
-> fallback (§2). §3's three discovery states are implemented: an unreachable,
-> erroring, or unreadable runtime document renders a retryable connectivity
-> error, and builds that deliberately run without one (`vite preview`, the
-> api-mock dev loop) opt back into the standalone fallback with
-> `VITE_CONSOLE_RUNTIME_FALLBACK`. The full platform-project provisioner,
-> first-party Console session authorization, effective-permission exposure,
-> and seed-input contract remain future work.
+> fallback (§2). §3's three discovery states are implemented on both surfaces
+> that read the runtime document: an unreachable, erroring, or unreadable
+> document renders a retryable connectivity error in the Console and in the
+> hosted login shell, each with copy for its own audience. Console builds that
+> deliberately run without a document (`vite preview`, the api-mock dev loop)
+> opt back into the standalone fallback with `VITE_CONSOLE_RUNTIME_FALLBACK`;
+> the shell has no such lane and no such flag. The full platform-project
+> provisioner, first-party Console session authorization, effective-permission
+> exposure, and seed-input contract remain future work.
 > **Scope:** `apps/console`, plus the server-owned bootstrap and authorization
-> contracts on which it depends. See
+> contracts on which it depends. §2 and §3's runtime-document rules also bind
+> `apps/login-ui`, which reads the same document. See
 > [`apps/console/AGENTS.md`](../../AGENTS.md).
 > **Context:** Issues [#555](https://github.com/zitadel/nextgen/issues/555)
 > (Console / Customer Portal epic) and
@@ -222,6 +225,32 @@ portal — is satisfied at least as well by rendering an error, since an error
 state cannot render portal surfaces either. Development and preview builds that
 run without a backend must opt in explicitly rather than rely on a silent
 production fallback.
+
+**The hosted login shell holds the same three states, with different copy.**
+`apps/login-ui` reads this document for the same reason the Console does, so
+the rule binds it too — and the deployment topology makes the third state
+sharper there, not narrower. The shell is served from the binary's embedded
+assets and touches no storage, while the document is resolved per request from
+the default project and its encryption key; a healthy binary in front of an
+unhealthy database therefore serves the sign-in page and fails this fetch. The
+shell used to render "no project yet" for exactly that, telling the people
+trying to sign in that the deployment had never been set up.
+
+What differs is who is reading. The setup hint keeps its operator copy on both
+surfaces, because a deployment with no project has no application to send an
+end user to the sign-in page in the first place. The connectivity error does
+not: "check that the Zitadel server is running" is Console copy for a Console
+audience, and the shell says instead that sign-in is unavailable and worth
+retrying, carrying the failure clause in a demoted line for whoever can act on
+it. Distinguishing the states is the requirement; matching the Console's
+wording is not.
+
+The shell also needs no backend-less opt-in, and must not grow one on
+symmetry alone. The Console's `VITE_CONSOLE_RUNTIME_FALLBACK` exists because
+real lanes serve the Console with no document to read; nothing serves the
+shell that way, and previewing it without a backend is what an explicit
+`?project_id=` covers. A flag with no consumer is only a way to reintroduce
+the silent fallback.
 
 The publishable key is browser-safe public-plane material under ADR 036. The
 document never contains a project secret, seed credential, license key,

--- a/apps/login-ui/src/main.ts
+++ b/apps/login-ui/src/main.ts
@@ -140,10 +140,13 @@ function loginWidget(projectId: string, publishableKey?: string): HTMLElement {
  * reachable and answering honestly, and only the client threw the answer
  * away.
  *
- * `mode` is what makes state 2 a positive assertion rather than an absence:
- * the resolver always sets it, including when the deployment has no project,
- * so a 2xx body without it is some other document (a proxy's error envelope,
- * a dev server's `index.html`) and must not read as "no project yet". This is
+ * {@link parseRuntime} is what makes state 2 a positive assertion rather than
+ * an absence. `mode` carries most of it — the resolver always sets it,
+ * including when the deployment has no project, so a 2xx body without it is
+ * some other document (a proxy's error envelope, a dev server's `index.html`)
+ * and must not read as "no project yet". The field types carry the rest: a
+ * document is only "not provisioned" when the ids are *absent*, never when
+ * they are present and unreadable. This is
  * why the shell no longer tolerates a non-JSON 200: `vite dev` proxies this
  * path to the backend (`vite.config.mts`), so the only surface still
  * answering `index.html` here is `vite preview`, which has no backend to sign
@@ -170,31 +173,43 @@ async function fetchRuntime(): Promise<RuntimeResult> {
     return { ok: false, detail: "the response was not valid JSON" };
   }
 
-  if (!isRuntimeDocument(doc)) {
-    return { ok: false, detail: "the response was not a runtime document" };
-  }
+  const runtime = parseRuntime(doc);
+  if (!runtime) return { ok: false, detail: "the response was not a runtime document" };
 
-  return {
-    ok: true,
-    runtime: {
-      projectId: optionalString(doc.console_project_id),
-      publishableKey: optionalString(doc.publishable_key),
-    },
-  };
+  return { ok: true, runtime };
 }
 
-function isRuntimeDocument(doc: unknown): doc is Record<string, unknown> {
-  if (typeof doc !== "object" || doc === null) return false;
-  const { mode } = doc as Record<string, unknown>;
-  return mode === "standalone" || mode === "platform";
+/**
+ * Reads a runtime document, or reports that this is not one.
+ *
+ * The type checks are the whole point, so they do not coerce. Every field is
+ * either **absent** — which is how the document says "not provisioned yet",
+ * since the server omits both ids rather than emitting empty ones (ADR 0004
+ * §2's shape, `omitempty` in `cmd/server/console_runtime.go`) — or a usable
+ * string. Anything else present in its place (a number, `null`, `""`) came
+ * from something that is not the server, and quietly reading it as absence
+ * would land back in state 2 and render "no project yet" for a document the
+ * shell could not actually understand: the same misdiagnosis one field lower
+ * down than the one this change set out to fix.
+ */
+function parseRuntime(doc: unknown): DeploymentRuntime | undefined {
+  if (typeof doc !== "object" || doc === null) return undefined;
+  const record = doc as Record<string, unknown>;
+  const { mode, console_project_id: projectId, publishable_key: publishableKey } = record;
+
+  if (mode !== "standalone" && mode !== "platform") return undefined;
+  if (!absentOrString(projectId) || !absentOrString(publishableKey)) return undefined;
+
+  return { projectId, publishableKey };
+}
+
+/** JSON cannot carry `undefined`, so it means the key was absent, not empty. */
+function absentOrString(value: unknown): value is string | undefined {
+  return value === undefined || (typeof value === "string" && value !== "");
 }
 
 function describeCause(cause: unknown): string {
   return cause instanceof Error ? cause.message : String(cause);
-}
-
-function optionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value !== "" ? value : undefined;
 }
 
 /**

--- a/apps/login-ui/src/main.ts
+++ b/apps/login-ui/src/main.ts
@@ -7,7 +7,7 @@ import "./styles.css";
  *
  * Which project it signs into is a *deployment* fact, so it is discovered at
  * boot rather than baked into the build (the same reasoning as Console
- * ADR 0004 §3, which this shell shares an endpoint with). Precedence:
+ * ADR 0004 §2, which this shell shares an endpoint with). Precedence:
  *
  * 1. `?project_id=` / `?project-id=` — an explicit caller wins.
  * 2. `VITE_PROJECT_ID` — dev-only override, for running against a hand-minted
@@ -20,6 +20,11 @@ import "./styles.css";
  * back to the literal `"demo"`, which is not a project id any deployment
  * has: `/ui/login/` opened without a query param rendered "flow definition:
  * not found" on every server ever shipped.
+ *
+ * Discovery has the three outcomes Console ADR 0004 §3 keeps distinct, and
+ * this shell keeps them distinct too — for a different reason than the
+ * console, so see {@link fetchRuntime} and {@link unavailableNotice} for what
+ * changes when the audience is people signing in rather than operators.
  *
  * The publishable key has to ride the element's `project` **property**: the
  * declarative attribute path cannot carry one (`projectFromAttrs` in
@@ -44,6 +49,13 @@ interface DeploymentRuntime {
   publishableKey?: string;
 }
 
+/**
+ * What discovery resolved to. `ok` means the endpoint answered with a runtime
+ * document — which may or may not name a project; `detail` is the clause
+ * explaining why there is no document at all.
+ */
+type RuntimeResult = { ok: true; runtime: DeploymentRuntime } | { ok: false; detail: string };
+
 const params = new URLSearchParams(window.location.search);
 const devProjectId = import.meta.env.DEV ? import.meta.env.VITE_PROJECT_ID : undefined;
 const devProxyPath = import.meta.env.DEV ? import.meta.env.VITE_PROXY_PATH : undefined;
@@ -62,48 +74,123 @@ async function start(): Promise<void> {
   if (!app) return;
 
   // Only pay for the round trip when nothing more specific answered; an
-  // explicit `?project_id=` must not be delayed by it.
-  const runtime = requestedProjectId ? {} : await fetchRuntime();
-  const projectId = requestedProjectId ?? runtime.projectId;
-
-  if (!projectId) {
-    app.append(setupHint());
+  // explicit `?project_id=` must not be delayed by it — and never reaches the
+  // error branch below, because it never asks the server anything.
+  if (requestedProjectId) {
+    app.replaceChildren(loginWidget(requestedProjectId));
     return;
   }
 
+  await discover(app);
+}
+
+/**
+ * Runs discovery and paints whichever of its three outcomes it resolved to:
+ * the widget, the setup hint, or the connectivity error.
+ *
+ * Retry re-enters here rather than reloading the page — a reload costs the
+ * same round trip and would drop anything the caller's URL carried. There is
+ * no resolved document to preserve across attempts, unlike the console's
+ * `retryRuntime`, which must not swap the sign-in project under a mounted
+ * router: nothing is mounted here until discovery succeeds, and the success
+ * branch replaces this screen for good.
+ */
+async function discover(app: HTMLElement): Promise<void> {
+  const result = await fetchRuntime();
+
+  if (!result.ok) {
+    app.replaceChildren(unavailableNotice(result.detail, () => discover(app)));
+    return;
+  }
+
+  const { projectId, publishableKey } = result.runtime;
+  app.replaceChildren(projectId ? loginWidget(projectId, publishableKey) : setupHint());
+}
+
+function loginWidget(projectId: string, publishableKey?: string): HTMLElement {
   const login = document.createElement("zitadel-login");
   // The hosted shell IS the page — opt into the full-page chrome the
   // widget-first default no longer paints on its own.
   login.setAttribute("variant", "page");
   login.setAttribute("purpose", "login");
-  login.project = Object.freeze({
-    projectId,
-    proxyPath,
-    publishableKey: runtime.publishableKey,
-  });
-  app.append(login);
+  login.project = Object.freeze({ projectId, proxyPath, publishableKey });
+  return login;
 }
 
 /**
- * Reads the deployment's runtime document. Never throws: an unreachable or
- * non-JSON response (the dev server answers unknown paths with `index.html`)
- * resolves to "nothing discovered", which surfaces as the setup hint rather
- * than as a widget pointed at a project that does not exist.
+ * Reads the deployment's runtime document. Never throws; it reports which of
+ * Console ADR 0004 §3's three discovery states the endpoint is in:
+ *
+ * 1. **reachable and provisioned** — a runtime document naming a project.
+ * 2. **reachable and not provisioned** — a runtime document without
+ *    `console_project_id`; the setup hint.
+ * 3. **unreachable, non-2xx, or unreadable** — `ok: false`; the connectivity
+ *    error.
+ *
+ * The shell used to collapse 3 into 2, and the mux makes that worse than it
+ * looks rather than better. `/ui/login/` is served from the binary's embedded
+ * assets and touches no storage, while this document is resolved per request
+ * from the default project and its encryption key (`standaloneRuntimeResolver`,
+ * `cmd/server/console_runtime.go`), which answers `500` when that lookup
+ * fails. So a healthy binary in front of an unhealthy database served this
+ * page and then told the people trying to sign in that the deployment had
+ * never been set up — an outage reported as a configuration state, to the
+ * audience least able to tell the difference. That is the console's argument
+ * one layer further down: there the server was unreachable, here it is
+ * reachable and answering honestly, and only the client threw the answer
+ * away.
+ *
+ * `mode` is what makes state 2 a positive assertion rather than an absence:
+ * the resolver always sets it, including when the deployment has no project,
+ * so a 2xx body without it is some other document (a proxy's error envelope,
+ * a dev server's `index.html`) and must not read as "no project yet". This is
+ * why the shell no longer tolerates a non-JSON 200: `vite dev` proxies this
+ * path to the backend (`vite.config.mts`), so the only surface still
+ * answering `index.html` here is `vite preview`, which has no backend to sign
+ * into either way — previewing widget chrome without one is what
+ * `?project_id=` is for. Hence no `*_RUNTIME_FALLBACK` opt-in on this side:
+ * no automated lane serves the shell without the document
+ * (`console-e2e:e2e-embedded` runs the real binary with both surfaces on),
+ * and a flag with no consumer is one more way to ship the bug back.
  */
-async function fetchRuntime(): Promise<DeploymentRuntime> {
+async function fetchRuntime(): Promise<RuntimeResult> {
+  let response: Response;
   try {
-    const response = await fetch(RUNTIME_URL, { credentials: "same-origin" });
-    if (!response.ok) return {};
-    const doc: unknown = await response.json();
-    if (typeof doc !== "object" || doc === null) return {};
-    const record = doc as Record<string, unknown>;
-    return {
-      projectId: optionalString(record.console_project_id),
-      publishableKey: optionalString(record.publishable_key),
-    };
-  } catch {
-    return {};
+    response = await fetch(RUNTIME_URL, { credentials: "same-origin" });
+  } catch (cause) {
+    return { ok: false, detail: `the request failed (${describeCause(cause)})` };
   }
+
+  if (!response.ok) return { ok: false, detail: `the server answered ${response.status}` };
+
+  let doc: unknown;
+  try {
+    doc = await response.json();
+  } catch {
+    return { ok: false, detail: "the response was not valid JSON" };
+  }
+
+  if (!isRuntimeDocument(doc)) {
+    return { ok: false, detail: "the response was not a runtime document" };
+  }
+
+  return {
+    ok: true,
+    runtime: {
+      projectId: optionalString(doc.console_project_id),
+      publishableKey: optionalString(doc.publishable_key),
+    },
+  };
+}
+
+function isRuntimeDocument(doc: unknown): doc is Record<string, unknown> {
+  if (typeof doc !== "object" || doc === null) return false;
+  const { mode } = doc as Record<string, unknown>;
+  return mode === "standalone" || mode === "platform";
+}
+
+function describeCause(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
 }
 
 function optionalString(value: unknown): string | undefined {
@@ -112,15 +199,16 @@ function optionalString(value: unknown): string | undefined {
 
 /**
  * Rendered when the deployment has no project to sign in to — the server
- * never creates one (Console ADR 0004 §2), the customer's `zitadel setup`
+ * never creates one (Console ADR 0004 §3), the customer's `zitadel setup`
  * does, and the first project created becomes the default this shell picks
  * up on the next load.
+ *
+ * Operator copy on an end-user page, deliberately: a deployment with no
+ * project has no application to send anyone here, so whoever reads this is
+ * the person setting it up.
  */
 function setupHint(): HTMLElement {
-  const hint = document.createElement("div");
-  hint.className = "setup-hint";
-  const heading = document.createElement("h1");
-  heading.textContent = "No project yet";
+  const hint = notice("No project yet");
   const body = document.createElement("p");
   body.append(
     "This deployment has no project to sign in to. Create one from your application with ",
@@ -129,8 +217,65 @@ function setupHint(): HTMLElement {
     code("?project_id=…"),
     " to sign in to a specific project.",
   );
-  hint.append(heading, body);
+  hint.append(body);
   return hint;
+}
+
+/**
+ * Rendered when the runtime document could not be read at all — the state
+ * that used to render the setup hint (see {@link fetchRuntime}).
+ *
+ * The console's equivalent screen addresses an operator and says so ("Server
+ * unavailable … check that the Zitadel server is running"). This one is the
+ * page a customer's users reach, and telling them to check a server is as
+ * useless as telling them to run a CLI. So the copy says the true thing they
+ * can act on — it is the service, not them, and it is worth another try —
+ * while the technical clause rides along in a muted line, because the person
+ * who *can* act on it usually meets this screen in a support ticket or over
+ * someone's shoulder.
+ *
+ * Retry is a click, not a timer: what this screen reports is usually a
+ * database or a proxy on its way back, and a fleet of open sign-in tabs
+ * re-polling it is the last thing that deployment needs.
+ */
+function unavailableNotice(detail: string, onRetry: () => Promise<void>): HTMLElement {
+  const unavailable = notice("Sign-in is unavailable");
+
+  const body = document.createElement("p");
+  body.textContent =
+    "This deployment could not be reached, so there is nothing to sign in to yet. " +
+    "It is usually temporary — try again in a moment.";
+
+  const technical = document.createElement("p");
+  technical.className = "shell-notice__detail";
+  technical.append("Could not read ", code(RUNTIME_URL), ` — ${detail}.`);
+
+  const retry = document.createElement("button");
+  retry.type = "button";
+  retry.textContent = "Try again";
+  retry.addEventListener("click", () => {
+    retry.disabled = true;
+    retry.textContent = "Retrying…";
+    // A successful retry has already replaced the screen this button is on,
+    // so the reset only lands while the deployment is still unreachable.
+    void onRetry().finally(() => {
+      retry.disabled = false;
+      retry.textContent = "Try again";
+    });
+  });
+
+  unavailable.append(body, technical, retry);
+  return unavailable;
+}
+
+/** The shared surface for the two screens the shell paints instead of the widget. */
+function notice(title: string): HTMLElement {
+  const element = document.createElement("div");
+  element.className = "shell-notice";
+  const heading = document.createElement("h1");
+  heading.textContent = title;
+  element.append(heading);
+  return element;
 }
 
 function code(text: string): HTMLElement {

--- a/apps/login-ui/src/styles.css
+++ b/apps/login-ui/src/styles.css
@@ -11,12 +11,13 @@ body {
 }
 
 /*
- * Shown instead of the widget when the deployment has no project yet
- * (`src/main.ts`). The widget paints its own page chrome, so this branch has
- * to bring its own surface — dark-only, like the rest of the login surface
- * (ADR 014 §5).
+ * The two screens the shell paints itself instead of the widget (`src/main.ts`):
+ * the setup hint, when the deployment has no project yet, and the connectivity
+ * error, when its runtime document could not be read at all. The widget paints
+ * its own page chrome, so these have to bring their own surface — dark-only,
+ * like the rest of the login surface (ADR 014 §5).
  */
-.setup-hint {
+.shell-notice {
   box-sizing: border-box;
   display: flex;
   min-height: 100vh;
@@ -31,14 +32,14 @@ body {
   text-align: center;
 }
 
-.setup-hint h1 {
+.shell-notice h1 {
   margin: 0;
   font-family: var(--zl-font-family-heading);
   font-size: 1.25rem;
   font-weight: 500;
 }
 
-.setup-hint p {
+.shell-notice p {
   margin: 0;
   max-width: 32rem;
   color: var(--zl-color-text-secondary-gray);
@@ -46,11 +47,49 @@ body {
   line-height: 1.5;
 }
 
-.setup-hint code {
+.shell-notice code {
   border-radius: 4px;
   background: var(--zl-color-surface-hover-subtle);
   padding: 0.1rem 0.35rem;
   color: var(--zl-color-text-primary-white);
   font-family: var(--zl-font-family-mono);
   font-size: 0.85em;
+}
+
+/*
+ * The failure clause on the connectivity error. Present but demoted: it is the
+ * only actionable line for whoever can fix the deployment, and noise to the
+ * person who just wanted to sign in.
+ */
+.shell-notice__detail {
+  color: var(--zl-color-text-disabled);
+  font-size: 0.8125rem;
+}
+
+.shell-notice__detail code {
+  background: none;
+  padding: 0;
+  color: inherit;
+}
+
+.shell-notice button {
+  margin-top: 0.5rem;
+  border: none;
+  border-radius: 8px;
+  background: var(--zl-color-surface-default-white);
+  padding: 0.5rem 1.25rem;
+  color: var(--zl-color-text-button-default);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.shell-notice button:hover:not(:disabled) {
+  background: var(--zl-color-surface-hover-strong);
+}
+
+.shell-notice button:disabled {
+  cursor: default;
+  opacity: 0.6;
 }


### PR DESCRIPTION
## Summary

Stacked on #904 (itself stacked on #876). Base retargets to `main` as the stack merges.

The hosted sign-in shell's boot-time discovery (`GET /console/runtime.json`) collapsed an unreachable endpoint, a non-`2xx` answer, and an unparseable body into the same empty document as a deployment that genuinely has no project — so all three rendered the "No project yet — run `npx @zitadel/cli setup`" hint, on the page a customer's end users sign in on.

Console ADR 0004 §3 already rules that out ("an unreachable endpoint is an error, not a mode") and #904 implements it for the Console. This is the login-shell half. It is a deliberate decision rather than a copy, because the obvious argument for letting the shell keep degrading quietly — its audience is end users, so a raw error may be worse than a wrong hint — does not survive the code:

- **The failure is the likely one, not a narrow window.** `/ui/login/` is served from the binary's embedded assets and touches no storage, while `/console/runtime.json` is resolved *per request* from the default project and its encryption key (`standaloneRuntimeResolver`, `cmd/server/console_runtime.go`) and answers `500` when that lookup fails. Server up + database down is the ordinary case, and it reported an availability incident as a configuration state to the audience least able to tell the difference.
- **There was no quiet option to keep.** Without a project id the shell cannot render the widget either way, so the choice was only ever wrong error screen vs. right one — the status quo already showed a terminal screen carrying a developer CLI command.

### What changed

- `fetchRuntime()` returns a result rather than a document, and `parseRuntime()` decides which state the answer is in. **`mode` carries most of the distinction**: the resolver always sets it, including when the deployment has no project, so a `2xx` body without it (a proxy's error envelope, a dev server's `index.html`) no longer reads as "no project yet". **The field types carry the rest**: a document is "not provisioned" only when the ids are *absent* — which is how the server says it (`omitempty`) — never when they are present and unreadable. Coercing `{"console_project_id": 42}` to "absent" would land straight back in the setup hint.
- **Copy diverges from the Console's on purpose.** The setup hint keeps its operator wording on both surfaces, because a deployment with no project has no application to send an end user to the sign-in page. The error does not: it says sign-in is unavailable and worth retrying, and demotes the failure clause to a muted line for whoever actually meets this screen — usually in a support ticket. Retry re-runs discovery in place, on a click rather than a timer, since what it reports is typically a database on its way back.
- **No `*_RUNTIME_FALLBACK` opt-in on this side.** The Console's exists because real lanes serve it with no document to read. Nothing serves the shell that way: `vite dev` proxies this path to the backend, `vite preview` has no backend to sign into either way, `?project_id=` covers previewing widget chrome without one, and `console-e2e:e2e-embedded` runs the real binary with both surfaces on. ADR §3 now says this explicitly so it does not get added later on symmetry alone.
- ADR 0004 §3 gains a hosted-shell subsection (topology, the copy split, why no opt-in); the header note and Scope line now name both surfaces that read the document.

## Validation

```
moon run login-ui:typecheck login-ui:lint console-e2e:typecheck console-e2e:lint   # clean
moon run console:typecheck console:lint console:test                               # 114 passed
moon run console-e2e:e2e-embedded                                                  # 13 passed (6 new)
```

Re-run after merging #904's branch in, so the numbers above cover both halves of the stack together. The two pre-existing `console:lint` warnings are in `apps/console/scripts/dev-real.mts` and are untouched by this change.

The new cases in `apps/console-e2e/src-embedded/hosted-login.spec.ts` stub `/console/runtime.json` per test, for the deployment states this lane's own provisioned instance cannot produce: a reachable-but-projectless deployment (setup hint survives), a `500`, an aborted request, a `2xx` non-document, and a non-string id per field. The `500` case's retry falls through to the real server, so recovery is asserted against a genuine document rather than a fixture.

## Release notes / changeset

Changeset: `.changeset/login-shell-runtime-unreachable-error.md` — `@zitadel/server` patch (the shell ships embedded in the binary).

## Notes

- Review alongside #904 — the two are one decision applied to the two surfaces that read the same document, and §3 only reads coherently with both.
- A review finding against the whole stack caught both parsers validating `mode` and then coercing every other field, which left a wrongly-typed id reading as "no project yet". Fixed on both sides (here in `64340765`, in #904 as `c6905c93`), with the same rule and the same helper, so the two surfaces read the document identically. `null` and `""` count as malformed rather than absent: the server emits neither, so a lenient reading is exactly the bug.
- Drive-by: the module doc's first paragraph cited ADR 0004 §3 for the "discovered at boot, not baked into the build" reasoning; that is §2's decision. Corrected while restructuring the comment.
- Not done, and out of scope here: letting `@zitadel/api-mock` serve `/console/runtime.json`, which would remove the Console's need for the opt-in flag in the mock dev loop.