### PR TITLE
fix: start the server container as its declared non-root user

### DIFF
--- a/.changeset/olive-cups-shave.md
+++ b/.changeset/olive-cups-shave.md
@@ -1,0 +1,6 @@
+---
+"@zitadel/cli": patch
+"@zitadel/server": patch
+---
+
+The Zitadel server container now starts as the non-root user it ships with. It previously created a data directory next to its own entrypoint before reading configuration, which is not writable by that user, so the container exited before serving — and setting a data directory via environment or config file did not avoid it. This also fixes `zitadel start --runtime docker`, which failed the same way.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN apt-get update \
   && chown -R 65532:65532 /var/lib/zitadel
 
 COPY $TARGETPLATFORM/nextgen /usr/local/bin/nextgen
+# Without this the data dir defaults next to the entrypoint, in root-owned
+# /usr/local/bin, which the non-root USER below cannot create. Point it at the
+# volume prepared above so `docker run <image>` works with no extra flags.
+ENV NEXTGEN_SERVER_DATA_DIR=/var/lib/zitadel/nextgen-data
 USER 65532:65532
 VOLUME ["/var/lib/zitadel/nextgen-data"]
 EXPOSE 8080

--- a/apps/cli/tests/unit/lib/local-server/docker.test.ts
+++ b/apps/cli/tests/unit/lib/local-server/docker.test.ts
@@ -1,9 +1,25 @@
+import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 import { CONTAINER_DATA_DIR } from "../../../../src/lib/local-server/runtime";
 import { dockerRunArgs } from "../../../../src/lib/local-server/docker";
 
 describe("local server Docker helpers", () => {
+  // The server derives its default data dir next to the entrypoint, which lives
+  // in root-owned /usr/local/bin. Without this ENV the image cannot start as the
+  // non-root USER it declares, and `zitadel start --runtime docker` dies before
+  // serving. CI has no Docker, so this parity check is the gate.
+  it("ships an image whose data dir default matches the mount the CLI provides", async () => {
+    const dockerfile = await readFile(
+      new URL("../../../../../../Dockerfile", import.meta.url),
+      "utf8",
+    );
+
+    expect(dockerfile).toContain(`ENV NEXTGEN_SERVER_DATA_DIR=${CONTAINER_DATA_DIR}`);
+    // The declared USER is what makes the default location unwritable.
+    expect(dockerfile).toContain("USER 65532:65532");
+  });
+
   it("builds the single-container run command without an explicit encryption key", () => {
     const args = dockerRunArgs({
       containerName: "zitadel-server-test",

--- a/cmd/server/runtime.go
+++ b/cmd/server/runtime.go
@@ -20,17 +20,26 @@ const (
 	defaultMasterKeyDirName = "master-keys"
 )
 
+// defaultServerDataDir computes the fallback data dir and must stay free of
+// side effects: it runs while seeding config defaults, before configuration has
+// selected a data dir. Creating a directory here would make the process depend
+// on a location it may never use — the container entrypoint sits in root-owned
+// /usr/local/bin, so an eager mkdir there aborts startup for the image's own
+// non-root user even when data_dir points somewhere writable.
+// Use ensureServerDataDir once the configured dir is known.
 func defaultServerDataDir() (string, error) {
 	exe, err := os.Executable()
 	if err != nil {
 		return "", fmt.Errorf("resolve executable path: %w", err)
 	}
-	path := filepath.Join(filepath.Dir(exe), defaultDataDirName)
-	err = os.MkdirAll(path, 0o700)
-	if err != nil {
-		return "", fmt.Errorf("failed to create server data dir: %w", err)
+	return filepath.Join(filepath.Dir(exe), defaultDataDirName), nil
+}
+
+func ensureServerDataDir(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return fmt.Errorf("failed to create server data dir: %w", err)
 	}
-	return path, nil
+	return nil
 }
 
 func serverMasterKeyDir(cfg ServerConfig) (string, error) {

--- a/cmd/server/runtime_test.go
+++ b/cmd/server/runtime_test.go
@@ -52,6 +52,9 @@ func TestLoadConfigCreatesOnlyTheConfiguredDataDir(t *testing.T) {
 }
 
 func TestEnsureServerDataDirReportsAnUnwritableParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not enforce the POSIX mode bits this test makes the parent unwritable with")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("root ignores directory permissions")
 	}

--- a/cmd/server/runtime_test.go
+++ b/cmd/server/runtime_test.go
@@ -11,6 +11,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// clearDefaultDataDir removes the data dir beside the test binary so an earlier
+// loadConfig test cannot make these assertions order-dependent. Safe to call:
+// the parallel tests in this package never touch the default data dir.
+func clearDefaultDataDir(t *testing.T) string {
+	t.Helper()
+	path, err := defaultServerDataDir()
+	require.NoError(t, err)
+	require.NotEmpty(t, path)
+	require.NoError(t, os.RemoveAll(path))
+	return path
+}
+
+// The container entrypoint lives in root-owned /usr/local/bin, so deriving the
+// default must not touch the filesystem: an eager mkdir there aborted startup
+// for the image's own non-root user even when data_dir pointed elsewhere.
+func TestDefaultServerDataDirHasNoSideEffects(t *testing.T) {
+	path := clearDefaultDataDir(t)
+
+	_, err := defaultServerDataDir()
+	require.NoError(t, err)
+
+	assert.NoDirExists(t, path, "computing the default data dir must not create it")
+}
+
+func TestLoadConfigCreatesOnlyTheConfiguredDataDir(t *testing.T) {
+	defaultDir := clearDefaultDataDir(t)
+	dataDir := filepath.Join(t.TempDir(), "configured")
+	t.Setenv("NEXTGEN_SERVER_DATA_DIR", dataDir)
+
+	configPath := filepath.Join(t.TempDir(), "nextgen.yaml")
+	require.NoError(t, os.WriteFile(configPath, nil, 0o600))
+
+	cfg, err := loadConfig(configPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, dataDir, cfg.Server.DataDir)
+	assert.DirExists(t, dataDir)
+	assert.NoDirExists(t, defaultDir, "the unused default data dir must not be created")
+}
+
+func TestEnsureServerDataDirReportsAnUnwritableParent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	parent := t.TempDir()
+	require.NoError(t, os.Chmod(parent, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+
+	err := ensureServerDataDir(filepath.Join(parent, "nextgen-data"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create server data dir")
+}
+
 func TestLoadConfigCreatesAndReusesMasterKeyFile(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("NEXTGEN_SERVER_DATA_DIR", dataDir)

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -435,6 +435,14 @@ func loadConfig(configPath string) (Config, error) {
 	if err := v.Unmarshal(&cfg); err != nil {
 		return Config{}, fmt.Errorf("decode config: %w", err)
 	}
+	// Create the data dir configuration actually selected, not the default
+	// computed above — an explicit empty data_dir still means the default.
+	if cfg.Server.DataDir == "" {
+		cfg.Server.DataDir = dataDir
+	}
+	if err := ensureServerDataDir(cfg.Server.DataDir); err != nil {
+		return Config{}, err
+	}
 	if err := ensureServerMasterKey(&cfg.Server); err != nil {
 		return Config{}, err
 	}

--- a/moon.yml
+++ b/moon.yml
@@ -37,6 +37,17 @@ tasks:
       cache: false
       runInCI: false
 
+  # Starts a built image the way an operator would — no flags, no volumes, no
+  # --user override — and asserts it serves. Covers the container contract that
+  # unit tests cannot: the Dockerfile's data dir default against the non-root
+  # USER it declares. Needs a local Docker daemon and an image built by
+  # `node scripts/build-local-runtime-image.mjs`, so it stays out of CI.
+  smoke-container:
+    command: "node scripts/smoke-container.mjs"
+    options:
+      cache: false
+      runInCI: false
+
   check:
     command: "node scripts/check.mjs"
     options:

--- a/scripts/smoke-container.mjs
+++ b/scripts/smoke-container.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Runs a built server image the way an operator would — no flags, no volumes,
+// no --user override — and asserts it reaches the point where it serves.
+//
+// This is the only check that covers the whole container contract at once: the
+// Dockerfile's data dir default, the declared non-root USER, and the server's
+// own directory handling. CI has no Docker, so it is opt-in; the CI-enforced
+// halves are TestDefaultServerDataDirHasNoSideEffects (cmd/server) and the
+// Dockerfile parity assertion in the CLI's docker unit tests.
+import { setTimeout as delay } from "node:timers/promises";
+
+import { isDirectRun, run, runCapture } from "./dev-process.mjs";
+import { LOCAL_RUNTIME_IMAGE } from "./build-local-runtime-image.mjs";
+
+const READY_LOG = "structured logger configured";
+const CONTAINER_NAME = "zitadel-nextgen-smoke";
+
+export async function smokeContainer(options = {}) {
+  const image = options.image ?? LOCAL_RUNTIME_IMAGE;
+  const name = options.containerName ?? CONTAINER_NAME;
+  const port = options.port ?? 28080;
+  const timeoutMs = options.timeoutMs ?? 90_000;
+  const runFn = options.run ?? run;
+  const runCaptureFn = options.runCapture ?? runCapture;
+
+  await runFn("docker", ["rm", "--force", name], { stdio: "ignore" }).catch(() => {});
+  // Deliberately minimal: any flag added here weakens what the check proves.
+  await runFn("docker", [
+    "run",
+    "--detach",
+    "--name",
+    name,
+    "--publish",
+    `127.0.0.1:${port}:8080`,
+    image,
+  ]);
+
+  try {
+    const deadline = Date.now() + timeoutMs;
+    let logs = "";
+    while (Date.now() < deadline) {
+      // The server logs to stderr, so both streams have to be considered.
+      const captured = await runCaptureFn("docker", ["logs", name]).catch(() => null);
+      logs = captured ? `${captured.stdout}${captured.stderr}` : "";
+      if (logs.includes(READY_LOG)) break;
+      const state = await runCaptureFn("docker", [
+        "inspect",
+        "-f",
+        "{{.State.Running}}",
+        name,
+      ]).catch(() => ({ stdout: "false" }));
+      if (state.stdout.trim() !== "true") {
+        throw new Error(`container exited before serving:\n${logs}`);
+      }
+      await delay(1000);
+    }
+    if (!logs.includes(READY_LOG)) {
+      throw new Error(`container never logged ${JSON.stringify(READY_LOG)}:\n${logs}`);
+    }
+
+    // Logging is not serving: probe the port the image exposes.
+    let status = 0;
+    while (Date.now() < deadline && status !== 200) {
+      status = await fetch(`http://127.0.0.1:${port}/healthz`)
+        .then((response) => response.status)
+        .catch(() => 0);
+      if (status !== 200) await delay(1000);
+    }
+    if (status !== 200) {
+      throw new Error(`container logged readiness but /healthz returned ${status}`);
+    }
+
+    return { image, port, status };
+  } finally {
+    await runFn("docker", ["rm", "--force", name], { stdio: "ignore" }).catch(() => {});
+  }
+}
+
+if (isDirectRun(import.meta.url)) {
+  try {
+    const result = await smokeContainer({ image: process.argv[2] });
+    process.stderr.write(`[smoke-container] ${result.image} started as its default user\n`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

The published server image cannot start as the non-root user it ships with:

```
docker run --rm ghcr.io/zitadel/nextgen:0.1.0-alpha.18
# Error: failed to create server data dir: mkdir /usr/local/bin/nextgen-data: permission denied
```

`loadConfig` called `defaultServerDataDir()` purely to seed a viper default, but that helper was not a path computation — it did an `os.MkdirAll` next to the executable. The Dockerfile's entrypoint is `/usr/local/bin/nextgen` under `USER 65532`, and `/usr/local/bin` is root-owned, so the mkdir was denied and the process exited before serving. Because it ran while computing the *default*, neither `NEXTGEN_SERVER_DATA_DIR` nor a `-c` config file avoided it — both were verified to fail identically, and the image's pre-created, correctly-chowned `/var/lib/zitadel/nextgen-data` was never reached.

- `defaultServerDataDir()` is now a pure path computation; a new `ensureServerDataDir()` creates only the directory configuration actually selected, after unmarshalling.
- The Dockerfile defaults `NEXTGEN_SERVER_DATA_DIR` to the volume it already prepares. The Go change alone is not enough — a bare `docker run` with no env would still resolve the default into root-owned `/usr/local/bin`.

**This also fixes `zitadel start --runtime docker`**, which died the same way: `dockerRunArgs` passes `--user` with the host identity, which is likewise not root.

Not caused by #889 — reproduced on the published `0.1.0-alpha.18` image and on a local build from `main` (`18ed11e0`). The eager mkdir arrived in `79028aa0` (KEK, #626).

## Validation

- `go test ./cmd/server/` — green, run 3x for order independence (the new assertions clear the default dir first, since other tests in the package call `loadConfig` without the env var and leave it behind)
- `moon run cli:lint cli:typecheck cli:test` — green
- `gofmt -l cmd/server/` clean, `go vet ./cmd/server/` clean
- Rebuilt the image from this branch and ran it as its declared user with no flags, no volumes, no `--user` override: reaches `structured logger configured`, `/healthz` → 200
- Ran the CLI's `--runtime docker` shape (host volume + host uid + env): `/healthz` → 200, with `master-keys/` and `zitadel.db` landing in the mounted host dir
- Each guard was proven to fail without its fix: reintroducing the `MkdirAll` fails both `cmd/server` tests with their exact messages; stashing the Dockerfile change fails the parity test; `scripts/smoke-container.mjs` exits 1 against published `0.1.0-alpha.18` with the precise error above

## Release notes / changeset

Changeset: `.changeset/olive-cups-shave.md` — the server container starts as its declared non-root user, and `zitadel start --runtime docker` works (`@zitadel/server`, `@zitadel/cli`).

## Notes

**No CI lane exercises the docker runtime at all** — that is the coverage hole that let this ship. Three guards were added, but only two can gate CI:

| guard | gates CI |
| --- | --- |
| `cmd/server`: the default must not touch the filesystem; `loadConfig` creates the configured dir, not the default | yes |
| `apps/cli`: the Dockerfile's data dir default must match `CONTAINER_DATA_DIR`, the mount the CLI provides | yes |
| `scripts/smoke-container.mjs` (`moon run workspace:smoke-container`): starts a built image with no flags and asserts it serves | no — needs a local Docker daemon |

Making this genuinely un-regressable needs a Docker-enabled CI lane, which is worth deciding separately from this fix.

Reviewer note: the smoke script reads both `docker logs` streams — the server logs to stderr, and reading only stdout makes the check silently pass nothing.