### PR TITLE
docs(api): describe dotted field paths and add a worked example

### DIFF
--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -11472,8 +11472,9 @@ func (s *FactorMethod) UnmarshalText(data []byte) error {
 // Does not contain display text — only a `text_key` resolved client-side.
 // Ref: #
 type Field struct {
-	// Field name, matching a property in the flow's user schema. Carries
-	// the submitted value back to the engine.
+	// Field name, matching a property in the flow's user schema — a
+	// dotted path (`address.street`) for a nested property. Carries the
+	// submitted value back to the engine.
 	Name string `json:"name"`
 	// The input kind the client should render. Encodes the formats and
 	// JSON types that map to a familiar HTML input: `email`, `url`,
@@ -11484,7 +11485,8 @@ type Field struct {
 	// Localization key for the field label.
 	TextKey string `json:"text_key"`
 	// The field MUST be present and non-empty on submit. Mirrors the
-	// schema's top-level `required` array.
+	// schema's `required` array at every level of the field's path: a
+	// nested leaf is required only when each of its ancestors is too.
 	Required OptBool `json:"required"`
 	// Pre-filled value (e.g., an identifier carried over from a pivot).
 	Value jx.Raw `json:"value"`
@@ -12573,10 +12575,15 @@ type FlowDefinitionStep struct {
 	// and returned in the API response as `step.name`.
 	Name string `json:"name"`
 	// Schema property names to collect from the user. Each entry references
-	// a property in the flow's user schema. The engine resolves field type,
+	// a property in the flow's user schema, naming a nested one by its
+	// dotted path (`address.street`). The engine resolves field type,
 	// validation rules, and implicit outcomes from schema annotations
 	// (e.g. a property with `x-unique` set implies a `user_not_found`
-	// transition outcome).
+	// transition outcome). An object- or array-typed property has no
+	// field-shaped input: collect its leaves instead. Collecting a leaf
+	// materializes every object above it, so an optional object's own
+	// `required` entries have to be collected too once any step reaches
+	// into it.
 	Fields []string `json:"fields"`
 	// Ordered list of actions the user can take. The action name is what the
 	// frontend sends back in the submit request. If omitted, the engine

--- a/api/openapi/components/flows/field.yaml
+++ b/api/openapi/components/flows/field.yaml
@@ -7,8 +7,9 @@ properties:
   name:
     type: string
     description: |
-      Field name, matching a property in the flow's user schema. Carries
-      the submitted value back to the engine.
+      Field name, matching a property in the flow's user schema — a
+      dotted path (`address.street`) for a nested property. Carries the
+      submitted value back to the engine.
     example: email
   type:
     type: string
@@ -28,7 +29,8 @@ properties:
     default: false
     description: |
       The field MUST be present and non-empty on submit. Mirrors the
-      schema's top-level `required` array.
+      schema's `required` array at every level of the field's path: a
+      nested leaf is required only when each of its ancestors is too.
   value:
     description: Pre-filled value (e.g., an identifier carried over from a pivot).
   validation:

--- a/api/openapi/components/flows/flow-definition-step.yaml
+++ b/api/openapi/components/flows/flow-definition-step.yaml
@@ -22,10 +22,15 @@ properties:
     type: array
     description: |
       Schema property names to collect from the user. Each entry references
-      a property in the flow's user schema. The engine resolves field type,
+      a property in the flow's user schema, naming a nested one by its
+      dotted path (`address.street`). The engine resolves field type,
       validation rules, and implicit outcomes from schema annotations
       (e.g. a property with `x-unique` set implies a `user_not_found`
-      transition outcome).
+      transition outcome). An object- or array-typed property has no
+      field-shaped input: collect its leaves instead. Collecting a leaf
+      materializes every object above it, so an optional object's own
+      `required` entries have to be collected too once any step reaches
+      into it.
     items:
       type: string
     default: []

--- a/api/openapi/endpoints/flow_definitions/examples/07-nested-profile-fields/README.md
+++ b/api/openapi/endpoints/flow_definitions/examples/07-nested-profile-fields/README.md
@@ -1,0 +1,77 @@
+# 07 — Nested Profile Fields
+
+Two-step signup that collects an object-typed schema property one leaf at a
+time. Credentials land on the first step, the `address` leaves on the second,
+and `on_success: create_user` writes the whole document at the end.
+
+## Capabilities exercised
+
+- **Nested properties by dotted path.** `address.street` addresses the `street`
+  property of the object-typed `address` property. The engine walks one
+  `properties` level per segment.
+- Ancestor-chain manifest: `create_user`'s manifest is `[identifier, password]`
+  and both are collected on `signup`, an upstream step, so the validator accepts
+  the writer on `address`.
+- Terminal `complete: show`.
+
+## Graph
+
+```mermaid
+flowchart TD
+    start([Start: purpose=register]) --> signup
+    signup["signup<br/>fields: email, password"]
+    address["address<br/>fields: address.street, address.city, address.zipCode<br/>on_success: create_user"]
+    done([done<br/>complete: show])
+
+    signup -- submit --> address
+    address -- submit --> done
+```
+
+## Walk-through
+
+1. `POST /flow` with `purpose: register` → engine returns the `signup` step.
+2. The user submits `email` and `password`.
+3. The `address` step renders **three ordinary text inputs**, named
+   `address.street`, `address.city`, and `address.zipCode`. A nested leaf is a
+   scalar, so it needs no new field type — the dotted name is the only
+   difference.
+4. The client submits them flat, keyed by those same names. The engine merges
+   them into a nested document:
+
+   ```json
+   { "email": "…", "address": { "street": "…", "city": "…", "zipCode": "…" } }
+   ```
+
+5. `on_success: create_user` validates that document against the user schema —
+   including `address`'s own `properties` — then stores one attribute per leaf,
+   keyed `address.street`, `address.city`, `address.zipCode`. Reading the user
+   back returns `address` as a nested object.
+
+## Notes
+
+- **The field path and the attribute key are the same string.** That is the
+  point of the dotted spelling: a step's `fields` entry, the wire field `name`,
+  the submitted key, and the stored attribute key never diverge.
+- **A field's `required` flag is conjunctive over the chain.** A leaf is marked
+  required only when every object above it is required too. `address` is
+  optional at the root of the example schema, so all three inputs render
+  optional.
+- **Collecting into an optional object still brings its own `required` into
+  force.** The object appears in the submitted document only because a step
+  collected something beneath it, and from there the document has to satisfy
+  the rest of its `required` list. `address` lists `street` and `city`, so this
+  definition has to collect both: dropping `address.street` is rejected when the
+  definition is saved, with `required fields [address.street] in user schema are
+  missing in the flow definition steps`. A step collecting nothing under
+  `address` is fine — the object never materializes, so it demands nothing.
+- **Requiring `address` at the root demands its leaves unconditionally.**
+  `address.street` and `address.city` then have to be collected whether or not
+  any step touches the object, because the document cannot omit `address` at
+  all.
+- **Name a leaf, never the object.** `"fields": ["address"]` is rejected when
+  the definition is saved: an object has no field-shaped input. The same holds
+  for an array-typed property.
+- A nested leaf may carry `x-unique`, which makes it an identifier field and
+  contributes the `user_not_found` / `user_already_exists` outcomes exactly as a
+  top-level one would. This example keeps its leaves plain so the graph stays
+  about nesting.

--- a/api/openapi/endpoints/flow_definitions/examples/07-nested-profile-fields/flow-definition.json
+++ b/api/openapi/endpoints/flow_definitions/examples/07-nested-profile-fields/flow-definition.json
@@ -1,0 +1,58 @@
+{
+  "project_id": "${PROJECT_ID}",
+  "schema_uri": "https://nextgen.com/flow-definition.json",
+  "flow_definition": {
+    "name": "nested-profile-register",
+    "status": "active",
+    "user_schema": "${USER_SCHEMA_URL}",
+    "purposes": {
+      "register": "signup"
+    },
+    "steps": [
+      {
+        "name": "signup",
+        "fields": [
+          "email",
+          "x-auth-methods#password"
+        ],
+        "actions": [
+          {
+            "name": "submit",
+            "kind": "submit",
+            "primary": true
+          }
+        ],
+        "transitions": {
+          "submit": {
+            "target": "address"
+          }
+        }
+      },
+      {
+        "name": "address",
+        "fields": [
+          "address.street",
+          "address.city",
+          "address.zipCode"
+        ],
+        "actions": [
+          {
+            "name": "submit",
+            "kind": "submit",
+            "primary": true
+          }
+        ],
+        "on_success": "create_user",
+        "transitions": {
+          "submit": {
+            "target": "done"
+          }
+        }
+      },
+      {
+        "name": "done",
+        "complete": "show"
+      }
+    ]
+  }
+}

--- a/api/openapi/endpoints/flow_definitions/examples/README.md
+++ b/api/openapi/endpoints/flow_definitions/examples/README.md
@@ -22,6 +22,7 @@ For the shape and validation rules, see
 | [04](./04-passkey-register/) | `register` | passkey | Passkey signup with provisional user finalized on verify. |
 | [05](./05-combined-login-register/) | `login` + `register` | password | Flip-table coverage between sub-flows. |
 | [06](./06-combined-password-passkey/) | `login` + `register` | password, passkey | Both methods on both purposes plus post-signup passkey upsell. |
+| [07](./07-nested-profile-fields/) | `register` | password | Nested schema properties collected by dotted path. |
 
 The server's embedded default project flow is
 `packages/config/defaults/default-login.json` (via `embed.go`) — that file is
@@ -42,7 +43,9 @@ the properties present on the step — there is no step `type`:
 - A step with `fields` collects user input validated against the
   `user_schema`. Schema annotations (`x-unique`, `x-auth-methods`)
   and reserved credential field names (`x-auth-methods#<method>`)
-  drive implicit dispatch behavior at runtime.
+  drive implicit dispatch behavior at runtime. A nested property is named by
+  its dotted path (`address.street`) — the object itself has no field-shaped
+  input, so collect its leaves.
 - A step with `actions` exposes user-selectable buttons. Two action names are
   engine-handled — `passkey` (login) and `passkey_register` (signup) — and
   trigger the two-phase WebAuthn ceremony.

--- a/api/openapi/endpoints/flow_definitions/examples_test.go
+++ b/api/openapi/endpoints/flow_definitions/examples_test.go
@@ -35,7 +35,16 @@ var exampleUserSchema = []byte(`{
     "givenName":   { "type": "string" },
     "familyName":  { "type": "string" },
     "phoneNumber": { "type": "string" },
-    "dateOfBirth": { "type": "string", "format": "date" }
+    "dateOfBirth": { "type": "string", "format": "date" },
+    "address": {
+      "type": "object",
+      "required": ["street", "city"],
+      "properties": {
+        "street":  { "type": "string", "minLength": 1 },
+        "city":    { "type": "string", "minLength": 1 },
+        "zipCode": { "type": "string" }
+      }
+    }
   }
 }`)
 
@@ -67,6 +76,7 @@ func TestExampleFlowDefinitions(t *testing.T) {
 		{"04-passkey-register", "examples/04-passkey-register/flow-definition.json"},
 		{"05-combined-login-register", "examples/05-combined-login-register/flow-definition.json"},
 		{"06-combined-password-passkey", "examples/06-combined-password-passkey/flow-definition.json"},
+		{"07-nested-profile-fields", "examples/07-nested-profile-fields/flow-definition.json"},
 	}
 
 	for _, ex := range examples {

--- a/api/openapi/endpoints/schemas/flow-definition.json
+++ b/api/openapi/endpoints/schemas/flow-definition.json
@@ -151,7 +151,7 @@
               "password"
             ]
           ],
-          "description": "Schema property names to collect from the user on this step. Each entry must resolve to a property in the definition's `user_schema`, or use the reserved token `x-auth-methods#<method>` (e.g. `x-auth-methods#password`) to collect a credential proof for a method enabled at the schema root. The engine reads the schema's `x-*` annotations to derive: - field type and validation (rendered into the runtime payload), - implicit transition outcomes - e.g. a property with a non-empty `x-unique` scope makes `user_not_found` a valid `transitions` key on this step."
+          "description": "Schema property names to collect from the user on this step. Each entry must resolve to a property in the definition's `user_schema` — naming a nested property by its dotted path (`address.street`), since an object- or array-typed property has no field-shaped input — or use the reserved token `x-auth-methods#<method>` (e.g. `x-auth-methods#password`) to collect a credential proof for a method enabled at the schema root. Collecting a leaf materializes every object above it, so an optional object's own `required` entries must be collected too once any step reaches into it. The engine reads the schema's `x-*` annotations to derive: - field type and validation (rendered into the runtime payload), - implicit transition outcomes - e.g. a property with a non-empty `x-unique` scope makes `user_not_found` a valid `transitions` key on this step."
         },
         "actions": {
           "type": "array",

--- a/docs/design/flowengine/flow-definition-rules.md
+++ b/docs/design/flowengine/flow-definition-rules.md
@@ -34,7 +34,7 @@ present.
 | Property | Meaning |
 |---|---|
 | `name` | Unique within the definition. Used as the `Transitions` target. |
-| `fields` | Ordered array of user-schema property names or reserved authentication-method fields such as `x-auth-methods#password`. Resolved at runtime to per-field type, validation, uniqueness scope, and `FlowFieldChallenge`. |
+| `fields` | Ordered array of user-schema property names or reserved authentication-method fields such as `x-auth-methods#password`. A nested property is named by its dotted path (`address.street`). Resolved at runtime to per-field type, validation, uniqueness scope, and `FlowFieldChallenge`. |
 | `actions` | Ordered array of `{ name, kind, text_key?, primary? }`. The client echoes `name` back in `submit`. |
 | `gates` | Definition-schema map of gate name → `{ kind, provider, config }`. Captcha is the only gate kind in the enum, but today's runtime neither emits nor enforces gates and rejects `gate_proofs`. |
 | `sso_providers` | Definition-schema list of `{ id, name, template }`. Today's runtime does not emit providers and rejects SSO submissions. |
@@ -71,6 +71,7 @@ Transition values:
 - `user_schema` URL resolves to a user-type schema. May be deferred until promotion to runtime use.
 - **Flip-table coverage.** A definition that serves both `login` and `register` must wire `user_not_found` (login entry) and `user_already_exists` (register entry) on the entry step. Solo-purpose flows don't need the counter outcome. See [ADR 017](../../adrs/017-flow-engine-auth-attempt-dispatch.md).
 - **`on_success` manifest cross-check.** Every credential kind a mutation establishes (per `ManifestForOnSuccess`) must be collected on the step itself or on some upstream step in the graph. `create_user` establishes `{identifier, password}` — both must appear in `fields` somewhere reachable.
+- **Required-field coverage.** Every path the user schema requires is collected by some step. The check descends: a required object contributes its own nested `required` entries, and a required object declaring none is satisfied by any leaf beneath it. Collecting a leaf materializes every object above it, so an optional object's `required` entries come into force as soon as any step reaches into it — and demand nothing when no step does.
 
 ### Step
 
@@ -80,7 +81,7 @@ Transition values:
 - Every key in `transitions` is either an action name declared in this step's `actions` or a reserved engine-emitted outcome.
 - **`back` is a reserved action name.** The engine injects a `back` action on rendered responses when there's a step to return to (non-empty back stack on a non-terminal step). Authors must not declare an action named `back`, regardless of `kind`.
 - When `sso_providers` is non-empty, `transitions.callback` is defined. The `sso` action itself is engine-handled and never appears in `transitions`.
-- Every entry in `fields` resolves to a property in the referenced `user_schema`.
+- Every entry in `fields` resolves to a property in the referenced `user_schema`, descending one `properties` level per dotted segment. The property must be scalar: an object or array is rejected, including one that declares `properties` or `items` without spelling out a `type`.
 - A step with an identifier-shaped field (schema property with non-empty `x-unique`) may declare a `user_not_found` transition; absence of the transition means the engine errors on lookup failure rather than routing. See [ADR 017](../../adrs/017-flow-engine-auth-attempt-dispatch.md) for the direction this is heading.
 
 ### Graph

--- a/docs/design/flowengine/flow-engine.md
+++ b/docs/design/flowengine/flow-engine.md
@@ -80,7 +80,7 @@ POST   /flow_definitions/{id}/simulate    Dry-run with mock input
 
 Steps do not have a `type`. Instead, the engine derives behavior from the step's properties:
 
-- **`fields`** — array of user-schema property names or reserved authentication-method fields such as `x-auth-methods#password`. The engine resolves each field's type, validation, and implicit outcomes from the user schema. For example, a property with a non-empty `x-unique` scope is an identifier and implies a `user_not_found` outcome in transitions.
+- **`fields`** — array of user-schema property names or reserved authentication-method fields such as `x-auth-methods#password`. A nested property is named by its dotted path (`address.street`) — the same string the attribute store keys it under — and an object- or array-typed property is rejected, since it has no field-shaped input. The engine resolves each field's type, validation, and implicit outcomes from the user schema. For example, a property with a non-empty `x-unique` scope is an identifier and implies a `user_not_found` outcome in transitions.
 - **`on_success`** — server-side mutation to run after the step's fields validate (`"create_user"` is the only shipped value). Executes before the transition fires.
 - **`complete`** — marks the step as terminal (`"redirect"` or `"show"`).
 - **`gates`** — definition-schema contract for keyed security challenges such as `{ "captcha": { "kind": "captcha", "provider": … } }`. This is not runtime-supported today: the engine emits an empty `gates` object and rejects `gate_proofs`. Passkey is not a gate — authenticator ceremonies run as credential auth_attempts.

--- a/packages/config/meta-schemas/flow-definition.json
+++ b/packages/config/meta-schemas/flow-definition.json
@@ -151,7 +151,7 @@
               "password"
             ]
           ],
-          "description": "Schema property names to collect from the user on this step. Each entry must resolve to a property in the definition's `user_schema`, or use the reserved token `x-auth-methods#<method>` (e.g. `x-auth-methods#password`) to collect a credential proof for a method enabled at the schema root. The engine reads the schema's `x-*` annotations to derive: - field type and validation (rendered into the runtime payload), - implicit transition outcomes - e.g. a property with a non-empty `x-unique` scope makes `user_not_found` a valid `transitions` key on this step."
+          "description": "Schema property names to collect from the user on this step. Each entry must resolve to a property in the definition's `user_schema` — naming a nested property by its dotted path (`address.street`), since an object- or array-typed property has no field-shaped input — or use the reserved token `x-auth-methods#<method>` (e.g. `x-auth-methods#password`) to collect a credential proof for a method enabled at the schema root. Collecting a leaf materializes every object above it, so an optional object's own `required` entries must be collected too once any step reaches into it. The engine reads the schema's `x-*` annotations to derive: - field type and validation (rendered into the runtime payload), - implicit transition outcomes - e.g. a property with a non-empty `x-unique` scope makes `user_not_found` a valid `transitions` key on this step."
         },
         "actions": {
           "type": "array",


### PR DESCRIPTION
Documents dotted field paths and the optional-object required rule, and adds the `07-nested-profile-fields` worked example. Description text only; the `oas_schemas_gen.go` diff is regenerated doc comments.

🚧 **Blocked:** nested leaves render `required: false` but the object materializes on submit, so blanks fail at `create_user`. Fixing that first, since it changes what this text should say.