### PR TITLE
refactor: return domain objects from SchemaService.ListSchemas

### DIFF
--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -85,11 +85,11 @@ func (h *Handler) ListSchemas(ctx context.Context, params api.ListSchemasParams)
 		return nil, err
 	}
 
-	resp := make(api.ListSchemasResponse, len(schemas), len(schemas))
+	resp := make(api.ListSchemasResponse, len(schemas))
 
 	for i, schema := range schemas {
 		resp[i] = api.ListSchemasResponseItem{
-			ID:        schema.ID,
+			ID:        schema.URL,
 			CreatedAt: schema.CreatedAt,
 		}
 	}

--- a/internal/service/schema_service.go
+++ b/internal/service/schema_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/url"
-	"time"
 
 	"github.com/zitadel/nextgen/internal/audit"
 	"github.com/zitadel/nextgen/internal/domain"
@@ -23,11 +22,6 @@ type CreateSchemaByURLInput struct {
 	ProjectID string
 	TeamID    string
 	URL       url.URL
-}
-
-type ListSchemasOutputItem struct {
-	ID        string
-	CreatedAt time.Time
 }
 
 // ---- Secondary ports -------------------------------------------------------------
@@ -129,7 +123,7 @@ func (s *SchemaService) GetSchema(ctx context.Context, projectID string, teamID 
 	return schema, nil
 }
 
-func (s *SchemaService) ListSchemas(ctx context.Context, projectID, objectType string, offset int, token string) ([]ListSchemasOutputItem, error) {
+func (s *SchemaService) ListSchemas(ctx context.Context, projectID, objectType string, offset int, token string) ([]*domain.JSONSchema, error) {
 	filters := []database.Filter[domain.JSONSchemaField]{
 		database.Equal(database.Col(domain.JSONSchemaFieldProjectID), projectID),
 	}
@@ -154,14 +148,5 @@ func (s *SchemaService) ListSchemas(ctx context.Context, projectID, objectType s
 		return nil, mapListError(err, "failed to list schemas")
 	}
 
-	// TODO: make list not return the entire schema, just the fields we want
-	output := make([]ListSchemasOutputItem, len(result.Items))
-	for i, schema := range result.Items {
-		output[i] = ListSchemasOutputItem{
-			ID:        schema.URL,
-			CreatedAt: schema.CreatedAt,
-		}
-	}
-
-	return output, nil
+	return result.Items, nil
 }


### PR DESCRIPTION
## Summary

First PR of a three-PR stack for #921 (listSchemas should return the full schema document).

`SchemaService.ListSchemas` returned a narrow `ListSchemasOutputItem` projection, discarding the schema payload the storage layer already fetches on every dialect. This converges the service on the house pattern (`UserService.ListUsers`): the service returns whole `*domain.JSONSchema` rows and the API layer does the wire projection. `ListSchemasOutputItem` and its projection loop are deleted.

The wire output is unchanged: `GET /schemas` still returns `[{id, created_at}]`. The next PR in the stack changes the contract to the envelope representation; this refactor keeps that diff focused on the contract.

## Validation

- `moon run server:vet` and `moon run server:test` pass (the latter includes `server:check-generate`); the existing integration tests (`TestSchemaRevisions`, authz list assertions) pass unchanged, which is the proof of no wire change.

## Release notes / changeset

No changeset: internal refactor, no shipped behavior change (per the decision table).

## Notes

- Stack: this PR → contract flip (spec + server + api-mock + mechanical client adaptation) → console N+1 deletion.
- Also fixed an S1019 lint nit (`make` with redundant capacity) on the touched line in `internal/api/schema.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)