### PR TITLE
feat: return the full schema document from the schema read endpoints

### DIFF
--- a/.changeset/schema-read-envelope.md
+++ b/.changeset/schema-read-envelope.md
@@ -1,0 +1,6 @@
+---
+"@zitadel/server": minor
+"@zitadel/cli": patch
+---
+
+`GET /schemas` and `GET /schemas/{id}` now return each schema as an `{id, schema, metadata}` envelope carrying the full customer-authored document, and `GET /schemas` wraps its rows in a `{schemas: [...]}` object. The two read endpoints share one representation; the resource `id` and `metadata.created_at` are server-owned and can no longer collide with keys in the document. Clients that read the bare document from `GET /schemas/{id}` or the bare `{id, created_at}` array from `GET /schemas` must unwrap the envelope.

--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -32321,118 +32321,6 @@ func (s *GetSchemaByIdNotFound) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes GetSchemaByIdOK as json.
-func (s GetSchemaByIdOK) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-func (s GetSchemaByIdOK) encodeFields(e *jx.Encoder) {
-	switch s.Type {
-	case UserSchemaGetSchemaByIdOK:
-		e.FieldStart("kind")
-		e.Str("user-schema")
-		{
-			s := s.UserSchema
-			{
-				e.FieldStart("$schema")
-				e.Str("https://json-schema.org/draft/2020-12/schema")
-			}
-			{
-				if s.ObjectType.Set {
-					e.FieldStart("objectType")
-					s.ObjectType.Encode(e)
-				}
-			}
-			{
-				e.FieldStart("metaSchema")
-				json.EncodeURI(e, s.MetaSchema)
-			}
-			{
-				e.FieldStart("x-auth-methods")
-				s.XMinusAuthMinusMethods.Encode(e)
-			}
-			{
-				if s.Properties.Set {
-					e.FieldStart("properties")
-					s.Properties.Encode(e)
-				}
-			}
-			for k, elem := range s.AdditionalProps {
-				e.FieldStart(k)
-
-				if len(elem) != 0 {
-					e.Raw(elem)
-				}
-			}
-		}
-	}
-}
-
-// Decode decodes GetSchemaByIdOK from json.
-func (s *GetSchemaByIdOK) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode GetSchemaByIdOK to nil")
-	}
-	// Sum type discriminator.
-	if typ := d.Next(); typ != jx.Object {
-		return errors.Errorf("unexpected json type %q", typ)
-	}
-
-	var found bool
-	if err := d.Capture(func(d *jx.Decoder) error {
-		return d.ObjBytes(func(d *jx.Decoder, key []byte) error {
-			if found {
-				return d.Skip()
-			}
-			switch string(key) {
-			case "kind":
-				typ, err := d.Str()
-				if err != nil {
-					return err
-				}
-				switch typ {
-				case "user-schema":
-					s.Type = UserSchemaGetSchemaByIdOK
-					found = true
-				default:
-					return errors.Errorf("unknown type %s", typ)
-				}
-				return nil
-			}
-			return d.Skip()
-		})
-	}); err != nil {
-		return errors.Wrap(err, "capture")
-	}
-	if !found {
-		return errors.New("unable to detect sum type variant")
-	}
-	switch s.Type {
-	case UserSchemaGetSchemaByIdOK:
-		if err := s.UserSchema.Decode(d); err != nil {
-			return err
-		}
-	default:
-		return errors.Errorf("inferred invalid type: %s", s.Type)
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s GetSchemaByIdOK) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *GetSchemaByIdOK) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes GetSessionErrorResponse as json.
 func (s GetSessionErrorResponse) Encode(e *jx.Encoder) {
 	e.ObjStart()
@@ -34889,15 +34777,27 @@ func (s *ListFlowDefinitionsErrorResponse) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes ListSchemasResponse as json.
-func (s ListSchemasResponse) Encode(e *jx.Encoder) {
-	unwrapped := []ListSchemasResponseItem(s)
+// Encode implements json.Marshaler.
+func (s *ListSchemasResponse) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
 
-	e.ArrStart()
-	for _, elem := range unwrapped {
-		elem.Encode(e)
+// encodeFields encodes fields.
+func (s *ListSchemasResponse) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("schemas")
+		e.ArrStart()
+		for _, elem := range s.Schemas {
+			elem.Encode(e)
+		}
+		e.ArrEnd()
 	}
-	e.ArrEnd()
+}
+
+var jsonFieldsNameOfListSchemasResponse = [1]string{
+	0: "schemas",
 }
 
 // Decode decodes ListSchemasResponse from json.
@@ -34905,108 +34805,39 @@ func (s *ListSchemasResponse) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode ListSchemasResponse to nil")
 	}
-	var unwrapped []ListSchemasResponseItem
-	if err := func() error {
-		unwrapped = make([]ListSchemasResponseItem, 0)
-		if err := d.Arr(func(d *jx.Decoder) error {
-			var elem ListSchemasResponseItem
-			if err := elem.Decode(d); err != nil {
-				return err
-			}
-			unwrapped = append(unwrapped, elem)
-			return nil
-		}); err != nil {
-			return err
-		}
-		return nil
-	}(); err != nil {
-		return errors.Wrap(err, "alias")
-	}
-	*s = ListSchemasResponse(unwrapped)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s ListSchemasResponse) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ListSchemasResponse) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s *ListSchemasResponseItem) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields encodes fields.
-func (s *ListSchemasResponseItem) encodeFields(e *jx.Encoder) {
-	{
-		e.FieldStart("id")
-		e.Str(s.ID)
-	}
-	{
-		e.FieldStart("created_at")
-		json.EncodeDateTime(e, s.CreatedAt)
-	}
-}
-
-var jsonFieldsNameOfListSchemasResponseItem = [2]string{
-	0: "id",
-	1: "created_at",
-}
-
-// Decode decodes ListSchemasResponseItem from json.
-func (s *ListSchemasResponseItem) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ListSchemasResponseItem to nil")
-	}
 	var requiredBitSet [1]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
-		case "id":
+		case "schemas":
 			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				v, err := d.Str()
-				s.ID = string(v)
-				if err != nil {
+				s.Schemas = make([]Schema, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem Schema
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Schemas = append(s.Schemas, elem)
+					return nil
+				}); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"id\"")
-			}
-		case "created_at":
-			requiredBitSet[0] |= 1 << 1
-			if err := func() error {
-				v, err := json.DecodeDateTime(d)
-				s.CreatedAt = v
-				if err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"created_at\"")
+				return errors.Wrap(err, "decode field \"schemas\"")
 			}
 		default:
 			return d.Skip()
 		}
 		return nil
 	}); err != nil {
-		return errors.Wrap(err, "decode ListSchemasResponseItem")
+		return errors.Wrap(err, "decode ListSchemasResponse")
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000011,
+		0b00000001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -35018,8 +34849,8 @@ func (s *ListSchemasResponseItem) Decode(d *jx.Decoder) error {
 				bitIdx := bits.TrailingZeros8(result)
 				fieldIdx := i*8 + bitIdx
 				var name string
-				if fieldIdx < len(jsonFieldsNameOfListSchemasResponseItem) {
-					name = jsonFieldsNameOfListSchemasResponseItem[fieldIdx]
+				if fieldIdx < len(jsonFieldsNameOfListSchemasResponse) {
+					name = jsonFieldsNameOfListSchemasResponse[fieldIdx]
 				} else {
 					name = strconv.Itoa(fieldIdx)
 				}
@@ -35040,14 +34871,14 @@ func (s *ListSchemasResponseItem) Decode(d *jx.Decoder) error {
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *ListSchemasResponseItem) MarshalJSON() ([]byte, error) {
+func (s *ListSchemasResponse) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ListSchemasResponseItem) UnmarshalJSON(data []byte) error {
+func (s *ListSchemasResponse) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -53061,6 +52892,132 @@ func (s *SchNotFoundDetails) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *Schema) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *Schema) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("id")
+		e.Str(s.ID)
+	}
+	{
+		e.FieldStart("schema")
+		s.Schema.Encode(e)
+	}
+	{
+		e.FieldStart("metadata")
+		s.Metadata.Encode(e)
+	}
+}
+
+var jsonFieldsNameOfSchema = [3]string{
+	0: "id",
+	1: "schema",
+	2: "metadata",
+}
+
+// Decode decodes Schema from json.
+func (s *Schema) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode Schema to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "id":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.ID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"id\"")
+			}
+		case "schema":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				if err := s.Schema.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"schema\"")
+			}
+		case "metadata":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				if err := s.Metadata.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"metadata\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode Schema")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfSchema) {
+					name = jsonFieldsNameOfSchema[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *Schema) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *Schema) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *SchemaCreatedEvent) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -53699,6 +53656,214 @@ func (s SchemaCreatedEventMetadata) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *SchemaCreatedEventMetadata) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes SchemaDocument as json.
+func (s SchemaDocument) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+func (s SchemaDocument) encodeFields(e *jx.Encoder) {
+	switch s.Type {
+	case UserSchemaSchemaDocument:
+		e.FieldStart("kind")
+		e.Str("user-schema")
+		{
+			s := s.UserSchema
+			{
+				e.FieldStart("$schema")
+				e.Str("https://json-schema.org/draft/2020-12/schema")
+			}
+			{
+				if s.ObjectType.Set {
+					e.FieldStart("objectType")
+					s.ObjectType.Encode(e)
+				}
+			}
+			{
+				e.FieldStart("metaSchema")
+				json.EncodeURI(e, s.MetaSchema)
+			}
+			{
+				e.FieldStart("x-auth-methods")
+				s.XMinusAuthMinusMethods.Encode(e)
+			}
+			{
+				if s.Properties.Set {
+					e.FieldStart("properties")
+					s.Properties.Encode(e)
+				}
+			}
+			for k, elem := range s.AdditionalProps {
+				e.FieldStart(k)
+
+				if len(elem) != 0 {
+					e.Raw(elem)
+				}
+			}
+		}
+	}
+}
+
+// Decode decodes SchemaDocument from json.
+func (s *SchemaDocument) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode SchemaDocument to nil")
+	}
+	// Sum type discriminator.
+	if typ := d.Next(); typ != jx.Object {
+		return errors.Errorf("unexpected json type %q", typ)
+	}
+
+	var found bool
+	if err := d.Capture(func(d *jx.Decoder) error {
+		return d.ObjBytes(func(d *jx.Decoder, key []byte) error {
+			if found {
+				return d.Skip()
+			}
+			switch string(key) {
+			case "kind":
+				typ, err := d.Str()
+				if err != nil {
+					return err
+				}
+				switch typ {
+				case "user-schema":
+					s.Type = UserSchemaSchemaDocument
+					found = true
+				default:
+					return errors.Errorf("unknown type %s", typ)
+				}
+				return nil
+			}
+			return d.Skip()
+		})
+	}); err != nil {
+		return errors.Wrap(err, "capture")
+	}
+	if !found {
+		return errors.New("unable to detect sum type variant")
+	}
+	switch s.Type {
+	case UserSchemaSchemaDocument:
+		if err := s.UserSchema.Decode(d); err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("inferred invalid type: %s", s.Type)
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s SchemaDocument) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *SchemaDocument) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *SchemaMetadata) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *SchemaMetadata) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("created_at")
+		json.EncodeDateTime(e, s.CreatedAt)
+	}
+}
+
+var jsonFieldsNameOfSchemaMetadata = [1]string{
+	0: "created_at",
+}
+
+// Decode decodes SchemaMetadata from json.
+func (s *SchemaMetadata) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode SchemaMetadata to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "created_at":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := json.DecodeDateTime(d)
+				s.CreatedAt = v
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"created_at\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode SchemaMetadata")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfSchemaMetadata) {
+					name = jsonFieldsNameOfSchemaMetadata[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *SchemaMetadata) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *SchemaMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/api/generated/oas_response_decoders_gen.go
+++ b/api/generated/oas_response_decoders_gen.go
@@ -4453,7 +4453,7 @@ func decodeGetSchemaByIdResponse(resp *http.Response) (res GetSchemaByIdRes, _ e
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response GetSchemaByIdOK
+			var response Schema
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err

--- a/api/generated/oas_response_encoders_gen.go
+++ b/api/generated/oas_response_encoders_gen.go
@@ -2143,7 +2143,7 @@ func encodeGetReadyResponse(response GetReadyRes, w http.ResponseWriter, span tr
 
 func encodeGetSchemaByIdResponse(response GetSchemaByIdRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
-	case *GetSchemaByIdOK:
+	case *Schema:
 		if err := func() error {
 			if err := response.Validate(); err != nil {
 				return err

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -17360,46 +17360,6 @@ type GetSchemaByIdNotFound ErrorDetails
 
 func (*GetSchemaByIdNotFound) getSchemaByIdRes() {}
 
-// GetSchemaByIdOK represents sum type.
-type GetSchemaByIdOK struct {
-	Type       GetSchemaByIdOKType // switch on this field
-	UserSchema UserSchema
-}
-
-// GetSchemaByIdOKType is oneOf type of GetSchemaByIdOK.
-type GetSchemaByIdOKType string
-
-// Possible values for GetSchemaByIdOKType.
-const (
-	UserSchemaGetSchemaByIdOK GetSchemaByIdOKType = "user-schema"
-)
-
-// IsUserSchema reports whether GetSchemaByIdOK is UserSchema.
-func (s GetSchemaByIdOK) IsUserSchema() bool { return s.Type == UserSchemaGetSchemaByIdOK }
-
-// SetUserSchema sets GetSchemaByIdOK to UserSchema.
-func (s *GetSchemaByIdOK) SetUserSchema(v UserSchema) {
-	s.Type = UserSchemaGetSchemaByIdOK
-	s.UserSchema = v
-}
-
-// GetUserSchema returns UserSchema and true boolean if GetSchemaByIdOK is UserSchema.
-func (s GetSchemaByIdOK) GetUserSchema() (v UserSchema, ok bool) {
-	if !s.IsUserSchema() {
-		return v, false
-	}
-	return s.UserSchema, true
-}
-
-// NewUserSchemaGetSchemaByIdOK returns new GetSchemaByIdOK from UserSchema.
-func NewUserSchemaGetSchemaByIdOK(v UserSchema) GetSchemaByIdOK {
-	var s GetSchemaByIdOK
-	s.SetUserSchema(v)
-	return s
-}
-
-func (*GetSchemaByIdOK) getSchemaByIdRes() {}
-
 // GetSessionErrorResponse represents sum type.
 type GetSessionErrorResponse struct {
 	Type                 GetSessionErrorResponseType // switch on this field
@@ -18809,35 +18769,23 @@ func (s *ListFlowDefinitionsPurpose) UnmarshalText(data []byte) error {
 	}
 }
 
-type ListSchemasResponse []ListSchemasResponseItem
+// List of schemas, newest first.
+// Ref: #
+type ListSchemasResponse struct {
+	Schemas []Schema `json:"schemas"`
+}
+
+// GetSchemas returns the value of Schemas.
+func (s *ListSchemasResponse) GetSchemas() []Schema {
+	return s.Schemas
+}
+
+// SetSchemas sets the value of Schemas.
+func (s *ListSchemasResponse) SetSchemas(val []Schema) {
+	s.Schemas = val
+}
 
 func (*ListSchemasResponse) listSchemasRes() {}
-
-type ListSchemasResponseItem struct {
-	// The unique identifier for this schema.
-	ID        string    `json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-}
-
-// GetID returns the value of ID.
-func (s *ListSchemasResponseItem) GetID() string {
-	return s.ID
-}
-
-// GetCreatedAt returns the value of CreatedAt.
-func (s *ListSchemasResponseItem) GetCreatedAt() time.Time {
-	return s.CreatedAt
-}
-
-// SetID sets the value of ID.
-func (s *ListSchemasResponseItem) SetID(val string) {
-	s.ID = val
-}
-
-// SetCreatedAt sets the value of CreatedAt.
-func (s *ListSchemasResponseItem) SetCreatedAt(val time.Time) {
-	s.CreatedAt = val
-}
 
 type ListUserPasskeysBadRequest ErrorDetails
 
@@ -33868,6 +33816,55 @@ func (s *SchNotFoundDetails) init() SchNotFoundDetails {
 	return m
 }
 
+// A schema resource: the server-owned envelope around a customer-authored
+// JSON Schema document.
+// `schema` is the customer-authored document, served verbatim: its keys and
+// contents are defined entirely by its author. The rest of the object — `id`,
+// `metadata` — is the server-owned envelope. Keeping the two apart means the
+// document may declare any property (including `id` or `metadata`) without
+// colliding with the envelope, and the resource `id` stays distinguishable
+// from the document's own `$id`.
+// Ref: #
+type Schema struct {
+	// The resource id: the server-minted `sch_*` identifier, or the
+	// customer-supplied `$id` URI when the document declared one at creation.
+	ID       string         `json:"id"`
+	Schema   SchemaDocument `json:"schema"`
+	Metadata SchemaMetadata `json:"metadata"`
+}
+
+// GetID returns the value of ID.
+func (s *Schema) GetID() string {
+	return s.ID
+}
+
+// GetSchema returns the value of Schema.
+func (s *Schema) GetSchema() SchemaDocument {
+	return s.Schema
+}
+
+// GetMetadata returns the value of Metadata.
+func (s *Schema) GetMetadata() SchemaMetadata {
+	return s.Metadata
+}
+
+// SetID sets the value of ID.
+func (s *Schema) SetID(val string) {
+	s.ID = val
+}
+
+// SetSchema sets the value of Schema.
+func (s *Schema) SetSchema(val SchemaDocument) {
+	s.Schema = val
+}
+
+// SetMetadata sets the value of Metadata.
+func (s *Schema) SetMetadata(val SchemaMetadata) {
+	s.Metadata = val
+}
+
+func (*Schema) getSchemaByIdRes() {}
+
 // Merged schema.
 // Ref: #
 type SchemaCreatedEvent struct {
@@ -34324,6 +34321,62 @@ func (s *SchemaCreatedEventMetadata) init() SchemaCreatedEventMetadata {
 		*s = m
 	}
 	return m
+}
+
+// The customer-authored JSON Schema document, served verbatim.
+// Ref: #
+// SchemaDocument represents sum type.
+type SchemaDocument struct {
+	Type       SchemaDocumentType // switch on this field
+	UserSchema UserSchema
+}
+
+// SchemaDocumentType is oneOf type of SchemaDocument.
+type SchemaDocumentType string
+
+// Possible values for SchemaDocumentType.
+const (
+	UserSchemaSchemaDocument SchemaDocumentType = "user-schema"
+)
+
+// IsUserSchema reports whether SchemaDocument is UserSchema.
+func (s SchemaDocument) IsUserSchema() bool { return s.Type == UserSchemaSchemaDocument }
+
+// SetUserSchema sets SchemaDocument to UserSchema.
+func (s *SchemaDocument) SetUserSchema(v UserSchema) {
+	s.Type = UserSchemaSchemaDocument
+	s.UserSchema = v
+}
+
+// GetUserSchema returns UserSchema and true boolean if SchemaDocument is UserSchema.
+func (s SchemaDocument) GetUserSchema() (v UserSchema, ok bool) {
+	if !s.IsUserSchema() {
+		return v, false
+	}
+	return s.UserSchema, true
+}
+
+// NewUserSchemaSchemaDocument returns new SchemaDocument from UserSchema.
+func NewUserSchemaSchemaDocument(v UserSchema) SchemaDocument {
+	var s SchemaDocument
+	s.SetUserSchema(v)
+	return s
+}
+
+// Ref: #
+type SchemaMetadata struct {
+	// The time when the schema was created.
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// GetCreatedAt returns the value of CreatedAt.
+func (s *SchemaMetadata) GetCreatedAt() time.Time {
+	return s.CreatedAt
+}
+
+// SetCreatedAt sets the value of CreatedAt.
+func (s *SchemaMetadata) SetCreatedAt(val time.Time) {
+	s.CreatedAt = val
 }
 
 type SchemaURI url.URL

--- a/api/generated/oas_validators_gen.go
+++ b/api/generated/oas_validators_gen.go
@@ -3676,18 +3676,6 @@ func (s GateKind) Validate() error {
 	}
 }
 
-func (s GetSchemaByIdOK) Validate() error {
-	switch s.Type {
-	case UserSchemaGetSchemaByIdOK:
-		if err := s.UserSchema.Validate(); err != nil {
-			return err
-		}
-		return nil
-	default:
-		return errors.Errorf("invalid type %q", s.Type)
-	}
-}
-
 func (s *IdentifierFactorPayload) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -3933,10 +3921,42 @@ func (s ListFlowDefinitionsPurpose) Validate() error {
 	}
 }
 
-func (s ListSchemasResponse) Validate() error {
-	alias := ([]ListSchemasResponseItem)(s)
-	if alias == nil {
-		return errors.New("nil is invalid value")
+func (s *ListSchemasResponse) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if s.Schemas == nil {
+			return errors.New("nil is invalid value")
+		}
+		var failures []validate.FieldError
+		for i, elem := range s.Schemas {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "schemas",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
 	}
 	return nil
 }
@@ -5381,6 +5401,29 @@ func (s RequestAPIPayloadMethod) Validate() error {
 	}
 }
 
+func (s *Schema) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Schema.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "schema",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *SchemaCreatedEvent) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -5497,6 +5540,18 @@ func (s SchemaCreatedEventDelegationType) Validate() error {
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s SchemaDocument) Validate() error {
+	switch s.Type {
+	case UserSchemaSchemaDocument:
+		if err := s.UserSchema.Validate(); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.Errorf("invalid type %q", s.Type)
 	}
 }
 

--- a/api/openapi/endpoints/schemas/by_id/methods.yaml
+++ b/api/openapi/endpoints/schemas/by_id/methods.yaml
@@ -20,12 +20,7 @@ get:
       content:
         application/json:
           schema:
-            oneOf:
-              - $ref: ../user-schema.yaml
-            discriminator:
-              propertyName: kind
-              mapping:
-                user-schema: ../user-schema.yaml
+            $ref: ../schema.yaml
     '400':
       description: The provided input was not valid
       content:

--- a/api/openapi/endpoints/schemas/list-schemas-response.yaml
+++ b/api/openapi/endpoints/schemas/list-schemas-response.yaml
@@ -1,13 +1,9 @@
-type: array
-items:
-  type: object
-  required:
-    - id
-    - created_at
-  properties:
-    id:
-      type: string
-      description: The unique identifier for this schema.
-    created_at:
-      type: string
-      format: date-time
+type: object
+description: List of schemas, newest first.
+required:
+  - schemas
+properties:
+  schemas:
+    type: array
+    items:
+      $ref: schema.yaml

--- a/api/openapi/endpoints/schemas/schema-document.yaml
+++ b/api/openapi/endpoints/schemas/schema-document.yaml
@@ -1,0 +1,8 @@
+title: SchemaDocument
+description: The customer-authored JSON Schema document, served verbatim.
+oneOf:
+  - $ref: user-schema.yaml
+discriminator:
+  propertyName: kind
+  mapping:
+    user-schema: user-schema.yaml

--- a/api/openapi/endpoints/schemas/schema-metadata.yaml
+++ b/api/openapi/endpoints/schemas/schema-metadata.yaml
@@ -1,0 +1,9 @@
+title: SchemaMetadata
+type: object
+required:
+  - created_at
+properties:
+  created_at:
+    type: string
+    format: date-time
+    description: The time when the schema was created.

--- a/api/openapi/endpoints/schemas/schema.yaml
+++ b/api/openapi/endpoints/schemas/schema.yaml
@@ -1,0 +1,29 @@
+title: Schema
+description: |
+  A schema resource: the server-owned envelope around a customer-authored
+  JSON Schema document.
+
+  `schema` is the customer-authored document, served verbatim: its keys and
+  contents are defined entirely by its author. The rest of the object — `id`,
+  `metadata` — is the server-owned envelope. Keeping the two apart means the
+  document may declare any property (including `id` or `metadata`) without
+  colliding with the envelope, and the resource `id` stays distinguishable
+  from the document's own `$id`.
+type: object
+required:
+  - id
+  - schema
+  - metadata
+properties:
+  id:
+    readOnly: true
+    type: string
+    description: |
+      The resource id: the server-minted `sch_*` identifier, or the
+      customer-supplied `$id` URI when the document declared one at creation.
+    example: sch_01H455VB4213EF62K49QF6M73F
+  schema:
+    $ref: schema-document.yaml
+  metadata:
+    readOnly: true
+    $ref: schema-metadata.yaml

--- a/api/openapi/readme.md
+++ b/api/openapi/readme.md
@@ -50,7 +50,8 @@ This API uses **cursor-based pagination** (`page_token` / `next_page_token`), no
 - Treat `page_token` as opaque — do not attempt to decode or construct it.
 
 > **Note:** `GET /schemas` currently accepts both the legacy `offset` parameter
-> and `page_token`, but its response is a bare array with no `next_page_token`.
+> and `page_token`, but implements neither and its response carries no
+> `next_page_token` yet.
 > It does not yet implement a complete pagination convention and should be normalized.
 > New list endpoints must use cursor-based pagination — see `POST /sessions/query` as the reference implementation.
 

--- a/apps/cli/src/commands/schemas/list.ts
+++ b/apps/cli/src/commands/schemas/list.ts
@@ -3,7 +3,10 @@ import { Flags } from "@oclif/core";
 import { consola } from "consola";
 
 import { createZitadelClient, type ZitadelClient } from "@zitadel/api/client";
-import type { ListSchemas200Item } from "@zitadel/api/generated/model";
+import type {
+  GetSchemaById200,
+  ListSchemas200SchemasItem,
+} from "@zitadel/api/generated/model";
 
 import { BaseCommand, type JsonEnvelope } from "../../lib/oclif";
 import { environmentSchema } from "../../lib/environment";
@@ -47,14 +50,17 @@ export default class SchemasList extends BaseCommand {
     });
 
     const objectType = flags["object-type"];
-    const revisions = await client.listSchemas({
+    const { schemas: revisions } = await client.listSchemas({
       project_id: secret.project_id,
       object_type: objectType,
     });
 
     // The envelope's row shape is a contract; project it explicitly so a field
     // added to the API later cannot leak into stdout.
-    const revisionRows = revisions.map((r) => ({ id: r.id, created_at: r.created_at }));
+    const revisionRows = revisions.map((r) => ({
+      id: r.id,
+      created_at: r.metadata.created_at,
+    }));
 
     if (revisions.length === 0) {
       const message = `No revisions found for objectType "${objectType}".`;
@@ -83,7 +89,7 @@ export default class SchemasList extends BaseCommand {
       message: `Revisions of objectType "${objectType}" (newest first)`,
       options: revisions.map((r, idx) => ({
         value: r.id,
-        label: `${r.created_at}   ${r.id}${idx === 0 ? "   (latest)" : ""}`,
+        label: `${r.metadata.created_at}   ${r.id}${idx === 0 ? "   (latest)" : ""}`,
       })),
     });
     if (isCancel(picked)) {
@@ -124,15 +130,24 @@ export default class SchemasList extends BaseCommand {
  */
 export async function fetchSchemaRevision(client: ZitadelClient, id: string): Promise<unknown> {
   // Flat-by-id: authz resolves the project from RSI; no project_id query.
-  return client.getSchemaById(encodeURIComponent(id));
+  // The response is the `{id, schema, metadata}` envelope; the revision body
+  // callers want is the customer-authored document inside it.
+  const body = (await client.getSchemaById(encodeURIComponent(id))) as GetSchemaById200;
+  return body.schema;
 }
 
-function renderTable(objectType: string, revisions: ReadonlyArray<ListSchemas200Item>): string {
+function renderTable(
+  objectType: string,
+  revisions: ReadonlyArray<ListSchemas200SchemasItem>,
+): string {
   const header = `Revisions of objectType "${objectType}" (${revisions.length}, newest first)`;
   const idCol = Math.max("id".length, ...revisions.map((r) => r.id.length));
-  const createdCol = Math.max("created_at".length, ...revisions.map((r) => r.created_at.length));
+  const createdCol = Math.max(
+    "created_at".length,
+    ...revisions.map((r) => r.metadata.created_at.length),
+  );
   const rows = revisions.map(
-    (r) => `${r.created_at.padEnd(createdCol)}  ${r.id.padEnd(idCol)}`,
+    (r) => `${r.metadata.created_at.padEnd(createdCol)}  ${r.id.padEnd(idCol)}`,
   );
   return [
     header,

--- a/apps/cli/src/lib/setup-resources.ts
+++ b/apps/cli/src/lib/setup-resources.ts
@@ -9,6 +9,7 @@ import type {
   CreateFlowDefinition201,
   CreateSchema201,
   CreateSchemaBody,
+  GetSchemaById200,
 } from "@zitadel/api/generated/model";
 import type { ZitadelClient } from "@zitadel/api/client";
 import {
@@ -110,9 +111,13 @@ export async function materializeSetupResources(opts: {
   // the template body and its hash (parity is best-effort at setup).
   let schemaHash = hashForState({ normalize: normalizeSchemaBody }, schemaBody);
   try {
-    const canonical = (await opts.client.getSchemaById(
-      encodeURIComponent(schemaId),
-    )) as object;
+    // The response is the `{id, schema, metadata}` envelope; the local config
+    // file keeps only the customer-authored document.
+    const canonical = (
+      (await opts.client.getSchemaById(
+        encodeURIComponent(schemaId),
+      )) as unknown as GetSchemaById200
+    ).schema;
     const written = await writeBackResource(
       opts.cwd,
       DEFAULT_SCHEMA_CONFIG_PATH,

--- a/apps/cli/src/lib/sync/syncers.ts
+++ b/apps/cli/src/lib/sync/syncers.ts
@@ -147,8 +147,12 @@ class SchemaSyncer implements ResourceSyncer {
 
   async fetch(id: string): Promise<object> {
     // Flat-by-id: authz resolves the project from RSI; no project_id query.
-    const body = await this.client.getSchemaById(encodeURIComponent(id));
-    return body as unknown as GetSchemaById200;
+    // The response is the `{id, schema, metadata}` envelope; only the
+    // customer-authored document is written back to `.zitadel/schemas/`.
+    const body = (await this.client.getSchemaById(
+      encodeURIComponent(id),
+    )) as unknown as GetSchemaById200;
+    return body.schema;
   }
 }
 

--- a/apps/cli/tests/unit/commands/schemas-list.test.ts
+++ b/apps/cli/tests/unit/commands/schemas-list.test.ts
@@ -44,7 +44,7 @@ describe("schemas list", () => {
   it("returns an empty payload with a helpful message when no revisions exist", async () => {
     const cwd = await makeProject();
     server.use(
-      http.get("*/schemas", () => HttpResponse.json([])),
+      http.get("*/schemas", () => HttpResponse.json({ schemas: [] })),
     );
 
     const res = await runCliForTest([
@@ -79,10 +79,20 @@ describe("schemas list", () => {
         const url = new URL(request.url);
         expect(url.searchParams.get("project_id")).toBe("proj_test");
         expect(url.searchParams.get("object_type")).toBe("human-user");
-        return HttpResponse.json([
-          { id: "sch_02", created_at: "2026-07-02T00:00:00Z" },
-          { id: "sch_01", created_at: "2026-06-01T00:00:00Z" },
-        ]);
+        return HttpResponse.json({
+          schemas: [
+            {
+              id: "sch_02",
+              schema: { kind: "user-schema" },
+              metadata: { created_at: "2026-07-02T00:00:00Z" },
+            },
+            {
+              id: "sch_01",
+              schema: { kind: "user-schema" },
+              metadata: { created_at: "2026-06-01T00:00:00Z" },
+            },
+          ],
+        });
       }),
     );
 
@@ -109,8 +119,9 @@ describe("schemas list", () => {
     };
     expect(json.status).toBe("ok");
     expect(json.data.count).toBe(2);
-    // Envelope rows are snake_case like the rest of the data contract,
-    // even though the server response is camelCase.
+    // Rows stay the flat `{id, created_at}` stdout contract even though the
+    // wire response nests the timestamp in `metadata` and carries the full
+    // document.
     expect(json.data.revisions).toEqual([
       { id: "sch_02", created_at: "2026-07-02T00:00:00Z" },
       { id: "sch_01", created_at: "2026-06-01T00:00:00Z" },
@@ -125,7 +136,11 @@ describe("schemas list", () => {
     server.use(
       http.get("*/schemas/:id", ({ request }) => {
         receivedPath = new URL(request.url).pathname;
-        return HttpResponse.json({ kind: "user-schema" });
+        return HttpResponse.json({
+          id: urlId,
+          schema: { kind: "user-schema" },
+          metadata: { created_at: "2026-06-01T00:00:00Z" },
+        });
       }),
     );
     const client = createZitadelClient({ baseUrl: "https://api.zitadel.cloud" });
@@ -133,6 +148,7 @@ describe("schemas list", () => {
     const body = await fetchSchemaRevision(client, urlId);
 
     expect(receivedPath).toBe(`/schemas/${encodeURIComponent(urlId)}`);
+    // The revision body is the customer document unwrapped from the envelope.
     expect(body).toEqual({ kind: "user-schema" });
   });
 });

--- a/apps/cli/tests/unit/lib/setup-resources.test.ts
+++ b/apps/cli/tests/unit/lib/setup-resources.test.ts
@@ -98,7 +98,13 @@ describe("materializeSetupResources", () => {
     };
     const client = {
       createSchema: vi.fn().mockResolvedValue({ id: "sch_01KWHF" }),
-      getSchemaById: vi.fn().mockResolvedValue(canonical),
+      // `GET /schemas/{id}` serves the `{id, schema, metadata}` envelope;
+      // write-back must unwrap the document before it reaches disk.
+      getSchemaById: vi.fn().mockResolvedValue({
+        id: "sch_01KWHF",
+        schema: canonical,
+        metadata: { created_at: "2026-01-01T00:00:00Z" },
+      }),
       createFlowDefinition: vi.fn().mockResolvedValue({
         id: "flow_01KWHG",
         status: "active",

--- a/apps/cli/tests/unit/lib/sync/syncers.test.ts
+++ b/apps/cli/tests/unit/lib/sync/syncers.test.ts
@@ -90,7 +90,11 @@ describe("SchemaSyncer", () => {
         return HttpResponse.json({ id: "schema-id-1" }, { status: 201 });
       }),
       http.get(`${BASE}/schemas/schema-id-1`, () =>
-        HttpResponse.json({ kind: "user-schema", version: 1 }),
+        HttpResponse.json({
+          id: "schema-id-1",
+          schema: { kind: "user-schema", version: 1 },
+          metadata: { created_at: "2026-01-01T00:00:00Z" },
+        }),
       ),
     );
     const [schema] = makeSyncers({ client, projectId: "proj-1", env: {}, cwd: "/tmp/zitadel-sync-test" });
@@ -99,7 +103,8 @@ describe("SchemaSyncer", () => {
     const result = await schema.create(data);
 
     expect(result.id).toBe("schema-id-1");
-    // The stored body comes from the follow-up fetch, feeding write-back.
+    // The stored body comes from the follow-up fetch, feeding write-back —
+    // the document unwrapped from the envelope, never the envelope itself.
     expect(result.canonical).toEqual({ kind: "user-schema", version: 1 });
     expect(new URL(receivedUrl).searchParams.get("project_id")).toBe("proj-1");
     expect(receivedBody).toEqual(data);
@@ -138,7 +143,11 @@ describe("SchemaSyncer", () => {
     server.use(
       http.get(`${BASE}/schemas/schema-id-1`, ({ request }) => {
         receivedUrl = request.url;
-        return HttpResponse.json({ kind: "user-schema", version: 1 });
+        return HttpResponse.json({
+          id: "schema-id-1",
+          schema: { kind: "user-schema", version: 1 },
+          metadata: { created_at: "2026-01-01T00:00:00Z" },
+        });
       }),
     );
     const [schema] = makeSyncers({ client, projectId: "proj-1", env: {}, cwd: "/tmp/zitadel-sync-test" });

--- a/apps/console-e2e/src-real/add-user.spec.ts
+++ b/apps/console-e2e/src-real/add-user.spec.ts
@@ -50,10 +50,10 @@ async function projectSchema(zitadel: {
   api: { getSchemaById: (id: string) => Promise<unknown> };
   handle: { schemaId: string };
 }) {
-  const schema = (await zitadel.api.getSchemaById(zitadel.handle.schemaId)) as {
-    properties?: Record<string, unknown>;
-    required?: string[];
+  const envelope = (await zitadel.api.getSchemaById(zitadel.handle.schemaId)) as {
+    schema?: { properties?: Record<string, unknown>; required?: string[] };
   };
+  const schema = envelope.schema ?? {};
   return {
     properties: Object.keys(schema.properties ?? {}).sort(),
     required: new Set(schema.required ?? []),

--- a/apps/console/src/components/add-user-sheet.spec.tsx
+++ b/apps/console/src/components/add-user-sheet.spec.tsx
@@ -56,12 +56,22 @@ function stubSchemas(
     http.get(USERS_URL, () => HttpResponse.json({ users: [] })),
     http.post(PROJECTS_QUERY_URL, () => HttpResponse.json({ projects })),
     http.get(SCHEMAS_URL, () =>
-      HttpResponse.json(
-        Object.keys(schemas).map((id) => ({ id, created_at: "2026-07-01T00:00:00Z" })),
-      ),
+      HttpResponse.json({
+        schemas: Object.entries(schemas).map(([id, body]) => ({
+          id,
+          schema: body,
+          metadata: { created_at: "2026-07-01T00:00:00Z" },
+        })),
+      }),
     ),
     ...Object.entries(schemas).map(([id, body]) =>
-      http.get(`${SCHEMAS_URL}/${id}`, () => HttpResponse.json(body)),
+      http.get(`${SCHEMAS_URL}/${id}`, () =>
+        HttpResponse.json({
+          id,
+          schema: body,
+          metadata: { created_at: "2026-07-01T00:00:00Z" },
+        }),
+      ),
     ),
   );
 }

--- a/apps/console/src/components/add-user-sheet.tsx
+++ b/apps/console/src/components/add-user-sheet.tsx
@@ -124,12 +124,10 @@ function AddUserForm({
     void (async () => {
       try {
         const projectId = getConsoleProjectId();
-        const listed = await api.listSchemas({ project_id: projectId });
-        // `listSchemas` returns only `{ id, created_at }`, so each schema's
-        // document — the properties this form renders — needs its own fetch.
+        const listed = (await api.listSchemas({ project_id: projectId })).schemas;
         const options = await Promise.all(
           listed.map(async (entry) => {
-            const schema = (await api.getSchemaById(entry.id)) as UserSchema;
+            const schema = (await api.getSchemaById(entry.id)).schema as UserSchema;
             return {
               id: entry.id,
               schema,

--- a/apps/console/src/routes/_authed/schemas/$schemaId.tsx
+++ b/apps/console/src/routes/_authed/schemas/$schemaId.tsx
@@ -13,7 +13,8 @@ import { type UserSchema, schemaAuthMethods, schemaDisplayName } from "@/lib/sch
 import { api } from "../../../api/zitadel";
 
 export const Route = createFileRoute("/_authed/schemas/$schemaId")({
-  loader: ({ params }) => api.getSchemaById(params.schemaId) as Promise<UserSchema>,
+  loader: ({ params }) =>
+    api.getSchemaById(params.schemaId).then((body) => body.schema as UserSchema),
   component: SchemaDetail,
 });
 

--- a/apps/console/src/routes/_authed/schemas/index.tsx
+++ b/apps/console/src/routes/_authed/schemas/index.tsx
@@ -26,16 +26,14 @@ export const Route = createFileRoute("/_authed/schemas/")({
   staticData: { nav: { label: "User schemas", order: 1, parent: "/users" } },
   loader: async () => {
     const projectId = getConsoleProjectId();
-    // `GET /schemas` returns `{ id, created_at }` and nothing else, so the
-    // row's name, attributes and sign-in methods all have to come from each
-    // document. The list is configuration and stays small (~20, decisions log
-    // D0a/D7), so fetching them together is cheap and there is no pagination
+    // The list is configuration and stays small (~20, decisions log D0a/D7),
+    // so fetching the documents together is cheap and there is no pagination
     // to interleave with.
-    const entries = await api.listSchemas({ project_id: projectId });
+    const entries = (await api.listSchemas({ project_id: projectId })).schemas;
     const documents = await Promise.all(
       entries.map(async (entry) => {
         try {
-          return (await api.getSchemaById(entry.id)) as UserSchema;
+          return (await api.getSchemaById(entry.id)).schema as UserSchema;
         } catch {
           // One unreadable document costs its row's detail, not the screen.
           return undefined;
@@ -46,7 +44,7 @@ export const Route = createFileRoute("/_authed/schemas/")({
     // and the row keeps the console's camelCase.
     return entries.map((entry, index) => ({
       id: entry.id,
-      createdAt: entry.created_at,
+      createdAt: entry.metadata.created_at,
       schema: documents[index],
     }));
   },

--- a/apps/console/src/routes/_authed/schemas/schemas.spec.tsx
+++ b/apps/console/src/routes/_authed/schemas/schemas.spec.tsx
@@ -65,13 +65,22 @@ afterAll(() => {
   vi.unstubAllEnvs();
 });
 
+const CREATED_AT = "2026-07-12T16:59:04Z";
+
+/** One `{id, schema, metadata}` wire envelope around a document. */
+function envelope(id: string, doc: object) {
+  return { id, schema: doc, metadata: { created_at: CREATED_AT } };
+}
+
 /** `GET /schemas` plus `GET /schemas/{id}` for one document. */
 function serveBusiness() {
   server.use(
     http.get(SCHEMAS_URL, () =>
-      HttpResponse.json([{ id: "sch_business", created_at: "2026-07-12T16:59:04Z" }]),
+      HttpResponse.json({ schemas: [envelope("sch_business", BUSINESS)] }),
     ),
-    http.get(`${SCHEMAS_URL}/sch_business`, () => HttpResponse.json(BUSINESS)),
+    http.get(`${SCHEMAS_URL}/sch_business`, () =>
+      HttpResponse.json(envelope("sch_business", BUSINESS)),
+    ),
   );
 }
 
@@ -109,16 +118,13 @@ describe("user schemas list", () => {
     // loads — `GET /schemas/{id}` serialises from a Go map and its key order is
     // randomised. It is not a claim about which method is offered first: that
     // is the flow's, from the order of its step's actions.
+    const both = {
+      ...BUSINESS,
+      "x-auth-methods": { password: { enabled: true }, passkey: { enabled: true } },
+    };
     server.use(
-      http.get(SCHEMAS_URL, () =>
-        HttpResponse.json([{ id: "sch_both", created_at: "2026-07-12T16:59:04Z" }]),
-      ),
-      http.get(`${SCHEMAS_URL}/sch_both`, () =>
-        HttpResponse.json({
-          ...BUSINESS,
-          "x-auth-methods": { password: { enabled: true }, passkey: { enabled: true } },
-        }),
-      ),
+      http.get(SCHEMAS_URL, () => HttpResponse.json({ schemas: [envelope("sch_both", both)] })),
+      http.get(`${SCHEMAS_URL}/sch_both`, () => HttpResponse.json(envelope("sch_both", both))),
     );
     await renderAt("/schemas");
     expect(await screen.findByText("Passkey + Password")).toBeInTheDocument();
@@ -134,7 +140,7 @@ describe("user schemas list", () => {
     expect(screen.getByText("Created")).toBeInTheDocument();
     // Derived rather than hardcoded: the row renders the viewer's locale, so
     // asserting one locale's output would pass only on machines set to it.
-    const created = new Date("2026-07-12T16:59:04Z").toLocaleDateString(undefined, {
+    const created = new Date(CREATED_AT).toLocaleDateString(undefined, {
       day: "numeric",
       month: "short",
       year: "numeric",
@@ -173,7 +179,7 @@ describe("user schemas list", () => {
     // cost that row's detail, not the screen.
     server.use(
       http.get(SCHEMAS_URL, () =>
-        HttpResponse.json([{ id: "sch_broken", created_at: "2026-07-12T16:59:04Z" }]),
+        HttpResponse.json({ schemas: [envelope("sch_broken", {})] }),
       ),
       http.get(`${SCHEMAS_URL}/sch_broken`, () => new HttpResponse(null, { status: 500 })),
     );
@@ -210,10 +216,8 @@ describe("user schema detail", () => {
     // more than one level, so it is inert; the segments either side of it still
     // navigate.
     server.use(
-      http.get(SCHEMAS_URL, () =>
-        HttpResponse.json([{ id: "sch_deep", created_at: "2026-07-12T16:59:04Z" }]),
-      ),
-      http.get(`${SCHEMAS_URL}/sch_deep`, () => HttpResponse.json(DEEP)),
+      http.get(SCHEMAS_URL, () => HttpResponse.json({ schemas: [envelope("sch_deep", DEEP)] })),
+      http.get(`${SCHEMAS_URL}/sch_deep`, () => HttpResponse.json(envelope("sch_deep", DEEP))),
     );
     await renderAt("/schemas/sch_deep");
     await screen.findByRole("heading", { name: "Deep" });

--- a/apps/console/src/routes/_authed/users/$userId.tsx
+++ b/apps/console/src/routes/_authed/users/$userId.tsx
@@ -47,7 +47,7 @@ export const Route = createFileRoute("/_authed/users/$userId")({
       schemaId
         ? api
             .getSchemaById(schemaId)
-            .then((value) => value as UserSchema)
+            .then((value) => value.schema as UserSchema)
             .catch(() => undefined)
         : Promise.resolve(undefined),
       api

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -74,7 +74,7 @@ async function columnsForUsers(users: Record<string, unknown>[]): Promise<Schema
   const schemas = await Promise.all(
     schemaIds.map(async (id) => {
       try {
-        return (await api.getSchemaById(id)) as UserSchema;
+        return (await api.getSchemaById(id)).schema as UserSchema;
       } catch {
         // One unreadable schema costs its columns, not the screen. The rows
         // still render from the fallback below.

--- a/apps/console/src/routes/_authed/users/user-detail.spec.tsx
+++ b/apps/console/src/routes/_authed/users/user-detail.spec.tsx
@@ -52,7 +52,13 @@ function stub({
 } = {}) {
   server.use(
     http.get(`${USERS_URL}/${USER_ID}`, () => HttpResponse.json(user)),
-    http.get(`${SCHEMAS_URL}/sch_business`, () => HttpResponse.json(BUSINESS)),
+    http.get(`${SCHEMAS_URL}/sch_business`, () =>
+      HttpResponse.json({
+        id: "sch_business",
+        schema: BUSINESS,
+        metadata: { created_at: "2026-07-01T00:00:00Z" },
+      }),
+    ),
     http.get(`${USERS_URL}/${USER_ID}/passkeys`, () =>
       passkeysStatus === 200
         ? HttpResponse.json({ passkeys })
@@ -99,12 +105,16 @@ describe("user detail", () => {
       ),
       http.get(`${SCHEMAS_URL}/sch_business`, () =>
         HttpResponse.json({
-          title: "Business",
-          properties: {
-            email: { type: "string", format: "email" },
-            headcount: { type: "integer", title: "Headcount" },
-            verified: { type: "boolean", title: "Verified" },
+          id: "sch_business",
+          schema: {
+            title: "Business",
+            properties: {
+              email: { type: "string", format: "email" },
+              headcount: { type: "integer", title: "Headcount" },
+              verified: { type: "boolean", title: "Verified" },
+            },
           },
+          metadata: { created_at: "2026-07-01T00:00:00Z" },
         }),
       ),
       http.get(`${USERS_URL}/${USER_ID}/passkeys`, () => HttpResponse.json({ passkeys: [] })),

--- a/apps/console/src/routes/_authed/users/users.spec.tsx
+++ b/apps/console/src/routes/_authed/users/users.spec.tsx
@@ -83,12 +83,16 @@ describe("users screen", () => {
       ),
       http.get(`${SCHEMAS_URL}/sch_business`, () =>
         HttpResponse.json({
-          title: "Business",
-          required: ["email"],
-          properties: {
-            email: { type: "string", format: "email" },
-            companyName: { type: "string", title: "Company name" },
+          id: "sch_business",
+          schema: {
+            title: "Business",
+            required: ["email"],
+            properties: {
+              email: { type: "string", format: "email" },
+              companyName: { type: "string", title: "Company name" },
+            },
           },
+          metadata: { created_at: "2026-07-01T00:00:00Z" },
         }),
       ),
     );
@@ -121,10 +125,14 @@ describe("users screen", () => {
       ),
       http.get(`${SCHEMAS_URL}/sch_business`, () =>
         HttpResponse.json({
-          properties: {
-            email: { type: "string", format: "email" },
-            companyName: { type: "string", title: "Company name" },
+          id: "sch_business",
+          schema: {
+            properties: {
+              email: { type: "string", format: "email" },
+              companyName: { type: "string", title: "Company name" },
+            },
           },
+          metadata: { created_at: "2026-07-01T00:00:00Z" },
         }),
       ),
     );

--- a/apps/console/src/routes/auth-guard.spec.tsx
+++ b/apps/console/src/routes/auth-guard.spec.tsx
@@ -53,7 +53,7 @@ vi.mock("@zitadel/sdk-react", () => ({
  * landed. A path pattern rather than an absolute URL: this spec imports the
  * router statically, so `api/zitadel.ts` binds its base before any `stubEnv`.
  */
-const server = setupServer(http.get("*/api/schemas", () => HttpResponse.json([])));
+const server = setupServer(http.get("*/api/schemas", () => HttpResponse.json({ schemas: [] })));
 
 beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
 afterAll(() => server.close());

--- a/internal/api/integration_test/authz_test.go
+++ b/internal/api/integration_test/authz_test.go
@@ -513,7 +513,7 @@ func TestListAuthzTeamScopedOnlyPartialView(t *testing.T) {
 	listResp, err := client.ListSchemas(t.Context(), api.ListSchemasParams{ProjectID: api.ProjectID(project.ID)})
 	require.NoError(t, err)
 	require.IsType(t, &api.ListSchemasResponse{}, listResp, helpers.MustMarshal(t, listResp))
-	require.Empty(t, *listResp.(*api.ListSchemasResponse))
+	require.Empty(t, listResp.(*api.ListSchemasResponse).Schemas)
 
 	teamsResp, err := client.QueryTeams(t.Context(), &api.QueryTeamsRequest{}, api.QueryTeamsParams{ProjectID: api.ProjectID(project.ID)})
 	require.NoError(t, err)

--- a/internal/api/integration_test/schema_test.go
+++ b/internal/api/integration_test/schema_test.go
@@ -184,7 +184,13 @@ func TestGetSchema(t *testing.T) {
 			})
 			assert.NoError(t, err)
 
-			assert.IsType(t, &api.GetSchemaByIdOK{}, resp, helpers.MustMarshal(t, resp))
+			if assert.IsType(t, &api.Schema{}, resp, helpers.MustMarshal(t, resp)) {
+				schema := resp.(*api.Schema)
+				assert.Equal(t, schemaID, schema.ID)
+				assert.False(t, schema.Metadata.CreatedAt.IsZero())
+				_, ok := schema.Schema.GetUserSchema()
+				assert.True(t, ok, "envelope should carry the user-schema document")
+			}
 		})
 	})
 
@@ -305,12 +311,21 @@ func TestSchemaRevisions(t *testing.T) {
 			)
 			require.NoError(t, err)
 			if assert.IsType(t, &api.ListSchemasResponse{}, resp, helpers.MustMarshal(t, resp)) {
-				list := *(resp.(*api.ListSchemasResponse))
+				list := resp.(*api.ListSchemasResponse).Schemas
 				// ensure all revisions are present
 				assert.Len(t, list, len(tc.schemaRevisions))
 
 				// ensure list endpoint is LIFO and latest items match
 				assert.Equal(t, list[0].ID, lastCreatedID)
+
+				// every row carries the full document alongside the envelope
+				for _, item := range list {
+					doc, ok := item.Schema.GetUserSchema()
+					if assert.True(t, ok, "list row should carry the user-schema document") {
+						assert.Equal(t, tc.objectType, doc.ObjectType.Value)
+					}
+					assert.False(t, item.Metadata.CreatedAt.IsZero())
+				}
 			}
 		})
 	}

--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -58,16 +58,11 @@ func (h *Handler) GetSchemaById(ctx context.Context, params api.GetSchemaByIdPar
 		return nil, err
 	}
 
-	apiSchema := api.UserSchema{}
-	err = apiSchema.UnmarshalJSON(schema.Schema)
+	apiSchema, err := domainSchemaToApiSchema(schema)
 	if err != nil {
 		return nil, err
 	}
-
-	return &api.GetSchemaByIdOK{
-		Type:       api.UserSchemaGetSchemaByIdOK,
-		UserSchema: apiSchema,
-	}, nil
+	return apiSchema, nil
 }
 
 func (h *Handler) ListSchemas(ctx context.Context, params api.ListSchemasParams) (api.ListSchemasRes, error) {
@@ -85,16 +80,31 @@ func (h *Handler) ListSchemas(ctx context.Context, params api.ListSchemasParams)
 		return nil, err
 	}
 
-	resp := make(api.ListSchemasResponse, len(schemas))
-
+	resp := api.ListSchemasResponse{Schemas: make([]api.Schema, len(schemas))}
 	for i, schema := range schemas {
-		resp[i] = api.ListSchemasResponseItem{
-			ID:        schema.URL,
-			CreatedAt: schema.CreatedAt,
+		apiSchema, err := domainSchemaToApiSchema(schema)
+		if err != nil {
+			return nil, err
 		}
+		resp.Schemas[i] = *apiSchema
 	}
 
 	return &resp, nil
+}
+
+// domainSchemaToApiSchema wraps the stored customer-authored document in the
+// server-owned envelope; every schema read goes through it.
+func domainSchemaToApiSchema(schema *domain.JSONSchema) (*api.Schema, error) {
+	document := api.UserSchema{}
+	if err := document.UnmarshalJSON(schema.Schema); err != nil {
+		return nil, err
+	}
+
+	return &api.Schema{
+		ID:       schema.URL,
+		Schema:   api.NewUserSchemaSchemaDocument(document),
+		Metadata: api.SchemaMetadata{CreatedAt: schema.CreatedAt},
+	}, nil
 }
 
 // ------------------ Errors ---------------

--- a/packages/api-mock/src/platform-handlers.ts
+++ b/packages/api-mock/src/platform-handlers.ts
@@ -31,8 +31,10 @@ import type {
   GetFlowDefinition200,
   GetProject200,
   GetSchemaById200,
+  GetSchemaById200Schema,
   InitClaim201,
   ListFlowDefinitions200,
+  ListSchemas200,
   ListFlowDefinitions200FlowDefinitionsItem,
   UpdateFlowDefinition200,
 } from "@zitadel/api/generated/model";
@@ -183,15 +185,16 @@ type FlowDefinitionRecord = {
 
 /**
  * Server-side metadata wrapped around the schema body so the mock can answer
- * `POST /schemas` (returns id), `GET /schemas/:id` (returns body), and
- * `GET /schemas` (list — id + createdAt, filterable by object_type).
+ * `POST /schemas` (returns id) and, for `GET /schemas/:id` and `GET /schemas`,
+ * build the `{id, schema, metadata}` envelope around the stored document
+ * (list filterable by object_type).
  */
 type SchemaRecord = {
   id: string;
   projectId: string;
   objectType?: string;
   createdAt: string;
-  body: GetSchemaById200;
+  body: GetSchemaById200Schema;
 };
 
 /**
@@ -277,8 +280,8 @@ function flowListItemResponse(r: FlowDefinitionRecord): ListFlowDefinitions200Fl
   };
 }
 
-function defaultHumanUserSchema(): GetSchemaById200 {
-  return getDefaultHumanUserSchema() as unknown as GetSchemaById200;
+function defaultHumanUserSchema(): GetSchemaById200Schema {
+  return getDefaultHumanUserSchema() as unknown as GetSchemaById200Schema;
 }
 
 function seedDefaultProjectResources(projectID: string, createdAt: string): void {
@@ -304,7 +307,7 @@ function seedDefaultProjectResources(projectID: string, createdAt: string): void
   });
 }
 
-function schemaObjectType(body: GetSchemaById200): string | undefined {
+function schemaObjectType(body: GetSchemaById200Schema): string | undefined {
   const value = (body as unknown as { objectType?: unknown }).objectType;
   return typeof value === "string" ? value : undefined;
 }
@@ -677,7 +680,7 @@ export function setupPlatformHandlers() {
         return body.response;
       }
 
-      const schemaBody = raw as unknown as GetSchemaById200;
+      const schemaBody = raw as unknown as GetSchemaById200Schema;
       const id = `sch_${shortId()}`;
       store.schemas.set(id, {
         id,
@@ -703,9 +706,14 @@ export function setupPlatformHandlers() {
         .filter((r) => r.projectId === projectId)
         .filter((r) => !objectTypeFilter || r.objectType === objectTypeFilter)
         .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
-      return HttpResponse.json(
-        records.map((r) => ({ id: r.id, created_at: r.createdAt })),
-      );
+      const responseBody: ListSchemas200 = {
+        schemas: records.map((r) => ({
+          id: r.id,
+          schema: r.body,
+          metadata: { created_at: r.createdAt },
+        })),
+      };
+      return HttpResponse.json(responseBody);
     }),
 
     http.get("*/schemas/:id", ({ params, request }) => {
@@ -724,7 +732,12 @@ export function setupPlatformHandlers() {
       if (!record) {
         return HttpResponse.json(errorBody("not_found", "resource not found"), { status: 404 });
       }
-      return HttpResponse.json(record.body);
+      const responseBody: GetSchemaById200 = {
+        id: record.id,
+        schema: record.body,
+        metadata: { created_at: record.createdAt },
+      };
+      return HttpResponse.json(responseBody);
     }),
 
     http.delete("*/schemas/:id", ({ params, request }) => {

--- a/packages/api-mock/src/server.ts
+++ b/packages/api-mock/src/server.ts
@@ -23,6 +23,7 @@
  *   POST   /projects/:id/claim/init   — mint a claim challenge
  *   GET    /projects/:id/claim/status — poll a claim challenge
  *   POST   /schemas                   — create user schema
+ *   GET    /schemas                   — list user schemas
  *   GET    /schemas/:id               — fetch user schema
  *   DELETE /schemas/:id               — delete user schema
  *   POST   /flow_definitions          — create flow definition

--- a/packages/api-mock/src/spec-conformance.spec.ts
+++ b/packages/api-mock/src/spec-conformance.spec.ts
@@ -256,10 +256,12 @@ describe("api-mock spec conformance — responses match orval-generated zod", ()
     expect(ownerDelete.status).toBe(204);
   });
 
-  test("GET /schemas/:id round-trips the raw uploaded document (no zod re-shaping)", async () => {
+  test("GET /schemas/:id round-trips the raw uploaded document inside the envelope (no zod re-shaping)", async () => {
     // The real server persists the uploaded JSON Schema bytes verbatim, and
     // schema documents legitimately carry fields the request zod strips
-    // (title, description, custom x-* extensions). The mock must do the same.
+    // (title, description, custom x-* extensions). The mock must do the same,
+    // serving the document under `schema` in the {id, schema, metadata}
+    // envelope.
     const doc = {
       kind: "user-schema",
       metaSchema: "https://nextgen.com/api/schemas/user-schema.json",
@@ -276,7 +278,38 @@ describe("api-mock spec conformance — responses match orval-generated zod", ()
 
     const res = await fetch(`${BASE}/schemas/${id}`);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual(doc);
+    const body = (await res.json()) as {
+      id: string;
+      schema: unknown;
+      metadata: { created_at: string };
+    };
+    expect(body.id).toBe(id);
+    expect(body.schema).toEqual(doc);
+    expect(typeof body.metadata.created_at).toBe("string");
+  });
+
+  test("GET /schemas lists envelopes carrying the full document", async () => {
+    const doc = {
+      kind: "user-schema",
+      metaSchema: "https://nextgen.com/api/schemas/user-schema.json",
+      objectType: "conformance-list",
+      "x-auth-methods": { password: { enabled: true } },
+    };
+    const create = await fetch(`${BASE}/schemas?project_id=proj_schema_list`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(doc),
+    });
+    const { id } = (await create.json()) as { id: string };
+
+    const res = await fetch(`${BASE}/schemas?project_id=proj_schema_list`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      schemas: Array<{ id: string; schema: unknown; metadata: { created_at: string } }>;
+    };
+    const row = body.schemas.find((entry) => entry.id === id);
+    expect(row?.schema).toEqual(doc);
+    expect(typeof row?.metadata.created_at).toBe("string");
   });
 
   test("POST /schemas with invalid kind returns spec-compliant 400 envelope", async () => {

--- a/packages/api-mock/tsconfig.spec.json
+++ b/packages/api-mock/tsconfig.spec.json
@@ -8,7 +8,7 @@
     "module": "esnext",
     "moduleResolution": "bundler"
   },
-  "include": ["vitest.config.ts", "src/**/*.spec.ts"],
+  "include": ["src/**/*.spec.ts"],
   "references": [
     {
       "path": "./tsconfig.lib.json"


### PR DESCRIPTION
## Summary

Second PR of the three-PR stack for #921 (listSchemas should return the full schema document). Stacked on #929.

`GET /schemas/{id}` and `GET /schemas` described two disjoint halves of a schema: the bare customer document with no id or timestamp, and a bare `[{id, created_at}]` array with no document. Both now serve one representation, mirroring the user envelope (ADR 052):

```json
{
  "id": "sch_01K...",
  "schema": { "kind": "user-schema", "objectType": "human-user", "properties": { ... } },
  "metadata": { "created_at": "2026-08-14T10:49:43Z" }
}
```

- New `schema.yaml` / `schema-document.yaml` / `schema-metadata.yaml` specs; `GET /schemas` wraps rows in `{schemas: [...]}` like every other list endpoint. The envelope keeps server-owned fields collision-safe against schema-defined keys, and the resource `id` stays distinguishable from the document's own `$id`.
- `internal/api/schema.go` gains the single `domainSchemaToApiSchema` mapper (analogous to `domainUserToApiUser`); both read handlers go through it.
- api-mock serves the envelope from its stored records.
- Consumers adapt **mechanically only**: the CLI list command reads `{schemas}` and `metadata.created_at` (stdout contract unchanged), the CLI syncers and setup write-back unwrap `.schema` so `.zitadel/schemas/*.json` GitOps files stay bare documents, and console call sites unwrap `.schema`. The console's per-row N+1 loops intentionally survive this PR — deleting them is the third PR, keeping this diff reviewable as the contract flip.

Left open on purpose: pagination (#924), latest-revision cardinality (#923), kind filtering (#922), and the `POST /schemas` response (stays `{id}`).

## Validation

- `moon run server:openapi`, `moon run server:generate` (no drift), `moon run server:vet`, `moon run server:test`, and `moon run server:test-postgres` pass — `TestGetSchema` and `TestSchemaRevisions` now assert the envelope (id echoes/mints, `metadata.created_at` set, document present on every list row).
- `moon run api:generate`, then `api:test`, `api-mock:test` (spec-conformance gained a `GET /schemas` envelope case), `console:test` (118/118), `cli:test`, and package typechecks pass.
- `corepack pnpm exec changeset status --since origin/main` passes.
- `api-mock:typecheck` turned out to be a pre-existing landmine this PR stepped on: pnpm resolves two peer-hashed vitest instances, and tsc treats their identical types as unrelated as soon as `vitest.config.ts` is typechecked. It never surfaced before because moon only runs the task for PRs touching `packages/api-mock`. Fixed here by dropping the config from the typecheck include, matching `components` and `storybook` (second commit).

## Release notes / changeset

`.changeset/schema-read-envelope.md` — `@zitadel/server` minor, `@zitadel/cli` patch: the schema read endpoints now return the `{id, schema, metadata}` envelope and the list wraps rows in `{schemas: [...]}`; clients reading the bare document or bare array must unwrap.

## Notes

- Stack: #929 (service refactor) → **this PR** (contract flip) → console N+1 deletion (next).
- Nested field name `schema`, no promotion of `object_type`/`kind`, and the list-object flip were confirmed with Marco against the ticket's open questions.
- Also updates the stale bare-array note in `api/openapi/readme.md` and fixes the missed `listSchemas` stub in `auth-guard.spec.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

