### PR TITLE
fix(console): render the schema directory and user schema picker from the list response

### DIFF
--- a/.changeset/console-schema-single-fetch.md
+++ b/.changeset/console-schema-single-fetch.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+The console renders the schema directory and the add-user schema picker from the single `GET /schemas` response instead of fetching every schema's document individually.

--- a/apps/console-e2e/src-real/add-user.spec.ts
+++ b/apps/console-e2e/src-real/add-user.spec.ts
@@ -31,9 +31,9 @@ async function openDrawer(page: Page, user: { email: string; password: string })
   await page.getByRole("button", { name: "Add", exact: true }).click();
   const drawer = page.getByRole("dialog", { name: "Add user" });
   await expect(drawer).toBeVisible();
-  // Two fetches gate the form: the drawer shows "Loading schemas…" until the
-  // list resolves, and fields mount only once the selected schema's definition
-  // arrives. Locator actions auto-wait through both, but one-shot reads
+  // One fetch gates the form: the drawer shows "Loading schemas…" until the
+  // list — which carries each schema's document (#921) — resolves and the
+  // fields mount. Locator actions auto-wait through it, but one-shot reads
   // (`renderedFields`) and raw key presses don't — so only hand tests a drawer
   // whose form is actually on screen.
   await expect(drawer.locator('input[data-slot="input"]').first()).toBeVisible();

--- a/apps/console/src/components/add-user-sheet.spec.tsx
+++ b/apps/console/src/components/add-user-sheet.spec.tsx
@@ -55,6 +55,8 @@ function stubSchemas(
   server.use(
     http.get(USERS_URL, () => HttpResponse.json({ users: [] })),
     http.post(PROJECTS_QUERY_URL, () => HttpResponse.json({ projects })),
+    // The list carries the documents (#921), so the sheet needs no per-schema
+    // stubs — a reintroduced `GET /schemas/{id}` has no handler here.
     http.get(SCHEMAS_URL, () =>
       HttpResponse.json({
         schemas: Object.entries(schemas).map(([id, body]) => ({
@@ -63,15 +65,6 @@ function stubSchemas(
           metadata: { created_at: "2026-07-01T00:00:00Z" },
         })),
       }),
-    ),
-    ...Object.entries(schemas).map(([id, body]) =>
-      http.get(`${SCHEMAS_URL}/${id}`, () =>
-        HttpResponse.json({
-          id,
-          schema: body,
-          metadata: { created_at: "2026-07-01T00:00:00Z" },
-        }),
-      ),
     ),
   );
 }

--- a/apps/console/src/components/add-user-sheet.tsx
+++ b/apps/console/src/components/add-user-sheet.tsx
@@ -125,17 +125,15 @@ function AddUserForm({
       try {
         const projectId = getConsoleProjectId();
         const listed = (await api.listSchemas({ project_id: projectId })).schemas;
-        const options = await Promise.all(
-          listed.map(async (entry) => {
-            const schema = (await api.getSchemaById(entry.id)).schema as UserSchema;
-            return {
-              id: entry.id,
-              schema,
-              name: schemaDisplayName(schema, entry.id),
-              summary: schemaFieldSummary(schema),
-            } satisfies SchemaOption;
-          }),
-        );
+        const options = listed.map((entry) => {
+          const schema = entry.schema as UserSchema;
+          return {
+            id: entry.id,
+            schema,
+            name: schemaDisplayName(schema, entry.id),
+            summary: schemaFieldSummary(schema),
+          } satisfies SchemaOption;
+        });
         if (cancelled) return;
         setSchemas(options);
         // Projects are a secondary concern: a failure here must not block user

--- a/apps/console/src/routes/_authed/schemas/index.tsx
+++ b/apps/console/src/routes/_authed/schemas/index.tsx
@@ -26,26 +26,13 @@ export const Route = createFileRoute("/_authed/schemas/")({
   staticData: { nav: { label: "User schemas", order: 1, parent: "/users" } },
   loader: async () => {
     const projectId = getConsoleProjectId();
-    // The list is configuration and stays small (~20, decisions log D0a/D7),
-    // so fetching the documents together is cheap and there is no pagination
-    // to interleave with.
     const entries = (await api.listSchemas({ project_id: projectId })).schemas;
-    const documents = await Promise.all(
-      entries.map(async (entry) => {
-        try {
-          return (await api.getSchemaById(entry.id)).schema as UserSchema;
-        } catch {
-          // One unreadable document costs its row's detail, not the screen.
-          return undefined;
-        }
-      }),
-    );
     // Mapped rather than spread so the wire's `created_at` stops at the loader
     // and the row keeps the console's camelCase.
-    return entries.map((entry, index) => ({
+    return entries.map((entry) => ({
       id: entry.id,
       createdAt: entry.metadata.created_at,
-      schema: documents[index],
+      schema: entry.schema as UserSchema,
     }));
   },
   component: SchemasScreen,
@@ -104,19 +91,17 @@ function SchemaRow({
 }: {
   id: string;
   createdAt: string;
-  schema: UserSchema | undefined;
+  schema: UserSchema;
 }) {
-  const name = schema ? schemaDisplayName(schema, id) : id;
-  const attributes = schema ? schemaProperties(schema).map((property) => property.key) : [];
+  const name = schemaDisplayName(schema, id);
+  const attributes = schemaProperties(schema).map((property) => property.key);
   // "Passkey + Password" reads off the document's own `x-auth-methods`. The
   // annotation says which methods the user type supports; the order they are
   // offered in belongs to the flow, not to the schema.
-  const signIn = schema
-    ? schemaAuthMethods(schema)
-        .filter((method) => method.enabled)
-        .map((method) => method.label)
-        .join(" + ")
-    : "";
+  const signIn = schemaAuthMethods(schema)
+    .filter((method) => method.enabled)
+    .map((method) => method.label)
+    .join(" + ");
 
   return (
     <div className="group relative flex flex-col gap-4 border-b border-border px-6 py-3.5 last:border-b-0 hover:bg-accent lg:flex-row lg:items-center lg:gap-6">

--- a/apps/console/src/routes/_authed/schemas/schemas.spec.tsx
+++ b/apps/console/src/routes/_authed/schemas/schemas.spec.tsx
@@ -72,7 +72,16 @@ function envelope(id: string, doc: object) {
   return { id, schema: doc, metadata: { created_at: CREATED_AT } };
 }
 
-/** `GET /schemas` plus `GET /schemas/{id}` for one document. */
+/**
+ * `GET /schemas` only: the list carries the documents, so the directory must
+ * not fetch anything else — a reintroduced per-row `GET /schemas/{id}` has no
+ * handler here and fails the spec.
+ */
+function serveList(...rows: Array<{ id: string; schema: object; metadata: object }>) {
+  server.use(http.get(SCHEMAS_URL, () => HttpResponse.json({ schemas: rows })));
+}
+
+/** The detail screen's pair: the list for navigation, the document by id. */
 function serveBusiness() {
   server.use(
     http.get(SCHEMAS_URL, () =>
@@ -96,7 +105,7 @@ async function renderAt(path: string) {
 
 describe("user schemas list", () => {
   it("shows the schema name, its attributes and its enabled sign-in methods", async () => {
-    serveBusiness();
+    serveList(envelope("sch_business", BUSINESS));
     await renderAt("/schemas");
 
     expect(await screen.findByRole("heading", { name: "User schemas" })).toBeInTheDocument();
@@ -115,23 +124,20 @@ describe("user schemas list", () => {
 
   it("joins the enabled methods in a stable order", async () => {
     // Alphabetical by annotation key, so the chip does not reshuffle between
-    // loads — `GET /schemas/{id}` serialises from a Go map and its key order is
-    // randomised. It is not a claim about which method is offered first: that
-    // is the flow's, from the order of its step's actions.
+    // loads — the document arrives serialised from a Go map and its key order
+    // is randomised. It is not a claim about which method is offered first:
+    // that is the flow's, from the order of its step's actions.
     const both = {
       ...BUSINESS,
       "x-auth-methods": { password: { enabled: true }, passkey: { enabled: true } },
     };
-    server.use(
-      http.get(SCHEMAS_URL, () => HttpResponse.json({ schemas: [envelope("sch_both", both)] })),
-      http.get(`${SCHEMAS_URL}/sch_both`, () => HttpResponse.json(envelope("sch_both", both))),
-    );
+    serveList(envelope("sch_both", both));
     await renderAt("/schemas");
     expect(await screen.findByText("Passkey + Password")).toBeInTheDocument();
   });
 
   it("identifies a schema by its id and creation date (D10)", async () => {
-    serveBusiness();
+    serveList(envelope("sch_business", BUSINESS));
     await renderAt("/schemas");
     await screen.findByRole("link", { name: "Business" });
 
@@ -154,7 +160,7 @@ describe("user schemas list", () => {
     // The design system's note on `Schema Row`: the row is the click target and
     // hover is the affordance, so a stretched link covers it — one focusable
     // control, still keyboard- and middle-click-navigable.
-    serveBusiness();
+    serveList(envelope("sch_business", BUSINESS));
     await renderAt("/schemas");
 
     const link = await screen.findByRole("link", { name: "Business" });
@@ -163,7 +169,7 @@ describe("user schemas list", () => {
   });
 
   it("offers no way to create, edit or delete a schema (D0b)", async () => {
-    serveBusiness();
+    serveList(envelope("sch_business", BUSINESS));
     await renderAt("/schemas");
     await screen.findByRole("link", { name: "Business" });
 
@@ -174,17 +180,20 @@ describe("user schemas list", () => {
     expect(screen.queryByRole("button", { name: /^Add/ })).not.toBeInTheDocument();
   });
 
-  it("still lists a schema whose document cannot be read", async () => {
-    // The name and chips come from the document, so a 500 on one of them must
-    // cost that row's detail, not the screen.
+  it("renders one list request and no per-row document fetches", async () => {
+    // The whole point of the envelope (#921): the directory renders from
+    // `GET /schemas` alone. `serveList` registers no by-id handler, so this
+    // also fails if a per-row fetch sneaks back in.
+    const listCalls = vi.fn();
     server.use(
-      http.get(SCHEMAS_URL, () =>
-        HttpResponse.json({ schemas: [envelope("sch_broken", {})] }),
-      ),
-      http.get(`${SCHEMAS_URL}/sch_broken`, () => new HttpResponse(null, { status: 500 })),
+      http.get(SCHEMAS_URL, () => {
+        listCalls();
+        return HttpResponse.json({ schemas: [envelope("sch_business", BUSINESS)] });
+      }),
     );
     await renderAt("/schemas");
-    expect(await screen.findByRole("link", { name: "sch_broken" })).toBeInTheDocument();
+    await screen.findByRole("link", { name: "Business" });
+    expect(listCalls).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Third and last PR of the stack for #921, on top of #930. The contract PR made `GET /schemas` carry each schema's full document; this PR collects the payoff in the console:

- The schema directory loader (`schemas/index.tsx`) and the add-user sheet build their rows/options straight from the list response — both per-row `getSchemaById` fan-outs (the workarounds the ticket cites) are deleted.
- The per-row "unreadable document" fallback goes with the second fetch: `SchemaRow` now takes the document unconditionally.
- The list specs serve **only** the list handler, so a reintroduced per-row fetch fails loudly; a new spec asserts the directory renders from exactly one list request. The now-impossible "still lists a schema whose document cannot be read" spec is deleted.
- The console-e2e drawer comment describing two gating fetches is updated to one (comment-only; the wait logic was already shape-agnostic).

Closes #921: with this PR, every acceptance criterion is met (single list call carries what a row renders, both read endpoints share one representation, envelope fields are collision-safe, both N+1 loops are gone, and the CLI list command works against the new response — adapted in #930).

## Validation

- `moon run console:typecheck` and `moon run console:test` pass (118/118, including the rewritten schemas and add-user-sheet specs and the new single-request spec).
- `corepack pnpm exec changeset status --since origin/main` passes.

## Release notes / changeset

`.changeset/console-schema-single-fetch.md` — `@zitadel/server` patch: the console renders the schema directory and add-user schema picker from the single `GET /schemas` response instead of one request per schema.

## Notes

- Stack: #929 (service refactor) → #930 (contract flip) → **this PR**.
- The users directory's per-user schema lookup (`users/index.tsx`) is keyed off each user's `schema` pointer, so a fatter list response does not remove it — out of scope here, as in the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
