### PR TITLE
test(login): cover the select field branch in every branding design

### DIFF
--- a/packages/components/src/orchestrator/design-templates.spec.ts
+++ b/packages/components/src/orchestrator/design-templates.spec.ts
@@ -17,6 +17,7 @@ const locale: Record<string, string> = {
   "identifier.title": "Sign in",
   "identifier.field.email": "Work email",
   "identifier.field.remember": "Remember me",
+  "identifier.field.department": "Department",
   "identifier.action.register.lead": "New here? ",
   "identifier.action.register.link": "Create an account",
   "submit.continue": "Continue",
@@ -29,6 +30,13 @@ const step: CreateFlow201Step = {
   fields: [
     { name: "email", type: "email", text_key: "identifier.field.email", required: true },
     { name: "remember", type: "checkbox", text_key: "identifier.field.remember" },
+    {
+      name: "department",
+      type: "select",
+      text_key: "identifier.field.department",
+      required: true,
+      validation: { enum: ["Engineering", "Support"] },
+    },
   ],
   actions: [
     { name: "submit", kind: "submit", text_key: "submit.continue", primary: true },
@@ -54,6 +62,17 @@ const context = {
   challenge: null,
 };
 
+/**
+ * Parses rendered HTML into a queryable fragment so attribute assertions read
+ * the decoded attribute value rather than matching the serialiser's escaping
+ * (`options='{...}'` comes back out as `options="{&quot;...&quot;}"`).
+ */
+function parseFragment(html: string): DocumentFragment {
+  const element = document.createElement("template");
+  element.innerHTML = html;
+  return element.content;
+}
+
 function renderDesign(design: string): string {
   const engine = createLiquidEngine({ locale });
   const { template } = getDefaultBrandingConfig(design);
@@ -70,9 +89,25 @@ describe("branding design catalog", () => {
       it("renders the declared field and primary action after the full pipeline", () => {
         expect(html).toContain('name="email"');
         expect(html).toContain('data-testid="zitadel-field-remember"');
+        expect(html).toContain('data-testid="zitadel-field-department"');
         expect(html).toContain('data-testid="zitadel-action-submit"');
         expect(html).toContain('data-action="register"');
         expect(html).toContain('data-action="recover"');
+      });
+
+      it("serialises a select field's enum into the <zl-select> options attribute", () => {
+        // The `{% case f.type %}` field loop is duplicated byte-identically
+        // across all six templates (each design is independently ejectable per
+        // ADR 037), and `select` is the one arm the shared fixture used to
+        // never reach — it was only ever covered through `default.liquid`.
+        const select = parseFragment(html).querySelector('zl-select[name="department"]');
+        expect(select).not.toBeNull();
+        expect(select?.getAttribute("label")).toBe("Department");
+        expect(select?.hasAttribute("required")).toBe(true);
+        expect(JSON.parse(select?.getAttribute("options") ?? "null")).toEqual([
+          { value: "Engineering", label: "Engineering" },
+          { value: "Support", label: "Support" },
+        ]);
       });
 
       it("consumes its mandatory_gates marker", () => {
@@ -81,6 +116,9 @@ describe("branding design catalog", () => {
         // append a second field or submit button.
         expect(html.match(/data-testid="zitadel-field-email"/g) ?? []).toHaveLength(1);
         expect(html.match(/data-testid="zitadel-action-submit"/g) ?? []).toHaveLength(1);
+        // A required `select` already renders as <zl-select>; the patcher must
+        // recognise it and not append a generic <zl-field> alongside.
+        expect(html.match(/data-testid="zitadel-field-department"/g) ?? []).toHaveLength(1);
       });
 
       it("survives sanitisation structurally", () => {


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why. -->

- The Liquid field-rendering loop (`{% for f in fields %}` with a `{% case f.type %}` dispatch over `checkbox` / `select` / default input) is duplicated byte-identically across six templates: the built-in `packages/components/src/orchestrator/templates/default.liquid` plus the five ejectable branding designs under `packages/config/defaults/branding/*/login.liquid`. The duplication is deliberate — each design is self-contained so `zitadel branding eject --design X` writes a standalone file (ADR 037, #563).
- The catalog parity test loops every design in `BRANDING_DESIGNS`, but its shared fixture declared only `email` (type `email`) and `remember` (type `checkbox`). The `select` arm — the one that renders `<zl-select options='{{ f.validation.enum | selectOptions | json }}'>` — was therefore never reached for the five branding designs; it was covered only through `default.liquid`'s own tests. A hand-edit that broke one design's select branch shipped green.
- Adds a required `select` field with a closed `validation.enum` to the fixture step and asserts, per design, that the rendered `<zl-select>` carries its localised label, its `required` flag, and `options` built from the enum. Existing email/checkbox assertions are unchanged.
- The `consumes its mandatory_gates marker` test gains a duplicate check for the new field: a *required* select must not trip the safety net into appending a generic `<zl-field>` alongside it. That regression was previously guarded only in isolation in `mandatory-gates.spec.ts`; it is now proven per design through the real pipeline.

No shared partial was extracted — that is a separate open design question, and the six copies stay as they are.

## Validation

<!-- List exact commands run. If validation was not run, say so explicitly. -->

- `moon run components:test` — 33 files, 425 tests passed (32 in `design-templates.spec.ts`, up from 27).
- `moon run components:typecheck components:lint` — clean; no new lint warnings attributable to the spec.
- `pnpm exec oxfmt --check packages/components/src/orchestrator/design-templates.spec.ts` — formatted.
- Mutation-tested to prove the assertion is not vacuous, restoring each template afterwards (`git status` clean, only the spec is modified):
  - dropped `options='…'` from `minimal/login.liquid` → exactly one failure, `minimal` only (`expected null to deeply equal [ Array(2) ]`);
  - deleted the whole `{% when 'select' %}` arm from `split/login.liquid` → exactly one failure, `split` only (`expected null not to be null` — the field falls through to the `<zl-field>` default arm).

## Release notes / changeset

<!-- The title type follows from this answer -->

- No changeset required — no shipped behavior changed. The PR is exclusively a `*.spec.ts` change (`.changeset/README.md#decision-table`, row 3), which is also why the title type is `test`.

## Notes

<!-- Add reviewer context, follow-ups, risks, or "None". -->

- The assertion parses the rendered HTML into a fragment and reads the decoded `options` attribute rather than string-matching it. The value passes through two escaping hops — Liquid runs with `outputEscape: "escape"`, so the `| json` output is HTML-encoded before the sanitiser's serialiser re-encodes it — and a `JSON.parse` round-trip is both stronger and immune to that churn.
- `options` is already on `zlSelectManifest.attrs`, so it survives the DOMPurify pass; the test would catch it if that ever changed.
- Fixture naming (`department`, enum `["Engineering", "Support"]`) matches the existing select fixture idiom in `embedding.browser.spec.ts`.
- Setup note for anyone reproducing locally in a fresh worktree: `moon run components:test` fails with `tsx/tsdown/orval: command not found` until `pnpm install --frozen-lockfile` has been run.
