### PR TITLE
fix: resolve login identifiers only against unique attribute values

### DIFF
--- a/.changeset/identifier-lookup-unique-registry.md
+++ b/.changeset/identifier-lookup-unique-registry.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+Login identifier lookups now match only uniquely-registered attribute values. Previously, an equal value stored under the same key as a non-unique attribute of another user (for example a notification email address) made the lookup ambiguous and rejected the legitimate user's sign-in.

--- a/internal/service/statement.go
+++ b/internal/service/statement.go
@@ -227,6 +227,11 @@ type UserQueryOptions struct {
 	AttributeKeys []string
 	// Attributes, when non-empty, restricts to users matching all key/value pairs.
 	Attributes []domain.Attribute
+	// UniqueAttributesOnly restricts Attributes matching to values recorded
+	// in the unique-attributes registry. Identifier lookups set it so an
+	// equal value in a non-unique property of another user (for example a
+	// notification address) cannot make the lookup ambiguous.
+	UniqueAttributesOnly bool
 	// MembershipTeamID, when set, requires an active team membership.
 	MembershipTeamID *string
 }

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -516,10 +516,13 @@ type UserStatementsLookup struct {
 	Pool StatementPool
 }
 
+// GetByAttributes resolves a login identifier, so it matches only uniquely
+// registered values: an equal value in a non-unique property of another user
+// must not make the lookup ambiguous and reject the sign-in.
 func (l UserStatementsLookup) GetByAttributes(ctx context.Context, projectID string, attrs []domain.Attribute) (*domain.User, error) {
 	return l.Pool.Statements().GetUser(ctx,
 		database.Equal(database.Col(domain.UserFieldProjectID), projectID),
-		UserQueryOptions{Attributes: attrs},
+		UserQueryOptions{Attributes: attrs, UniqueAttributesOnly: true},
 	)
 }
 

--- a/internal/storage/dialect/postgres/user.go
+++ b/internal/storage/dialect/postgres/user.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 
@@ -65,7 +66,8 @@ SELECT 1;
 
 	userQuery = `SELECT project_id, schema_url, id, lifecycle_owner_team_id, status, created_at, updated_at FROM zitadel_nextgen.users`
 
-	userAttributesTable = "zitadel_nextgen.user_attributes"
+	userAttributesTable       = "zitadel_nextgen.user_attributes"
+	userUniqueAttributesTable = "zitadel_nextgen.user_unique_attributes"
 
 	userAttributesByIDsQuery = `
 SELECT user_id, key, value
@@ -216,6 +218,17 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 			return nil, fmt.Errorf("marshal attribute %q: %w", a.Key, err)
 		}
 		writeConjunct(&compiler, &hasWhere)
+		if opts.UniqueAttributesOnly {
+			hash := sha256.Sum256(raw)
+			compiler.WriteString("EXISTS (SELECT 1 FROM ")
+			compiler.WriteString(userUniqueAttributesTable)
+			compiler.WriteString(" ua WHERE ua.project_id = zitadel_nextgen.users.project_id AND ua.user_id = zitadel_nextgen.users.id AND ua.key = ")
+			compiler.WriteArg(a.Key)
+			compiler.WriteString(" AND ua.value_hash = ")
+			compiler.WriteArg(hash[:])
+			compiler.WriteString(")")
+			continue
+		}
 		compiler.WriteString("EXISTS (SELECT 1 FROM ")
 		compiler.WriteString(userAttributesTable)
 		compiler.WriteString(" a WHERE a.project_id = zitadel_nextgen.users.project_id AND a.user_id = zitadel_nextgen.users.id AND a.key = ")

--- a/internal/storage/dialect/spanner/user.go
+++ b/internal/storage/dialect/spanner/user.go
@@ -2,6 +2,7 @@ package spanner
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 
@@ -166,6 +167,15 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 			return nil, fmt.Errorf("marshal attribute %q: %w", a.Key, err)
 		}
 		writeConjunct(&compiler, &hasWhere)
+		if opts.UniqueAttributesOnly {
+			hash := sha256.Sum256(raw)
+			compiler.WriteString("EXISTS (SELECT 1 FROM user_unique_attributes ua WHERE ua.project_id = users.project_id AND ua.user_id = users.id AND ua.key = ")
+			compiler.WriteArg(a.Key)
+			compiler.WriteString(" AND ua.value_hash = ")
+			compiler.WriteArg(hash[:])
+			compiler.WriteString(")")
+			continue
+		}
 		compiler.WriteString("EXISTS (SELECT 1 FROM ")
 		compiler.WriteString(userAttributesTable)
 		compiler.WriteString(" a WHERE a.project_id = users.project_id AND a.user_id = users.id AND a.key = ")

--- a/internal/storage/dialect/sqlite/user.go
+++ b/internal/storage/dialect/sqlite/user.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -160,6 +161,15 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 			return nil, fmt.Errorf("marshal attribute %q: %w", a.Key, err)
 		}
 		writeConjunct(&compiler, &hasWhere)
+		if opts.UniqueAttributesOnly {
+			hash := sha256.Sum256(raw)
+			compiler.WriteString("EXISTS (SELECT 1 FROM user_unique_attributes ua WHERE ua.project_id = users.project_id AND ua.user_id = users.id AND ua.key = ")
+			compiler.WriteArg(string(a.Key))
+			compiler.WriteString(" AND ua.value_hash = ")
+			compiler.WriteArg(hash[:])
+			compiler.WriteString(")")
+			continue
+		}
 		compiler.WriteString("EXISTS (SELECT 1 FROM user_attributes a WHERE a.project_id = users.project_id AND a.user_id = users.id AND a.key = ")
 		compiler.WriteArg(string(a.Key))
 		compiler.WriteString(" AND a.value = ")

--- a/internal/storage/stmttest/user_test.go
+++ b/internal/storage/stmttest/user_test.go
@@ -367,3 +367,37 @@ func assertUserAttributes(t *testing.T, user *domain.User, want map[string]any) 
 	}
 	assert.Equal(t, want, got)
 }
+
+func TestUserStatements_GetUser_UniqueAttributesOnly(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, d dialect) {
+		projectID, schemaURL := ensureUserTestProject(t, d.stmts)
+
+		owner := newTestUser(t, projectID, schemaURL, "user_unique_owner", "shared@example.com", "Owner")
+		require.NoError(t, d.stmts.CreateUser(t.Context(), owner))
+
+		// A second user carries the same value under the same key, but
+		// without a uniqueness scope (e.g. a notification address).
+		dupEmail, err := domain.NewCreateAttribute("email", "shared@example.com", domain.AttributeUniquenessUnspecified)
+		require.NoError(t, err)
+		dup := &domain.CreateUser{
+			ProjectID:  projectID,
+			SchemaURL:  schemaURL,
+			ID:         "user_unique_dup",
+			Attributes: []domain.CreateAttribute{*dupEmail},
+		}
+		require.NoError(t, d.stmts.CreateUser(t.Context(), dup))
+
+		attrs := []domain.Attribute{{Key: "email", Value: "shared@example.com"}}
+		projectFilter := database.Equal(database.Col(domain.UserFieldProjectID), projectID)
+
+		_, err = d.stmts.GetUser(t.Context(), projectFilter, service.UserQueryOptions{Attributes: attrs})
+		require.Error(t, err, "the plain attribute match sees both users")
+
+		got, err := d.stmts.GetUser(t.Context(), projectFilter, service.UserQueryOptions{
+			Attributes:           attrs,
+			UniqueAttributesOnly: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, owner.ID, got.ID)
+	})
+}


### PR DESCRIPTION
## Summary

The login identifier lookup (`UserStatementsLookup.GetByAttributes`, used by auth-attempt user verification) matched any `user_attributes` row with the same key and value. An equal value stored *without* a uniqueness scope on another user — e.g. a notification email address on a second account whose schema doesn't mark `email` unique — made the lookup return two rows, and the legitimate user's sign-in was rejected as `user_not_found`.

Identifier lookups now match through the `user_unique_attributes` registry (key + SHA-256 value hash), which by construction holds only uniquely-scoped values — it is the index that was built for exactly this lookup (see its schema comment). Concretely:

- `UserQueryOptions` gains `UniqueAttributesOnly`; when set, the per-attribute `EXISTS` compiles against the unique registry instead of the EAV table, in all three dialects.
- Only the auth-path adapter sets it. Plain attribute matching for list filtering is unchanged.
- Team- and project-scoped registry rows both match, preserving today's behavior for team-unique identifiers.

Standalone correctness fix; independently motivated, but consistent with the resolution-scoping contract proposed in ADR 057 (#959, context: #956).

## Validation

- New portable suite case `TestUserStatements_GetUser_UniqueAttributesOnly` in `internal/storage/stmttest`: two users share a value under the same key, one uniquely scoped — the plain match errors (ambiguous), the unique-only match resolves the registered owner. Green on the sqlite lane locally (`go test -tags sqlite_integration ./internal/storage/stmttest/ -run TestUserStatements_GetUser_UniqueAttributesOnly`); postgres/spanner lanes run in CI.
- `go build ./internal/...`, `go vet`, `go test ./internal/service/`, `gofmt -l` clean.
- `node scripts/check-pr-title.mjs` passes.

## Release notes / changeset

`.changeset/identifier-lookup-unique-registry.md` — patch for `@zitadel/server` (user-facing sign-in fix).

## Notes

- The registry lookup also uses the hash-indexed primary key `(project_id, team_id, key, value_hash)` instead of scanning EAV values — a small perf win on the hot login path.
- Follow-ups tracked elsewhere: the dead direct-API `IdentifierProof` path and full resolution scoping land with ADR 057 (#959).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Manual reproduction

Product-level walk-through against a local server (sqlite). Gotcha first: under `go run` the default data dir tracks the temp executable, so every restart starts an empty database — pin it before starting:

```sh
export NEXTGEN_SERVER_DATA_DIR=/tmp/nextgen-data
moon run workspace:server
```

Setup (once, either branch): create a project (`POST /projects`, note `id` + `project_secret`), then a second user schema whose `email` carries **no** `x-unique` (copy `metaSchema` from the seeded default; disable password/passkey in `x-auth-methods`), then two users: Alice under the seeded default schema with `alice@example.com`, and a second account under the notify schema with the **same address** — legal, since that property is non-unique.

Test: start a login flow (`POST /flow`, purpose `login`, keep the `_zflow` cookie) and submit Alice's email into the identifier step.

| branch | submitted email | resulting step |
|---|---|---|
| `main` | `alice@example.com` | `register` — Alice is treated as not found: her unique row and the notify account's non-unique row both match, and exactly-one refuses |
| this PR | `alice@example.com` | `password` — the lookup goes through the unique-attributes registry, which the notify address never entered |

Same database, same submit, verified across a branch switch with persistent data.
