### PR TITLE
fix: block login and revoke sessions for non-active users

### DIFF
--- a/.changeset/user-status-enforcement.md
+++ b/.changeset/user-status-enforcement.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+Enforce user status: a non-active (suspended, deactivated, or pending purge) user can no longer log in, deactivation revokes the user's sessions and tokens in the same transaction, and user reads hide `pending_purge` records while keeping deactivated users visible to management APIs.

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -392,7 +392,8 @@ function userStatus(user: Record<string, unknown>): string | undefined {
  * as live controls that did nothing:
  *
  *   - `Edit user` — no `PATCH`/`PUT /users/{user_id}` endpoint (#693)
- *   - `Deactivate` — no `status` field and no lifecycle endpoint (#553)
+ *   - `Deactivate` — no lifecycle endpoint (#962; the `status` field landed
+ *     with #721, and #553 made deactivation actually lock the user out)
  *   - `Reset password` — `PUT /users/{user_id}/password` exists, but the screen
  *     that would collect the new password does not; the menu item alone had
  *     nothing behind it

--- a/internal/api/integration_test/user_status_test.go
+++ b/internal/api/integration_test/user_status_test.go
@@ -1,0 +1,198 @@
+//go:build postgres_integration || spanner_integration
+
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/go-faster/jx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	api "github.com/zitadel/nextgen/api/generated"
+	apischemas "github.com/zitadel/nextgen/api/openapi/endpoints/schemas"
+	"github.com/zitadel/nextgen/internal/api/integration_test/helpers"
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+)
+
+// TestTeamDelete_LocksOutDeactivatedUser is the #553 end-to-end: deleting a
+// team deactivates its lifecycle-owned users, and deactivation must actually
+// lock them out. Before the delete the user logs in and holds a session;
+// after it the session is revoked, a fresh login resolves the user exactly
+// like an unknown one, and the management API still serves the user with the
+// honest deactivated status.
+func TestTeamDelete_LocksOutDeactivatedUser(t *testing.T) {
+	t.Parallel()
+
+	testServer := harness.EnsureTestServer(t)
+	project, err := harness.EnsureProjectService(t).Create(t.Context(), helpers.ProjectName(), nil, true)
+	require.NoError(t, err)
+	team, err := harness.EnsureTeamService(t).Create(t.Context(), service.CreateTeamInput{
+		ProjectID: project.ID,
+		Name:      helpers.TeamName(),
+	})
+	require.NoError(t, err)
+
+	schemaURL := apischemas.DefaultHumanUserSchemaURL(helpers.BuiltinSchemaBaseURL)
+	const (
+		userID    = "user_deact-lockout-01"
+		userEmail = "deact-lockout@example.com"
+		userPass  = "correct-horse-battery-staple"
+	)
+
+	emailAttr, err := domain.NewCreateAttribute("email", userEmail, domain.AttributeUniquenessProject)
+	require.NoError(t, err)
+	users := harness.EnsureUserFixture(t)
+	require.NoError(t, users.Create(t.Context(), &domain.CreateUser{
+		ProjectID:               project.ID,
+		SchemaURL:               schemaURL,
+		ID:                      userID,
+		LifecycleOwnerTeamID:    &team.ID,
+		InitialMembershipTeamID: &team.ID,
+		Attributes:              domain.CreateAttributes{*emailAttr},
+	}))
+	encodedHash, err := harness.EnsureHasher(t).Hash(userPass)
+	require.NoError(t, err)
+	require.NoError(t, users.SetPassword(t.Context(), &domain.SetUserPassword{
+		ProjectID:   project.ID,
+		UserID:      userID,
+		EncodedHash: encodedHash,
+	}))
+
+	client, err := helpers.NewApiClient(testServer.URL)
+	require.NoError(t, err)
+	harness.SetProjectSecretOnApiClient(t, client, project)
+	projectSecret, err := harness.EnsureTokenService(t).GenerateJWE(t.Context(), project.Token())
+	require.NoError(t, err)
+
+	// The not_found-routing definition makes unknown and deactivated
+	// identifiers land on the same terminal, which is the point of Q12's
+	// generic rejection: no account-status oracle.
+	defResp, err := client.CreateFlowDefinition(t.Context(), &api.CreateFlowDefinitionRequest{
+		ProjectID:      api.ProjectID(project.ID),
+		FlowDefinition: passwordLoginFlowWithNotFoundFlowDefinition(schemaURL),
+	})
+	require.NoError(t, err)
+	require.IsType(t, &api.FlowDefinitionDetailResponse{}, defResp, "create flow definition: %s", helpers.MustMarshal(t, defResp))
+
+	// submitIdentifier starts a fresh flow and submits the email; it returns
+	// the step the flow lands on plus the flow handle for follow-up steps.
+	submitIdentifier := func(t *testing.T) (*api.SubmitFlowStepOK, api.SubmitFlowStepParams) {
+		t.Helper()
+		createResp, err := client.CreateFlow(t.Context(), &api.CreateFlowRequest{
+			ProjectID: api.ProjectID(project.ID),
+			Purpose:   api.CreateFlowRequestPurposeLogin,
+		})
+		require.NoError(t, err)
+		require.IsType(t, &api.FlowResponseHeaders{}, createResp, helpers.MustMarshal(t, createResp))
+		flowHeaders := createResp.(*api.FlowResponseHeaders)
+		params := api.SubmitFlowStepParams{
+			ID:    flowHeaders.Response.ID,
+			Zflow: mustExtractZflow(t, flowHeaders.SetCookie.Value),
+		}
+		idResp, err := client.SubmitFlowStep(t.Context(), &api.FlowSubmitRequest{
+			Action: "submit",
+			Fields: api.NewOptFlowSubmitRequestFields(api.FlowSubmitRequestFields{
+				"email": jx.Raw(`"` + userEmail + `"`),
+			}),
+		}, params)
+		require.NoError(t, err)
+		require.IsType(t, &api.SubmitFlowStepOK{}, idResp, helpers.MustMarshal(t, idResp))
+		idOK := idResp.(*api.SubmitFlowStepOK)
+		params.Zflow = mustExtractZflow(t, idOK.SetCookie.Value)
+		return idOK, params
+	}
+
+	getMySession := func(t *testing.T, cookie *http.Cookie) int {
+		t.Helper()
+		meReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, testServer.URL+"/sessions/me", nil)
+		require.NoError(t, err)
+		meReq.AddCookie(cookie)
+		meResp, err := testServer.Client().Do(meReq)
+		require.NoError(t, err)
+		defer func() { _ = meResp.Body.Close() }()
+		return meResp.StatusCode
+	}
+
+	// 1. The active user logs in: identifier resolves, password verifies,
+	// and the handoff token exchanges into a session cookie.
+	idOK, params := submitIdentifier(t)
+	require.Equal(t, "password", idOK.Response.Step.Name, "an active user's identifier must resolve")
+	pwResp, err := client.SubmitFlowStep(t.Context(), &api.FlowSubmitRequest{
+		Action: "submit",
+		Fields: api.NewOptFlowSubmitRequestFields(api.FlowSubmitRequestFields{
+			"x-auth-methods#password": jx.Raw(`"` + userPass + `"`),
+		}),
+	}, params)
+	require.NoError(t, err)
+	require.IsType(t, &api.SubmitFlowStepOK{}, pwResp, helpers.MustMarshal(t, pwResp))
+	pwOK := pwResp.(*api.SubmitFlowStepOK)
+	require.Equal(t, "done", pwOK.Response.Step.Name)
+	handoffToken, hasToken := pwOK.Response.HandoffToken.Get()
+	require.True(t, hasToken, "expected handoff token after successful password login")
+
+	exchangeBody, err := json.Marshal(map[string]string{"handoff_token": handoffToken})
+	require.NoError(t, err)
+	exchangeReq, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		testServer.URL+"/sessions/exchange?project_id="+project.ID, bytes.NewReader(exchangeBody))
+	require.NoError(t, err)
+	exchangeReq.Header.Set("Content-Type", "application/json")
+	exchangeReq.Header.Set("Authorization", "Bearer "+projectSecret)
+	exchangeResp, err := testServer.Client().Do(exchangeReq)
+	require.NoError(t, err)
+	defer func() { _ = exchangeResp.Body.Close() }()
+	if exchangeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(exchangeResp.Body)
+		t.Fatalf("exchange returned %d: %s", exchangeResp.StatusCode, body)
+	}
+	var sessionCookie *http.Cookie
+	for _, cookie := range exchangeResp.Cookies() {
+		if cookie.Name == "__nextgen_session" {
+			sessionCookie = cookie
+		}
+	}
+	require.NotNil(t, sessionCookie, "exchange must set the __nextgen_session cookie")
+	require.Equal(t, http.StatusOK, getMySession(t, sessionCookie), "the session must work before the delete")
+
+	// 2. Deleting the owning team deactivates the lifecycle-owned user.
+	delResp, err := client.DeleteTeam(t.Context(), api.DeleteTeamParams{TeamID: api.TeamID(team.ID)})
+	require.NoError(t, err)
+	require.IsType(t, &api.DeleteTeamNoContent{}, delResp, helpers.MustMarshal(t, delResp))
+
+	// 3. The pre-delete session died inside the same transaction.
+	assert.Equal(t, http.StatusUnauthorized, getMySession(t, sessionCookie),
+		"a deactivated user's live session must be revoked")
+
+	// 4. A fresh login resolves the deactivated user exactly like an unknown one.
+	idOK, _ = submitIdentifier(t)
+	assert.Equal(t, "not_found", idOK.Response.Step.Name,
+		"a deactivated identifier must be indistinguishable from an unknown one")
+	assert.True(t, idOK.Response.Step.Complete.Set, "expected terminal step")
+
+	// 5. The management plane still serves the user, with the honest status.
+	getResp, err := client.GetUserByID(t.Context(), api.GetUserByIDParams{UserID: api.UserID(userID)})
+	require.NoError(t, err)
+	require.IsType(t, &api.User{}, getResp, helpers.MustMarshal(t, getResp))
+	assert.Equal(t, api.UserMetadataStatusDeactivated, getResp.(*api.User).Metadata.Status)
+
+	listResp, err := client.ListUsers(t.Context(), api.ListUsersParams{})
+	require.NoError(t, err)
+	require.IsType(t, &api.ListUsersResponse{}, listResp, helpers.MustMarshal(t, listResp))
+	listed := false
+	for _, item := range listResp.(*api.ListUsersResponse).Users {
+		if userID == userIDOf(t, item) {
+			listed = true
+		}
+	}
+	assert.True(t, listed, "a deactivated user must stay visible in the management list")
+}
+
+// userIDOf reads the envelope id of a listed user.
+func userIDOf(t *testing.T, user api.User) string {
+	t.Helper()
+	return string(user.ID)
+}

--- a/internal/service/auth_attempt.go
+++ b/internal/service/auth_attempt.go
@@ -497,6 +497,17 @@ func (s *authAttemptService) verify(ctx context.Context, attempt *domain.AuthAtt
 		// the attempt so the subject is pinned and the session/handoff carries the user id. For an
 		// identified login the user factor is already present and unchanged.
 		if userFactor == nil && verification.UserID != "" {
+			// The assertion never touched the users row, so this is the one
+			// login path that skips the active-status check in the identifier
+			// lookup. Require an active user here too (#553), with the same
+			// generic rejection.
+			if _, err := s.stmts.Statements().GetUser(ctx, database.And(
+				database.Equal(database.Col(domain.UserFieldProjectID), attempt.ProjectID),
+				database.Equal(database.Col(domain.UserFieldID), verification.UserID),
+				database.Equal(database.Col(domain.UserFieldStatus), domain.UserStatusActive.String()),
+			), UserQueryOptions{}); err != nil {
+				return passkeyChallenge, nil, domain.ErrAuthAttemptProofRejected(err)
+			}
 			attempt.SetUserFactor(&domain.User{ID: verification.UserID})
 		}
 		// Use the verified user as the source of truth: it is set for both identified and

--- a/internal/service/auth_attempt_test.go
+++ b/internal/service/auth_attempt_test.go
@@ -767,3 +767,105 @@ func TestAuthAttemptService_VerifyPasskeyProof(t *testing.T) {
 		assert.ErrorIs(t, err, domain.ErrAuthAttemptProofRejected(nil))
 	})
 }
+
+// discoverableChallengeAttempt returns an attempt carrying only an issued
+// discoverable (usernameless) passkey challenge, plus the signed assertion
+// whose user handle resolves the user.
+func (f passkeyFixture) discoverableChallengeAttempt(t *testing.T, challengeID string) (*domain.AuthAttempt, []byte) {
+	t.Helper()
+
+	challenge, err := domain.CreatePasskeyChallenge("", nil, "preferred", passkeyRPID, f.origins)
+	require.NoError(t, err)
+	check := domain.SetAuthChallengePasskey(challengeID, time.Now(), time.Time{}, 0)
+	check.PasskeyChallenge = challenge
+
+	attempt := &domain.AuthAttempt{
+		ProjectID: "proj",
+		ID:        "att-1",
+		Checks:    []domain.AuthCheck{check},
+	}
+
+	rawChallenge, err := base64.RawURLEncoding.DecodeString(challenge.Challenge)
+	require.NoError(t, err)
+	assertion := virtualwebauthn.CreateAssertionResponse(f.rp, f.auth, f.cred, virtualwebauthn.AssertionOptions{
+		Challenge:      rawChallenge,
+		RelyingPartyID: challenge.RPID,
+	})
+	return attempt, []byte(assertion)
+}
+
+func TestAuthAttemptService_VerifyPasskeyProof_Discoverable(t *testing.T) {
+	// The discoverable path never went through the identifier lookup, so its
+	// user read must carry the active-status guard (#553).
+	activeUserFilter := database.And(
+		database.Equal(database.Col(domain.UserFieldProjectID), "proj"),
+		database.Equal(database.Col(domain.UserFieldID), passkeyUserID),
+		database.Equal(database.Col(domain.UserFieldStatus), domain.UserStatusActive.String()),
+	)
+
+	t.Run("binds an active user", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		f := newPasskeyFixture(t)
+		attempt, assertion := f.discoverableChallengeAttempt(t, "ch-1")
+
+		var succeededFactor domain.AuthFactor
+		stmts := mocks.NewMockAllStatements(ctrl)
+		stmts.EXPECT().GetAuthAttemptByID(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, string, string) (*domain.AuthAttempt, error) {
+			return attempt, nil
+		})
+		stmts.EXPECT().AuthAttemptChallengeSucceeded(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _, _ string, factor domain.AuthFactor, _ string) error {
+			succeededFactor = factor
+			return nil
+		})
+		expectListUserPasskeys(stmts, []*domain.UserPasskey{f.passkey})
+		stmts.EXPECT().GetUser(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, filter database.Filter[domain.UserField], _ service.UserQueryOptions) (*domain.User, error) {
+				assert.Equal(t, activeUserFilter, filter)
+				return &domain.User{ProjectID: "proj", ID: passkeyUserID}, nil
+			})
+		stmts.EXPECT().UpdateUserPasskey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+		svc := newAuthAttemptSvc(ctrl, stmts, nil, nil)
+		got, err := svc.VerifyProof(t.Context(), service.VerifyProofInput{
+			ProjectID:   "proj",
+			AttemptID:   "att-1",
+			ChallengeID: "ch-1",
+			Proof:       service.PasskeyProof{AssertionResponse: assertion},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.IsType(t, &domain.AuthFactorPasskey{}, succeededFactor)
+		assert.Equal(t, passkeyUserID, succeededFactor.(*domain.AuthFactorPasskey).UserID)
+	})
+
+	t.Run("rejects a non-active user", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		f := newPasskeyFixture(t)
+		attempt, assertion := f.discoverableChallengeAttempt(t, "ch-1")
+
+		stmts := mocks.NewMockAllStatements(ctrl)
+		stmts.EXPECT().GetAuthAttemptByID(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, string, string) (*domain.AuthAttempt, error) {
+			return attempt, nil
+		})
+		stmts.EXPECT().AuthAttemptChallengeFailed(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		expectListUserPasskeys(stmts, []*domain.UserPasskey{f.passkey})
+		// The assertion itself verifies; the status gate must still reject,
+		// with the same error an invalid assertion gets.
+		stmts.EXPECT().GetUser(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, filter database.Filter[domain.UserField], _ service.UserQueryOptions) (*domain.User, error) {
+				assert.Equal(t, activeUserFilter, filter)
+				return nil, database.NewNoRowFoundError(nil)
+			})
+
+		svc := newAuthAttemptSvc(ctrl, stmts, nil, nil)
+		_, err := svc.VerifyProof(t.Context(), service.VerifyProofInput{
+			ProjectID:   "proj",
+			AttemptID:   "att-1",
+			ChallengeID: "ch-1",
+			Proof:       service.PasskeyProof{AssertionResponse: assertion},
+		})
+
+		assert.ErrorIs(t, err, domain.ErrAuthAttemptProofRejected(nil))
+	})
+}

--- a/internal/service/session.go
+++ b/internal/service/session.go
@@ -129,6 +129,22 @@ func (s *sessionService) Exchange(ctx context.Context, input ExchangeInput) (*do
 		if err != nil {
 			return err
 		}
+		// The attempt behind the handoff token was verified earlier; the user
+		// may have been deactivated in between, and revocation only sweeps
+		// sessions that already exist. Gate the mint on an active user so a
+		// deactivation cannot race an in-flight login (#553).
+		if session.UserID != nil && *session.UserID != "" {
+			if _, err := tx.Statements().GetUser(ctx, database.And(
+				database.Equal(database.Col(domain.UserFieldProjectID), input.ProjectID),
+				database.Equal(database.Col(domain.UserFieldID), *session.UserID),
+				database.Equal(database.Col(domain.UserFieldStatus), domain.UserStatusActive.String()),
+			), UserQueryOptions{}); err != nil {
+				if _, ok := errors.AsType[*database.NoRowFoundError](err); ok {
+					return domain.ErrSessionInvalidHandoffToken()
+				}
+				return fmt.Errorf("failed to check the session user status: %w", err)
+			}
+		}
 		if err := emitSessionEstablished(ctx, tx.Statements(), session); err != nil {
 			return err
 		}

--- a/internal/service/session_test.go
+++ b/internal/service/session_test.go
@@ -133,6 +133,8 @@ func TestSessionService_Exchange(t *testing.T) {
 	cfg := sessionConfigForTest()
 	idempotencyKey := "retry-1"
 	exchangedSession := &domain.Session{ProjectID: "proj", ID: "sess"}
+	exchangedUserID := "user-1"
+	userBoundSession := &domain.Session{ProjectID: "proj", ID: "sess", UserID: &exchangedUserID}
 	overrideTTL := 2 * time.Hour
 	invalidZero := time.Duration(0)
 	invalidAboveMax := cfg.MaxTTL + time.Second
@@ -143,9 +145,33 @@ func TestSessionService_Exchange(t *testing.T) {
 		wantTTL    time.Duration
 		repoResult *domain.Session
 		repoErr    error
+		userResult *domain.User
+		userErr    error
 		want       *domain.Session
 		wantErr    error
 	}{
+		{
+			name: "mints for an active user",
+			input: service.ExchangeInput{
+				ProjectID:    "proj",
+				HandoffToken: "handoff-token",
+			},
+			wantTTL:    cfg.DefaultTTL,
+			repoResult: userBoundSession,
+			userResult: &domain.User{ProjectID: "proj", ID: exchangedUserID},
+			want:       userBoundSession,
+		},
+		{
+			name: "rejects a user deactivated between verify and exchange",
+			input: service.ExchangeInput{
+				ProjectID:    "proj",
+				HandoffToken: "handoff-token",
+			},
+			wantTTL:    cfg.DefaultTTL,
+			repoResult: userBoundSession,
+			userErr:    database.NewNoRowFoundError(nil),
+			wantErr:    domain.ErrSessionInvalidHandoffToken(),
+		},
 		{
 			name: "returns exchanged session with default ttl",
 			input: service.ExchangeInput{
@@ -233,6 +259,19 @@ func TestSessionService_Exchange(t *testing.T) {
 							t.Fatalf("Exchange ttl = %v, want %v", gotTTL, tt.wantTTL)
 						}
 						return tt.repoResult, tt.repoErr
+					})
+			}
+			if tt.userResult != nil || tt.userErr != nil {
+				statements.EXPECT().
+					GetUser(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, filter database.Filter[domain.UserField], _ service.UserQueryOptions) (*domain.User, error) {
+						// The mint gate must require the active status (#553).
+						assert.Equal(t, database.And(
+							database.Equal(database.Col(domain.UserFieldProjectID), tt.input.ProjectID),
+							database.Equal(database.Col(domain.UserFieldID), *tt.repoResult.UserID),
+							database.Equal(database.Col(domain.UserFieldStatus), domain.UserStatusActive.String()),
+						), filter)
+						return tt.userResult, tt.userErr
 					})
 			}
 

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -193,7 +193,16 @@ func (s *userService) DeleteUser(ctx context.Context, input DeleteUserInput) err
 
 func (s *userService) ListUsers(ctx context.Context, input ListUsersInput) (*ListUsersOutput, error) {
 	result, err := s.v2Pool.Statements().ListUsers(ctx, &database.ListOptions[domain.UserField]{
-		Filter: database.Equal(database.Col(domain.UserFieldProjectID), input.ProjectID),
+		Filter: database.And(
+			database.Equal(database.Col(domain.UserFieldProjectID), input.ProjectID),
+			// A pending_purge user is awaiting deletion by the cleanup job, so
+			// reads treat it as already gone (matches the team guard).
+			database.Or(
+				database.Equal(database.Col(domain.UserFieldStatus), domain.UserStatusActive.String()),
+				database.Equal(database.Col(domain.UserFieldStatus), domain.UserStatusSuspended.String()),
+				database.Equal(database.Col(domain.UserFieldStatus), domain.UserStatusDeactivated.String()),
+			),
+		),
 		Pagination: database.Page[domain.UserField]{
 			Limit:  uint32(normalizeLimit(input.Limit)),
 			Cursor: []byte(input.PageToken),
@@ -313,6 +322,11 @@ func (s *userService) GetUserByID(ctx context.Context, input GetUserInput) (*dom
 			return nil, domain.ErrUserNotFound()
 		}
 		return nil, domain.ErrInternal(err).WithMessage("failed to get user from database")
+	}
+	// A pending_purge user is awaiting deletion by the cleanup job, so reads
+	// treat it as already gone (matches the team guard).
+	if user.Metadata.Status == domain.UserStatusPendingPurge {
+		return nil, domain.ErrUserNotFound()
 	}
 
 	return user, nil
@@ -517,8 +531,14 @@ type UserStatementsLookup struct {
 }
 
 func (l UserStatementsLookup) GetByAttributes(ctx context.Context, projectID string, attrs []domain.Attribute) (*domain.User, error) {
+	// Login resolution requires an active user (#553): a suspended,
+	// deactivated, or pending_purge identity must not resolve, and must be
+	// indistinguishable from an unknown login name.
 	return l.Pool.Statements().GetUser(ctx,
-		database.Equal(database.Col(domain.UserFieldProjectID), projectID),
+		database.And(
+			database.Equal(database.Col(domain.UserFieldProjectID), projectID),
+			database.Equal(database.Col(domain.UserFieldStatus), domain.UserStatusActive.String()),
+		),
 		UserQueryOptions{Attributes: attrs},
 	)
 }

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -1,0 +1,151 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+	servicemocks "github.com/zitadel/nextgen/internal/service/mocks"
+	"github.com/zitadel/nextgen/internal/storage/database"
+)
+
+func newMockedUserService(t *testing.T, setupStmt func(*servicemocks.MockAllStatements)) (service.UserService, service.StatementPool) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	pool := servicemocks.NewMockStatementPool(ctrl)
+	statements := servicemocks.NewMockAllStatements(ctrl)
+	pool.EXPECT().Statements().Return(statements).AnyTimes()
+	if setupStmt != nil {
+		setupStmt(statements)
+	}
+	return service.NewUserService(pool, nil, nil), pool
+}
+
+func TestUserService_GetUserByID(t *testing.T) {
+	t.Parallel()
+
+	userWithStatus := func(status domain.UserStatus) *domain.User {
+		return &domain.User{
+			ProjectID: "proj_1",
+			ID:        "user_1",
+			Metadata:  domain.UserMetadata{Status: status},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		setupStmt func(*servicemocks.MockAllStatements)
+		wantErr   error
+		check     func(t *testing.T, got *domain.User)
+	}{
+		{
+			name: "returns an active user",
+			setupStmt: func(s *servicemocks.MockAllStatements) {
+				s.EXPECT().GetUser(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(userWithStatus(domain.UserStatusActive), nil)
+			},
+			check: func(t *testing.T, got *domain.User) {
+				assert.Equal(t, "user_1", got.ID)
+			},
+		},
+		{
+			name: "deactivated user stays visible",
+			setupStmt: func(s *servicemocks.MockAllStatements) {
+				s.EXPECT().GetUser(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(userWithStatus(domain.UserStatusDeactivated), nil)
+			},
+			check: func(t *testing.T, got *domain.User) {
+				assert.Equal(t, domain.UserStatusDeactivated, got.Metadata.Status)
+			},
+		},
+		{
+			name: "pending_purge user reads as not found",
+			setupStmt: func(s *servicemocks.MockAllStatements) {
+				s.EXPECT().GetUser(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(userWithStatus(domain.UserStatusPendingPurge), nil)
+			},
+			wantErr: domain.ErrUserNotFound(),
+		},
+		{
+			name: "missing user reads as not found",
+			setupStmt: func(s *servicemocks.MockAllStatements) {
+				s.EXPECT().GetUser(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, database.NewNoRowFoundError(nil))
+			},
+			wantErr: domain.ErrUserNotFound(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, _ := newMockedUserService(t, tc.setupStmt)
+
+			got, err := svc.GetUserByID(t.Context(), service.GetUserInput{ProjectID: "proj_1", UserID: "user_1"})
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			tc.check(t, got)
+		})
+	}
+}
+
+func TestUserService_ListUsers(t *testing.T) {
+	t.Parallel()
+
+	svc, _ := newMockedUserService(t, func(s *servicemocks.MockAllStatements) {
+		s.EXPECT().ListUsers(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, opts *database.ListOptions[domain.UserField], _ service.UserQueryOptions) (*database.ListResult[*domain.User], error) {
+				// List hides pending_purge users; every query carries this guard.
+				assert.Equal(t, database.And(
+					database.Equal(database.Col(domain.UserFieldProjectID), "proj_1"),
+					database.Or(
+						database.Equal(database.Col(domain.UserFieldStatus), "active"),
+						database.Equal(database.Col(domain.UserFieldStatus), "suspended"),
+						database.Equal(database.Col(domain.UserFieldStatus), "deactivated"),
+					),
+				), opts.Filter)
+				return &database.ListResult[*domain.User]{
+					Items:      []*domain.User{{ID: "user_1"}},
+					NextCursor: []byte("next"),
+				}, nil
+			})
+	})
+
+	got, err := svc.ListUsers(t.Context(), service.ListUsersInput{ProjectID: "proj_1"})
+	require.NoError(t, err)
+	assert.Len(t, got.Items, 1)
+	assert.Equal(t, "next", got.NextPageToken)
+}
+
+func TestUserStatementsLookup_GetByAttributes(t *testing.T) {
+	t.Parallel()
+
+	attrs := []domain.Attribute{{Key: "email", Value: "user@example.com"}}
+	_, pool := newMockedUserService(t, func(s *servicemocks.MockAllStatements) {
+		s.EXPECT().GetUser(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, filter database.Filter[domain.UserField], opts service.UserQueryOptions) (*domain.User, error) {
+				// Login resolution must require the active status (#553).
+				assert.Equal(t, database.And(
+					database.Equal(database.Col(domain.UserFieldProjectID), "proj_1"),
+					database.Equal(database.Col(domain.UserFieldStatus), domain.UserStatusActive.String()),
+				), filter)
+				assert.Equal(t, attrs, opts.Attributes)
+				return nil, database.NewNoRowFoundError(nil)
+			})
+	})
+
+	lookup := service.UserStatementsLookup{Pool: pool}
+	_, err := lookup.GetByAttributes(t.Context(), "proj_1", attrs)
+	assert.ErrorIs(t, err, new(database.NoRowFoundError))
+}

--- a/internal/storage/dialect/postgres/team.go
+++ b/internal/storage/dialect/postgres/team.go
@@ -39,6 +39,24 @@ WHERE project_id = $2 AND status <> $1
     SELECT id FROM zitadel_nextgen.users
     WHERE project_id = $3 AND lifecycle_owner_team_id = $4
   )`
+
+	// Deactivating owned users must revoke their access immediately (ADR 024):
+	// their tokens and sessions go in the same transaction as the status flip.
+	revokeOwnedUsersTokensStmt = `
+DELETE FROM zitadel_nextgen.tokens
+WHERE project_id = $1
+  AND user_id IN (
+    SELECT id FROM zitadel_nextgen.users
+    WHERE project_id = $2 AND lifecycle_owner_team_id = $3
+  )`
+
+	revokeOwnedUsersSessionsStmt = `
+DELETE FROM zitadel_nextgen.sessions
+WHERE project_id = $1
+  AND user_id IN (
+    SELECT id FROM zitadel_nextgen.users
+    WHERE project_id = $2 AND lifecycle_owner_team_id = $3
+  )`
 )
 
 type teamStatements struct{ statement }
@@ -166,6 +184,8 @@ func (ts teamStatements) DeactivateTeam(ctx context.Context, projectID, id strin
 			{deactivateTeamMembershipsStmt, []any{membershipRemoved, projectID, id}},
 			{deactivateTeamOwnedUsersStmt, []any{userDeactivated, projectID, id}},
 			{deactivateOwnedUsersMembershipsStmt, []any{membershipRemoved, projectID, projectID, id}},
+			{revokeOwnedUsersTokensStmt, []any{projectID, projectID, id}},
+			{revokeOwnedUsersSessionsStmt, []any{projectID, projectID, id}},
 		} {
 			if _, err := tx.Exec(ctx, step.sql, step.args...); err != nil {
 				return wrapError(err)

--- a/internal/storage/dialect/postgres/user.go
+++ b/internal/storage/dialect/postgres/user.go
@@ -92,6 +92,19 @@ DELETE FROM zitadel_nextgen.team_memberships
 WHERE project_id = $1 AND user_id = $2
 `
 
+	// Deactivation must revoke access immediately (ADR 024): tokens and
+	// sessions are deleted in the same transaction that flips the status.
+	// Hard delete needs no equivalent — the user FK cascades take them.
+	revokeUserTokensStmt = `
+DELETE FROM zitadel_nextgen.tokens
+WHERE project_id = $1 AND user_id = $2
+`
+
+	revokeUserSessionsStmt = `
+DELETE FROM zitadel_nextgen.sessions
+WHERE project_id = $1 AND user_id = $2
+`
+
 	deleteUserStmt = `
 DELETE FROM zitadel_nextgen.users
 WHERE project_id = $1 AND id = $2
@@ -277,6 +290,12 @@ func (us userStatements) DeactivateUser(ctx context.Context, projectID, userID s
 			return wrapError(pgx.ErrNoRows)
 		}
 		if _, err = tx.Exec(ctx, deactivateUserMembershipsStmt, domain.MembershipStatusRemoved.String(), projectID, userID); err != nil {
+			return wrapError(err)
+		}
+		if _, err = tx.Exec(ctx, revokeUserTokensStmt, projectID, userID); err != nil {
+			return wrapError(err)
+		}
+		if _, err = tx.Exec(ctx, revokeUserSessionsStmt, projectID, userID); err != nil {
 			return wrapError(err)
 		}
 		edges := newAuthzMembershipEdgeStatements(tx)

--- a/internal/storage/dialect/spanner/team.go
+++ b/internal/storage/dialect/spanner/team.go
@@ -40,6 +40,24 @@ WHERE project_id = @p2 AND status <> @p1
     SELECT id FROM users
     WHERE project_id = @p3 AND lifecycle_owner_team_id = @p4
   )`
+
+	// Deactivating owned users must revoke their access immediately (ADR 024):
+	// their tokens and sessions go in the same transaction as the status flip.
+	revokeOwnedUsersTokensStmt = `
+DELETE FROM tokens
+WHERE project_id = @p1
+  AND user_id IN (
+    SELECT id FROM users
+    WHERE project_id = @p2 AND lifecycle_owner_team_id = @p3
+  )`
+
+	revokeOwnedUsersSessionsStmt = `
+DELETE FROM sessions
+WHERE project_id = @p1
+  AND user_id IN (
+    SELECT id FROM users
+    WHERE project_id = @p2 AND lifecycle_owner_team_id = @p3
+  )`
 )
 
 var teamColumns = []string{
@@ -164,6 +182,8 @@ func (ts teamStatements) DeactivateTeam(ctx context.Context, projectID, id strin
 			{deactivateTeamMembershipsStmt, []any{membershipRemoved, projectID, id}},
 			{deactivateTeamOwnedUsersStmt, []any{userDeactivated, projectID, id}},
 			{deactivateOwnedUsersMembershipsStmt, []any{membershipRemoved, projectID, projectID, id}},
+			{revokeOwnedUsersTokensStmt, []any{projectID, projectID, id}},
+			{revokeOwnedUsersSessionsStmt, []any{projectID, projectID, id}},
 		} {
 			if _, err := tx.Update(ctx, buildStatement(step.sql, step.args...).statement()); err != nil {
 				return err

--- a/internal/storage/dialect/spanner/user.go
+++ b/internal/storage/dialect/spanner/user.go
@@ -45,6 +45,13 @@ WHERE project_id = @p2 AND user_id = @p3 AND status <> @p1`
 
 	deleteUserMembershipsStmt = `DELETE FROM team_memberships WHERE project_id = @p1 AND user_id = @p2`
 
+	// Deactivation must revoke access immediately (ADR 024): tokens and
+	// sessions are deleted in the same transaction that flips the status.
+	// Hard delete needs no equivalent — the user FK cascades take them.
+	revokeUserTokensStmt = `DELETE FROM tokens WHERE project_id = @p1 AND user_id = @p2`
+
+	revokeUserSessionsStmt = `DELETE FROM sessions WHERE project_id = @p1 AND user_id = @p2`
+
 	deleteUserStmt = `DELETE FROM users WHERE project_id = @p1 AND id = @p2`
 
 	userExistsStmt = `SELECT EXISTS (
@@ -232,6 +239,12 @@ func (us userStatements) DeactivateUser(ctx context.Context, projectID, userID s
 		if _, err = tx.Update(ctx, buildStatement(deactivateUserMembershipsStmt,
 			domain.MembershipStatusRemoved.String(), projectID, userID,
 		).statement()); err != nil {
+			return err
+		}
+		if _, err = tx.Update(ctx, buildStatement(revokeUserTokensStmt, projectID, userID).statement()); err != nil {
+			return err
+		}
+		if _, err = tx.Update(ctx, buildStatement(revokeUserSessionsStmt, projectID, userID).statement()); err != nil {
 			return err
 		}
 		edges := newAuthzMembershipEdgeStatements(tx)

--- a/internal/storage/dialect/sqlite/team.go
+++ b/internal/storage/dialect/sqlite/team.go
@@ -30,6 +30,16 @@ WHERE project_id = ? AND lifecycle_owner_team_id = ? AND status <> ?`
 WHERE project_id = ? AND status <> ?
   AND user_id IN (SELECT id FROM users WHERE project_id = ? AND lifecycle_owner_team_id = ?)`
 
+	// Deactivating owned users must revoke their access immediately (ADR 024):
+	// their tokens and sessions go in the same transaction as the status flip.
+	revokeOwnedUsersTokensStmt = `DELETE FROM tokens
+WHERE project_id = ?
+  AND user_id IN (SELECT id FROM users WHERE project_id = ? AND lifecycle_owner_team_id = ?)`
+
+	revokeOwnedUsersSessionsStmt = `DELETE FROM sessions
+WHERE project_id = ?
+  AND user_id IN (SELECT id FROM users WHERE project_id = ? AND lifecycle_owner_team_id = ?)`
+
 	getTeamQuery = `SELECT project_id, id, name, status, created_at, updated_at FROM teams`
 )
 
@@ -153,6 +163,8 @@ func (ts teamStatements) DeactivateTeam(ctx context.Context, projectID, id strin
 			{deactivateTeamMembershipsStmt, []any{membershipRemoved, now, projectID, id, membershipRemoved}},
 			{deactivateTeamOwnedUsersStmt, []any{userDeactivated, now, projectID, id, userDeactivated}},
 			{deactivateOwnedUsersMembershipsStmt, []any{membershipRemoved, now, projectID, membershipRemoved, projectID, id}},
+			{revokeOwnedUsersTokensStmt, []any{projectID, projectID, id}},
+			{revokeOwnedUsersSessionsStmt, []any{projectID, projectID, id}},
 		} {
 			if _, err := tx.Exec(ctx, step.sql, step.args...); err != nil {
 				return wrapError(err)

--- a/internal/storage/dialect/sqlite/user.go
+++ b/internal/storage/dialect/sqlite/user.go
@@ -42,6 +42,13 @@ WHERE project_id = ? AND user_id = ? AND status <> ?`
 
 	deleteUserMembershipsStmt = `DELETE FROM team_memberships WHERE project_id = ? AND user_id = ?`
 
+	// Deactivation must revoke access immediately (ADR 024): tokens and
+	// sessions are deleted in the same transaction that flips the status.
+	// Hard delete needs no equivalent — the user FK cascades take them.
+	revokeUserTokensStmt = `DELETE FROM tokens WHERE project_id = ? AND user_id = ?`
+
+	revokeUserSessionsStmt = `DELETE FROM sessions WHERE project_id = ? AND user_id = ?`
+
 	deleteUserStmt = `DELETE FROM users WHERE project_id = ? AND id = ?`
 
 	userExistsStmt = `SELECT EXISTS (SELECT 1 FROM users WHERE project_id = ? AND id = ?)`
@@ -224,6 +231,12 @@ func (us userStatements) DeactivateUser(ctx context.Context, projectID, userID s
 			domain.MembershipStatusRemoved.String(), now, projectID, userID,
 			domain.MembershipStatusRemoved.String(),
 		); err != nil {
+			return wrapError(err)
+		}
+		if _, err = tx.Exec(ctx, revokeUserTokensStmt, projectID, userID); err != nil {
+			return wrapError(err)
+		}
+		if _, err = tx.Exec(ctx, revokeUserSessionsStmt, projectID, userID); err != nil {
 			return wrapError(err)
 		}
 		edges := newAuthzMembershipEdgeStatements(tx)

--- a/internal/storage/stmttest/session_test.go
+++ b/internal/storage/stmttest/session_test.go
@@ -422,3 +422,82 @@ func TestSessionStatements_List_StateColumnFilters(t *testing.T) {
 		assert.ElementsMatch(t, []string{activeID}, ids(userBound), "live and user_id IS NOT NULL")
 	})
 }
+
+// exchangeUserSession seeds a session bound to userID (with its session token)
+// through the attempt→handoff→exchange pipeline.
+func exchangeUserSession(t *testing.T, stmts service.AllStatements, projectID, userID string) *domain.Session {
+	t.Helper()
+	plain, _ := handoffCompletedAttemptWithUser(t, stmts, projectID, userID)
+	session, err := stmts.ExchangeSession(t.Context(), projectID, plain, nil, time.Hour)
+	require.NoError(t, err)
+	require.NotEmpty(t, session.TokenID)
+	require.NotNil(t, session.UserID)
+	t.Cleanup(func() {
+		_ = stmts.DeleteSessionByID(context.Background(), projectID, session.ID)
+	})
+	return session
+}
+
+func TestUserStatements_DeactivateRevokesSessionsAndTokens(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, d dialect) {
+		projectID, schemaURL := ensureUserTestProject(t, d.stmts)
+		user := newTestUser(t, projectID, schemaURL, "user-deact-"+uniqueSuffix(t), "deact@example.com", "Deactivated User")
+		require.NoError(t, d.stmts.CreateUser(t.Context(), user))
+
+		session := exchangeUserSession(t, d.stmts, projectID, user.ID)
+		// A personal access token is user-bound without a session; it must go too.
+		pat := &domain.Token{
+			ProjectID: projectID,
+			UserID:    user.ID,
+			Type:      domain.TokenTypePersonalAccessToken,
+			Scope:     []string{},
+		}
+		require.NoError(t, d.stmts.CreateToken(t.Context(), pat))
+		t.Cleanup(func() {
+			_ = d.stmts.DeleteTokenByID(context.Background(), projectID, pat.TokenID)
+		})
+
+		require.NoError(t, d.stmts.DeactivateUser(t.Context(), projectID, user.ID))
+
+		_, err := d.stmts.GetSessionByID(t.Context(), projectID, session.ID)
+		assert.True(t, errors.Is(err, domain.ErrSessionNotFound()), "session should be revoked on deactivate: %v", err)
+		_, err = d.stmts.GetTokenByID(t.Context(), projectID, session.TokenID)
+		assert.ErrorIs(t, err, new(database.NoRowFoundError), "session token should be revoked on deactivate")
+		_, err = d.stmts.GetTokenByID(t.Context(), projectID, pat.TokenID)
+		assert.ErrorIs(t, err, new(database.NoRowFoundError), "personal access token should be revoked on deactivate")
+	})
+}
+
+func TestTeamStatements_DeactivateRevokesOwnedUsersSessionsAndTokens(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, d dialect) {
+		projectID, schemaURL := ensureUserTestProject(t, d.stmts)
+		ownerTeamID := "team-deact-" + uniqueSuffix(t)
+		require.NoError(t, d.stmts.CreateTeam(t.Context(), newTestTeam(projectID, ownerTeamID)))
+
+		teamOwned := newTestUser(t, projectID, schemaURL, "usr-owned-"+ownerTeamID, "owned-sess@example.com", "Owned")
+		teamOwned.LifecycleOwnerTeamID = &ownerTeamID
+		require.NoError(t, d.stmts.CreateUser(t.Context(), teamOwned))
+		selfOwned := newTestUser(t, projectID, schemaURL, "usr-self-"+ownerTeamID, "self-sess@example.com", "Self")
+		require.NoError(t, d.stmts.CreateUser(t.Context(), selfOwned))
+		require.NoError(t, d.stmts.CreateTeamMembership(t.Context(), &domain.TeamMembership{
+			ProjectID: projectID, TeamID: ownerTeamID, UserID: selfOwned.ID, Status: domain.MembershipStatusActive,
+		}))
+
+		ownedSession := exchangeUserSession(t, d.stmts, projectID, teamOwned.ID)
+		selfSession := exchangeUserSession(t, d.stmts, projectID, selfOwned.ID)
+
+		_, err := d.stmts.DeactivateTeam(t.Context(), projectID, ownerTeamID)
+		require.NoError(t, err)
+
+		_, err = d.stmts.GetSessionByID(t.Context(), projectID, ownedSession.ID)
+		assert.True(t, errors.Is(err, domain.ErrSessionNotFound()), "owned user's session should be revoked with the team: %v", err)
+		_, err = d.stmts.GetTokenByID(t.Context(), projectID, ownedSession.TokenID)
+		assert.ErrorIs(t, err, new(database.NoRowFoundError), "owned user's token should be revoked with the team")
+
+		// A self-owned member only loses the roster, not their own access.
+		_, err = d.stmts.GetSessionByID(t.Context(), projectID, selfSession.ID)
+		assert.NoError(t, err, "self-owned member's session must survive team deactivation")
+		_, err = d.stmts.GetTokenByID(t.Context(), projectID, selfSession.TokenID)
+		assert.NoError(t, err, "self-owned member's token must survive team deactivation")
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #553.

Deactivating a user now actually locks them out. Before this PR the status column was storage-only: a user deactivated by the team-delete cascade could still log in, and their live sessions and tokens survived until expiry.

<details>
<summary><h3>What is enforced, and where</h3></summary>

- **Login**: identifier resolution requires `status == active` (`UserStatementsLookup.GetByAttributes`), so a suspended, deactivated, or pending-purge user is indistinguishable from an unknown login name. The discoverable (usernameless) passkey path, which resolves the user cryptographically and never read the users row, gets the same guard with the same generic rejection. Session exchange carries a terminal active-status gate inside the mint transaction, so a deactivation cannot race an in-flight login.
- **Revocation**: `DeactivateUser` and the `DELETE /teams/{team_id}` owned-user cascade delete the affected users' sessions and tokens inside the same transaction that flips the status (ADR 024), in all three dialects. Hard user delete already cascades sessions and tokens via the FK and is unchanged.
- **Reads**: `GET /users/{user_id}` answers 404 for a `pending_purge` user and `GET /users` excludes them, matching the existing team guards. Deactivated and suspended users stay fully visible to the management plane so they can be audited and reactivated.

</details>

Scope decisions from grooming the issue:

- No API contract change: no `status` filter param on `GET /users` (the console MVP excludes list filtering, decision D5 in #630).
- Grants and resource-scope-index rows stay intact on deactivation, keeping it reversible; access is cut at the authentication boundary. Known residue: a deactivated user can still appear in authz-filtered lists.
- No user deactivate/reactivate endpoint here; that is #962, and the console row-menu TODO now points there instead of #553.
- `sk_team_` keys are unmintable groundwork today; the team-status check at authentication belongs to whoever ships minting (noted in #962).

## Validation

- New `stmttest` suites (`forEachDialect`): user deactivation revokes sessions and tokens (session token and PAT); the team cascade revokes lifecycle-owned users' credentials and spares other members'. Green on sqlite and postgres locally.
- New service unit tests: user service (`pending_purge` get/list guards, login lookup filter), auth attempt (discoverable passkey binds an active user, rejects a non-active one with the generic proof rejection), session (exchange gate rejects a user deactivated between verify and exchange).
- New integration test `TestTeamDelete_LocksOutDeactivatedUser`: the full wire journey. Login flow succeeds and mints a session; `DELETE /teams/{team_id}`; the old session cookie gets 401; a fresh login lands on the `not_found` terminal exactly like an unknown email; `GET /users/{user_id}` and `GET /users` still serve the user with `metadata.status = deactivated`. Green on postgres.
- `moon ci :lint :typecheck :build :test` green locally.

## Release notes / changeset

`.changeset/user-status-enforcement.md`, `@zitadel/server` patch: enforce user status at login, revoke sessions and tokens on deactivation, hide `pending_purge` users from reads.

## Notes

- The enforcement predicate is `status == active`, so the currently unwritten `suspended` status is enforced the day something starts writing it.
- Nothing in the API can set a user `deactivated` directly yet; the team-delete cascade is the only trigger. The lifecycle endpoints are tracked in #962 and will inherit the revocation for free, since it lives in the `DeactivateUser` statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
