### PR TITLE
feat(api): store requestor context on request.api metadata

### DIFF
--- a/.changeset/request-api-client-metadata.md
+++ b/.changeset/request-api-client-metadata.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": minor
+---
+
+Record observed requestor IP, User-Agent, and Origin on Path A `request.api` event metadata so SIEM pipelines can join mutations via `request_id`.

--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -20138,6 +20138,13 @@ func (s *EventMetadata) encodeFields(e *jx.Encoder) {
 			s.Client.Encode(e)
 		}
 	}
+	for k, elem := range s.AdditionalProps {
+		e.FieldStart(k)
+
+		if len(elem) != 0 {
+			e.Raw(elem)
+		}
+	}
 }
 
 var jsonFieldsNameOfEventMetadata = [1]string{
@@ -20149,6 +20156,7 @@ func (s *EventMetadata) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode EventMetadata to nil")
 	}
+	s.AdditionalProps = map[string]jx.Raw{}
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -20163,7 +20171,18 @@ func (s *EventMetadata) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"client\"")
 			}
 		default:
-			return errors.Errorf("unexpected field %q", k)
+			var elem jx.Raw
+			if err := func() error {
+				v, err := d.RawAppend(nil)
+				elem = jx.Raw(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrapf(err, "decode field %q", k)
+			}
+			s.AdditionalProps[string(k)] = elem
 		}
 		return nil
 	}); err != nil {
@@ -20182,6 +20201,64 @@ func (s *EventMetadata) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *EventMetadata) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s EventMetadataAdditional) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields implements json.Marshaler.
+func (s EventMetadataAdditional) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
+
+		if len(elem) != 0 {
+			e.Raw(elem)
+		}
+	}
+}
+
+// Decode decodes EventMetadataAdditional from json.
+func (s *EventMetadataAdditional) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode EventMetadataAdditional to nil")
+	}
+	m := s.init()
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		var elem jx.Raw
+		if err := func() error {
+			v, err := d.RawAppend(nil)
+			elem = jx.Raw(v)
+			if err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode EventMetadataAdditional")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s EventMetadataAdditional) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *EventMetadataAdditional) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -2461,64 +2461,6 @@ func (s *AuthAttemptCreatedEventDelegationType) UnmarshalJSON(data []byte) error
 }
 
 // Encode implements json.Marshaler.
-func (s AuthAttemptCreatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s AuthAttemptCreatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes AuthAttemptCreatedEventMetadata from json.
-func (s *AuthAttemptCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode AuthAttemptCreatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AuthAttemptCreatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s AuthAttemptCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AuthAttemptCreatedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *AuthAttemptHandedOffEvent) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -3099,64 +3041,6 @@ func (s AuthAttemptHandedOffEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *AuthAttemptHandedOffEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s AuthAttemptHandedOffEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s AuthAttemptHandedOffEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes AuthAttemptHandedOffEventMetadata from json.
-func (s *AuthAttemptHandedOffEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode AuthAttemptHandedOffEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AuthAttemptHandedOffEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s AuthAttemptHandedOffEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AuthAttemptHandedOffEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -4068,64 +3952,6 @@ func (s *AuthCheckFailedEventDelegationType) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s AuthCheckFailedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s AuthCheckFailedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes AuthCheckFailedEventMetadata from json.
-func (s *AuthCheckFailedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode AuthCheckFailedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AuthCheckFailedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s AuthCheckFailedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AuthCheckFailedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *AuthCheckPayload) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -4841,64 +4667,6 @@ func (s *AuthCheckSucceededEventDelegationType) UnmarshalJSON(data []byte) error
 }
 
 // Encode implements json.Marshaler.
-func (s AuthCheckSucceededEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s AuthCheckSucceededEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes AuthCheckSucceededEventMetadata from json.
-func (s *AuthCheckSucceededEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode AuthCheckSucceededEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AuthCheckSucceededEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s AuthCheckSucceededEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AuthCheckSucceededEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *AuthFactorPasskeyEnrolledEvent) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -5484,64 +5252,6 @@ func (s *AuthFactorPasskeyEnrolledEventDelegationType) UnmarshalJSON(data []byte
 }
 
 // Encode implements json.Marshaler.
-func (s AuthFactorPasskeyEnrolledEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s AuthFactorPasskeyEnrolledEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes AuthFactorPasskeyEnrolledEventMetadata from json.
-func (s *AuthFactorPasskeyEnrolledEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode AuthFactorPasskeyEnrolledEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AuthFactorPasskeyEnrolledEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s AuthFactorPasskeyEnrolledEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AuthFactorPasskeyEnrolledEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *AuthFactorPasswordSetEvent) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -6122,64 +5832,6 @@ func (s AuthFactorPasswordSetEventDelegationType) MarshalJSON() ([]byte, error) 
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *AuthFactorPasswordSetEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s AuthFactorPasswordSetEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s AuthFactorPasswordSetEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes AuthFactorPasswordSetEventMetadata from json.
-func (s *AuthFactorPasswordSetEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode AuthFactorPasswordSetEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AuthFactorPasswordSetEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s AuthFactorPasswordSetEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AuthFactorPasswordSetEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -7121,64 +6773,6 @@ func (s *AuthTokenIssuedEventDelegationType) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s AuthTokenIssuedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s AuthTokenIssuedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes AuthTokenIssuedEventMetadata from json.
-func (s *AuthTokenIssuedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode AuthTokenIssuedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AuthTokenIssuedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s AuthTokenIssuedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AuthTokenIssuedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *AuthTokenIssuedPayload) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -7835,64 +7429,6 @@ func (s AuthTokenRevokedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *AuthTokenRevokedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s AuthTokenRevokedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s AuthTokenRevokedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes AuthTokenRevokedEventMetadata from json.
-func (s *AuthTokenRevokedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode AuthTokenRevokedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AuthTokenRevokedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s AuthTokenRevokedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AuthTokenRevokedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -8666,64 +8202,6 @@ func (s AuthzGrantedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *AuthzGrantedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s AuthzGrantedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s AuthzGrantedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes AuthzGrantedEventMetadata from json.
-func (s *AuthzGrantedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode AuthzGrantedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode AuthzGrantedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s AuthzGrantedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *AuthzGrantedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -9538,64 +9016,6 @@ func (s BrandingCreatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *BrandingCreatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s BrandingCreatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s BrandingCreatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes BrandingCreatedEventMetadata from json.
-func (s *BrandingCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode BrandingCreatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode BrandingCreatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s BrandingCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *BrandingCreatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -20704,6 +20124,166 @@ func (s *Event) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *EventMetadata) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *EventMetadata) encodeFields(e *jx.Encoder) {
+	{
+		if s.Client.Set {
+			e.FieldStart("client")
+			s.Client.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfEventMetadata = [1]string{
+	0: "client",
+}
+
+// Decode decodes EventMetadata from json.
+func (s *EventMetadata) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode EventMetadata to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "client":
+			if err := func() error {
+				s.Client.Reset()
+				if err := s.Client.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"client\"")
+			}
+		default:
+			return errors.Errorf("unexpected field %q", k)
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode EventMetadata")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *EventMetadata) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *EventMetadata) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *EventMetadataClient) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *EventMetadataClient) encodeFields(e *jx.Encoder) {
+	{
+		if s.IP.Set {
+			e.FieldStart("ip")
+			s.IP.Encode(e)
+		}
+	}
+	{
+		if s.UserAgent.Set {
+			e.FieldStart("user_agent")
+			s.UserAgent.Encode(e)
+		}
+	}
+	{
+		if s.Origin.Set {
+			e.FieldStart("origin")
+			s.Origin.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfEventMetadataClient = [3]string{
+	0: "ip",
+	1: "user_agent",
+	2: "origin",
+}
+
+// Decode decodes EventMetadataClient from json.
+func (s *EventMetadataClient) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode EventMetadataClient to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "ip":
+			if err := func() error {
+				s.IP.Reset()
+				if err := s.IP.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"ip\"")
+			}
+		case "user_agent":
+			if err := func() error {
+				s.UserAgent.Reset()
+				if err := s.UserAgent.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"user_agent\"")
+			}
+		case "origin":
+			if err := func() error {
+				s.Origin.Reset()
+				if err := s.Origin.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"origin\"")
+			}
+		default:
+			return errors.Errorf("unexpected field %q", k)
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode EventMetadataClient")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *EventMetadataClient) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *EventMetadataClient) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *EvtInvalid) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -27407,64 +26987,6 @@ func (s *FlowdefCreatedEventDelegationType) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s FlowdefCreatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s FlowdefCreatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes FlowdefCreatedEventMetadata from json.
-func (s *FlowdefCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode FlowdefCreatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode FlowdefCreatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s FlowdefCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *FlowdefCreatedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *FlowdefDeletedEvent) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -28045,64 +27567,6 @@ func (s FlowdefDeletedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *FlowdefDeletedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s FlowdefDeletedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s FlowdefDeletedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes FlowdefDeletedEventMetadata from json.
-func (s *FlowdefDeletedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode FlowdefDeletedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode FlowdefDeletedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s FlowdefDeletedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *FlowdefDeletedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -30485,64 +29949,6 @@ func (s FlowdefUpdatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *FlowdefUpdatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s FlowdefUpdatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s FlowdefUpdatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes FlowdefUpdatedEventMetadata from json.
-func (s *FlowdefUpdatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode FlowdefUpdatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode FlowdefUpdatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s FlowdefUpdatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *FlowdefUpdatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -37085,40 +36491,6 @@ func (s *OptAuthAttemptCreatedEventDelegationType) UnmarshalJSON(data []byte) er
 	return s.Decode(d)
 }
 
-// Encode encodes AuthAttemptCreatedEventMetadata as json.
-func (o OptAuthAttemptCreatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes AuthAttemptCreatedEventMetadata from json.
-func (o *OptAuthAttemptCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptAuthAttemptCreatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(AuthAttemptCreatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptAuthAttemptCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptAuthAttemptCreatedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes AuthAttemptHandedOffEventDelegationType as json.
 func (o OptAuthAttemptHandedOffEventDelegationType) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -37148,40 +36520,6 @@ func (s OptAuthAttemptHandedOffEventDelegationType) MarshalJSON() ([]byte, error
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptAuthAttemptHandedOffEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes AuthAttemptHandedOffEventMetadata as json.
-func (o OptAuthAttemptHandedOffEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes AuthAttemptHandedOffEventMetadata from json.
-func (o *OptAuthAttemptHandedOffEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptAuthAttemptHandedOffEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(AuthAttemptHandedOffEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptAuthAttemptHandedOffEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptAuthAttemptHandedOffEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -37219,40 +36557,6 @@ func (s *OptAuthCheckFailedEventDelegationType) UnmarshalJSON(data []byte) error
 	return s.Decode(d)
 }
 
-// Encode encodes AuthCheckFailedEventMetadata as json.
-func (o OptAuthCheckFailedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes AuthCheckFailedEventMetadata from json.
-func (o *OptAuthCheckFailedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptAuthCheckFailedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(AuthCheckFailedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptAuthCheckFailedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptAuthCheckFailedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes AuthCheckSucceededEventDelegationType as json.
 func (o OptAuthCheckSucceededEventDelegationType) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -37282,40 +36586,6 @@ func (s OptAuthCheckSucceededEventDelegationType) MarshalJSON() ([]byte, error) 
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptAuthCheckSucceededEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes AuthCheckSucceededEventMetadata as json.
-func (o OptAuthCheckSucceededEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes AuthCheckSucceededEventMetadata from json.
-func (o *OptAuthCheckSucceededEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptAuthCheckSucceededEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(AuthCheckSucceededEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptAuthCheckSucceededEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptAuthCheckSucceededEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -37353,40 +36623,6 @@ func (s *OptAuthFactorPasskeyEnrolledEventDelegationType) UnmarshalJSON(data []b
 	return s.Decode(d)
 }
 
-// Encode encodes AuthFactorPasskeyEnrolledEventMetadata as json.
-func (o OptAuthFactorPasskeyEnrolledEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes AuthFactorPasskeyEnrolledEventMetadata from json.
-func (o *OptAuthFactorPasskeyEnrolledEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptAuthFactorPasskeyEnrolledEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(AuthFactorPasskeyEnrolledEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptAuthFactorPasskeyEnrolledEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptAuthFactorPasskeyEnrolledEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes AuthFactorPasswordSetEventDelegationType as json.
 func (o OptAuthFactorPasswordSetEventDelegationType) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -37416,40 +36652,6 @@ func (s OptAuthFactorPasswordSetEventDelegationType) MarshalJSON() ([]byte, erro
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptAuthFactorPasswordSetEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes AuthFactorPasswordSetEventMetadata as json.
-func (o OptAuthFactorPasswordSetEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes AuthFactorPasswordSetEventMetadata from json.
-func (o *OptAuthFactorPasswordSetEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptAuthFactorPasswordSetEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(AuthFactorPasswordSetEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptAuthFactorPasswordSetEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptAuthFactorPasswordSetEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -37520,40 +36722,6 @@ func (s *OptAuthTokenIssuedEventDelegationType) UnmarshalJSON(data []byte) error
 	return s.Decode(d)
 }
 
-// Encode encodes AuthTokenIssuedEventMetadata as json.
-func (o OptAuthTokenIssuedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes AuthTokenIssuedEventMetadata from json.
-func (o *OptAuthTokenIssuedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptAuthTokenIssuedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(AuthTokenIssuedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptAuthTokenIssuedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptAuthTokenIssuedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes AuthTokenRevokedEventDelegationType as json.
 func (o OptAuthTokenRevokedEventDelegationType) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -37583,40 +36751,6 @@ func (s OptAuthTokenRevokedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptAuthTokenRevokedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes AuthTokenRevokedEventMetadata as json.
-func (o OptAuthTokenRevokedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes AuthTokenRevokedEventMetadata from json.
-func (o *OptAuthTokenRevokedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptAuthTokenRevokedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(AuthTokenRevokedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptAuthTokenRevokedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptAuthTokenRevokedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -37684,40 +36818,6 @@ func (s OptAuthzGrantedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptAuthzGrantedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes AuthzGrantedEventMetadata as json.
-func (o OptAuthzGrantedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes AuthzGrantedEventMetadata from json.
-func (o *OptAuthzGrantedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptAuthzGrantedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(AuthzGrantedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptAuthzGrantedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptAuthzGrantedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -37819,40 +36919,6 @@ func (s OptBrandingCreatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptBrandingCreatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes BrandingCreatedEventMetadata as json.
-func (o OptBrandingCreatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes BrandingCreatedEventMetadata from json.
-func (o *OptBrandingCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptBrandingCreatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(BrandingCreatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptBrandingCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptBrandingCreatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -38292,6 +37358,72 @@ func (s OptErrorDetailsDetails) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptErrorDetailsDetails) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes EventMetadata as json.
+func (o OptEventMetadata) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes EventMetadata from json.
+func (o *OptEventMetadata) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptEventMetadata to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptEventMetadata) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptEventMetadata) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes EventMetadataClient as json.
+func (o OptEventMetadataClient) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes EventMetadataClient from json.
+func (o *OptEventMetadataClient) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptEventMetadataClient to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptEventMetadataClient) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptEventMetadataClient) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -39236,40 +38368,6 @@ func (s *OptFlowdefCreatedEventDelegationType) UnmarshalJSON(data []byte) error 
 	return s.Decode(d)
 }
 
-// Encode encodes FlowdefCreatedEventMetadata as json.
-func (o OptFlowdefCreatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes FlowdefCreatedEventMetadata from json.
-func (o *OptFlowdefCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptFlowdefCreatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(FlowdefCreatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptFlowdefCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptFlowdefCreatedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes FlowdefDeletedEventDelegationType as json.
 func (o OptFlowdefDeletedEventDelegationType) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -39299,40 +38397,6 @@ func (s OptFlowdefDeletedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptFlowdefDeletedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes FlowdefDeletedEventMetadata as json.
-func (o OptFlowdefDeletedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes FlowdefDeletedEventMetadata from json.
-func (o *OptFlowdefDeletedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptFlowdefDeletedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(FlowdefDeletedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptFlowdefDeletedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptFlowdefDeletedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -39705,40 +38769,6 @@ func (s OptFlowdefUpdatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptFlowdefUpdatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes FlowdefUpdatedEventMetadata as json.
-func (o OptFlowdefUpdatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes FlowdefUpdatedEventMetadata from json.
-func (o *OptFlowdefUpdatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptFlowdefUpdatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(FlowdefUpdatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptFlowdefUpdatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptFlowdefUpdatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -42051,40 +41081,6 @@ func (s *OptProjectCreatedEventDelegationType) UnmarshalJSON(data []byte) error 
 	return s.Decode(d)
 }
 
-// Encode encodes ProjectCreatedEventMetadata as json.
-func (o OptProjectCreatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes ProjectCreatedEventMetadata from json.
-func (o *OptProjectCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptProjectCreatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(ProjectCreatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptProjectCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptProjectCreatedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes ProjectDeletedEventDelegationType as json.
 func (o OptProjectDeletedEventDelegationType) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -42118,40 +41114,6 @@ func (s *OptProjectDeletedEventDelegationType) UnmarshalJSON(data []byte) error 
 	return s.Decode(d)
 }
 
-// Encode encodes ProjectDeletedEventMetadata as json.
-func (o OptProjectDeletedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes ProjectDeletedEventMetadata from json.
-func (o *OptProjectDeletedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptProjectDeletedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(ProjectDeletedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptProjectDeletedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptProjectDeletedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes ProjectUpdatedEventDelegationType as json.
 func (o OptProjectUpdatedEventDelegationType) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -42181,40 +41143,6 @@ func (s OptProjectUpdatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptProjectUpdatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes ProjectUpdatedEventMetadata as json.
-func (o OptProjectUpdatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes ProjectUpdatedEventMetadata from json.
-func (o *OptProjectUpdatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptProjectUpdatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(ProjectUpdatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptProjectUpdatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptProjectUpdatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -42385,40 +41313,6 @@ func (s *OptRequestAPIEventDelegationType) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes RequestAPIEventMetadata as json.
-func (o OptRequestAPIEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes RequestAPIEventMetadata from json.
-func (o *OptRequestAPIEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptRequestAPIEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(RequestAPIEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptRequestAPIEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptRequestAPIEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes SchInvalidRequestDetails as json.
 func (o OptSchInvalidRequestDetails) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -42516,40 +41410,6 @@ func (s OptSchemaCreatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptSchemaCreatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes SchemaCreatedEventMetadata as json.
-func (o OptSchemaCreatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes SchemaCreatedEventMetadata from json.
-func (o *OptSchemaCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptSchemaCreatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(SchemaCreatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptSchemaCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptSchemaCreatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -42858,40 +41718,6 @@ func (s *OptSessionDeletedEventDelegationType) UnmarshalJSON(data []byte) error 
 	return s.Decode(d)
 }
 
-// Encode encodes SessionDeletedEventMetadata as json.
-func (o OptSessionDeletedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes SessionDeletedEventMetadata from json.
-func (o *OptSessionDeletedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptSessionDeletedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(SessionDeletedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptSessionDeletedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptSessionDeletedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes SessionEstablishedEventDelegationType as json.
 func (o OptSessionEstablishedEventDelegationType) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -42921,40 +41747,6 @@ func (s OptSessionEstablishedEventDelegationType) MarshalJSON() ([]byte, error) 
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptSessionEstablishedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes SessionEstablishedEventMetadata as json.
-func (o OptSessionEstablishedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes SessionEstablishedEventMetadata from json.
-func (o *OptSessionEstablishedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptSessionEstablishedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(SessionEstablishedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptSessionEstablishedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptSessionEstablishedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -43060,40 +41852,6 @@ func (s *OptTeamCreatedEventDelegationType) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes TeamCreatedEventMetadata as json.
-func (o OptTeamCreatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes TeamCreatedEventMetadata from json.
-func (o *OptTeamCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptTeamCreatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(TeamCreatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptTeamCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptTeamCreatedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes TeamDeactivatedEventDelegationType as json.
 func (o OptTeamDeactivatedEventDelegationType) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -43123,40 +41881,6 @@ func (s OptTeamDeactivatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptTeamDeactivatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes TeamDeactivatedEventMetadata as json.
-func (o OptTeamDeactivatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes TeamDeactivatedEventMetadata from json.
-func (o *OptTeamDeactivatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptTeamDeactivatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(TeamDeactivatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptTeamDeactivatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptTeamDeactivatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -43223,40 +41947,6 @@ func (s OptTeamUpdatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptTeamUpdatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes TeamUpdatedEventMetadata as json.
-func (o OptTeamUpdatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes TeamUpdatedEventMetadata from json.
-func (o *OptTeamUpdatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptTeamUpdatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(TeamUpdatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptTeamUpdatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptTeamUpdatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -43465,40 +42155,6 @@ func (s *OptUserCreateFailedEventDelegationType) UnmarshalJSON(data []byte) erro
 	return s.Decode(d)
 }
 
-// Encode encodes UserCreateFailedEventMetadata as json.
-func (o OptUserCreateFailedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes UserCreateFailedEventMetadata from json.
-func (o *OptUserCreateFailedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptUserCreateFailedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(UserCreateFailedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptUserCreateFailedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptUserCreateFailedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode encodes UserCreatedEventDelegationType as json.
 func (o OptUserCreatedEventDelegationType) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -43528,40 +42184,6 @@ func (s OptUserCreatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptUserCreatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes UserCreatedEventMetadata as json.
-func (o OptUserCreatedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes UserCreatedEventMetadata from json.
-func (o *OptUserCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptUserCreatedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(UserCreatedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptUserCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptUserCreatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -43629,40 +42251,6 @@ func (s OptUserDeletedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptUserDeletedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes UserDeletedEventMetadata as json.
-func (o OptUserDeletedEventMetadata) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes UserDeletedEventMetadata from json.
-func (o *OptUserDeletedEventMetadata) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptUserDeletedEventMetadata to nil")
-	}
-	o.Set = true
-	o.Value = make(UserDeletedEventMetadata)
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptUserDeletedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptUserDeletedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -47097,64 +45685,6 @@ func (s *ProjectCreatedEventDelegationType) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s ProjectCreatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s ProjectCreatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes ProjectCreatedEventMetadata from json.
-func (s *ProjectCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ProjectCreatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ProjectCreatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s ProjectCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ProjectCreatedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *ProjectDeletedEvent) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -47735,64 +46265,6 @@ func (s ProjectDeletedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *ProjectDeletedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s ProjectDeletedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s ProjectDeletedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes ProjectDeletedEventMetadata from json.
-func (s *ProjectDeletedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ProjectDeletedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ProjectDeletedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s ProjectDeletedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ProjectDeletedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -48688,64 +47160,6 @@ func (s ProjectUpdatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *ProjectUpdatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s ProjectUpdatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s ProjectUpdatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes ProjectUpdatedEventMetadata from json.
-func (s *ProjectUpdatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode ProjectUpdatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode ProjectUpdatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s ProjectUpdatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *ProjectUpdatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -51890,64 +50304,6 @@ func (s *RequestAPIEventDelegationType) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s RequestAPIEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s RequestAPIEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes RequestAPIEventMetadata from json.
-func (s *RequestAPIEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode RequestAPIEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode RequestAPIEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s RequestAPIEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *RequestAPIEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *RequestAPIPayload) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -53837,64 +52193,6 @@ func (s SchemaCreatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *SchemaCreatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s SchemaCreatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s SchemaCreatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes SchemaCreatedEventMetadata from json.
-func (s *SchemaCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode SchemaCreatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode SchemaCreatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s SchemaCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *SchemaCreatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -56242,64 +54540,6 @@ func (s *SessionDeletedEventDelegationType) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s SessionDeletedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s SessionDeletedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes SessionDeletedEventMetadata from json.
-func (s *SessionDeletedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode SessionDeletedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode SessionDeletedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s SessionDeletedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *SessionDeletedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *SessionDeletedPayload) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -56943,64 +55183,6 @@ func (s SessionEstablishedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *SessionEstablishedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s SessionEstablishedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s SessionEstablishedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes SessionEstablishedEventMetadata from json.
-func (s *SessionEstablishedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode SessionEstablishedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode SessionEstablishedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s SessionEstablishedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *SessionEstablishedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -59902,64 +58084,6 @@ func (s *TeamCreatedEventDelegationType) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s TeamCreatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s TeamCreatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes TeamCreatedEventMetadata from json.
-func (s *TeamCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode TeamCreatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode TeamCreatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s TeamCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *TeamCreatedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *TeamDeactivatedEvent) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -60540,64 +58664,6 @@ func (s TeamDeactivatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *TeamDeactivatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s TeamDeactivatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s TeamDeactivatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes TeamDeactivatedEventMetadata from json.
-func (s *TeamDeactivatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode TeamDeactivatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode TeamDeactivatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s TeamDeactivatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *TeamDeactivatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -61530,64 +59596,6 @@ func (s TeamUpdatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *TeamUpdatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s TeamUpdatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s TeamUpdatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes TeamUpdatedEventMetadata from json.
-func (s *TeamUpdatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode TeamUpdatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode TeamUpdatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s TeamUpdatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *TeamUpdatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -63802,64 +61810,6 @@ func (s *UserCreateFailedEventDelegationType) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s UserCreateFailedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s UserCreateFailedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes UserCreateFailedEventMetadata from json.
-func (s *UserCreateFailedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode UserCreateFailedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode UserCreateFailedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s UserCreateFailedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *UserCreateFailedEventMetadata) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
 func (s *UserCreateFailedPayload) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -64503,64 +62453,6 @@ func (s UserCreatedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *UserCreatedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s UserCreatedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s UserCreatedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes UserCreatedEventMetadata from json.
-func (s *UserCreatedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode UserCreatedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode UserCreatedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s UserCreatedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *UserCreatedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -65314,64 +63206,6 @@ func (s UserDeletedEventDelegationType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *UserDeletedEventDelegationType) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode implements json.Marshaler.
-func (s UserDeletedEventMetadata) Encode(e *jx.Encoder) {
-	e.ObjStart()
-	s.encodeFields(e)
-	e.ObjEnd()
-}
-
-// encodeFields implements json.Marshaler.
-func (s UserDeletedEventMetadata) encodeFields(e *jx.Encoder) {
-	for k, elem := range s {
-		e.FieldStart(k)
-
-		if len(elem) != 0 {
-			e.Raw(elem)
-		}
-	}
-}
-
-// Decode decodes UserDeletedEventMetadata from json.
-func (s *UserDeletedEventMetadata) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode UserDeletedEventMetadata to nil")
-	}
-	m := s.init()
-	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
-		var elem jx.Raw
-		if err := func() error {
-			v, err := d.RawAppend(nil)
-			elem = jx.Raw(v)
-			if err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			return errors.Wrapf(err, "decode field %q", k)
-		}
-		m[string(k)] = elem
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "decode UserDeletedEventMetadata")
-	}
-
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s UserDeletedEventMetadata) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *UserDeletedEventMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -570,10 +570,9 @@ type AuthAttemptCreatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptAuthAttemptCreatedEventMetadata `json:"metadata"`
-	Payload  EmptyEventPayload                  `json:"payload"`
+	FlowID   OptNilString      `json:"flow_id"`
+	Metadata OptEventMetadata  `json:"metadata"`
+	Payload  EmptyEventPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -677,7 +676,7 @@ func (s *AuthAttemptCreatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *AuthAttemptCreatedEvent) GetMetadata() OptAuthAttemptCreatedEventMetadata {
+func (s *AuthAttemptCreatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -787,7 +786,7 @@ func (s *AuthAttemptCreatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *AuthAttemptCreatedEvent) SetMetadata(val OptAuthAttemptCreatedEventMetadata) {
+func (s *AuthAttemptCreatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -977,18 +976,6 @@ func (s *AuthAttemptCreatedEventDelegationType) UnmarshalText(data []byte) error
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type AuthAttemptCreatedEventMetadata map[string]jx.Raw
-
-func (s *AuthAttemptCreatedEventMetadata) init() AuthAttemptCreatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Merged schema.
 // Ref: #
 type AuthAttemptHandedOffEvent struct {
@@ -1028,10 +1015,9 @@ type AuthAttemptHandedOffEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptAuthAttemptHandedOffEventMetadata `json:"metadata"`
-	Payload  EmptyEventPayload                    `json:"payload"`
+	FlowID   OptNilString      `json:"flow_id"`
+	Metadata OptEventMetadata  `json:"metadata"`
+	Payload  EmptyEventPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -1135,7 +1121,7 @@ func (s *AuthAttemptHandedOffEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *AuthAttemptHandedOffEvent) GetMetadata() OptAuthAttemptHandedOffEventMetadata {
+func (s *AuthAttemptHandedOffEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -1245,7 +1231,7 @@ func (s *AuthAttemptHandedOffEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *AuthAttemptHandedOffEvent) SetMetadata(val OptAuthAttemptHandedOffEventMetadata) {
+func (s *AuthAttemptHandedOffEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -1433,18 +1419,6 @@ func (s *AuthAttemptHandedOffEventDelegationType) UnmarshalText(data []byte) err
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type AuthAttemptHandedOffEventMetadata map[string]jx.Raw
-
-func (s *AuthAttemptHandedOffEventMetadata) init() AuthAttemptHandedOffEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 // The current state of an authentication attempt.
@@ -1693,10 +1667,9 @@ type AuthCheckFailedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptAuthCheckFailedEventMetadata `json:"metadata"`
-	Payload  AuthCheckPayload                `json:"payload"`
+	FlowID   OptNilString     `json:"flow_id"`
+	Metadata OptEventMetadata `json:"metadata"`
+	Payload  AuthCheckPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -1800,7 +1773,7 @@ func (s *AuthCheckFailedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *AuthCheckFailedEvent) GetMetadata() OptAuthCheckFailedEventMetadata {
+func (s *AuthCheckFailedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -1910,7 +1883,7 @@ func (s *AuthCheckFailedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *AuthCheckFailedEvent) SetMetadata(val OptAuthCheckFailedEventMetadata) {
+func (s *AuthCheckFailedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -2100,18 +2073,6 @@ func (s *AuthCheckFailedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type AuthCheckFailedEventMetadata map[string]jx.Raw
-
-func (s *AuthCheckFailedEventMetadata) init() AuthCheckFailedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Payload for `auth.check.failed` / `auth.check.succeeded`.
 // `auth_attempt_id` joins the check to its attempt for SIEM correlation.
 // Ref: #
@@ -2190,10 +2151,9 @@ type AuthCheckSucceededEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptAuthCheckSucceededEventMetadata `json:"metadata"`
-	Payload  AuthCheckPayload                   `json:"payload"`
+	FlowID   OptNilString     `json:"flow_id"`
+	Metadata OptEventMetadata `json:"metadata"`
+	Payload  AuthCheckPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -2297,7 +2257,7 @@ func (s *AuthCheckSucceededEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *AuthCheckSucceededEvent) GetMetadata() OptAuthCheckSucceededEventMetadata {
+func (s *AuthCheckSucceededEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -2407,7 +2367,7 @@ func (s *AuthCheckSucceededEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *AuthCheckSucceededEvent) SetMetadata(val OptAuthCheckSucceededEventMetadata) {
+func (s *AuthCheckSucceededEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -2597,18 +2557,6 @@ func (s *AuthCheckSucceededEventDelegationType) UnmarshalText(data []byte) error
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type AuthCheckSucceededEventMetadata map[string]jx.Raw
-
-func (s *AuthCheckSucceededEventMetadata) init() AuthCheckSucceededEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Merged schema.
 // Ref: #
 type AuthFactorPasskeyEnrolledEvent struct {
@@ -2648,10 +2596,9 @@ type AuthFactorPasskeyEnrolledEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptAuthFactorPasskeyEnrolledEventMetadata `json:"metadata"`
-	Payload  AuthFactorPayload                         `json:"payload"`
+	FlowID   OptNilString      `json:"flow_id"`
+	Metadata OptEventMetadata  `json:"metadata"`
+	Payload  AuthFactorPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -2755,7 +2702,7 @@ func (s *AuthFactorPasskeyEnrolledEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *AuthFactorPasskeyEnrolledEvent) GetMetadata() OptAuthFactorPasskeyEnrolledEventMetadata {
+func (s *AuthFactorPasskeyEnrolledEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -2865,7 +2812,7 @@ func (s *AuthFactorPasskeyEnrolledEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *AuthFactorPasskeyEnrolledEvent) SetMetadata(val OptAuthFactorPasskeyEnrolledEventMetadata) {
+func (s *AuthFactorPasskeyEnrolledEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -3055,18 +3002,6 @@ func (s *AuthFactorPasskeyEnrolledEventDelegationType) UnmarshalText(data []byte
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type AuthFactorPasskeyEnrolledEventMetadata map[string]jx.Raw
-
-func (s *AuthFactorPasskeyEnrolledEventMetadata) init() AuthFactorPasskeyEnrolledEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Merged schema.
 // Ref: #
 type AuthFactorPasswordSetEvent struct {
@@ -3106,10 +3041,9 @@ type AuthFactorPasswordSetEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptAuthFactorPasswordSetEventMetadata `json:"metadata"`
-	Payload  AuthFactorPayload                     `json:"payload"`
+	FlowID   OptNilString      `json:"flow_id"`
+	Metadata OptEventMetadata  `json:"metadata"`
+	Payload  AuthFactorPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -3213,7 +3147,7 @@ func (s *AuthFactorPasswordSetEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *AuthFactorPasswordSetEvent) GetMetadata() OptAuthFactorPasswordSetEventMetadata {
+func (s *AuthFactorPasswordSetEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -3323,7 +3257,7 @@ func (s *AuthFactorPasswordSetEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *AuthFactorPasswordSetEvent) SetMetadata(val OptAuthFactorPasswordSetEventMetadata) {
+func (s *AuthFactorPasswordSetEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -3513,18 +3447,6 @@ func (s *AuthFactorPasswordSetEventDelegationType) UnmarshalText(data []byte) er
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type AuthFactorPasswordSetEventMetadata map[string]jx.Raw
-
-func (s *AuthFactorPasswordSetEventMetadata) init() AuthFactorPasswordSetEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Payload for `auth.factor.*` events.
 // Ref: #
 type AuthFactorPayload struct {
@@ -3667,10 +3589,9 @@ type AuthTokenIssuedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptAuthTokenIssuedEventMetadata `json:"metadata"`
-	Payload  AuthTokenIssuedPayload          `json:"payload"`
+	FlowID   OptNilString           `json:"flow_id"`
+	Metadata OptEventMetadata       `json:"metadata"`
+	Payload  AuthTokenIssuedPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -3774,7 +3695,7 @@ func (s *AuthTokenIssuedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *AuthTokenIssuedEvent) GetMetadata() OptAuthTokenIssuedEventMetadata {
+func (s *AuthTokenIssuedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -3884,7 +3805,7 @@ func (s *AuthTokenIssuedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *AuthTokenIssuedEvent) SetMetadata(val OptAuthTokenIssuedEventMetadata) {
+func (s *AuthTokenIssuedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -4074,18 +3995,6 @@ func (s *AuthTokenIssuedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type AuthTokenIssuedEventMetadata map[string]jx.Raw
-
-func (s *AuthTokenIssuedEventMetadata) init() AuthTokenIssuedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Payload for `auth.token.issued` events.
 // Ref: #
 type AuthTokenIssuedPayload struct {
@@ -4141,10 +4050,9 @@ type AuthTokenRevokedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptAuthTokenRevokedEventMetadata `json:"metadata"`
-	Payload  EmptyEventPayload                `json:"payload"`
+	FlowID   OptNilString      `json:"flow_id"`
+	Metadata OptEventMetadata  `json:"metadata"`
+	Payload  EmptyEventPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -4248,7 +4156,7 @@ func (s *AuthTokenRevokedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *AuthTokenRevokedEvent) GetMetadata() OptAuthTokenRevokedEventMetadata {
+func (s *AuthTokenRevokedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -4358,7 +4266,7 @@ func (s *AuthTokenRevokedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *AuthTokenRevokedEvent) SetMetadata(val OptAuthTokenRevokedEventMetadata) {
+func (s *AuthTokenRevokedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -4548,18 +4456,6 @@ func (s *AuthTokenRevokedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type AuthTokenRevokedEventMetadata map[string]jx.Raw
-
-func (s *AuthTokenRevokedEventMetadata) init() AuthTokenRevokedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Merged schema.
 // Ref: #
 type AuthUnauthorized struct {
@@ -4683,10 +4579,9 @@ type AuthzGrantedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptAuthzGrantedEventMetadata `json:"metadata"`
-	Payload  AuthzGrantedPayload          `json:"payload"`
+	FlowID   OptNilString        `json:"flow_id"`
+	Metadata OptEventMetadata    `json:"metadata"`
+	Payload  AuthzGrantedPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -4790,7 +4685,7 @@ func (s *AuthzGrantedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *AuthzGrantedEvent) GetMetadata() OptAuthzGrantedEventMetadata {
+func (s *AuthzGrantedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -4900,7 +4795,7 @@ func (s *AuthzGrantedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *AuthzGrantedEvent) SetMetadata(val OptAuthzGrantedEventMetadata) {
+func (s *AuthzGrantedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -5090,18 +4985,6 @@ func (s *AuthzGrantedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type AuthzGrantedEventMetadata map[string]jx.Raw
-
-func (s *AuthzGrantedEventMetadata) init() AuthzGrantedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Payload for `authz.granted` events.
 // Ref: #
 type AuthzGrantedPayload struct {
@@ -5261,10 +5144,9 @@ type BrandingCreatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptBrandingCreatedEventMetadata `json:"metadata"`
-	Payload  BrandingCreatedPayload          `json:"payload"`
+	FlowID   OptNilString           `json:"flow_id"`
+	Metadata OptEventMetadata       `json:"metadata"`
+	Payload  BrandingCreatedPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -5368,7 +5250,7 @@ func (s *BrandingCreatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *BrandingCreatedEvent) GetMetadata() OptBrandingCreatedEventMetadata {
+func (s *BrandingCreatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -5478,7 +5360,7 @@ func (s *BrandingCreatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *BrandingCreatedEvent) SetMetadata(val OptBrandingCreatedEventMetadata) {
+func (s *BrandingCreatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -5666,18 +5548,6 @@ func (s *BrandingCreatedEventDelegationType) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type BrandingCreatedEventMetadata map[string]jx.Raw
-
-func (s *BrandingCreatedEventMetadata) init() BrandingCreatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 // Allowlisted fields for `branding.created`. Omits `liquid_template`.
@@ -10917,6 +10787,70 @@ func NewUserDeletedEventEvent(v UserDeletedEvent) Event {
 
 func (*Event) getEventRes() {}
 
+// Emit-time metadata, already redacted at write. Path A request.api may
+// set client with observed requestor context for SIEM join on request_id.
+// Not a live risk-evaluator input (ADR 019). Untrusted client-supplied
+// correlation belongs in client_hints if ever accepted; parent_span_id
+// is reserved for OTEL export projection.
+// Ref: #
+type EventMetadata struct {
+	// Observed HTTP requestor context on Path A request.api only.
+	// Path B events omit this object. Join via request_id.
+	Client OptEventMetadataClient `json:"client"`
+}
+
+// GetClient returns the value of Client.
+func (s *EventMetadata) GetClient() OptEventMetadataClient {
+	return s.Client
+}
+
+// SetClient sets the value of Client.
+func (s *EventMetadata) SetClient(val OptEventMetadataClient) {
+	s.Client = val
+}
+
+// Observed HTTP requestor context on Path A request.api only.
+// Path B events omit this object. Join via request_id.
+type EventMetadataClient struct {
+	// Client IP from the first X-Forwarded-For hop or RemoteAddr.
+	// Proxy-dependent (see https://github.com/zitadel/nextgen/issues/802).
+	IP OptString `json:"ip"`
+	// Observed User-Agent header. Spoofable.
+	UserAgent OptString `json:"user_agent"`
+	// Origin header, or Host when Origin is absent.
+	Origin OptString `json:"origin"`
+}
+
+// GetIP returns the value of IP.
+func (s *EventMetadataClient) GetIP() OptString {
+	return s.IP
+}
+
+// GetUserAgent returns the value of UserAgent.
+func (s *EventMetadataClient) GetUserAgent() OptString {
+	return s.UserAgent
+}
+
+// GetOrigin returns the value of Origin.
+func (s *EventMetadataClient) GetOrigin() OptString {
+	return s.Origin
+}
+
+// SetIP sets the value of IP.
+func (s *EventMetadataClient) SetIP(val OptString) {
+	s.IP = val
+}
+
+// SetUserAgent sets the value of UserAgent.
+func (s *EventMetadataClient) SetUserAgent(val OptString) {
+	s.UserAgent = val
+}
+
+// SetOrigin sets the value of Origin.
+func (s *EventMetadataClient) SetOrigin(val OptString) {
+	s.Origin = val
+}
+
 // Merged schema.
 // Ref: #
 type EvtInvalid struct {
@@ -14065,10 +13999,9 @@ type FlowdefCreatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptFlowdefCreatedEventMetadata `json:"metadata"`
-	Payload  FlowdefPayload                 `json:"payload"`
+	FlowID   OptNilString     `json:"flow_id"`
+	Metadata OptEventMetadata `json:"metadata"`
+	Payload  FlowdefPayload   `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -14172,7 +14105,7 @@ func (s *FlowdefCreatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *FlowdefCreatedEvent) GetMetadata() OptFlowdefCreatedEventMetadata {
+func (s *FlowdefCreatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -14282,7 +14215,7 @@ func (s *FlowdefCreatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *FlowdefCreatedEvent) SetMetadata(val OptFlowdefCreatedEventMetadata) {
+func (s *FlowdefCreatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -14472,18 +14405,6 @@ func (s *FlowdefCreatedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type FlowdefCreatedEventMetadata map[string]jx.Raw
-
-func (s *FlowdefCreatedEventMetadata) init() FlowdefCreatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Merged schema.
 // Ref: #
 type FlowdefDeletedEvent struct {
@@ -14523,10 +14444,9 @@ type FlowdefDeletedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptFlowdefDeletedEventMetadata `json:"metadata"`
-	Payload  EmptyEventPayload              `json:"payload"`
+	FlowID   OptNilString      `json:"flow_id"`
+	Metadata OptEventMetadata  `json:"metadata"`
+	Payload  EmptyEventPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -14630,7 +14550,7 @@ func (s *FlowdefDeletedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *FlowdefDeletedEvent) GetMetadata() OptFlowdefDeletedEventMetadata {
+func (s *FlowdefDeletedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -14740,7 +14660,7 @@ func (s *FlowdefDeletedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *FlowdefDeletedEvent) SetMetadata(val OptFlowdefDeletedEventMetadata) {
+func (s *FlowdefDeletedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -14928,18 +14848,6 @@ func (s *FlowdefDeletedEventDelegationType) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type FlowdefDeletedEventMetadata map[string]jx.Raw
-
-func (s *FlowdefDeletedEventMetadata) init() FlowdefDeletedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 // Merged schema.
@@ -15502,10 +15410,9 @@ type FlowdefUpdatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptFlowdefUpdatedEventMetadata `json:"metadata"`
-	Payload  FlowdefPayload                 `json:"payload"`
+	FlowID   OptNilString     `json:"flow_id"`
+	Metadata OptEventMetadata `json:"metadata"`
+	Payload  FlowdefPayload   `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -15609,7 +15516,7 @@ func (s *FlowdefUpdatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *FlowdefUpdatedEvent) GetMetadata() OptFlowdefUpdatedEventMetadata {
+func (s *FlowdefUpdatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -15719,7 +15626,7 @@ func (s *FlowdefUpdatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *FlowdefUpdatedEvent) SetMetadata(val OptFlowdefUpdatedEventMetadata) {
+func (s *FlowdefUpdatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -15907,18 +15814,6 @@ func (s *FlowdefUpdatedEventDelegationType) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type FlowdefUpdatedEventMetadata map[string]jx.Raw
-
-func (s *FlowdefUpdatedEventMetadata) init() FlowdefUpdatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 // A security challenge that must be satisfied before this step's submission
@@ -20124,52 +20019,6 @@ func (o OptAuthAttemptCreatedEventDelegationType) Or(d AuthAttemptCreatedEventDe
 	return d
 }
 
-// NewOptAuthAttemptCreatedEventMetadata returns new OptAuthAttemptCreatedEventMetadata with value set to v.
-func NewOptAuthAttemptCreatedEventMetadata(v AuthAttemptCreatedEventMetadata) OptAuthAttemptCreatedEventMetadata {
-	return OptAuthAttemptCreatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptAuthAttemptCreatedEventMetadata is optional AuthAttemptCreatedEventMetadata.
-type OptAuthAttemptCreatedEventMetadata struct {
-	Value AuthAttemptCreatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptAuthAttemptCreatedEventMetadata was set.
-func (o OptAuthAttemptCreatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptAuthAttemptCreatedEventMetadata) Reset() {
-	var v AuthAttemptCreatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptAuthAttemptCreatedEventMetadata) SetTo(v AuthAttemptCreatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptAuthAttemptCreatedEventMetadata) Get() (v AuthAttemptCreatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptAuthAttemptCreatedEventMetadata) Or(d AuthAttemptCreatedEventMetadata) AuthAttemptCreatedEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptAuthAttemptHandedOffEventDelegationType returns new OptAuthAttemptHandedOffEventDelegationType with value set to v.
 func NewOptAuthAttemptHandedOffEventDelegationType(v AuthAttemptHandedOffEventDelegationType) OptAuthAttemptHandedOffEventDelegationType {
 	return OptAuthAttemptHandedOffEventDelegationType{
@@ -20210,52 +20059,6 @@ func (o OptAuthAttemptHandedOffEventDelegationType) Get() (v AuthAttemptHandedOf
 
 // Or returns value if set, or given parameter if does not.
 func (o OptAuthAttemptHandedOffEventDelegationType) Or(d AuthAttemptHandedOffEventDelegationType) AuthAttemptHandedOffEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptAuthAttemptHandedOffEventMetadata returns new OptAuthAttemptHandedOffEventMetadata with value set to v.
-func NewOptAuthAttemptHandedOffEventMetadata(v AuthAttemptHandedOffEventMetadata) OptAuthAttemptHandedOffEventMetadata {
-	return OptAuthAttemptHandedOffEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptAuthAttemptHandedOffEventMetadata is optional AuthAttemptHandedOffEventMetadata.
-type OptAuthAttemptHandedOffEventMetadata struct {
-	Value AuthAttemptHandedOffEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptAuthAttemptHandedOffEventMetadata was set.
-func (o OptAuthAttemptHandedOffEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptAuthAttemptHandedOffEventMetadata) Reset() {
-	var v AuthAttemptHandedOffEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptAuthAttemptHandedOffEventMetadata) SetTo(v AuthAttemptHandedOffEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptAuthAttemptHandedOffEventMetadata) Get() (v AuthAttemptHandedOffEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptAuthAttemptHandedOffEventMetadata) Or(d AuthAttemptHandedOffEventMetadata) AuthAttemptHandedOffEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -20308,52 +20111,6 @@ func (o OptAuthCheckFailedEventDelegationType) Or(d AuthCheckFailedEventDelegati
 	return d
 }
 
-// NewOptAuthCheckFailedEventMetadata returns new OptAuthCheckFailedEventMetadata with value set to v.
-func NewOptAuthCheckFailedEventMetadata(v AuthCheckFailedEventMetadata) OptAuthCheckFailedEventMetadata {
-	return OptAuthCheckFailedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptAuthCheckFailedEventMetadata is optional AuthCheckFailedEventMetadata.
-type OptAuthCheckFailedEventMetadata struct {
-	Value AuthCheckFailedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptAuthCheckFailedEventMetadata was set.
-func (o OptAuthCheckFailedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptAuthCheckFailedEventMetadata) Reset() {
-	var v AuthCheckFailedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptAuthCheckFailedEventMetadata) SetTo(v AuthCheckFailedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptAuthCheckFailedEventMetadata) Get() (v AuthCheckFailedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptAuthCheckFailedEventMetadata) Or(d AuthCheckFailedEventMetadata) AuthCheckFailedEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptAuthCheckSucceededEventDelegationType returns new OptAuthCheckSucceededEventDelegationType with value set to v.
 func NewOptAuthCheckSucceededEventDelegationType(v AuthCheckSucceededEventDelegationType) OptAuthCheckSucceededEventDelegationType {
 	return OptAuthCheckSucceededEventDelegationType{
@@ -20394,52 +20151,6 @@ func (o OptAuthCheckSucceededEventDelegationType) Get() (v AuthCheckSucceededEve
 
 // Or returns value if set, or given parameter if does not.
 func (o OptAuthCheckSucceededEventDelegationType) Or(d AuthCheckSucceededEventDelegationType) AuthCheckSucceededEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptAuthCheckSucceededEventMetadata returns new OptAuthCheckSucceededEventMetadata with value set to v.
-func NewOptAuthCheckSucceededEventMetadata(v AuthCheckSucceededEventMetadata) OptAuthCheckSucceededEventMetadata {
-	return OptAuthCheckSucceededEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptAuthCheckSucceededEventMetadata is optional AuthCheckSucceededEventMetadata.
-type OptAuthCheckSucceededEventMetadata struct {
-	Value AuthCheckSucceededEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptAuthCheckSucceededEventMetadata was set.
-func (o OptAuthCheckSucceededEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptAuthCheckSucceededEventMetadata) Reset() {
-	var v AuthCheckSucceededEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptAuthCheckSucceededEventMetadata) SetTo(v AuthCheckSucceededEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptAuthCheckSucceededEventMetadata) Get() (v AuthCheckSucceededEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptAuthCheckSucceededEventMetadata) Or(d AuthCheckSucceededEventMetadata) AuthCheckSucceededEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -20492,52 +20203,6 @@ func (o OptAuthFactorPasskeyEnrolledEventDelegationType) Or(d AuthFactorPasskeyE
 	return d
 }
 
-// NewOptAuthFactorPasskeyEnrolledEventMetadata returns new OptAuthFactorPasskeyEnrolledEventMetadata with value set to v.
-func NewOptAuthFactorPasskeyEnrolledEventMetadata(v AuthFactorPasskeyEnrolledEventMetadata) OptAuthFactorPasskeyEnrolledEventMetadata {
-	return OptAuthFactorPasskeyEnrolledEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptAuthFactorPasskeyEnrolledEventMetadata is optional AuthFactorPasskeyEnrolledEventMetadata.
-type OptAuthFactorPasskeyEnrolledEventMetadata struct {
-	Value AuthFactorPasskeyEnrolledEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptAuthFactorPasskeyEnrolledEventMetadata was set.
-func (o OptAuthFactorPasskeyEnrolledEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptAuthFactorPasskeyEnrolledEventMetadata) Reset() {
-	var v AuthFactorPasskeyEnrolledEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptAuthFactorPasskeyEnrolledEventMetadata) SetTo(v AuthFactorPasskeyEnrolledEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptAuthFactorPasskeyEnrolledEventMetadata) Get() (v AuthFactorPasskeyEnrolledEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptAuthFactorPasskeyEnrolledEventMetadata) Or(d AuthFactorPasskeyEnrolledEventMetadata) AuthFactorPasskeyEnrolledEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptAuthFactorPasswordSetEventDelegationType returns new OptAuthFactorPasswordSetEventDelegationType with value set to v.
 func NewOptAuthFactorPasswordSetEventDelegationType(v AuthFactorPasswordSetEventDelegationType) OptAuthFactorPasswordSetEventDelegationType {
 	return OptAuthFactorPasswordSetEventDelegationType{
@@ -20578,52 +20243,6 @@ func (o OptAuthFactorPasswordSetEventDelegationType) Get() (v AuthFactorPassword
 
 // Or returns value if set, or given parameter if does not.
 func (o OptAuthFactorPasswordSetEventDelegationType) Or(d AuthFactorPasswordSetEventDelegationType) AuthFactorPasswordSetEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptAuthFactorPasswordSetEventMetadata returns new OptAuthFactorPasswordSetEventMetadata with value set to v.
-func NewOptAuthFactorPasswordSetEventMetadata(v AuthFactorPasswordSetEventMetadata) OptAuthFactorPasswordSetEventMetadata {
-	return OptAuthFactorPasswordSetEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptAuthFactorPasswordSetEventMetadata is optional AuthFactorPasswordSetEventMetadata.
-type OptAuthFactorPasswordSetEventMetadata struct {
-	Value AuthFactorPasswordSetEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptAuthFactorPasswordSetEventMetadata was set.
-func (o OptAuthFactorPasswordSetEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptAuthFactorPasswordSetEventMetadata) Reset() {
-	var v AuthFactorPasswordSetEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptAuthFactorPasswordSetEventMetadata) SetTo(v AuthFactorPasswordSetEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptAuthFactorPasswordSetEventMetadata) Get() (v AuthFactorPasswordSetEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptAuthFactorPasswordSetEventMetadata) Or(d AuthFactorPasswordSetEventMetadata) AuthFactorPasswordSetEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -20722,52 +20341,6 @@ func (o OptAuthTokenIssuedEventDelegationType) Or(d AuthTokenIssuedEventDelegati
 	return d
 }
 
-// NewOptAuthTokenIssuedEventMetadata returns new OptAuthTokenIssuedEventMetadata with value set to v.
-func NewOptAuthTokenIssuedEventMetadata(v AuthTokenIssuedEventMetadata) OptAuthTokenIssuedEventMetadata {
-	return OptAuthTokenIssuedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptAuthTokenIssuedEventMetadata is optional AuthTokenIssuedEventMetadata.
-type OptAuthTokenIssuedEventMetadata struct {
-	Value AuthTokenIssuedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptAuthTokenIssuedEventMetadata was set.
-func (o OptAuthTokenIssuedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptAuthTokenIssuedEventMetadata) Reset() {
-	var v AuthTokenIssuedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptAuthTokenIssuedEventMetadata) SetTo(v AuthTokenIssuedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptAuthTokenIssuedEventMetadata) Get() (v AuthTokenIssuedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptAuthTokenIssuedEventMetadata) Or(d AuthTokenIssuedEventMetadata) AuthTokenIssuedEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptAuthTokenRevokedEventDelegationType returns new OptAuthTokenRevokedEventDelegationType with value set to v.
 func NewOptAuthTokenRevokedEventDelegationType(v AuthTokenRevokedEventDelegationType) OptAuthTokenRevokedEventDelegationType {
 	return OptAuthTokenRevokedEventDelegationType{
@@ -20808,52 +20381,6 @@ func (o OptAuthTokenRevokedEventDelegationType) Get() (v AuthTokenRevokedEventDe
 
 // Or returns value if set, or given parameter if does not.
 func (o OptAuthTokenRevokedEventDelegationType) Or(d AuthTokenRevokedEventDelegationType) AuthTokenRevokedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptAuthTokenRevokedEventMetadata returns new OptAuthTokenRevokedEventMetadata with value set to v.
-func NewOptAuthTokenRevokedEventMetadata(v AuthTokenRevokedEventMetadata) OptAuthTokenRevokedEventMetadata {
-	return OptAuthTokenRevokedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptAuthTokenRevokedEventMetadata is optional AuthTokenRevokedEventMetadata.
-type OptAuthTokenRevokedEventMetadata struct {
-	Value AuthTokenRevokedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptAuthTokenRevokedEventMetadata was set.
-func (o OptAuthTokenRevokedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptAuthTokenRevokedEventMetadata) Reset() {
-	var v AuthTokenRevokedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptAuthTokenRevokedEventMetadata) SetTo(v AuthTokenRevokedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptAuthTokenRevokedEventMetadata) Get() (v AuthTokenRevokedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptAuthTokenRevokedEventMetadata) Or(d AuthTokenRevokedEventMetadata) AuthTokenRevokedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -20946,52 +20473,6 @@ func (o OptAuthzGrantedEventDelegationType) Get() (v AuthzGrantedEventDelegation
 
 // Or returns value if set, or given parameter if does not.
 func (o OptAuthzGrantedEventDelegationType) Or(d AuthzGrantedEventDelegationType) AuthzGrantedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptAuthzGrantedEventMetadata returns new OptAuthzGrantedEventMetadata with value set to v.
-func NewOptAuthzGrantedEventMetadata(v AuthzGrantedEventMetadata) OptAuthzGrantedEventMetadata {
-	return OptAuthzGrantedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptAuthzGrantedEventMetadata is optional AuthzGrantedEventMetadata.
-type OptAuthzGrantedEventMetadata struct {
-	Value AuthzGrantedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptAuthzGrantedEventMetadata was set.
-func (o OptAuthzGrantedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptAuthzGrantedEventMetadata) Reset() {
-	var v AuthzGrantedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptAuthzGrantedEventMetadata) SetTo(v AuthzGrantedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptAuthzGrantedEventMetadata) Get() (v AuthzGrantedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptAuthzGrantedEventMetadata) Or(d AuthzGrantedEventMetadata) AuthzGrantedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -21130,52 +20611,6 @@ func (o OptBrandingCreatedEventDelegationType) Get() (v BrandingCreatedEventDele
 
 // Or returns value if set, or given parameter if does not.
 func (o OptBrandingCreatedEventDelegationType) Or(d BrandingCreatedEventDelegationType) BrandingCreatedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptBrandingCreatedEventMetadata returns new OptBrandingCreatedEventMetadata with value set to v.
-func NewOptBrandingCreatedEventMetadata(v BrandingCreatedEventMetadata) OptBrandingCreatedEventMetadata {
-	return OptBrandingCreatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptBrandingCreatedEventMetadata is optional BrandingCreatedEventMetadata.
-type OptBrandingCreatedEventMetadata struct {
-	Value BrandingCreatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptBrandingCreatedEventMetadata was set.
-func (o OptBrandingCreatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptBrandingCreatedEventMetadata) Reset() {
-	var v BrandingCreatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptBrandingCreatedEventMetadata) SetTo(v BrandingCreatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptBrandingCreatedEventMetadata) Get() (v BrandingCreatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptBrandingCreatedEventMetadata) Or(d BrandingCreatedEventMetadata) BrandingCreatedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -21774,6 +21209,98 @@ func (o OptErrorDetailsDetails) Get() (v ErrorDetailsDetails, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptErrorDetailsDetails) Or(d ErrorDetailsDetails) ErrorDetailsDetails {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptEventMetadata returns new OptEventMetadata with value set to v.
+func NewOptEventMetadata(v EventMetadata) OptEventMetadata {
+	return OptEventMetadata{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptEventMetadata is optional EventMetadata.
+type OptEventMetadata struct {
+	Value EventMetadata
+	Set   bool
+}
+
+// IsSet returns true if OptEventMetadata was set.
+func (o OptEventMetadata) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptEventMetadata) Reset() {
+	var v EventMetadata
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptEventMetadata) SetTo(v EventMetadata) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptEventMetadata) Get() (v EventMetadata, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptEventMetadata) Or(d EventMetadata) EventMetadata {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptEventMetadataClient returns new OptEventMetadataClient with value set to v.
+func NewOptEventMetadataClient(v EventMetadataClient) OptEventMetadataClient {
+	return OptEventMetadataClient{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptEventMetadataClient is optional EventMetadataClient.
+type OptEventMetadataClient struct {
+	Value EventMetadataClient
+	Set   bool
+}
+
+// IsSet returns true if OptEventMetadataClient was set.
+func (o OptEventMetadataClient) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptEventMetadataClient) Reset() {
+	var v EventMetadataClient
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptEventMetadataClient) SetTo(v EventMetadataClient) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptEventMetadataClient) Get() (v EventMetadataClient, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptEventMetadataClient) Or(d EventMetadataClient) EventMetadataClient {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -23068,52 +22595,6 @@ func (o OptFlowdefCreatedEventDelegationType) Or(d FlowdefCreatedEventDelegation
 	return d
 }
 
-// NewOptFlowdefCreatedEventMetadata returns new OptFlowdefCreatedEventMetadata with value set to v.
-func NewOptFlowdefCreatedEventMetadata(v FlowdefCreatedEventMetadata) OptFlowdefCreatedEventMetadata {
-	return OptFlowdefCreatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptFlowdefCreatedEventMetadata is optional FlowdefCreatedEventMetadata.
-type OptFlowdefCreatedEventMetadata struct {
-	Value FlowdefCreatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptFlowdefCreatedEventMetadata was set.
-func (o OptFlowdefCreatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptFlowdefCreatedEventMetadata) Reset() {
-	var v FlowdefCreatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptFlowdefCreatedEventMetadata) SetTo(v FlowdefCreatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptFlowdefCreatedEventMetadata) Get() (v FlowdefCreatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptFlowdefCreatedEventMetadata) Or(d FlowdefCreatedEventMetadata) FlowdefCreatedEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptFlowdefDeletedEventDelegationType returns new OptFlowdefDeletedEventDelegationType with value set to v.
 func NewOptFlowdefDeletedEventDelegationType(v FlowdefDeletedEventDelegationType) OptFlowdefDeletedEventDelegationType {
 	return OptFlowdefDeletedEventDelegationType{
@@ -23154,52 +22635,6 @@ func (o OptFlowdefDeletedEventDelegationType) Get() (v FlowdefDeletedEventDelega
 
 // Or returns value if set, or given parameter if does not.
 func (o OptFlowdefDeletedEventDelegationType) Or(d FlowdefDeletedEventDelegationType) FlowdefDeletedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptFlowdefDeletedEventMetadata returns new OptFlowdefDeletedEventMetadata with value set to v.
-func NewOptFlowdefDeletedEventMetadata(v FlowdefDeletedEventMetadata) OptFlowdefDeletedEventMetadata {
-	return OptFlowdefDeletedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptFlowdefDeletedEventMetadata is optional FlowdefDeletedEventMetadata.
-type OptFlowdefDeletedEventMetadata struct {
-	Value FlowdefDeletedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptFlowdefDeletedEventMetadata was set.
-func (o OptFlowdefDeletedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptFlowdefDeletedEventMetadata) Reset() {
-	var v FlowdefDeletedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptFlowdefDeletedEventMetadata) SetTo(v FlowdefDeletedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptFlowdefDeletedEventMetadata) Get() (v FlowdefDeletedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptFlowdefDeletedEventMetadata) Or(d FlowdefDeletedEventMetadata) FlowdefDeletedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -23706,52 +23141,6 @@ func (o OptFlowdefUpdatedEventDelegationType) Get() (v FlowdefUpdatedEventDelega
 
 // Or returns value if set, or given parameter if does not.
 func (o OptFlowdefUpdatedEventDelegationType) Or(d FlowdefUpdatedEventDelegationType) FlowdefUpdatedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptFlowdefUpdatedEventMetadata returns new OptFlowdefUpdatedEventMetadata with value set to v.
-func NewOptFlowdefUpdatedEventMetadata(v FlowdefUpdatedEventMetadata) OptFlowdefUpdatedEventMetadata {
-	return OptFlowdefUpdatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptFlowdefUpdatedEventMetadata is optional FlowdefUpdatedEventMetadata.
-type OptFlowdefUpdatedEventMetadata struct {
-	Value FlowdefUpdatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptFlowdefUpdatedEventMetadata was set.
-func (o OptFlowdefUpdatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptFlowdefUpdatedEventMetadata) Reset() {
-	var v FlowdefUpdatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptFlowdefUpdatedEventMetadata) SetTo(v FlowdefUpdatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptFlowdefUpdatedEventMetadata) Get() (v FlowdefUpdatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptFlowdefUpdatedEventMetadata) Or(d FlowdefUpdatedEventMetadata) FlowdefUpdatedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -26946,52 +26335,6 @@ func (o OptProjectCreatedEventDelegationType) Or(d ProjectCreatedEventDelegation
 	return d
 }
 
-// NewOptProjectCreatedEventMetadata returns new OptProjectCreatedEventMetadata with value set to v.
-func NewOptProjectCreatedEventMetadata(v ProjectCreatedEventMetadata) OptProjectCreatedEventMetadata {
-	return OptProjectCreatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptProjectCreatedEventMetadata is optional ProjectCreatedEventMetadata.
-type OptProjectCreatedEventMetadata struct {
-	Value ProjectCreatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptProjectCreatedEventMetadata was set.
-func (o OptProjectCreatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptProjectCreatedEventMetadata) Reset() {
-	var v ProjectCreatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptProjectCreatedEventMetadata) SetTo(v ProjectCreatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptProjectCreatedEventMetadata) Get() (v ProjectCreatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptProjectCreatedEventMetadata) Or(d ProjectCreatedEventMetadata) ProjectCreatedEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptProjectDeletedEventDelegationType returns new OptProjectDeletedEventDelegationType with value set to v.
 func NewOptProjectDeletedEventDelegationType(v ProjectDeletedEventDelegationType) OptProjectDeletedEventDelegationType {
 	return OptProjectDeletedEventDelegationType{
@@ -27038,52 +26381,6 @@ func (o OptProjectDeletedEventDelegationType) Or(d ProjectDeletedEventDelegation
 	return d
 }
 
-// NewOptProjectDeletedEventMetadata returns new OptProjectDeletedEventMetadata with value set to v.
-func NewOptProjectDeletedEventMetadata(v ProjectDeletedEventMetadata) OptProjectDeletedEventMetadata {
-	return OptProjectDeletedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptProjectDeletedEventMetadata is optional ProjectDeletedEventMetadata.
-type OptProjectDeletedEventMetadata struct {
-	Value ProjectDeletedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptProjectDeletedEventMetadata was set.
-func (o OptProjectDeletedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptProjectDeletedEventMetadata) Reset() {
-	var v ProjectDeletedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptProjectDeletedEventMetadata) SetTo(v ProjectDeletedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptProjectDeletedEventMetadata) Get() (v ProjectDeletedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptProjectDeletedEventMetadata) Or(d ProjectDeletedEventMetadata) ProjectDeletedEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptProjectUpdatedEventDelegationType returns new OptProjectUpdatedEventDelegationType with value set to v.
 func NewOptProjectUpdatedEventDelegationType(v ProjectUpdatedEventDelegationType) OptProjectUpdatedEventDelegationType {
 	return OptProjectUpdatedEventDelegationType{
@@ -27124,52 +26421,6 @@ func (o OptProjectUpdatedEventDelegationType) Get() (v ProjectUpdatedEventDelega
 
 // Or returns value if set, or given parameter if does not.
 func (o OptProjectUpdatedEventDelegationType) Or(d ProjectUpdatedEventDelegationType) ProjectUpdatedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptProjectUpdatedEventMetadata returns new OptProjectUpdatedEventMetadata with value set to v.
-func NewOptProjectUpdatedEventMetadata(v ProjectUpdatedEventMetadata) OptProjectUpdatedEventMetadata {
-	return OptProjectUpdatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptProjectUpdatedEventMetadata is optional ProjectUpdatedEventMetadata.
-type OptProjectUpdatedEventMetadata struct {
-	Value ProjectUpdatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptProjectUpdatedEventMetadata was set.
-func (o OptProjectUpdatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptProjectUpdatedEventMetadata) Reset() {
-	var v ProjectUpdatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptProjectUpdatedEventMetadata) SetTo(v ProjectUpdatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptProjectUpdatedEventMetadata) Get() (v ProjectUpdatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptProjectUpdatedEventMetadata) Or(d ProjectUpdatedEventMetadata) ProjectUpdatedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -27406,52 +26657,6 @@ func (o OptRequestAPIEventDelegationType) Or(d RequestAPIEventDelegationType) Re
 	return d
 }
 
-// NewOptRequestAPIEventMetadata returns new OptRequestAPIEventMetadata with value set to v.
-func NewOptRequestAPIEventMetadata(v RequestAPIEventMetadata) OptRequestAPIEventMetadata {
-	return OptRequestAPIEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptRequestAPIEventMetadata is optional RequestAPIEventMetadata.
-type OptRequestAPIEventMetadata struct {
-	Value RequestAPIEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptRequestAPIEventMetadata was set.
-func (o OptRequestAPIEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptRequestAPIEventMetadata) Reset() {
-	var v RequestAPIEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptRequestAPIEventMetadata) SetTo(v RequestAPIEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptRequestAPIEventMetadata) Get() (v RequestAPIEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptRequestAPIEventMetadata) Or(d RequestAPIEventMetadata) RequestAPIEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptSchInvalidRequestDetails returns new OptSchInvalidRequestDetails with value set to v.
 func NewOptSchInvalidRequestDetails(v SchInvalidRequestDetails) OptSchInvalidRequestDetails {
 	return OptSchInvalidRequestDetails{
@@ -27584,52 +26789,6 @@ func (o OptSchemaCreatedEventDelegationType) Get() (v SchemaCreatedEventDelegati
 
 // Or returns value if set, or given parameter if does not.
 func (o OptSchemaCreatedEventDelegationType) Or(d SchemaCreatedEventDelegationType) SchemaCreatedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptSchemaCreatedEventMetadata returns new OptSchemaCreatedEventMetadata with value set to v.
-func NewOptSchemaCreatedEventMetadata(v SchemaCreatedEventMetadata) OptSchemaCreatedEventMetadata {
-	return OptSchemaCreatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptSchemaCreatedEventMetadata is optional SchemaCreatedEventMetadata.
-type OptSchemaCreatedEventMetadata struct {
-	Value SchemaCreatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptSchemaCreatedEventMetadata was set.
-func (o OptSchemaCreatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptSchemaCreatedEventMetadata) Reset() {
-	var v SchemaCreatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptSchemaCreatedEventMetadata) SetTo(v SchemaCreatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptSchemaCreatedEventMetadata) Get() (v SchemaCreatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptSchemaCreatedEventMetadata) Or(d SchemaCreatedEventMetadata) SchemaCreatedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -28050,52 +27209,6 @@ func (o OptSessionDeletedEventDelegationType) Or(d SessionDeletedEventDelegation
 	return d
 }
 
-// NewOptSessionDeletedEventMetadata returns new OptSessionDeletedEventMetadata with value set to v.
-func NewOptSessionDeletedEventMetadata(v SessionDeletedEventMetadata) OptSessionDeletedEventMetadata {
-	return OptSessionDeletedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptSessionDeletedEventMetadata is optional SessionDeletedEventMetadata.
-type OptSessionDeletedEventMetadata struct {
-	Value SessionDeletedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptSessionDeletedEventMetadata was set.
-func (o OptSessionDeletedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptSessionDeletedEventMetadata) Reset() {
-	var v SessionDeletedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptSessionDeletedEventMetadata) SetTo(v SessionDeletedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptSessionDeletedEventMetadata) Get() (v SessionDeletedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptSessionDeletedEventMetadata) Or(d SessionDeletedEventMetadata) SessionDeletedEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptSessionEstablishedEventDelegationType returns new OptSessionEstablishedEventDelegationType with value set to v.
 func NewOptSessionEstablishedEventDelegationType(v SessionEstablishedEventDelegationType) OptSessionEstablishedEventDelegationType {
 	return OptSessionEstablishedEventDelegationType{
@@ -28136,52 +27249,6 @@ func (o OptSessionEstablishedEventDelegationType) Get() (v SessionEstablishedEve
 
 // Or returns value if set, or given parameter if does not.
 func (o OptSessionEstablishedEventDelegationType) Or(d SessionEstablishedEventDelegationType) SessionEstablishedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptSessionEstablishedEventMetadata returns new OptSessionEstablishedEventMetadata with value set to v.
-func NewOptSessionEstablishedEventMetadata(v SessionEstablishedEventMetadata) OptSessionEstablishedEventMetadata {
-	return OptSessionEstablishedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptSessionEstablishedEventMetadata is optional SessionEstablishedEventMetadata.
-type OptSessionEstablishedEventMetadata struct {
-	Value SessionEstablishedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptSessionEstablishedEventMetadata was set.
-func (o OptSessionEstablishedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptSessionEstablishedEventMetadata) Reset() {
-	var v SessionEstablishedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptSessionEstablishedEventMetadata) SetTo(v SessionEstablishedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptSessionEstablishedEventMetadata) Get() (v SessionEstablishedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptSessionEstablishedEventMetadata) Or(d SessionEstablishedEventMetadata) SessionEstablishedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -28326,52 +27393,6 @@ func (o OptTeamCreatedEventDelegationType) Or(d TeamCreatedEventDelegationType) 
 	return d
 }
 
-// NewOptTeamCreatedEventMetadata returns new OptTeamCreatedEventMetadata with value set to v.
-func NewOptTeamCreatedEventMetadata(v TeamCreatedEventMetadata) OptTeamCreatedEventMetadata {
-	return OptTeamCreatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptTeamCreatedEventMetadata is optional TeamCreatedEventMetadata.
-type OptTeamCreatedEventMetadata struct {
-	Value TeamCreatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptTeamCreatedEventMetadata was set.
-func (o OptTeamCreatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptTeamCreatedEventMetadata) Reset() {
-	var v TeamCreatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptTeamCreatedEventMetadata) SetTo(v TeamCreatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptTeamCreatedEventMetadata) Get() (v TeamCreatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptTeamCreatedEventMetadata) Or(d TeamCreatedEventMetadata) TeamCreatedEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptTeamDeactivatedEventDelegationType returns new OptTeamDeactivatedEventDelegationType with value set to v.
 func NewOptTeamDeactivatedEventDelegationType(v TeamDeactivatedEventDelegationType) OptTeamDeactivatedEventDelegationType {
 	return OptTeamDeactivatedEventDelegationType{
@@ -28412,52 +27433,6 @@ func (o OptTeamDeactivatedEventDelegationType) Get() (v TeamDeactivatedEventDele
 
 // Or returns value if set, or given parameter if does not.
 func (o OptTeamDeactivatedEventDelegationType) Or(d TeamDeactivatedEventDelegationType) TeamDeactivatedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptTeamDeactivatedEventMetadata returns new OptTeamDeactivatedEventMetadata with value set to v.
-func NewOptTeamDeactivatedEventMetadata(v TeamDeactivatedEventMetadata) OptTeamDeactivatedEventMetadata {
-	return OptTeamDeactivatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptTeamDeactivatedEventMetadata is optional TeamDeactivatedEventMetadata.
-type OptTeamDeactivatedEventMetadata struct {
-	Value TeamDeactivatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptTeamDeactivatedEventMetadata was set.
-func (o OptTeamDeactivatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptTeamDeactivatedEventMetadata) Reset() {
-	var v TeamDeactivatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptTeamDeactivatedEventMetadata) SetTo(v TeamDeactivatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptTeamDeactivatedEventMetadata) Get() (v TeamDeactivatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptTeamDeactivatedEventMetadata) Or(d TeamDeactivatedEventMetadata) TeamDeactivatedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -28550,52 +27525,6 @@ func (o OptTeamUpdatedEventDelegationType) Get() (v TeamUpdatedEventDelegationTy
 
 // Or returns value if set, or given parameter if does not.
 func (o OptTeamUpdatedEventDelegationType) Or(d TeamUpdatedEventDelegationType) TeamUpdatedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptTeamUpdatedEventMetadata returns new OptTeamUpdatedEventMetadata with value set to v.
-func NewOptTeamUpdatedEventMetadata(v TeamUpdatedEventMetadata) OptTeamUpdatedEventMetadata {
-	return OptTeamUpdatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptTeamUpdatedEventMetadata is optional TeamUpdatedEventMetadata.
-type OptTeamUpdatedEventMetadata struct {
-	Value TeamUpdatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptTeamUpdatedEventMetadata was set.
-func (o OptTeamUpdatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptTeamUpdatedEventMetadata) Reset() {
-	var v TeamUpdatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptTeamUpdatedEventMetadata) SetTo(v TeamUpdatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptTeamUpdatedEventMetadata) Get() (v TeamUpdatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptTeamUpdatedEventMetadata) Or(d TeamUpdatedEventMetadata) TeamUpdatedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -28878,52 +27807,6 @@ func (o OptUserCreateFailedEventDelegationType) Or(d UserCreateFailedEventDelega
 	return d
 }
 
-// NewOptUserCreateFailedEventMetadata returns new OptUserCreateFailedEventMetadata with value set to v.
-func NewOptUserCreateFailedEventMetadata(v UserCreateFailedEventMetadata) OptUserCreateFailedEventMetadata {
-	return OptUserCreateFailedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptUserCreateFailedEventMetadata is optional UserCreateFailedEventMetadata.
-type OptUserCreateFailedEventMetadata struct {
-	Value UserCreateFailedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptUserCreateFailedEventMetadata was set.
-func (o OptUserCreateFailedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptUserCreateFailedEventMetadata) Reset() {
-	var v UserCreateFailedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptUserCreateFailedEventMetadata) SetTo(v UserCreateFailedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptUserCreateFailedEventMetadata) Get() (v UserCreateFailedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptUserCreateFailedEventMetadata) Or(d UserCreateFailedEventMetadata) UserCreateFailedEventMetadata {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
 // NewOptUserCreatedEventDelegationType returns new OptUserCreatedEventDelegationType with value set to v.
 func NewOptUserCreatedEventDelegationType(v UserCreatedEventDelegationType) OptUserCreatedEventDelegationType {
 	return OptUserCreatedEventDelegationType{
@@ -28964,52 +27847,6 @@ func (o OptUserCreatedEventDelegationType) Get() (v UserCreatedEventDelegationTy
 
 // Or returns value if set, or given parameter if does not.
 func (o OptUserCreatedEventDelegationType) Or(d UserCreatedEventDelegationType) UserCreatedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptUserCreatedEventMetadata returns new OptUserCreatedEventMetadata with value set to v.
-func NewOptUserCreatedEventMetadata(v UserCreatedEventMetadata) OptUserCreatedEventMetadata {
-	return OptUserCreatedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptUserCreatedEventMetadata is optional UserCreatedEventMetadata.
-type OptUserCreatedEventMetadata struct {
-	Value UserCreatedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptUserCreatedEventMetadata was set.
-func (o OptUserCreatedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptUserCreatedEventMetadata) Reset() {
-	var v UserCreatedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptUserCreatedEventMetadata) SetTo(v UserCreatedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptUserCreatedEventMetadata) Get() (v UserCreatedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptUserCreatedEventMetadata) Or(d UserCreatedEventMetadata) UserCreatedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -29102,52 +27939,6 @@ func (o OptUserDeletedEventDelegationType) Get() (v UserDeletedEventDelegationTy
 
 // Or returns value if set, or given parameter if does not.
 func (o OptUserDeletedEventDelegationType) Or(d UserDeletedEventDelegationType) UserDeletedEventDelegationType {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewOptUserDeletedEventMetadata returns new OptUserDeletedEventMetadata with value set to v.
-func NewOptUserDeletedEventMetadata(v UserDeletedEventMetadata) OptUserDeletedEventMetadata {
-	return OptUserDeletedEventMetadata{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptUserDeletedEventMetadata is optional UserDeletedEventMetadata.
-type OptUserDeletedEventMetadata struct {
-	Value UserDeletedEventMetadata
-	Set   bool
-}
-
-// IsSet returns true if OptUserDeletedEventMetadata was set.
-func (o OptUserDeletedEventMetadata) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptUserDeletedEventMetadata) Reset() {
-	var v UserDeletedEventMetadata
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptUserDeletedEventMetadata) SetTo(v UserDeletedEventMetadata) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptUserDeletedEventMetadata) Get() (v UserDeletedEventMetadata, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptUserDeletedEventMetadata) Or(d UserDeletedEventMetadata) UserDeletedEventMetadata {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -30399,10 +29190,9 @@ type ProjectCreatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptProjectCreatedEventMetadata `json:"metadata"`
-	Payload  ProjectPayload                 `json:"payload"`
+	FlowID   OptNilString     `json:"flow_id"`
+	Metadata OptEventMetadata `json:"metadata"`
+	Payload  ProjectPayload   `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -30506,7 +29296,7 @@ func (s *ProjectCreatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *ProjectCreatedEvent) GetMetadata() OptProjectCreatedEventMetadata {
+func (s *ProjectCreatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -30616,7 +29406,7 @@ func (s *ProjectCreatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *ProjectCreatedEvent) SetMetadata(val OptProjectCreatedEventMetadata) {
+func (s *ProjectCreatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -30806,18 +29596,6 @@ func (s *ProjectCreatedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type ProjectCreatedEventMetadata map[string]jx.Raw
-
-func (s *ProjectCreatedEventMetadata) init() ProjectCreatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Merged schema.
 // Ref: #
 type ProjectDeletedEvent struct {
@@ -30857,10 +29635,9 @@ type ProjectDeletedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptProjectDeletedEventMetadata `json:"metadata"`
-	Payload  EmptyEventPayload              `json:"payload"`
+	FlowID   OptNilString      `json:"flow_id"`
+	Metadata OptEventMetadata  `json:"metadata"`
+	Payload  EmptyEventPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -30964,7 +29741,7 @@ func (s *ProjectDeletedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *ProjectDeletedEvent) GetMetadata() OptProjectDeletedEventMetadata {
+func (s *ProjectDeletedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -31074,7 +29851,7 @@ func (s *ProjectDeletedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *ProjectDeletedEvent) SetMetadata(val OptProjectDeletedEventMetadata) {
+func (s *ProjectDeletedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -31264,18 +30041,6 @@ func (s *ProjectDeletedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type ProjectDeletedEventMetadata map[string]jx.Raw
-
-func (s *ProjectDeletedEventMetadata) init() ProjectDeletedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 type ProjectID string
 
 // Shared allowlisted fields for `project.created` (full snapshot) and
@@ -31413,10 +30178,9 @@ type ProjectUpdatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptProjectUpdatedEventMetadata `json:"metadata"`
-	Payload  ProjectPayload                 `json:"payload"`
+	FlowID   OptNilString     `json:"flow_id"`
+	Metadata OptEventMetadata `json:"metadata"`
+	Payload  ProjectPayload   `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -31520,7 +30284,7 @@ func (s *ProjectUpdatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *ProjectUpdatedEvent) GetMetadata() OptProjectUpdatedEventMetadata {
+func (s *ProjectUpdatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -31630,7 +30394,7 @@ func (s *ProjectUpdatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *ProjectUpdatedEvent) SetMetadata(val OptProjectUpdatedEventMetadata) {
+func (s *ProjectUpdatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -31818,18 +30582,6 @@ func (s *ProjectUpdatedEventDelegationType) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type ProjectUpdatedEventMetadata map[string]jx.Raw
-
-func (s *ProjectUpdatedEventMetadata) init() ProjectUpdatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 type QueryProjectsBadRequest ErrorDetails
@@ -32888,10 +31640,9 @@ type RequestAPIEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptRequestAPIEventMetadata `json:"metadata"`
-	Payload  RequestAPIPayload          `json:"payload"`
+	FlowID   OptNilString      `json:"flow_id"`
+	Metadata OptEventMetadata  `json:"metadata"`
+	Payload  RequestAPIPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -32995,7 +31746,7 @@ func (s *RequestAPIEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *RequestAPIEvent) GetMetadata() OptRequestAPIEventMetadata {
+func (s *RequestAPIEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -33105,7 +31856,7 @@ func (s *RequestAPIEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *RequestAPIEvent) SetMetadata(val OptRequestAPIEventMetadata) {
+func (s *RequestAPIEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -33293,18 +32044,6 @@ func (s *RequestAPIEventDelegationType) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type RequestAPIEventMetadata map[string]jx.Raw
-
-func (s *RequestAPIEventMetadata) init() RequestAPIEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 // Payload for `request.api` events.
@@ -34098,10 +32837,9 @@ type SchemaCreatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptSchemaCreatedEventMetadata `json:"metadata"`
-	Payload  SchemaCreatedPayload          `json:"payload"`
+	FlowID   OptNilString         `json:"flow_id"`
+	Metadata OptEventMetadata     `json:"metadata"`
+	Payload  SchemaCreatedPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -34205,7 +32943,7 @@ func (s *SchemaCreatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *SchemaCreatedEvent) GetMetadata() OptSchemaCreatedEventMetadata {
+func (s *SchemaCreatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -34315,7 +33053,7 @@ func (s *SchemaCreatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *SchemaCreatedEvent) SetMetadata(val OptSchemaCreatedEventMetadata) {
+func (s *SchemaCreatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -34503,18 +33241,6 @@ func (s *SchemaCreatedEventDelegationType) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type SchemaCreatedEventMetadata map[string]jx.Raw
-
-func (s *SchemaCreatedEventMetadata) init() SchemaCreatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 // Allowlisted fields for `schema.created`. The schema document itself is
@@ -35076,10 +33802,9 @@ type SessionDeletedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptSessionDeletedEventMetadata `json:"metadata"`
-	Payload  SessionDeletedPayload          `json:"payload"`
+	FlowID   OptNilString          `json:"flow_id"`
+	Metadata OptEventMetadata      `json:"metadata"`
+	Payload  SessionDeletedPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -35183,7 +33908,7 @@ func (s *SessionDeletedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *SessionDeletedEvent) GetMetadata() OptSessionDeletedEventMetadata {
+func (s *SessionDeletedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -35293,7 +34018,7 @@ func (s *SessionDeletedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *SessionDeletedEvent) SetMetadata(val OptSessionDeletedEventMetadata) {
+func (s *SessionDeletedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -35483,18 +34208,6 @@ func (s *SessionDeletedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type SessionDeletedEventMetadata map[string]jx.Raw
-
-func (s *SessionDeletedEventMetadata) init() SessionDeletedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Payload for `session.deleted` events.
 // Ref: #
 type SessionDeletedPayload struct {
@@ -35550,10 +34263,9 @@ type SessionEstablishedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptSessionEstablishedEventMetadata `json:"metadata"`
-	Payload  SessionEstablishedPayload          `json:"payload"`
+	FlowID   OptNilString              `json:"flow_id"`
+	Metadata OptEventMetadata          `json:"metadata"`
+	Payload  SessionEstablishedPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -35657,7 +34369,7 @@ func (s *SessionEstablishedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *SessionEstablishedEvent) GetMetadata() OptSessionEstablishedEventMetadata {
+func (s *SessionEstablishedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -35767,7 +34479,7 @@ func (s *SessionEstablishedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *SessionEstablishedEvent) SetMetadata(val OptSessionEstablishedEventMetadata) {
+func (s *SessionEstablishedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -35955,18 +34667,6 @@ func (s *SessionEstablishedEventDelegationType) UnmarshalText(data []byte) error
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type SessionEstablishedEventMetadata map[string]jx.Raw
-
-func (s *SessionEstablishedEventMetadata) init() SessionEstablishedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 // Payload for `session.established` events.
@@ -37802,10 +36502,9 @@ type TeamCreatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptTeamCreatedEventMetadata `json:"metadata"`
-	Payload  TeamPayload                 `json:"payload"`
+	FlowID   OptNilString     `json:"flow_id"`
+	Metadata OptEventMetadata `json:"metadata"`
+	Payload  TeamPayload      `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -37909,7 +36608,7 @@ func (s *TeamCreatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *TeamCreatedEvent) GetMetadata() OptTeamCreatedEventMetadata {
+func (s *TeamCreatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -38019,7 +36718,7 @@ func (s *TeamCreatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *TeamCreatedEvent) SetMetadata(val OptTeamCreatedEventMetadata) {
+func (s *TeamCreatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -38209,18 +36908,6 @@ func (s *TeamCreatedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type TeamCreatedEventMetadata map[string]jx.Raw
-
-func (s *TeamCreatedEventMetadata) init() TeamCreatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Merged schema.
 // Ref: #
 type TeamDeactivatedEvent struct {
@@ -38260,10 +36947,9 @@ type TeamDeactivatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptTeamDeactivatedEventMetadata `json:"metadata"`
-	Payload  EmptyEventPayload               `json:"payload"`
+	FlowID   OptNilString      `json:"flow_id"`
+	Metadata OptEventMetadata  `json:"metadata"`
+	Payload  EmptyEventPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -38367,7 +37053,7 @@ func (s *TeamDeactivatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *TeamDeactivatedEvent) GetMetadata() OptTeamDeactivatedEventMetadata {
+func (s *TeamDeactivatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -38477,7 +37163,7 @@ func (s *TeamDeactivatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *TeamDeactivatedEvent) SetMetadata(val OptTeamDeactivatedEventMetadata) {
+func (s *TeamDeactivatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -38665,18 +37351,6 @@ func (s *TeamDeactivatedEventDelegationType) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type TeamDeactivatedEventMetadata map[string]jx.Raw
-
-func (s *TeamDeactivatedEventMetadata) init() TeamDeactivatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 // Field to filter or sort teams by.
@@ -38902,10 +37576,9 @@ type TeamUpdatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptTeamUpdatedEventMetadata `json:"metadata"`
-	Payload  TeamPayload                 `json:"payload"`
+	FlowID   OptNilString     `json:"flow_id"`
+	Metadata OptEventMetadata `json:"metadata"`
+	Payload  TeamPayload      `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -39009,7 +37682,7 @@ func (s *TeamUpdatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *TeamUpdatedEvent) GetMetadata() OptTeamUpdatedEventMetadata {
+func (s *TeamUpdatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -39119,7 +37792,7 @@ func (s *TeamUpdatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *TeamUpdatedEvent) SetMetadata(val OptTeamUpdatedEventMetadata) {
+func (s *TeamUpdatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -39307,18 +37980,6 @@ func (s *TeamUpdatedEventDelegationType) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type TeamUpdatedEventMetadata map[string]jx.Raw
-
-func (s *TeamUpdatedEventMetadata) init() TeamUpdatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 // Merged schema.
@@ -40072,10 +38733,9 @@ type UserCreateFailedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptUserCreateFailedEventMetadata `json:"metadata"`
-	Payload  UserCreateFailedPayload          `json:"payload"`
+	FlowID   OptNilString            `json:"flow_id"`
+	Metadata OptEventMetadata        `json:"metadata"`
+	Payload  UserCreateFailedPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -40179,7 +38839,7 @@ func (s *UserCreateFailedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *UserCreateFailedEvent) GetMetadata() OptUserCreateFailedEventMetadata {
+func (s *UserCreateFailedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -40289,7 +38949,7 @@ func (s *UserCreateFailedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *UserCreateFailedEvent) SetMetadata(val OptUserCreateFailedEventMetadata) {
+func (s *UserCreateFailedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -40479,18 +39139,6 @@ func (s *UserCreateFailedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type UserCreateFailedEventMetadata map[string]jx.Raw
-
-func (s *UserCreateFailedEventMetadata) init() UserCreateFailedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Payload for `user.create.failed` events.
 // Ref: #
 type UserCreateFailedPayload struct {
@@ -40546,10 +39194,9 @@ type UserCreatedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptUserCreatedEventMetadata `json:"metadata"`
-	Payload  UserCreatedPayload          `json:"payload"`
+	FlowID   OptNilString       `json:"flow_id"`
+	Metadata OptEventMetadata   `json:"metadata"`
+	Payload  UserCreatedPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -40653,7 +39300,7 @@ func (s *UserCreatedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *UserCreatedEvent) GetMetadata() OptUserCreatedEventMetadata {
+func (s *UserCreatedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -40763,7 +39410,7 @@ func (s *UserCreatedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *UserCreatedEvent) SetMetadata(val OptUserCreatedEventMetadata) {
+func (s *UserCreatedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -40953,18 +39600,6 @@ func (s *UserCreatedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
-// Additional emit-time metadata (already redacted).
-type UserCreatedEventMetadata map[string]jx.Raw
-
-func (s *UserCreatedEventMetadata) init() UserCreatedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
-}
-
 // Payload for `user.created`. Identity is `entity_id`; attribute values
 // appear only for schema fields marked `x-audit`.
 // Ref: #
@@ -41054,10 +39689,9 @@ type UserDeletedEvent struct {
 	// Session correlation id.
 	SessionID OptNilString `json:"session_id"`
 	// Login flow correlation id.
-	FlowID OptNilString `json:"flow_id"`
-	// Additional emit-time metadata (already redacted).
-	Metadata OptUserDeletedEventMetadata `json:"metadata"`
-	Payload  EmptyEventPayload           `json:"payload"`
+	FlowID   OptNilString      `json:"flow_id"`
+	Metadata OptEventMetadata  `json:"metadata"`
+	Payload  EmptyEventPayload `json:"payload"`
 }
 
 // GetID returns the value of ID.
@@ -41161,7 +39795,7 @@ func (s *UserDeletedEvent) GetFlowID() OptNilString {
 }
 
 // GetMetadata returns the value of Metadata.
-func (s *UserDeletedEvent) GetMetadata() OptUserDeletedEventMetadata {
+func (s *UserDeletedEvent) GetMetadata() OptEventMetadata {
 	return s.Metadata
 }
 
@@ -41271,7 +39905,7 @@ func (s *UserDeletedEvent) SetFlowID(val OptNilString) {
 }
 
 // SetMetadata sets the value of Metadata.
-func (s *UserDeletedEvent) SetMetadata(val OptUserDeletedEventMetadata) {
+func (s *UserDeletedEvent) SetMetadata(val OptEventMetadata) {
 	s.Metadata = val
 }
 
@@ -41459,18 +40093,6 @@ func (s *UserDeletedEventDelegationType) UnmarshalText(data []byte) error {
 	default:
 		return errors.Errorf("invalid value: %q", data)
 	}
-}
-
-// Additional emit-time metadata (already redacted).
-type UserDeletedEventMetadata map[string]jx.Raw
-
-func (s *UserDeletedEventMetadata) init() UserDeletedEventMetadata {
-	m := *s
-	if m == nil {
-		m = map[string]jx.Raw{}
-		*s = m
-	}
-	return m
 }
 
 type UserID string

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -10788,15 +10788,13 @@ func NewUserDeletedEventEvent(v UserDeletedEvent) Event {
 func (*Event) getEventRes() {}
 
 // Emit-time metadata, already redacted at write. Path A request.api may
-// set client with observed requestor context for SIEM join on request_id.
-// Not a live risk-evaluator input (ADR 019). Untrusted client-supplied
-// correlation belongs in client_hints if ever accepted; parent_span_id
-// is reserved for OTEL export projection.
+// set client (ip, user_agent, origin) for SIEM join on request_id. Not a
+// live risk-evaluator input.
 // Ref: #
 type EventMetadata struct {
 	// Observed HTTP requestor context on Path A request.api only.
-	// Path B events omit this object. Join via request_id.
-	Client OptEventMetadataClient `json:"client"`
+	Client          OptEventMetadataClient `json:"client"`
+	AdditionalProps EventMetadataAdditional
 }
 
 // GetClient returns the value of Client.
@@ -10804,20 +10802,39 @@ func (s *EventMetadata) GetClient() OptEventMetadataClient {
 	return s.Client
 }
 
+// GetAdditionalProps returns the value of AdditionalProps.
+func (s *EventMetadata) GetAdditionalProps() EventMetadataAdditional {
+	return s.AdditionalProps
+}
+
 // SetClient sets the value of Client.
 func (s *EventMetadata) SetClient(val OptEventMetadataClient) {
 	s.Client = val
 }
 
+// SetAdditionalProps sets the value of AdditionalProps.
+func (s *EventMetadata) SetAdditionalProps(val EventMetadataAdditional) {
+	s.AdditionalProps = val
+}
+
+type EventMetadataAdditional map[string]jx.Raw
+
+func (s *EventMetadataAdditional) init() EventMetadataAdditional {
+	m := *s
+	if m == nil {
+		m = map[string]jx.Raw{}
+		*s = m
+	}
+	return m
+}
+
 // Observed HTTP requestor context on Path A request.api only.
-// Path B events omit this object. Join via request_id.
 type EventMetadataClient struct {
 	// Client IP from the first X-Forwarded-For hop or RemoteAddr.
-	// Proxy-dependent (see https://github.com/zitadel/nextgen/issues/802).
 	IP OptString `json:"ip"`
-	// Observed User-Agent header. Spoofable.
+	// Observed User-Agent header.
 	UserAgent OptString `json:"user_agent"`
-	// Origin header, or Host when Origin is absent.
+	// Origin header when present.
 	Origin OptString `json:"origin"`
 }
 

--- a/api/openapi/components/schemas/event-metadata.yaml
+++ b/api/openapi/components/schemas/event-metadata.yaml
@@ -1,0 +1,27 @@
+type: object
+description: |
+  Emit-time metadata, already redacted at write. Path A request.api may
+  set client with observed requestor context for SIEM join on request_id.
+  Not a live risk-evaluator input (ADR 019). Untrusted client-supplied
+  correlation belongs in client_hints if ever accepted; parent_span_id
+  is reserved for OTEL export projection.
+additionalProperties: false
+properties:
+  client:
+    description: |
+      Observed HTTP requestor context on Path A request.api only.
+      Path B events omit this object. Join via request_id.
+    type: object
+    additionalProperties: false
+    properties:
+      ip:
+        type: string
+        description: |
+          Client IP from the first X-Forwarded-For hop or RemoteAddr.
+          Proxy-dependent (see https://github.com/zitadel/nextgen/issues/802).
+      user_agent:
+        type: string
+        description: Observed User-Agent header. Spoofable.
+      origin:
+        type: string
+        description: Origin header, or Host when Origin is absent.

--- a/api/openapi/components/schemas/event-metadata.yaml
+++ b/api/openapi/components/schemas/event-metadata.yaml
@@ -1,27 +1,21 @@
 type: object
 description: |
   Emit-time metadata, already redacted at write. Path A request.api may
-  set client with observed requestor context for SIEM join on request_id.
-  Not a live risk-evaluator input (ADR 019). Untrusted client-supplied
-  correlation belongs in client_hints if ever accepted; parent_span_id
-  is reserved for OTEL export projection.
-additionalProperties: false
+  set client (ip, user_agent, origin) for SIEM join on request_id. Not a
+  live risk-evaluator input.
+additionalProperties: true
 properties:
   client:
-    description: |
-      Observed HTTP requestor context on Path A request.api only.
-      Path B events omit this object. Join via request_id.
+    description: Observed HTTP requestor context on Path A request.api only.
     type: object
     additionalProperties: false
     properties:
       ip:
         type: string
-        description: |
-          Client IP from the first X-Forwarded-For hop or RemoteAddr.
-          Proxy-dependent (see https://github.com/zitadel/nextgen/issues/802).
+        description: Client IP from the first X-Forwarded-For hop or RemoteAddr.
       user_agent:
         type: string
-        description: Observed User-Agent header. Spoofable.
+        description: Observed User-Agent header.
       origin:
         type: string
-        description: Origin header, or Host when Origin is absent.
+        description: Origin header when present.

--- a/api/openapi/endpoints/events/event-base.yaml
+++ b/api/openapi/endpoints/events/event-base.yaml
@@ -108,6 +108,4 @@ properties:
       - type: string
       - type: 'null'
   metadata:
-    description: Additional emit-time metadata (already redacted).
-    type: object
-    additionalProperties: true
+    $ref: ../../components/schemas/event-metadata.yaml

--- a/docs/adrs/048-wide-events-internal-audit-primitive.md
+++ b/docs/adrs/048-wide-events-internal-audit-primitive.md
@@ -265,10 +265,11 @@ into a **RequestContext** middleware:
   AuthGate did not run. Probes (`healthz` / `readyz` / `livez`) leave
   `project_id` empty and are skipped.
 - Path A `request.api` may set `metadata.client` (`ip`, `user_agent`, `origin`)
-  from the User-Agent middleware and Origin/Host. That is observed requestor
-  context for **export-time SIEM join** on `request_id`. Live bot/fraud
-  decisions stay [ADR 019](019-captcha-gate-and-bot-signals.md); do not read
-  event metadata as a risk-evaluator signal. Path B metadata stays `{}`.
+  from the User-Agent middleware (IP) and the `User-Agent` / `Origin` headers.
+  That is observed requestor context for **export-time SIEM join** on
+  `request_id`. Live bot/fraud decisions stay
+  [ADR 019](019-captcha-gate-and-bot-signals.md); do not read event metadata as
+  a risk-evaluator signal. Path B metadata stays `{}`.
 - Response header `X-Request-Id` echoes the assigned `request_id`.
 
 **Durability (batched insert, DB clock):** Request-wide events are **not**

--- a/docs/adrs/048-wide-events-internal-audit-primitive.md
+++ b/docs/adrs/048-wide-events-internal-audit-primitive.md
@@ -265,8 +265,8 @@ into a **RequestContext** middleware:
   AuthGate did not run. Probes (`healthz` / `readyz` / `livez`) leave
   `project_id` empty and are skipped.
 - Path A `request.api` may set `metadata.client` (`ip`, `user_agent`, `origin`)
-  from the User-Agent middleware (IP) and the `User-Agent` / `Origin` headers.
-  That is observed requestor context for **export-time SIEM join** on
+  from the User-Agent middleware (IP) and length-capped `User-Agent` / `Origin`
+  headers. That is observed requestor context for **export-time SIEM join** on
   `request_id`. Live bot/fraud decisions stay
   [ADR 019](019-captcha-gate-and-bot-signals.md); do not read event metadata as
   a risk-evaluator signal. Path B metadata stays `{}`.

--- a/docs/adrs/048-wide-events-internal-audit-primitive.md
+++ b/docs/adrs/048-wide-events-internal-audit-primitive.md
@@ -264,6 +264,11 @@ into a **RequestContext** middleware:
   Path B `FromContext` copies `request_id` from the HTTP middleware even when
   AuthGate did not run. Probes (`healthz` / `readyz` / `livez`) leave
   `project_id` empty and are skipped.
+- Path A `request.api` may set `metadata.client` (`ip`, `user_agent`, `origin`)
+  from the User-Agent middleware and Origin/Host. That is observed requestor
+  context for **export-time SIEM join** on `request_id`. Live bot/fraud
+  decisions stay [ADR 019](019-captcha-gate-and-bot-signals.md); do not read
+  event metadata as a risk-evaluator signal. Path B metadata stays `{}`.
 - Response header `X-Request-Id` echoes the assigned `request_id`.
 
 **Durability (batched insert, DB clock):** Request-wide events are **not**

--- a/docs/design/api/events-catalog.md
+++ b/docs/design/api/events-catalog.md
@@ -65,6 +65,12 @@ renamed. If origins become patchable later, the update delta includes the
 Event **columns** carry correlation: `request_id`, `session_id`, `flow_id`,
 `client_id`, `token_id`, `actor_id`, `entity_id`.
 
+Path A `request.api` may also carry observed requestor context on metadata
+(`ip`, `user_agent`, `origin` under `client`). Join Path B mutations to that
+snapshot via `request_id`. Exported events enable offline SIEM rules; they
+are not inputs to the live risk evaluator
+([bot-detection.md](../flowengine/bot-detection.md)).
+
 - Auth attempt `entity_id` ↔ check payload `auth_attempt_id`.
 - Session after handoff: `session_id` **column** (set via `EmitSpec.SessionID`;
   not duplicated in attempt payloads).
@@ -76,6 +82,9 @@ Event **columns** carry correlation: `request_id`, `session_id`, `flow_id`,
 | Trigger | `event_type` | `category` | Payload |
 |---------|--------------|------------|---------|
 | HTTP handler completes and `project_id` is known | `request.api` | `request` | `operation_id`, `method`, `route_template`, `status`, `duration_ms` |
+
+Path A metadata may include observed requestor `ip`, `user_agent`, and
+`origin` (under `client`). Path B metadata stays empty; join via `request_id`.
 
 `occurred_at` is request **start** so a `request_id` group sorts
 `request.api` first, then in-TX Path B mutations. `created_at` is flush time.

--- a/docs/design/api/events-catalog.md
+++ b/docs/design/api/events-catalog.md
@@ -83,9 +83,6 @@ are not inputs to the live risk evaluator
 |---------|--------------|------------|---------|
 | HTTP handler completes and `project_id` is known | `request.api` | `request` | `operation_id`, `method`, `route_template`, `status`, `duration_ms` |
 
-Path A metadata may include observed requestor `ip`, `user_agent`, and
-`origin` (under `client`). Path B metadata stays empty; join via `request_id`.
-
 `occurred_at` is request **start** so a `request_id` group sorts
 `request.api` first, then in-TX Path B mutations. `created_at` is flush time.
 Login/flow HTTP and `POST /projects` emit when the handler stamps `project_id`

--- a/docs/design/flowengine/bot-detection.md
+++ b/docs/design/flowengine/bot-detection.md
@@ -45,6 +45,10 @@ Bot detection is a **first-class, composable subsystem** — not an afterthought
               RiskResult and decides
 ```
 
+Do not read stored event metadata or `GET /events` as a risk-evaluator
+signal. Path A `request.api` requestor context is best-effort audit export
+for SIEM join on `request_id`, not a request-time input.
+
 ### Platform / edge signals
 
 Apps deployed behind an edge platform (e.g. Cloudflare, Vercel, Netlify) often already

--- a/internal/api/event_map_test.go
+++ b/internal/api/event_map_test.go
@@ -96,3 +96,51 @@ func TestEventToAPI_RequestAPI(t *testing.T) {
 	assert.Equal(t, api.RequestAPIPayloadMethodGET, v.Payload.Method)
 	assert.EqualValues(t, 200, v.Payload.Status)
 }
+
+func TestEventToAPI_RequestAPIClientMetadata(t *testing.T) {
+	t.Parallel()
+	payload, err := json.Marshal(domain.RequestAPIPayload{
+		OperationID:   "listEvents",
+		Method:        "GET",
+		RouteTemplate: "/events",
+		Status:        200,
+		DurationMs:    12,
+	})
+	require.NoError(t, err)
+	meta, err := json.Marshal(domain.EventMetadata{
+		Client: &domain.EventClientMetadata{
+			IP:        "203.0.113.9",
+			UserAgent: "Mozilla/5.0 (test)",
+			Origin:    "https://app.example.com",
+		},
+	})
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	got, err := eventToAPI(&domain.Event{
+		ID:         "evt_req",
+		ProjectID:  "proj_1",
+		EventType:  domain.EventTypeRequestAPI,
+		Category:   domain.EventCategoryRequest,
+		OccurredAt: now,
+		CreatedAt:  now,
+		ClientID:   "app_1",
+		Payload:    payload,
+		Metadata:   meta,
+	})
+	require.NoError(t, err)
+	v, ok := got.GetRequestAPIEvent()
+	require.True(t, ok)
+	md, ok := v.Metadata.Get()
+	require.True(t, ok)
+	client, ok := md.Client.Get()
+	require.True(t, ok)
+	ip, ok := client.IP.Get()
+	require.True(t, ok)
+	assert.Equal(t, "203.0.113.9", ip)
+	ua, ok := client.UserAgent.Get()
+	require.True(t, ok)
+	assert.Equal(t, "Mozilla/5.0 (test)", ua)
+	origin, ok := client.Origin.Get()
+	require.True(t, ok)
+	assert.Equal(t, "https://app.example.com", origin)
+}

--- a/internal/api/event_map_test.go
+++ b/internal/api/event_map_test.go
@@ -97,8 +97,8 @@ func TestEventToAPI_RequestAPI(t *testing.T) {
 	assert.EqualValues(t, 200, v.Payload.Status)
 }
 
-func TestEventToAPI_RequestAPIClientMetadata(t *testing.T) {
-	t.Parallel()
+func requestAPIEvent(t *testing.T, metadata json.RawMessage) *domain.Event {
+	t.Helper()
 	payload, err := json.Marshal(domain.RequestAPIPayload{
 		OperationID:   "listEvents",
 		Method:        "GET",
@@ -107,16 +107,8 @@ func TestEventToAPI_RequestAPIClientMetadata(t *testing.T) {
 		DurationMs:    12,
 	})
 	require.NoError(t, err)
-	meta, err := json.Marshal(domain.EventMetadata{
-		Client: &domain.EventClientMetadata{
-			IP:        "203.0.113.9",
-			UserAgent: "Mozilla/5.0 (test)",
-			Origin:    "https://app.example.com",
-		},
-	})
-	require.NoError(t, err)
 	now := time.Now().UTC()
-	got, err := eventToAPI(&domain.Event{
+	return &domain.Event{
 		ID:         "evt_req",
 		ProjectID:  "proj_1",
 		EventType:  domain.EventTypeRequestAPI,
@@ -125,8 +117,21 @@ func TestEventToAPI_RequestAPIClientMetadata(t *testing.T) {
 		CreatedAt:  now,
 		ClientID:   "app_1",
 		Payload:    payload,
-		Metadata:   meta,
+		Metadata:   metadata,
+	}
+}
+
+func TestEventToAPI_RequestAPIClientMetadata(t *testing.T) {
+	t.Parallel()
+	meta, err := json.Marshal(domain.EventMetadata{
+		Client: &domain.EventClientMetadata{
+			IP:        "203.0.113.9",
+			UserAgent: "Mozilla/5.0 (test)",
+			Origin:    "https://app.example.com",
+		},
 	})
+	require.NoError(t, err)
+	got, err := eventToAPI(requestAPIEvent(t, meta))
 	require.NoError(t, err)
 	v, ok := got.GetRequestAPIEvent()
 	require.True(t, ok)
@@ -143,4 +148,24 @@ func TestEventToAPI_RequestAPIClientMetadata(t *testing.T) {
 	origin, ok := client.Origin.Get()
 	require.True(t, ok)
 	assert.Equal(t, "https://app.example.com", origin)
+}
+
+func TestEventToAPI_RequestAPIMetadataKeepsUnknownKeys(t *testing.T) {
+	t.Parallel()
+	got, err := eventToAPI(requestAPIEvent(t, json.RawMessage(
+		`{"client":{"ip":"203.0.113.9"},"parent_span_id":"abc"}`,
+	)))
+	require.NoError(t, err)
+	v, ok := got.GetRequestAPIEvent()
+	require.True(t, ok)
+	md, ok := v.Metadata.Get()
+	require.True(t, ok)
+	client, ok := md.Client.Get()
+	require.True(t, ok)
+	ip, ok := client.IP.Get()
+	require.True(t, ok)
+	assert.Equal(t, "203.0.113.9", ip)
+	span, ok := md.AdditionalProps["parent_span_id"]
+	require.True(t, ok)
+	assert.Equal(t, `"abc"`, string(span))
 }

--- a/internal/audit/context_test.go
+++ b/internal/audit/context_test.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,7 @@ func TestFromContext_Empty(t *testing.T) {
 	assert.Equal(t, domain.EventCategoryEntity, ev.Category)
 	assert.Equal(t, "direct", ev.DelegationType)
 	assert.Empty(t, ev.ProjectID)
+	assert.Equal(t, json.RawMessage("{}"), ev.Metadata)
 }
 
 func TestFromContext_WithActor(t *testing.T) {

--- a/internal/audit/emit_test.go
+++ b/internal/audit/emit_test.go
@@ -2,6 +2,7 @@ package audit_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -74,4 +75,5 @@ func TestEmit_CopiesRequestIDFromMiddleware(t *testing.T) {
 	require.Equal(t, 1, cap.called)
 	require.NotNil(t, cap.last.RequestID)
 	require.Equal(t, "req_api", *cap.last.RequestID)
+	require.Equal(t, json.RawMessage("{}"), cap.last.Metadata)
 }

--- a/internal/audit/request_middleware.go
+++ b/internal/audit/request_middleware.go
@@ -1,7 +1,6 @@
 package audit
 
 import (
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -82,35 +81,24 @@ func WithRequestEventMiddleware(buf *RequestBuffer, next http.Handler) http.Hand
 		ev := FromContext(WithActorContext(r.Context(), *ac), domain.EventTypeRequestAPI, domain.EventCategoryRequest)
 		ev.ProjectID = ac.ProjectID
 		ev.Payload = payload
-		ev.Metadata = clientMetadataFromRequest(r)
+		if c := clientFromRequest(r); c != nil {
+			if meta, err := events.MarshalPayload(domain.EventMetadata{Client: c}); err == nil {
+				ev.Metadata = meta
+			}
+		}
 		buf.EnqueueSince(ev, start)
 	})
 }
 
-// clientMetadataFromRequest builds Path A metadata.client from the User-Agent
-// middleware snapshot plus Origin (Host fallback). Empty keys are omitted.
-// Path B must not call this — FromContext leaves metadata as {}.
-func clientMetadataFromRequest(r *http.Request) json.RawMessage {
-	client := domain.EventClientMetadata{}
-	if ua, ok := middleware.UserAgentFromContext(r.Context()); ok && ua != nil {
-		client.IP = ua.IP
-		if ua.Info != nil {
-			if s, ok := ua.Info["user_agent"].(string); ok {
-				client.UserAgent = s
-			}
-		}
+func clientFromRequest(r *http.Request) *domain.EventClientMetadata {
+	var c domain.EventClientMetadata
+	if ua, ok := middleware.UserAgentFromContext(r.Context()); ok {
+		c.IP = ua.IP
 	}
-	if origin := r.Header.Get("Origin"); origin != "" {
-		client.Origin = origin
-	} else if r.Host != "" {
-		client.Origin = r.Host
+	c.UserAgent = r.UserAgent()
+	c.Origin = r.Header.Get("Origin")
+	if c == (domain.EventClientMetadata{}) {
+		return nil
 	}
-	if client.IP == "" && client.UserAgent == "" && client.Origin == "" {
-		return json.RawMessage("{}")
-	}
-	raw, err := events.MarshalPayload(domain.EventMetadata{Client: &client})
-	if err != nil {
-		return json.RawMessage("{}")
-	}
-	return raw
+	return &c
 }

--- a/internal/audit/request_middleware.go
+++ b/internal/audit/request_middleware.go
@@ -2,11 +2,19 @@ package audit
 
 import (
 	"net/http"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/zitadel/nextgen/internal/api/middleware"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/storage/events"
+)
+
+// Untrusted header persist caps (Go's default header limit is ~1 MiB).
+const (
+	maxEventUserAgentBytes = 1024
+	maxEventOriginBytes    = 512
 )
 
 type statusCapturingWriter struct {
@@ -95,10 +103,20 @@ func clientFromRequest(r *http.Request) *domain.EventClientMetadata {
 	if ua, ok := middleware.UserAgentFromContext(r.Context()); ok {
 		c.IP = ua.IP
 	}
-	c.UserAgent = r.UserAgent()
-	c.Origin = r.Header.Get("Origin")
+	c.UserAgent = boundHeader(r.UserAgent(), maxEventUserAgentBytes)
+	c.Origin = boundHeader(r.Header.Get("Origin"), maxEventOriginBytes)
 	if c == (domain.EventClientMetadata{}) {
 		return nil
 	}
 	return &c
+}
+
+func boundHeader(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	for max > 0 && !utf8.RuneStart(s[max]) {
+		max--
+	}
+	return strings.Clone(s[:max])
 }

--- a/internal/audit/request_middleware.go
+++ b/internal/audit/request_middleware.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -81,6 +82,35 @@ func WithRequestEventMiddleware(buf *RequestBuffer, next http.Handler) http.Hand
 		ev := FromContext(WithActorContext(r.Context(), *ac), domain.EventTypeRequestAPI, domain.EventCategoryRequest)
 		ev.ProjectID = ac.ProjectID
 		ev.Payload = payload
+		ev.Metadata = clientMetadataFromRequest(r)
 		buf.EnqueueSince(ev, start)
 	})
+}
+
+// clientMetadataFromRequest builds Path A metadata.client from the User-Agent
+// middleware snapshot plus Origin (Host fallback). Empty keys are omitted.
+// Path B must not call this — FromContext leaves metadata as {}.
+func clientMetadataFromRequest(r *http.Request) json.RawMessage {
+	client := domain.EventClientMetadata{}
+	if ua, ok := middleware.UserAgentFromContext(r.Context()); ok && ua != nil {
+		client.IP = ua.IP
+		if ua.Info != nil {
+			if s, ok := ua.Info["user_agent"].(string); ok {
+				client.UserAgent = s
+			}
+		}
+	}
+	if origin := r.Header.Get("Origin"); origin != "" {
+		client.Origin = origin
+	} else if r.Host != "" {
+		client.Origin = r.Host
+	}
+	if client.IP == "" && client.UserAgent == "" && client.Origin == "" {
+		return json.RawMessage("{}")
+	}
+	raw, err := events.MarshalPayload(domain.EventMetadata{Client: &client})
+	if err != nil {
+		return json.RawMessage("{}")
+	}
+	return raw
 }

--- a/internal/audit/request_middleware_test.go
+++ b/internal/audit/request_middleware_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/zitadel/nextgen/internal/domain"
 )
 
-func TestRequestEventMiddleware_WaitCoversHandlerDuration(t *testing.T) {
+func startPathA(t *testing.T) (*channelInserter, *RequestBuffer) {
+	t.Helper()
 	ins := &channelInserter{}
 	buf := NewRequestBuffer(ins, RequestBufferConfig{
 		BatchSize: 1,
@@ -22,6 +23,20 @@ func TestRequestEventMiddleware_WaitCoversHandlerDuration(t *testing.T) {
 		MaxAge:    time.Hour,
 	})
 	t.Cleanup(buf.Close)
+	return ins, buf
+}
+
+func stampProject(projectID string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ac, ok := ActorSlotFromContext(r.Context()); ok {
+			ac.ProjectID = projectID
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestRequestEventMiddleware_WaitCoversHandlerDuration(t *testing.T) {
+	ins, buf := startPathA(t)
 
 	h := WithRequestEventMiddleware(buf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ac, ok := ActorSlotFromContext(r.Context())
@@ -41,13 +56,7 @@ func TestRequestEventMiddleware_WaitCoversHandlerDuration(t *testing.T) {
 }
 
 func TestRequestEventMiddleware_SkipsMissingProjectID(t *testing.T) {
-	ins := &channelInserter{}
-	buf := NewRequestBuffer(ins, RequestBufferConfig{
-		BatchSize: 1,
-		Capacity:  10,
-		MaxAge:    time.Hour,
-	})
-	t.Cleanup(buf.Close)
+	ins, buf := startPathA(t)
 
 	h := WithRequestEventMiddleware(buf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -56,16 +65,11 @@ func TestRequestEventMiddleware_SkipsMissingProjectID(t *testing.T) {
 	time.Sleep(40 * time.Millisecond)
 	assert.Equal(t, uint64(0), buf.Flushed())
 	assert.Equal(t, 0, buf.Len())
+	assert.Equal(t, 0, ins.count())
 }
 
 func TestRequestEventMiddleware_EmitsWhenProjectIDWithoutAuth(t *testing.T) {
-	ins := &channelInserter{}
-	buf := NewRequestBuffer(ins, RequestBufferConfig{
-		BatchSize: 1,
-		Capacity:  10,
-		MaxAge:    time.Hour,
-	})
-	t.Cleanup(buf.Close)
+	ins, buf := startPathA(t)
 
 	h := WithRequestEventMiddleware(buf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ac, ok := ActorSlotFromContext(r.Context())
@@ -91,21 +95,8 @@ func TestRequestEventMiddleware_EmitsWhenProjectIDWithoutAuth(t *testing.T) {
 }
 
 func TestRequestEventMiddleware_ClientMetadataFromUserAgentAndOrigin(t *testing.T) {
-	ins := &channelInserter{}
-	buf := NewRequestBuffer(ins, RequestBufferConfig{
-		BatchSize: 1,
-		Capacity:  10,
-		MaxAge:    time.Hour,
-	})
-	t.Cleanup(buf.Close)
-
-	inner := WithRequestEventMiddleware(buf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ac, ok := ActorSlotFromContext(r.Context())
-		require.True(t, ok)
-		ac.ProjectID = "proj_1"
-		w.WriteHeader(http.StatusOK)
-	}))
-	h := middleware.WithUserAgentMiddleware(inner)
+	ins, buf := startPathA(t)
+	h := middleware.WithUserAgentMiddleware(WithRequestEventMiddleware(buf, stampProject("proj_1")))
 
 	req := httptest.NewRequest(http.MethodPost, "/users", nil)
 	req.Header.Set("User-Agent", "Mozilla/5.0 (test)")
@@ -125,23 +116,12 @@ func TestRequestEventMiddleware_ClientMetadataFromUserAgentAndOrigin(t *testing.
 	assert.Equal(t, "https://app.example.com", meta.Client.Origin)
 }
 
-func TestRequestEventMiddleware_OriginFallsBackToHost(t *testing.T) {
-	ins := &channelInserter{}
-	buf := NewRequestBuffer(ins, RequestBufferConfig{
-		BatchSize: 1,
-		Capacity:  10,
-		MaxAge:    time.Hour,
-	})
-	t.Cleanup(buf.Close)
-
-	h := WithRequestEventMiddleware(buf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ac, ok := ActorSlotFromContext(r.Context())
-		require.True(t, ok)
-		ac.ProjectID = "proj_1"
-		w.WriteHeader(http.StatusOK)
-	}))
+func TestRequestEventMiddleware_OmitsOriginWhenHeaderMissing(t *testing.T) {
+	ins, buf := startPathA(t)
+	h := WithRequestEventMiddleware(buf, stampProject("proj_1"))
 	req := httptest.NewRequest(http.MethodGet, "/events", nil)
 	req.Host = "console.example.test"
+	req.Header.Set("User-Agent", "Mozilla/5.0 (test)")
 	req.Header.Del("Origin")
 	h.ServeHTTP(httptest.NewRecorder(), req)
 
@@ -152,28 +132,14 @@ func TestRequestEventMiddleware_OriginFallsBackToHost(t *testing.T) {
 	var meta domain.EventMetadata
 	require.NoError(t, json.Unmarshal(ins.events[0].Metadata, &meta))
 	require.NotNil(t, meta.Client)
-	assert.Equal(t, "console.example.test", meta.Client.Origin)
-	assert.Empty(t, meta.Client.IP)
-	assert.Empty(t, meta.Client.UserAgent)
+	assert.Equal(t, "Mozilla/5.0 (test)", meta.Client.UserAgent)
+	assert.Empty(t, meta.Client.Origin)
 }
 
 func TestRequestEventMiddleware_EmptyClientStaysEmptyObject(t *testing.T) {
-	ins := &channelInserter{}
-	buf := NewRequestBuffer(ins, RequestBufferConfig{
-		BatchSize: 1,
-		Capacity:  10,
-		MaxAge:    time.Hour,
-	})
-	t.Cleanup(buf.Close)
-
-	h := WithRequestEventMiddleware(buf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ac, ok := ActorSlotFromContext(r.Context())
-		require.True(t, ok)
-		ac.ProjectID = "proj_1"
-		w.WriteHeader(http.StatusOK)
-	}))
+	ins, buf := startPathA(t)
+	h := WithRequestEventMiddleware(buf, stampProject("proj_1"))
 	req := httptest.NewRequest(http.MethodGet, "/events", nil)
-	req.Host = ""
 	req.Header.Del("Origin")
 	req.Header.Del("User-Agent")
 	h.ServeHTTP(httptest.NewRecorder(), req)

--- a/internal/audit/request_middleware_test.go
+++ b/internal/audit/request_middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -134,6 +135,26 @@ func TestRequestEventMiddleware_OmitsOriginWhenHeaderMissing(t *testing.T) {
 	require.NotNil(t, meta.Client)
 	assert.Equal(t, "Mozilla/5.0 (test)", meta.Client.UserAgent)
 	assert.Empty(t, meta.Client.Origin)
+}
+
+func TestRequestEventMiddleware_TruncatesOversizedClientHeaders(t *testing.T) {
+	ins, buf := startPathA(t)
+	h := WithRequestEventMiddleware(buf, stampProject("proj_1"))
+	req := httptest.NewRequest(http.MethodGet, "/flow", nil)
+	req.Header.Set("User-Agent", strings.Repeat("a", maxEventUserAgentBytes-1)+"☃"+strings.Repeat("x", 2048))
+	req.Header.Set("Origin", strings.Repeat("b", maxEventOriginBytes+2048))
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Eventually(t, func() bool { return buf.Flushed() >= 1 }, 2*time.Second, 10*time.Millisecond)
+	ins.mu.Lock()
+	defer ins.mu.Unlock()
+	require.Len(t, ins.events, 1)
+	require.Less(t, len(ins.events[0].Metadata), 2048)
+	var meta domain.EventMetadata
+	require.NoError(t, json.Unmarshal(ins.events[0].Metadata, &meta))
+	require.NotNil(t, meta.Client)
+	assert.Equal(t, strings.Repeat("a", maxEventUserAgentBytes-1), meta.Client.UserAgent)
+	assert.Equal(t, strings.Repeat("b", maxEventOriginBytes), meta.Client.Origin)
 }
 
 func TestRequestEventMiddleware_EmptyClientStaysEmptyObject(t *testing.T) {

--- a/internal/audit/request_middleware_test.go
+++ b/internal/audit/request_middleware_test.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -87,4 +88,99 @@ func TestRequestEventMiddleware_EmitsWhenProjectIDWithoutAuth(t *testing.T) {
 	assert.Equal(t, "req_flow", *ins.events[0].RequestID)
 	require.Len(t, ins.waits, 1)
 	assert.GreaterOrEqual(t, ins.waits[0], 20*time.Millisecond)
+}
+
+func TestRequestEventMiddleware_ClientMetadataFromUserAgentAndOrigin(t *testing.T) {
+	ins := &channelInserter{}
+	buf := NewRequestBuffer(ins, RequestBufferConfig{
+		BatchSize: 1,
+		Capacity:  10,
+		MaxAge:    time.Hour,
+	})
+	t.Cleanup(buf.Close)
+
+	inner := WithRequestEventMiddleware(buf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ac, ok := ActorSlotFromContext(r.Context())
+		require.True(t, ok)
+		ac.ProjectID = "proj_1"
+		w.WriteHeader(http.StatusOK)
+	}))
+	h := middleware.WithUserAgentMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/users", nil)
+	req.Header.Set("User-Agent", "Mozilla/5.0 (test)")
+	req.Header.Set("X-Forwarded-For", "203.0.113.9")
+	req.Header.Set("Origin", "https://app.example.com")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Eventually(t, func() bool { return buf.Flushed() >= 1 }, 2*time.Second, 10*time.Millisecond)
+	ins.mu.Lock()
+	defer ins.mu.Unlock()
+	require.Len(t, ins.events, 1)
+	var meta domain.EventMetadata
+	require.NoError(t, json.Unmarshal(ins.events[0].Metadata, &meta))
+	require.NotNil(t, meta.Client)
+	assert.Equal(t, "203.0.113.9", meta.Client.IP)
+	assert.Equal(t, "Mozilla/5.0 (test)", meta.Client.UserAgent)
+	assert.Equal(t, "https://app.example.com", meta.Client.Origin)
+}
+
+func TestRequestEventMiddleware_OriginFallsBackToHost(t *testing.T) {
+	ins := &channelInserter{}
+	buf := NewRequestBuffer(ins, RequestBufferConfig{
+		BatchSize: 1,
+		Capacity:  10,
+		MaxAge:    time.Hour,
+	})
+	t.Cleanup(buf.Close)
+
+	h := WithRequestEventMiddleware(buf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ac, ok := ActorSlotFromContext(r.Context())
+		require.True(t, ok)
+		ac.ProjectID = "proj_1"
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	req.Host = "console.example.test"
+	req.Header.Del("Origin")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Eventually(t, func() bool { return buf.Flushed() >= 1 }, 2*time.Second, 10*time.Millisecond)
+	ins.mu.Lock()
+	defer ins.mu.Unlock()
+	require.Len(t, ins.events, 1)
+	var meta domain.EventMetadata
+	require.NoError(t, json.Unmarshal(ins.events[0].Metadata, &meta))
+	require.NotNil(t, meta.Client)
+	assert.Equal(t, "console.example.test", meta.Client.Origin)
+	assert.Empty(t, meta.Client.IP)
+	assert.Empty(t, meta.Client.UserAgent)
+}
+
+func TestRequestEventMiddleware_EmptyClientStaysEmptyObject(t *testing.T) {
+	ins := &channelInserter{}
+	buf := NewRequestBuffer(ins, RequestBufferConfig{
+		BatchSize: 1,
+		Capacity:  10,
+		MaxAge:    time.Hour,
+	})
+	t.Cleanup(buf.Close)
+
+	h := WithRequestEventMiddleware(buf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ac, ok := ActorSlotFromContext(r.Context())
+		require.True(t, ok)
+		ac.ProjectID = "proj_1"
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	req.Host = ""
+	req.Header.Del("Origin")
+	req.Header.Del("User-Agent")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Eventually(t, func() bool { return buf.Flushed() >= 1 }, 2*time.Second, 10*time.Millisecond)
+	ins.mu.Lock()
+	defer ins.mu.Unlock()
+	require.Len(t, ins.events, 1)
+	assert.JSONEq(t, `{}`, string(ins.events[0].Metadata))
 }

--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -113,6 +113,19 @@ type Event struct {
 	OccurredAtWait time.Duration
 }
 
+// EventClientMetadata is observed HTTP requestor context on Path A
+// request.api (ADR 048). Omit empty keys. Not a list-filter dimension.
+type EventClientMetadata struct {
+	IP        string `json:"ip,omitempty"`
+	UserAgent string `json:"user_agent,omitempty"`
+	Origin    string `json:"origin,omitempty"`
+}
+
+// EventMetadata is the typed events.metadata object.
+type EventMetadata struct {
+	Client *EventClientMetadata `json:"client,omitempty"`
+}
+
 // EventField enumerates filterable/sortable Event columns.
 type EventField uint8
 

--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -113,15 +113,14 @@ type Event struct {
 	OccurredAtWait time.Duration
 }
 
-// EventClientMetadata is observed HTTP requestor context on Path A
-// request.api (ADR 048). Omit empty keys. Not a list-filter dimension.
+// EventClientMetadata is Path A requestor context on events.metadata.client.
 type EventClientMetadata struct {
 	IP        string `json:"ip,omitempty"`
 	UserAgent string `json:"user_agent,omitempty"`
 	Origin    string `json:"origin,omitempty"`
 }
 
-// EventMetadata is the typed events.metadata object.
+// EventMetadata is the events.metadata JSON object.
 type EventMetadata struct {
 	Client *EventClientMetadata `json:"client,omitempty"`
 }

--- a/internal/storage/events/wire_test.go
+++ b/internal/storage/events/wire_test.go
@@ -41,31 +41,3 @@ func TestMarshalWire_SnakeCaseOmitsInsertHint(t *testing.T) {
 	assert.NotContains(t, got, "EventType")
 	assert.NotContains(t, got, "OccurredAtWait")
 }
-
-func TestMarshalWire_IncludesClientMetadata(t *testing.T) {
-	t.Parallel()
-	ev := &domain.Event{
-		ID:         "evt_req",
-		ProjectID:  "proj_1",
-		EventType:  domain.EventTypeRequestAPI,
-		Category:   domain.EventCategoryRequest,
-		OccurredAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
-		CreatedAt:  time.Date(2026, 1, 2, 3, 4, 6, 0, time.UTC),
-		ClientID:   "cli_1",
-		Payload:    json.RawMessage(`{"operation_id":"listEvents","method":"GET","route_template":"/events","status":200,"duration_ms":1}`),
-		Metadata:   json.RawMessage(`{"client":{"ip":"203.0.113.9","user_agent":"Mozilla/5.0 (test)","origin":"https://app.example.com"}}`),
-	}
-
-	raw, err := events.MarshalWire(ev)
-	require.NoError(t, err)
-
-	var got map[string]any
-	require.NoError(t, json.Unmarshal(raw, &got))
-	meta, ok := got["metadata"].(map[string]any)
-	require.True(t, ok)
-	client, ok := meta["client"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "203.0.113.9", client["ip"])
-	assert.Equal(t, "Mozilla/5.0 (test)", client["user_agent"])
-	assert.Equal(t, "https://app.example.com", client["origin"])
-}

--- a/internal/storage/events/wire_test.go
+++ b/internal/storage/events/wire_test.go
@@ -41,3 +41,31 @@ func TestMarshalWire_SnakeCaseOmitsInsertHint(t *testing.T) {
 	assert.NotContains(t, got, "EventType")
 	assert.NotContains(t, got, "OccurredAtWait")
 }
+
+func TestMarshalWire_IncludesClientMetadata(t *testing.T) {
+	t.Parallel()
+	ev := &domain.Event{
+		ID:         "evt_req",
+		ProjectID:  "proj_1",
+		EventType:  domain.EventTypeRequestAPI,
+		Category:   domain.EventCategoryRequest,
+		OccurredAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		CreatedAt:  time.Date(2026, 1, 2, 3, 4, 6, 0, time.UTC),
+		ClientID:   "cli_1",
+		Payload:    json.RawMessage(`{"operation_id":"listEvents","method":"GET","route_template":"/events","status":200,"duration_ms":1}`),
+		Metadata:   json.RawMessage(`{"client":{"ip":"203.0.113.9","user_agent":"Mozilla/5.0 (test)","origin":"https://app.example.com"}}`),
+	}
+
+	raw, err := events.MarshalWire(ev)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	meta, ok := got["metadata"].(map[string]any)
+	require.True(t, ok)
+	client, ok := meta["client"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "203.0.113.9", client["ip"])
+	assert.Equal(t, "Mozilla/5.0 (test)", client["user_agent"])
+	assert.Equal(t, "https://app.example.com", client["origin"])
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Path A `request.api` events now record observed requestor context on `metadata.client`: IP (from the User-Agent middleware), `User-Agent`, and `Origin` when that header is present. Path B mutations stay `{}`; SIEM pipelines join via `request_id`.

This is export-time audit data, not an input to the live risk evaluator (ADR 019).

## Validation

- `go test ./internal/audit/ ./internal/storage/events/ ./internal/api/ ./internal/domain/ -count=1`
- `moon run server:format`
- `TestRequestEventMiddleware_TruncatesOversizedClientHeaders` covers UTF-8-safe truncation of oversized `User-Agent` / `Origin`

## Release notes / changeset

Changeset: `.changeset/request-api-client-metadata.md` — Record observed requestor IP, User-Agent, and Origin on Path A `request.api` event metadata so SIEM pipelines can join mutations via `request_id`. Lists `@zitadel/server` (minor).

## Notes

- `origin` is the `Origin` header only. Host is not a fallback; same-origin browser calls that omit Origin simply omit the field.
- Outer `metadata` stays `additionalProperties: true` so reserved keys (`client_hints`, `parent_span_id`) do not 500 `GET /events`. Inner `client` stays closed.
- Untrusted `User-Agent` / `Origin` values are capped at persist (1024 / 512 bytes, UTF-8-safe, cloned off the header backing array) so a ~1 MiB header cannot amplify through the 2000-event Path A buffer.
- `fingerprint` stays on the envelope column; SDK name/version headers are still not persisted.
- Path A remains best-effort (batch flush). A dropped `request.api` row is the only copy of this snapshot for that request.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01338-316e-72fd-83c1-b7208a732e74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01338-316e-72fd-83c1-b7208a732e74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

