### PR TITLE
fix: compare unique attribute values case-insensitively

### DIFF
--- a/.changeset/unique-values-case-insensitive.md
+++ b/.changeset/unique-values-case-insensitive.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+Unique attribute values are now compared case-insensitively (Unicode case folding): `Alice@Example.com` and `alice@example.com` register as one unique value and resolve to the same user at sign-in regardless of typed casing. Stored attribute values keep their original casing.

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
+	golang.org/x/text v0.38.0
 	golang.org/x/tools v0.47.0
 	google.golang.org/api v0.280.0
 	google.golang.org/grpc v1.82.1
@@ -195,7 +196,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/internal/domain/attribute.go
+++ b/internal/domain/attribute.go
@@ -107,9 +107,6 @@ type CreateAttribute struct {
 }
 
 func NewCreateAttribute(key AttributeKey, value any, unique AttributeUniqueness) (*CreateAttribute, error) {
-	if _, err := json.Marshal(value); err != nil {
-		return nil, fmt.Errorf("failed to marshal attribute value: %w", err)
-	}
 	attr := &CreateAttribute{
 		Key:         key,
 		Value:       value,
@@ -121,6 +118,10 @@ func NewCreateAttribute(key AttributeKey, value any, unique AttributeUniqueness)
 			return nil, err
 		}
 		attr.ValueHash = hash
+	} else if _, err := json.Marshal(value); err != nil {
+		// UniqueValueHash marshals on the unique path; keep the same
+		// marshalability guarantee for non-unique values.
+		return nil, fmt.Errorf("failed to marshal attribute value: %w", err)
 	}
 	return attr, nil
 }

--- a/internal/domain/attribute.go
+++ b/internal/domain/attribute.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/text/cases"
+
 	"github.com/zitadel/nextgen/internal/maputil"
 )
 
@@ -105,8 +107,7 @@ type CreateAttribute struct {
 }
 
 func NewCreateAttribute(key AttributeKey, value any, unique AttributeUniqueness) (*CreateAttribute, error) {
-	raw, err := json.Marshal(value)
-	if err != nil {
+	if _, err := json.Marshal(value); err != nil {
 		return nil, fmt.Errorf("failed to marshal attribute value: %w", err)
 	}
 	attr := &CreateAttribute{
@@ -115,9 +116,30 @@ func NewCreateAttribute(key AttributeKey, value any, unique AttributeUniqueness)
 		UniqueScope: unique,
 	}
 	if unique != AttributeUniquenessUnspecified {
-		attr.ValueHash = sha256.Sum256(raw)
+		hash, err := UniqueValueHash(value)
+		if err != nil {
+			return nil, err
+		}
+		attr.ValueHash = hash
 	}
 	return attr, nil
+}
+
+// UniqueValueHash is the one comparison function behind attribute uniqueness:
+// the unique-attributes registry stores it and identifier resolution looks it
+// up, so both always agree on what counts as the same value (ADR 057 §4a).
+// String values are Unicode case-folded before hashing — Alice@Example.com
+// and alice@example.com are one unique value — while the attribute itself
+// keeps its original casing. Non-string values hash as encoded.
+func UniqueValueHash(value any) ([sha256.Size]byte, error) {
+	if s, ok := value.(string); ok {
+		value = cases.Fold().String(s)
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return [sha256.Size]byte{}, fmt.Errorf("failed to marshal attribute value: %w", err)
+	}
+	return sha256.Sum256(raw), nil
 }
 
 type CreateAttributes []CreateAttribute

--- a/internal/domain/attribute_test.go
+++ b/internal/domain/attribute_test.go
@@ -295,3 +295,37 @@ func mustNewCreateAttribute(t *testing.T, key AttributeKey, value any, unique At
 	require.NoError(t, err)
 	return *a
 }
+
+func TestUniqueValueHash(t *testing.T) {
+	upper, err := UniqueValueHash("Alice@Example.COM")
+	require.NoError(t, err)
+	lower, err := UniqueValueHash("alice@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, upper, lower, "casings of one string are one unique value")
+
+	eszett, err := UniqueValueHash("straße")
+	require.NoError(t, err)
+	folded, err := UniqueValueHash("STRASSE")
+	require.NoError(t, err)
+	assert.Equal(t, eszett, folded, "case folding is Unicode, not ASCII")
+
+	other, err := UniqueValueHash("bob@example.com")
+	require.NoError(t, err)
+	assert.NotEqual(t, lower, other)
+
+	num, err := UniqueValueHash(42)
+	require.NoError(t, err)
+	str, err := UniqueValueHash("42")
+	require.NoError(t, err)
+	assert.NotEqual(t, num, str, "non-strings hash as encoded, distinct from strings")
+}
+
+func TestNewCreateAttribute_UniqueHashIsNormalized(t *testing.T) {
+	a, err := NewCreateAttribute("email", "Alice@Example.com", AttributeUniquenessProject)
+	require.NoError(t, err)
+	b, err := NewCreateAttribute("email", "alice@example.com", AttributeUniquenessProject)
+	require.NoError(t, err)
+
+	assert.Equal(t, a.ValueHash, b.ValueHash, "the registry sees one value")
+	assert.Equal(t, "Alice@Example.com", a.Value, "the stored value keeps its casing")
+}

--- a/internal/storage/dialect/postgres/user.go
+++ b/internal/storage/dialect/postgres/user.go
@@ -212,10 +212,6 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 		compileFilter(&compiler, readFilter, v2user.Schema)
 	}
 	for _, a := range opts.Attributes {
-		raw, err := json.Marshal(a.Value)
-		if err != nil {
-			return nil, fmt.Errorf("marshal attribute %q: %w", a.Key, err)
-		}
 		writeConjunct(&compiler, &hasWhere)
 		if opts.UniqueAttributesOnly {
 			hash, err := domain.UniqueValueHash(a.Value)
@@ -230,6 +226,10 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 			compiler.WriteArg(hash[:])
 			compiler.WriteString(")")
 			continue
+		}
+		raw, err := json.Marshal(a.Value)
+		if err != nil {
+			return nil, fmt.Errorf("marshal attribute %q: %w", a.Key, err)
 		}
 		compiler.WriteString("EXISTS (SELECT 1 FROM ")
 		compiler.WriteString(userAttributesTable)

--- a/internal/storage/dialect/postgres/user.go
+++ b/internal/storage/dialect/postgres/user.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 
@@ -219,7 +218,10 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 		}
 		writeConjunct(&compiler, &hasWhere)
 		if opts.UniqueAttributesOnly {
-			hash := sha256.Sum256(raw)
+			hash, err := domain.UniqueValueHash(a.Value)
+			if err != nil {
+				return nil, fmt.Errorf("hash attribute %q: %w", a.Key, err)
+			}
 			compiler.WriteString("EXISTS (SELECT 1 FROM ")
 			compiler.WriteString(userUniqueAttributesTable)
 			compiler.WriteString(" ua WHERE ua.project_id = zitadel_nextgen.users.project_id AND ua.user_id = zitadel_nextgen.users.id AND ua.key = ")

--- a/internal/storage/dialect/spanner/user.go
+++ b/internal/storage/dialect/spanner/user.go
@@ -161,10 +161,6 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 		compileFilter(&compiler, readFilter, v2user.Schema)
 	}
 	for _, a := range opts.Attributes {
-		raw, err := json.Marshal(a.Value)
-		if err != nil {
-			return nil, fmt.Errorf("marshal attribute %q: %w", a.Key, err)
-		}
 		writeConjunct(&compiler, &hasWhere)
 		if opts.UniqueAttributesOnly {
 			hash, err := domain.UniqueValueHash(a.Value)
@@ -177,6 +173,10 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 			compiler.WriteArg(hash[:])
 			compiler.WriteString(")")
 			continue
+		}
+		raw, err := json.Marshal(a.Value)
+		if err != nil {
+			return nil, fmt.Errorf("marshal attribute %q: %w", a.Key, err)
 		}
 		compiler.WriteString("EXISTS (SELECT 1 FROM ")
 		compiler.WriteString(userAttributesTable)

--- a/internal/storage/dialect/spanner/user.go
+++ b/internal/storage/dialect/spanner/user.go
@@ -2,7 +2,6 @@ package spanner
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 
@@ -168,7 +167,10 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 		}
 		writeConjunct(&compiler, &hasWhere)
 		if opts.UniqueAttributesOnly {
-			hash := sha256.Sum256(raw)
+			hash, err := domain.UniqueValueHash(a.Value)
+			if err != nil {
+				return nil, fmt.Errorf("hash attribute %q: %w", a.Key, err)
+			}
 			compiler.WriteString("EXISTS (SELECT 1 FROM user_unique_attributes ua WHERE ua.project_id = users.project_id AND ua.user_id = users.id AND ua.key = ")
 			compiler.WriteArg(a.Key)
 			compiler.WriteString(" AND ua.value_hash = ")

--- a/internal/storage/dialect/sqlite/user.go
+++ b/internal/storage/dialect/sqlite/user.go
@@ -2,7 +2,6 @@ package sqlite
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -162,7 +161,10 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 		}
 		writeConjunct(&compiler, &hasWhere)
 		if opts.UniqueAttributesOnly {
-			hash := sha256.Sum256(raw)
+			hash, err := domain.UniqueValueHash(a.Value)
+			if err != nil {
+				return nil, fmt.Errorf("hash attribute %q: %w", a.Key, err)
+			}
 			compiler.WriteString("EXISTS (SELECT 1 FROM user_unique_attributes ua WHERE ua.project_id = users.project_id AND ua.user_id = users.id AND ua.key = ")
 			compiler.WriteArg(string(a.Key))
 			compiler.WriteString(" AND ua.value_hash = ")

--- a/internal/storage/dialect/sqlite/user.go
+++ b/internal/storage/dialect/sqlite/user.go
@@ -155,10 +155,6 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 		compileFilter(&compiler, readFilter, v2user.Schema)
 	}
 	for _, a := range opts.Attributes {
-		raw, err := json.Marshal(a.Value)
-		if err != nil {
-			return nil, fmt.Errorf("marshal attribute %q: %w", a.Key, err)
-		}
 		writeConjunct(&compiler, &hasWhere)
 		if opts.UniqueAttributesOnly {
 			hash, err := domain.UniqueValueHash(a.Value)
@@ -171,6 +167,10 @@ func (us userStatements) ListUsers(ctx context.Context, filter *database.ListOpt
 			compiler.WriteArg(hash[:])
 			compiler.WriteString(")")
 			continue
+		}
+		raw, err := json.Marshal(a.Value)
+		if err != nil {
+			return nil, fmt.Errorf("marshal attribute %q: %w", a.Key, err)
 		}
 		compiler.WriteString("EXISTS (SELECT 1 FROM user_attributes a WHERE a.project_id = users.project_id AND a.user_id = users.id AND a.key = ")
 		compiler.WriteArg(string(a.Key))

--- a/internal/storage/stmttest/user_test.go
+++ b/internal/storage/stmttest/user_test.go
@@ -401,3 +401,29 @@ func TestUserStatements_GetUser_UniqueAttributesOnly(t *testing.T) {
 		assert.Equal(t, owner.ID, got.ID)
 	})
 }
+
+func TestUserStatements_UniqueAttributes_CaseInsensitive(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, d dialect) {
+		projectID, schemaURL := ensureUserTestProject(t, d.stmts)
+
+		owner := newTestUser(t, projectID, schemaURL, "user_case_owner", "Alice@Example.com", "Alice")
+		require.NoError(t, d.stmts.CreateUser(t.Context(), owner))
+
+		// The same address in a different casing is the same unique value.
+		dup := newTestUser(t, projectID, schemaURL, "user_case_dup", "alice@example.com", "Impostor")
+		err := d.stmts.CreateUser(t.Context(), dup)
+		var uniqueErr *database.UniqueError
+		require.ErrorAs(t, err, &uniqueErr)
+
+		// Resolution matches regardless of the typed casing.
+		got, err := d.stmts.GetUser(t.Context(),
+			database.Equal(database.Col(domain.UserFieldProjectID), projectID),
+			service.UserQueryOptions{
+				Attributes:           []domain.Attribute{{Key: "email", Value: "ALICE@EXAMPLE.COM"}},
+				UniqueAttributesOnly: true,
+			},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, owner.ID, got.ID)
+	})
+}


### PR DESCRIPTION
## Summary

Implements ADR 057 §4a (#959): unique attribute values are compared **normalized**. Today the uniqueness hash is byte-exact over the raw JSON encoding, so `Alice@Example.com` and `alice@example.com` register as two distinct "unique" emails — a duplicate-account generator — and sign-in must reproduce the stored casing exactly.

- `domain.UniqueValueHash` is the single comparison function behind uniqueness: string values are Unicode case-folded (`x/text/cases.Fold`) before hashing; non-strings hash as encoded; the stored attribute keeps its original casing for display.
- The unique-attributes registry write (`NewCreateAttribute`) and the identifier-resolution lookups in all three dialects share the helper, so the constraint and resolution can never disagree about what counts as the same value — normalizing only one side would either let two casings register or leave lookups ambiguous.
- The per-property opt-out for genuinely case-sensitive values (`x-unique` object form, ADR §4a) ships later with the schema-keyword work; the default flip is safe now because the shipped default schema's only unique property is `email`.

**Stacked on #960** (base = `fix-identifier-lookup-unique-registry`): it changes the lookup lines that PR introduces. Retargets to `main` automatically once #960 merges.

Pre-release timing note: nothing is stored in production yet, so this is a code change; after launch it would be a backfill with latent-collision surfacing.

## Validation

- `internal/domain`: `TestUniqueValueHash` (casings equal, Unicode fold — `straße`/`STRASSE`, distinct values distinct, non-string vs string distinct) and `TestNewCreateAttribute_UniqueHashIsNormalized` (normalized hash, original casing preserved).
- `internal/storage/stmttest`: `TestUserStatements_UniqueAttributes_CaseInsensitive` — re-registering an address in a different casing fails with `database.UniqueError`; resolution matches regardless of typed casing. Full `TestUserStatements` suite green on the sqlite lane locally; postgres/spanner lanes in CI.
- `go build ./internal/...`, `gofmt -l` clean; `go mod tidy` promotes `golang.org/x/text` (already in the module graph) to direct.

## Release notes / changeset

`.changeset/unique-values-case-insensitive.md` — patch for `@zitadel/server`.

## Notes

- Both prototypes agree on normalization: oxidel ADR-016 lowercases all unique values; this uses full Unicode case folding and (per ADR 057) will grow a per-property opt-out.
- Trimming is deliberately not part of normalization — padded input is a schema-validation concern (`pattern`/`format`), not a silent mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Manual reproduction

Same setup as #960's walk-through (pinned `NEXTGEN_SERVER_DATA_DIR`, local server). Use a **fresh project per branch** — hashes are normalized at write time with no backfill, so rows written pre-fix don't demonstrate post-fix behavior.

Create a user with `Bob@Example.com` under the seeded default schema, then attempt a second user with `bob@example.com`, then submit `BOB@EXAMPLE.COM` to the login flow's identifier step:

| | `main` (base branch) | this PR |
|---|---|---|
| second create, other casing | **succeeds** — two "unique" accounts for one address | rejected: `user.already_exists` — "a user already exists with the given unique attributes" |
| login with never-stored casing | `register` — no exact-case match | `password` — case-folded resolution |
| stored attribute | as typed | still as typed (`Bob@Example.com`) — original casing preserved for display |
