### PR TITLE
feat(console): add the Team column to the users list

### DIFF
--- a/.changeset/console-users-team-column.md
+++ b/.changeset/console-users-team-column.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": minor
+---
+
+The console users list gains the Team column from the design: each row shows the user's team as a chip, with an exact `+n` indicator when the user belongs to further teams and search matching team names like every other column. Team data is read per row from the user's team roster and degrades to an empty cell when it cannot be loaded.

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
-import { Loader2, MoreVertical, Plus, Search, User } from "lucide-react";
+import { Building2, Loader2, MoreVertical, Plus, Search, User } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AddUserSheet } from "@/components/add-user-sheet";
@@ -11,6 +11,8 @@ import {
   RESOURCE_TABLE_WRAP,
   ResourceHeadCell,
 } from "@/components/resource-list";
+import { StatusBadge } from "@/components/status-badge";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -28,7 +30,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { StatusBadge } from "@/components/status-badge";
 
 import { api } from "../../../api/zitadel";
 import { displayValue, field } from "../../../lib/record";
@@ -42,10 +43,15 @@ export const Route = createFileRoute("/_authed/users/")({
   staticData: { nav: { label: "Users", order: 3, icon: User } },
   loader: async () => {
     const page = await api.listUsers({ limit: PAGE_SIZE });
+    const [columns, teams] = await Promise.all([
+      columnsForUsers(page.users),
+      teamsForUsers(page.users),
+    ]);
     return {
       users: page.users,
       nextPageToken: page.next_page_token ?? undefined,
-      columns: await columnsForUsers(page.users),
+      columns,
+      teams,
     };
   },
   component: UsersScreen,
@@ -83,6 +89,48 @@ async function columnsForUsers(users: Record<string, unknown>[]): Promise<Schema
     }),
   );
   return columnsFor(users, schemas.filter(isPresent));
+}
+
+/** The Team cell's data: the first page of the row's roster. */
+export interface RowTeams {
+  /** Fetched team names — the roster is ordered by team name server-side. */
+  names: string[];
+  /** Whether the roster continues beyond the fetched page. */
+  more: boolean;
+}
+
+/** Rosters are a cell, not a list: a handful covers "chip + exact +n". */
+const TEAM_CELL_LIMIT = 6;
+
+/**
+ * Rosters for a set of users — one `GET /users/{user_id}/teams` per user.
+ *
+ * The design's Team column (`716:14786`) needs team *names*, and `GET /users`
+ * does not carry them: #735's resolution kept the roster a per-user resource,
+ * and `metadata.lifecycle_owner_team_id` is lifecycle ownership, not
+ * membership. So the column costs one roster call per row — bounded by the
+ * page size, fired in parallel, and best-effort: a failed roster costs its
+ * cell, not the screen (the same posture as the schema fetch above).
+ */
+async function teamsForUsers(users: Record<string, unknown>[]): Promise<Map<string, RowTeams>> {
+  const rosters = new Map<string, RowTeams>();
+  await Promise.all(
+    users.map(async (user) => {
+      const id = field(user, "id");
+      if (!id) return;
+      try {
+        const page = await api.listUserTeams(id, { limit: TEAM_CELL_LIMIT });
+        rosters.set(id, {
+          names: page.teams.map((team) => team.name),
+          more: Boolean(page.next_page_token),
+        });
+      } catch {
+        // Absent from the map reads as "could not be loaded"; the cell
+        // renders an em dash rather than failing the row.
+      }
+    }),
+  );
+  return rosters;
 }
 
 interface UserRow {
@@ -141,12 +189,14 @@ function UsersScreen() {
   const [extra, setExtra] = useState<Record<string, unknown>[]>([]);
   const [nextPageToken, setNextPageToken] = useState(loaded.nextPageToken);
   const [columns, setColumns] = useState(loaded.columns);
+  const [teams, setTeams] = useState(loaded.teams);
   const [loadingMore, setLoadingMore] = useState(false);
 
   useEffect(() => {
     setExtra([]);
     setNextPageToken(loaded.nextPageToken);
     setColumns(loaded.columns);
+    setTeams(loaded.teams);
   }, [loaded]);
 
   // The loader hands back a new object on every invalidation, so its identity is
@@ -168,7 +218,10 @@ function UsersScreen() {
       const page = await api.listUsers({ limit: PAGE_SIZE, page_token: nextPageToken });
       // A later page can carry a schema the first page never referenced, which
       // would otherwise render its users with every cell blank.
-      const nextColumns = await columnsForUsers([...users, ...page.users]);
+      const [nextColumns, pageTeams] = await Promise.all([
+        columnsForUsers([...users, ...page.users]),
+        teamsForUsers(page.users),
+      ]);
       // A delete or a create while this was in flight has already reset the list
       // to a fresh first page. This page answers a question about the previous
       // one — appending it would re-add rows the server no longer returns — so
@@ -177,6 +230,7 @@ function UsersScreen() {
       setExtra((current) => [...current, ...page.users]);
       setNextPageToken(page.next_page_token ?? undefined);
       setColumns(nextColumns);
+      setTeams((current) => new Map([...current, ...pageTeams]));
     } finally {
       setLoadingMore(false);
     }
@@ -211,17 +265,26 @@ function UsersScreen() {
   // search whatever the project's schema actually defines.
   const rows = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    return users.map((user, index) => toUserRow(user, index, columns)).filter((row) => {
-      if (needle === "") return true;
-      return [row.id, ...columns.map((column) => row.values[column.key] ?? "")].some((value) =>
-        value.toLowerCase().includes(needle),
-      );
-    });
-  }, [users, query, columns]);
+    return users
+      .map((user, index) => toUserRow(user, index, columns))
+      .filter((row) => {
+        if (needle === "") return true;
+        // Team names join the haystack: the Team column is rendered, and search
+        // matches every rendered column.
+        const haystack = [
+          row.id,
+          ...columns.map((column) => row.values[column.key] ?? ""),
+          ...(teams.get(row.id)?.names ?? []),
+        ];
+        return haystack.some((value) => value.toLowerCase().includes(needle));
+      });
+  }, [users, query, columns, teams]);
 
   return (
     <div className={`${RESOURCE_PAGE} pt-4`}>
-      <h1 className={`${RESOURCE_HEADER} text-foreground font-serif text-2xl leading-6 tracking-tight`}>
+      <h1
+        className={`${RESOURCE_HEADER} text-foreground font-serif text-2xl leading-6 tracking-tight`}
+      >
         Users
       </h1>
 
@@ -268,6 +331,7 @@ function UsersScreen() {
                 <ResourceHeadCell key={column.key}>{column.label}</ResourceHeadCell>
               ))}
               <ResourceHeadCell>Status</ResourceHeadCell>
+              <ResourceHeadCell>Team</ResourceHeadCell>
               <ResourceHeadCell>ID</ResourceHeadCell>
               <TableHead className="h-14 w-[60px] px-6" />
             </TableRow>
@@ -276,7 +340,7 @@ function UsersScreen() {
             {rows.length === 0 ? (
               <TableRow className="border-0 hover:bg-transparent">
                 <TableCell
-                  colSpan={columns.length + 2}
+                  colSpan={columns.length + 3}
                   className="text-muted-foreground h-24 text-center"
                 >
                   {users.length === 0 ? "No users yet." : "No users match the current filters."}
@@ -309,6 +373,9 @@ function UsersScreen() {
                   ))}
                   <TableCell className={RESOURCE_CELL}>
                     <StatusBadge status={user.status} />
+                  </TableCell>
+                  <TableCell className={RESOURCE_CELL}>
+                    <TeamCell teams={teams.get(user.id)} />
                   </TableCell>
                   <TableCell className={`${RESOURCE_CELL} text-foreground truncate text-sm`}>
                     {user.id}
@@ -347,11 +414,7 @@ function UsersScreen() {
   );
 }
 
-function toUserRow(
-  user: Record<string, unknown>,
-  index: number,
-  columns: SchemaField[],
-): UserRow {
+function toUserRow(user: Record<string, unknown>, index: number, columns: SchemaField[]): UserRow {
   const id = field(user, "id") ?? `unknown-user-${index}`;
   const attributes = userAttributes(user);
   const values: Record<string, string> = {};
@@ -384,6 +447,33 @@ function userStatus(user: Record<string, unknown>): string | undefined {
   return field(metadata as Record<string, unknown>, "status");
 }
 
+/**
+ * The design's team chip (`716:14789`): an outline Badge — the component's own
+ * base already carries the chip's geometry (`rounded-full`, 12px svg slot,
+ * `text-xs font-medium`) — with the `Lucide Icon / Building2` glyph the node
+ * names, read off the node rather than picked by meaning.
+ *
+ * One chip per row, as the frames draw it. The roster can hold more (D1), so
+ * further memberships compress to an exact `+n` suffix — with a trailing `+`
+ * when the roster continues past the fetched page, because a number the cell
+ * cannot verify would be a guess. No roster (the call failed) and no
+ * memberships both render the em dash the other columns use for absence.
+ */
+function TeamCell({ teams }: { teams?: RowTeams }) {
+  if (!teams || teams.names.length === 0) {
+    return <span className="text-muted-foreground text-sm">—</span>;
+  }
+  const [first, ...rest] = teams.names;
+  const suffix =
+    rest.length > 0 ? `+${rest.length}${teams.more ? "+" : ""}` : teams.more ? "+" : undefined;
+  return (
+    <Badge variant="outline" title={teams.names.join(", ")}>
+      <Building2 aria-hidden />
+      <span className="max-w-[140px] truncate">{first}</span>
+      {suffix && <span className="text-muted-foreground">{suffix}</span>}
+    </Badge>
+  );
+}
 
 /**
  * The row menu carries only actions that reach the API.

--- a/apps/console/src/routes/_authed/users/users.spec.tsx
+++ b/apps/console/src/routes/_authed/users/users.spec.tsx
@@ -163,7 +163,10 @@ describe("users screen", () => {
                 email: "a@x.com",
               },
             },
-            { id: "user_2", attributes: { given_name: "Grace", family_name: "Hopper", email: "g@x.com" } },
+            {
+              id: "user_2",
+              attributes: { given_name: "Grace", family_name: "Hopper", email: "g@x.com" },
+            },
             { id: "user_3", attributes: { givenName: "Radia", email: "r@x.com" } },
           ],
         }),
@@ -183,7 +186,9 @@ describe("users screen", () => {
     // unrelated attribute as the name is worse than having none.
     server.use(
       http.get(USERS_URL, () =>
-        HttpResponse.json({ users: [{ id: "user_1", attributes: { username: "nope", email: "kenji@acme.com" } }] }),
+        HttpResponse.json({
+          users: [{ id: "user_1", attributes: { username: "nope", email: "kenji@acme.com" } }],
+        }),
       ),
     );
     await renderUsers();
@@ -195,7 +200,9 @@ describe("users screen", () => {
   it("shows the user id alongside the schema's own attributes", async () => {
     server.use(
       http.get(USERS_URL, () =>
-        HttpResponse.json({ users: [{ id: "user_1", attributes: { email: "kenji@acme.com", status: "Blocked" } }] }),
+        HttpResponse.json({
+          users: [{ id: "user_1", attributes: { email: "kenji@acme.com", status: "Blocked" } }],
+        }),
       ),
     );
     await renderUsers();
@@ -242,8 +249,14 @@ describe("users screen", () => {
       http.get(USERS_URL, () =>
         HttpResponse.json({
           users: [
-            { id: "user_1", attributes: { givenName: "Maya", familyName: "Patel", email: "maya@acme.com" } },
-            { id: "user_2", attributes: { givenName: "Sasha", familyName: "Kim", email: "sasha@acme.com" } },
+            {
+              id: "user_1",
+              attributes: { givenName: "Maya", familyName: "Patel", email: "maya@acme.com" },
+            },
+            {
+              id: "user_2",
+              attributes: { givenName: "Sasha", familyName: "Kim", email: "sasha@acme.com" },
+            },
           ],
         }),
       ),
@@ -271,7 +284,11 @@ describe("users screen", () => {
         HttpResponse.json({
           users: [
             { id: "user_1", metadata: { status: "active" }, attributes: { email: "a@x.com" } },
-            { id: "user_2", metadata: { status: "pending_purge" }, attributes: { email: "b@x.com" } },
+            {
+              id: "user_2",
+              metadata: { status: "pending_purge" },
+              attributes: { email: "b@x.com" },
+            },
             // Written before `metadata` existed: nothing is invented for it.
             { id: "user_3", attributes: { email: "c@x.com" } },
           ],
@@ -293,7 +310,9 @@ describe("users screen", () => {
     server.use(
       http.get(USERS_URL, () =>
         HttpResponse.json({
-          users: [{ id: "user_1", metadata: { status: "active" }, attributes: { email: "a@x.com" } }],
+          users: [
+            { id: "user_1", metadata: { status: "active" }, attributes: { email: "a@x.com" } },
+          ],
         }),
       ),
     );
@@ -347,7 +366,9 @@ describe("users screen", () => {
         const token = new URL(request.url).searchParams.get("page_token");
         if (token) {
           await secondPageSent;
-          return HttpResponse.json({ users: [{ id: "user_stale", attributes: { email: "stale@x.com" } }] });
+          return HttpResponse.json({
+            users: [{ id: "user_stale", attributes: { email: "stale@x.com" } }],
+          });
         }
         firstPageCalls += 1;
         return HttpResponse.json({
@@ -380,5 +401,101 @@ describe("users screen", () => {
     // The in-flight page is discarded rather than appended to the new list.
     expect(screen.queryByText("stale@x.com")).not.toBeInTheDocument();
     expect(screen.getByText("page1-2@x.com")).toBeInTheDocument();
+  });
+});
+
+/**
+ * The Team column (design `716:14786`): `GET /users` carries no team names, so
+ * the screen fetches each row's roster (`GET /users/{id}/teams`) — one call
+ * per user, best-effort.
+ */
+describe("team column", () => {
+  const TWO_USERS = {
+    users: [
+      { id: "user_1", schema: "sch_business", attributes: { email: "maya@acme.com" } },
+      { id: "user_2", schema: "sch_business", attributes: { email: "oscar@acme.com" } },
+    ],
+  };
+
+  function stubTeams(
+    rosters: Record<string, { teams: { id: string; name: string }[]; next_page_token?: string }>,
+  ) {
+    const calls: Record<string, number> = {};
+    for (const [userId, roster] of Object.entries(rosters)) {
+      server.use(
+        http.get(`${USERS_URL}/${userId}/teams`, () => {
+          calls[userId] = (calls[userId] ?? 0) + 1;
+          return HttpResponse.json(roster);
+        }),
+      );
+    }
+    return calls;
+  }
+
+  it("renders each user's team as a chip, one roster call per row", async () => {
+    server.use(http.get(USERS_URL, () => HttpResponse.json(TWO_USERS)));
+    const calls = stubTeams({
+      user_1: { teams: [{ id: "team_1", name: "Quantum UX" }] },
+      user_2: { teams: [{ id: "team_2", name: "Cedar Logic" }] },
+    });
+
+    await renderUsers();
+
+    expect(await screen.findByText("Quantum UX")).toBeInTheDocument();
+    expect(screen.getByText("Cedar Logic")).toBeInTheDocument();
+    // One roster request per row — the page size bounds the fan-out.
+    expect(calls).toEqual({ user_1: 1, user_2: 1 });
+  });
+
+  it("compresses extra memberships to a +n suffix on a single chip", async () => {
+    // D1: a user can belong to multiple teams, but the design draws one chip.
+    server.use(http.get(USERS_URL, () => HttpResponse.json(TWO_USERS)));
+    stubTeams({
+      user_1: {
+        teams: [
+          { id: "team_1", name: "Quantum UX" },
+          { id: "team_2", name: "Vortex AI" },
+        ],
+      },
+      user_2: { teams: [{ id: "team_3", name: "Cedar Logic" }] },
+    });
+
+    await renderUsers();
+
+    expect(await screen.findByText("Quantum UX")).toBeInTheDocument();
+    expect(screen.getByText("+1")).toBeInTheDocument();
+    // The second team rides the chip's title, not a second chip.
+    expect(screen.queryByText("Vortex AI")).not.toBeInTheDocument();
+  });
+
+  it("costs the cell, not the screen, when a roster cannot be read", async () => {
+    server.use(
+      http.get(USERS_URL, () => HttpResponse.json(TWO_USERS)),
+      http.get(`${USERS_URL}/user_1/teams`, () => new HttpResponse(null, { status: 500 })),
+    );
+    stubTeams({ user_2: { teams: [{ id: "team_3", name: "Cedar Logic" }] } });
+
+    await renderUsers();
+
+    // The failed row still renders; its team cell is an em dash.
+    expect(await screen.findByText("maya@acme.com")).toBeInTheDocument();
+    expect(screen.getByText("Cedar Logic")).toBeInTheDocument();
+    expect(screen.getAllByText("\u2014").length).toBeGreaterThan(0);
+  });
+
+  it("search matches the team column like every other rendered column", async () => {
+    server.use(http.get(USERS_URL, () => HttpResponse.json(TWO_USERS)));
+    stubTeams({
+      user_1: { teams: [{ id: "team_1", name: "Quantum UX" }] },
+      user_2: { teams: [{ id: "team_3", name: "Cedar Logic" }] },
+    });
+
+    await renderUsers();
+    await screen.findByText("Quantum UX");
+
+    await userEvent.type(screen.getByRole("searchbox", { name: "Search users" }), "cedar");
+
+    expect(screen.queryByText("maya@acme.com")).not.toBeInTheDocument();
+    expect(screen.getByText("oscar@acme.com")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Adds the users list's Team column, the last buildable piece of the design scope (#630, Figma `277:288291` / Filled frame `716:14541`). `GET /users` carries no team names (#735's resolution kept the roster a per-user resource, and `metadata.lifecycle_owner_team_id` is ownership, not membership), so the screen fetches each row's roster — one best-effort `GET /users/{user_id}/teams` per row, parallel and bounded by the page size. A failed roster costs its cell (em dash), not the screen, matching the schema-fetch posture.
- The cell is the design's chip (`716:14789`): an outline `Badge` — the component's base already carries the geometry (rounded-full, 12px svg slot, `text-xs font-medium`) — with the `Lucide Icon / Building2` glyph the node names, the first team name, and an exact `+n` suffix when the user belongs to more teams (trailing `+` when the roster pages past the fetched window, because an unverifiable number would be a guess). The full fetched roster rides the chip's `title`.
- Team names join the search haystack — search matches every rendered column, and Team is now one.
- `Load more` pages fetch their rosters the same way and merge, under the existing stale-page generation guard.

## Validation
- `pnpm vitest run` in `apps/console` — 130 passed (4 new: chip rendering with one roster call per row, `+n` compression with the second team absent from the DOM, roster failure costs the cell not the screen, search matches the team column).
- `pnpm run typecheck` in `apps/console` — clean (after `pnpm -F @zitadel/api run generate`; current `main` needs the regen regardless — the console passes `revisions` to `listSchemas` since #957).
- `pnpm exec oxlint` / `pnpm exec oxfmt --check` on the changed files — clean.
- Run against a fresh clone of `main` (`14cc4dff9`).
- Not run: a visual pass against the frame in `console:dev-real` — the seed creates users without memberships, so the Team column renders em dashes there (see Notes).

## Release notes / changeset
- Changeset: `.changeset/console-users-team-column.md` — the console users list shows each user's team as a chip, with a `+n` indicator for further memberships. Lists `@zitadel/server` (console ships embedded in the server container).

## Notes
- Per-row roster calls are a deliberate trade: the design needs team *names*, and no list-level source exists. If the list response ever carries names inline, `teamsForUsers` is the one function to delete — worth recording on #630 as the API follow-up that removes the N+1.
- Still open on #630, all API-gated rather than scope left behind: Last login (no field exists on the user), edit action (#693), sorting (server list is fixed newest-first; out of MVP), and the team-assignment dropdown the frame draws inside the column (no membership-write endpoint). The issue's "Blocked on #721" status is stale — #721 merged and its console side shipped earlier.
- Dev-loop gap worth a tiny follow-up: the `console:dev-real` seed creates users without `team_id`, so the column demos as em dashes out of the box; seeding a couple of teams + memberships would make it self-demonstrating.
- `routeTree.gen.ts` changes, if present, are plugin-generated from the route file (the exported `RowTeams` type), not hand-edited.
