### PR TITLE
docs(api): clarify what team_id does on the user endpoints

### DIFF
--- a/.changeset/document-user-team-id-parameter.md
+++ b/.changeset/document-user-team-id-parameter.md
@@ -1,0 +1,10 @@
+---
+"@zitadel/server": patch
+---
+
+Document what `team_id` does on the user endpoints. On `POST /users` it adds
+the new user to that team and scopes team-unique attributes; on
+`GET /users/{user_id}` it serves the user only when they hold an active
+membership there. Both are membership, not lifecycle ownership — which is
+reported as `metadata.lifecycle_owner_team_id` and cannot be set through the
+API. No request or response shape changed.

--- a/api/generated/oas_parameters_gen.go
+++ b/api/generated/oas_parameters_gen.go
@@ -607,7 +607,16 @@ func decodeCreateTeamParams(args [0]string, argsEscaped bool, r *http.Request) (
 type CreateUserParams struct {
 	// The unique identifier of the project.
 	ProjectID ProjectID
-	// The unique identifier of the team.
+	// Adds the new user to this team: creating the user also creates an
+	// active membership in it. Omit it to create a user with no memberships.
+	// This is team membership, not lifecycle ownership. It does not decide
+	// who may deprovision the user, and the created user stays self-owned
+	// either way. The owning team is reported on reads as
+	// `metadata.lifecycle_owner_team_id` and cannot be set through this API.
+	// See ADR 024.
+	// The team also scopes team-unique attributes for this create: an
+	// attribute the schema marks unique per team is checked against this
+	// team's members.
 	TeamID OptTeamID `json:",omitempty,omitzero"`
 }
 
@@ -2217,7 +2226,15 @@ func decodeGetTeamParams(args [1]string, argsEscaped bool, r *http.Request) (par
 
 // GetUserByIDParams is parameters of GetUserByID operation.
 type GetUserByIDParams struct {
-	// The unique identifier of the team.
+	// Serves the user only when they hold an active membership in this team,
+	// and answers `404` otherwise.
+	// This is team membership, not lifecycle ownership: it asks which team
+	// the user collaborates in, not which team may deprovision them. The
+	// owning team is reported separately as
+	// `metadata.lifecycle_owner_team_id`, and a user can belong to many teams
+	// while owning their own lifecycle. See ADR 024.
+	// Only active memberships match. A user who has been invited but has not
+	// accepted is not served.
 	TeamID OptTeamID `json:",omitempty,omitzero"`
 	UserID UserID
 }

--- a/api/openapi/endpoints/users/by_id/methods.yaml
+++ b/api/openapi/endpoints/users/by_id/methods.yaml
@@ -4,7 +4,25 @@ get:
   tags:
     - Users
   parameters:
-    - $ref: ../../../components/parameters/team-id.yaml
+    # Declared here rather than shared: `team_id` is the team parameter across
+    # the API, but what it does is the resource's own business. On a user it is
+    # membership, and saying so is the whole point of spelling it out locally.
+    - name: team_id
+      in: query
+      description: |
+        Serves the user only when they hold an active membership in this team,
+        and answers `404` otherwise.
+
+        This is team membership, not lifecycle ownership: it asks which team
+        the user collaborates in, not which team may deprovision them. The
+        owning team is reported separately as
+        `metadata.lifecycle_owner_team_id`, and a user can belong to many teams
+        while owning their own lifecycle. See ADR 024.
+
+        Only active memberships match. A user who has been invited but has not
+        accepted is not served.
+      schema:
+        $ref: ../../../components/schemas/team-id.yaml
     - name: user_id
       in: path
       required: true

--- a/api/openapi/endpoints/users/methods.yaml
+++ b/api/openapi/endpoints/users/methods.yaml
@@ -8,7 +8,26 @@ post:
         - user.write
   parameters:
     - $ref: ../../components/parameters/project-id.yaml
-    - $ref: ../../components/parameters/team-id.yaml
+    # Declared here rather than shared: `team_id` is the team parameter across
+    # the API, but what it does is the resource's own business. On a user it is
+    # membership, and saying so is the whole point of spelling it out locally.
+    - name: team_id
+      in: query
+      description: |
+        Adds the new user to this team: creating the user also creates an
+        active membership in it. Omit it to create a user with no memberships.
+
+        This is team membership, not lifecycle ownership. It does not decide
+        who may deprovision the user, and the created user stays self-owned
+        either way. The owning team is reported on reads as
+        `metadata.lifecycle_owner_team_id` and cannot be set through this API.
+        See ADR 024.
+
+        The team also scopes team-unique attributes for this create: an
+        attribute the schema marks unique per team is checked against this
+        team's members.
+      schema:
+        $ref: ../../components/schemas/team-id.yaml
   requestBody:
     required: true
     content:

--- a/docs/adrs/024-user-team-lifecycle-ownership.md
+++ b/docs/adrs/024-user-team-lifecycle-ownership.md
@@ -3,6 +3,29 @@
 > **Status:** Accepted
 > **Date:** 2026-06-11
 > **Context:** Project/team/user hierarchy, lifecycle ownership, deletion behavior
+>
+> **Amendment (2026-08-26):** the user endpoints' `team_id` query parameter is
+> **membership**, never lifecycle ownership. On `POST /users` it adds the new
+> user to that team; on `GET /users/{user_id}` it serves the user only when
+> they hold an active membership there. `team_id` stays the team parameter
+> across the API — the distinction is carried by each endpoint's own
+> documentation rather than by a longer name, so the parameter reads the same
+> everywhere and what it does stays the resource's own business.
+>
+> That works because the plain name is reserved for one relation. A resource
+> takes `team_id` only where membership is its natural relation to a team; a
+> resource with no membership relation does not take `team_id` at all, and
+> names the relation it actually has. `metadata.lifecycle_owner_team_id` is
+> that rule already applied on the user itself, and a session — which has no
+> membership relation — takes no plain `team_id` either, whatever its
+> team-scoped filter ends up being called.
+>
+> Lifecycle ownership has no write path today: reads report it as
+> `metadata.lifecycle_owner_team_id`, and no endpoint sets it. That is the
+> current state of the implementation, not a decision that it should stay that
+> way. Team-admin onboarding needs exactly that write path, and the shape it
+> takes is for the team-semantics use-case matrix to settle — this amendment
+> does not pre-empt it.
 
 ## Context
 


### PR DESCRIPTION
## Summary

`team_id` is the team query parameter across the API. 

Users are related to teams in both ways, via the lifecycle_owner_team_id and via team_membership.

This PR clarifies exactly what `team_id` means for `/users` endpoint:

- `POST /users?team_id=` adds the new user to that team — the dialects insert an active `team_memberships` row — and scopes team-unique attributes to it.
- `GET /users/{user_id}?team_id=` serves the user only when they hold an active membership there.
