### PR TITLE
feat(api): add POST /users/query

### DIFF
--- a/.changeset/add-query-users-endpoint.md
+++ b/.changeset/add-query-users-endpoint.md
@@ -1,0 +1,8 @@
+---
+"@zitadel/server": minor
+---
+
+Add `POST /users/query`, the structured-filter user list. Filter and sort by
+`created_at`, `id`, `schema`, `status`, or `lifecycle_owner_team_id`, paginated
+with the same cursor contract as the other query endpoints. Unlike them it
+takes no `project_id` — the users list is bound to the token's own project.

--- a/api/generated/oas_client_gen.go
+++ b/api/generated/oas_client_gen.go
@@ -440,6 +440,15 @@ type Invoker interface {
 	//
 	// POST /teams/query
 	QueryTeams(ctx context.Context, request *QueryTeamsRequest, params QueryTeamsParams) (QueryTeamsRes, error)
+	// QueryUsers invokes queryUsers operation.
+	//
+	// Returns the users of a project, paginated with a cursor.
+	// The project comes from the credential, not from a parameter: the operation
+	// is bound to the token's own project by construction. This is why it takes
+	// no `project_id`, unlike the other query endpoints.
+	//
+	// POST /users/query
+	QueryUsers(ctx context.Context, request *QueryUsersRequest) (QueryUsersRes, error)
 	// RevokeMySession invokes revokeMySession operation.
 	//
 	// Logs out by permanently deleting the session.
@@ -7075,6 +7084,128 @@ func (c *Client) sendQueryTeams(ctx context.Context, request *QueryTeamsRequest,
 
 	stage = "DecodeResponse"
 	result, err := decodeQueryTeamsResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// QueryUsers invokes queryUsers operation.
+//
+// Returns the users of a project, paginated with a cursor.
+// The project comes from the credential, not from a parameter: the operation
+// is bound to the token's own project by construction. This is why it takes
+// no `project_id`, unlike the other query endpoints.
+//
+// POST /users/query
+func (c *Client) QueryUsers(ctx context.Context, request *QueryUsersRequest) (QueryUsersRes, error) {
+	res, err := c.sendQueryUsers(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendQueryUsers(ctx context.Context, request *QueryUsersRequest) (res QueryUsersRes, err error) {
+	// Validate request before sending.
+	if err := func() error {
+		if err := request.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return res, errors.Wrap(err, "validate")
+	}
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("queryUsers"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.URLTemplateKey.String("/users/query"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, QueryUsersOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/users/query"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeQueryUsersRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			stage = "Security:OAuth2"
+			switch err := c.securityOAuth2(ctx, QueryUsersOperation, r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 0
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"OAuth2\"")
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
+		}
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeQueryUsersResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/api/generated/oas_defaults_gen.go
+++ b/api/generated/oas_defaults_gen.go
@@ -59,6 +59,14 @@ func (s *QueryTeamsRequest) setDefaults() {
 }
 
 // setDefaults set default value of fields.
+func (s *QueryUsersRequest) setDefaults() {
+	{
+		val := int(20)
+		s.Limit.SetTo(Limit(val))
+	}
+}
+
+// setDefaults set default value of fields.
 func (s *StepAction) setDefaults() {
 	{
 		val := bool(false)

--- a/api/generated/oas_handlers_gen.go
+++ b/api/generated/oas_handlers_gen.go
@@ -8756,6 +8756,196 @@ func (s *Server) handleQueryTeamsRequest(args [0]string, argsEscaped bool, w htt
 	}
 }
 
+// handleQueryUsersRequest handles queryUsers operation.
+//
+// Returns the users of a project, paginated with a cursor.
+// The project comes from the credential, not from a parameter: the operation
+// is bound to the token's own project by construction. This is why it takes
+// no `project_id`, unlike the other query endpoints.
+//
+// POST /users/query
+func (s *Server) handleQueryUsersRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("queryUsers"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/users/query"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), QueryUsersOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(codeAttr)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: QueryUsersOperation,
+			ID:   "queryUsers",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securityOAuth2(ctx, QueryUsersOperation, r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "OAuth2",
+					Err:              err,
+				}
+				defer recordError("Security:OAuth2", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+
+	var rawBody []byte
+	request, rawBody, close, err := s.decodeQueryUsersRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response QueryUsersRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    QueryUsersOperation,
+			OperationSummary: "Query users",
+			OperationID:      "queryUsers",
+			Body:             request,
+			RawBody:          rawBody,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = *QueryUsersRequest
+			Params   = struct{}
+			Response = QueryUsersRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.QueryUsers(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.QueryUsers(ctx, request)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeQueryUsersResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleRevokeMySessionRequest handles revokeMySession operation.
 //
 // Logs out by permanently deleting the session.

--- a/api/generated/oas_interfaces_gen.go
+++ b/api/generated/oas_interfaces_gen.go
@@ -185,6 +185,10 @@ type QueryTeamsRes interface {
 	queryTeamsRes()
 }
 
+type QueryUsersRes interface {
+	queryUsersRes()
+}
+
 type RevokeMySessionRes interface {
 	revokeMySessionRes()
 }

--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -37612,6 +37612,22 @@ func (s ListUsersErrorResponse) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case NotImplementedListUsersErrorResponse:
+		e.FieldStart("code")
+		e.Str("not_implemented")
+		{
+			s := s.NotImplemented
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
 	case ReqInvalidListUsersErrorResponse:
 		e.FieldStart("code")
 		e.Str("req.invalid")
@@ -37692,6 +37708,9 @@ func (s *ListUsersErrorResponse) Decode(d *jx.Decoder) error {
 				case "internal":
 					s.Type = InternalListUsersErrorResponse
 					found = true
+				case "not_implemented":
+					s.Type = NotImplementedListUsersErrorResponse
+					found = true
 				case "req.invalid":
 					s.Type = ReqInvalidListUsersErrorResponse
 					found = true
@@ -37721,6 +37740,10 @@ func (s *ListUsersErrorResponse) Decode(d *jx.Decoder) error {
 		}
 	case InternalListUsersErrorResponse:
 		if err := s.Internal.Decode(d); err != nil {
+			return err
+		}
+	case NotImplementedListUsersErrorResponse:
+		if err := s.NotImplemented.Decode(d); err != nil {
 			return err
 		}
 	case ReqInvalidListUsersErrorResponse:
@@ -43159,6 +43182,39 @@ func (s OptQueryTeamsRequestSorting) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptQueryTeamsRequestSorting) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes QueryUsersRequestSorting as json.
+func (o OptQueryUsersRequestSorting) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes QueryUsersRequestSorting from json.
+func (o *OptQueryUsersRequestSorting) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptQueryUsersRequestSorting to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptQueryUsersRequestSorting) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptQueryUsersRequestSorting) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -51255,6 +51311,810 @@ func (s *QueryTeamsUnauthorized) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *QueryTeamsUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes QueryUsersBadRequest as json.
+func (s *QueryUsersBadRequest) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes QueryUsersBadRequest from json.
+func (s *QueryUsersBadRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode QueryUsersBadRequest to nil")
+	}
+	var unwrapped ErrorDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = QueryUsersBadRequest(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *QueryUsersBadRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *QueryUsersBadRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes QueryUsersErrorResponse as json.
+func (s QueryUsersErrorResponse) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+func (s QueryUsersErrorResponse) encodeFields(e *jx.Encoder) {
+	switch s.Type {
+	case AuthUnauthorizedQueryUsersErrorResponse:
+		e.FieldStart("code")
+		e.Str("auth.unauthorized")
+		{
+			s := s.AuthUnauthorized
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
+	case InternalQueryUsersErrorResponse:
+		e.FieldStart("code")
+		e.Str("internal")
+		{
+			s := s.Internal
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
+	case NotImplementedQueryUsersErrorResponse:
+		e.FieldStart("code")
+		e.Str("not_implemented")
+		{
+			s := s.NotImplemented
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
+	case ReqInvalidQueryUsersErrorResponse:
+		e.FieldStart("code")
+		e.Str("req.invalid")
+		{
+			s := s.ReqInvalid
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
+	case UserNotFoundQueryUsersErrorResponse:
+		e.FieldStart("code")
+		e.Str("user.not_found")
+		{
+			s := s.UserNotFound
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
+	case UserPermissionDeniedQueryUsersErrorResponse:
+		e.FieldStart("code")
+		e.Str("user.permission_denied")
+		{
+			s := s.UserPermissionDenied
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
+	}
+}
+
+// Decode decodes QueryUsersErrorResponse from json.
+func (s *QueryUsersErrorResponse) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode QueryUsersErrorResponse to nil")
+	}
+	// Sum type discriminator.
+	if typ := d.Next(); typ != jx.Object {
+		return errors.Errorf("unexpected json type %q", typ)
+	}
+
+	var found bool
+	if err := d.Capture(func(d *jx.Decoder) error {
+		return d.ObjBytes(func(d *jx.Decoder, key []byte) error {
+			if found {
+				return d.Skip()
+			}
+			switch string(key) {
+			case "code":
+				typ, err := d.Str()
+				if err != nil {
+					return err
+				}
+				switch typ {
+				case "auth.unauthorized":
+					s.Type = AuthUnauthorizedQueryUsersErrorResponse
+					found = true
+				case "internal":
+					s.Type = InternalQueryUsersErrorResponse
+					found = true
+				case "not_implemented":
+					s.Type = NotImplementedQueryUsersErrorResponse
+					found = true
+				case "req.invalid":
+					s.Type = ReqInvalidQueryUsersErrorResponse
+					found = true
+				case "user.not_found":
+					s.Type = UserNotFoundQueryUsersErrorResponse
+					found = true
+				case "user.permission_denied":
+					s.Type = UserPermissionDeniedQueryUsersErrorResponse
+					found = true
+				default:
+					return errors.Errorf("unknown type %s", typ)
+				}
+				return nil
+			}
+			return d.Skip()
+		})
+	}); err != nil {
+		return errors.Wrap(err, "capture")
+	}
+	if !found {
+		return errors.New("unable to detect sum type variant")
+	}
+	switch s.Type {
+	case AuthUnauthorizedQueryUsersErrorResponse:
+		if err := s.AuthUnauthorized.Decode(d); err != nil {
+			return err
+		}
+	case InternalQueryUsersErrorResponse:
+		if err := s.Internal.Decode(d); err != nil {
+			return err
+		}
+	case NotImplementedQueryUsersErrorResponse:
+		if err := s.NotImplemented.Decode(d); err != nil {
+			return err
+		}
+	case ReqInvalidQueryUsersErrorResponse:
+		if err := s.ReqInvalid.Decode(d); err != nil {
+			return err
+		}
+	case UserNotFoundQueryUsersErrorResponse:
+		if err := s.UserNotFound.Decode(d); err != nil {
+			return err
+		}
+	case UserPermissionDeniedQueryUsersErrorResponse:
+		if err := s.UserPermissionDenied.Decode(d); err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("inferred invalid type: %s", s.Type)
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s QueryUsersErrorResponse) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *QueryUsersErrorResponse) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes QueryUsersForbidden as json.
+func (s *QueryUsersForbidden) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes QueryUsersForbidden from json.
+func (s *QueryUsersForbidden) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode QueryUsersForbidden to nil")
+	}
+	var unwrapped ErrorDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = QueryUsersForbidden(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *QueryUsersForbidden) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *QueryUsersForbidden) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *QueryUsersRequest) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *QueryUsersRequest) encodeFields(e *jx.Encoder) {
+	{
+		if s.Limit.Set {
+			e.FieldStart("limit")
+			s.Limit.Encode(e)
+		}
+	}
+	{
+		if s.PageToken.Set {
+			e.FieldStart("page_token")
+			s.PageToken.Encode(e)
+		}
+	}
+	{
+		if s.Sorting.Set {
+			e.FieldStart("sorting")
+			s.Sorting.Encode(e)
+		}
+	}
+	{
+		if s.Filter != nil {
+			e.FieldStart("filter")
+			e.ArrStart()
+			for _, elem := range s.Filter {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+}
+
+var jsonFieldsNameOfQueryUsersRequest = [4]string{
+	0: "limit",
+	1: "page_token",
+	2: "sorting",
+	3: "filter",
+}
+
+// Decode decodes QueryUsersRequest from json.
+func (s *QueryUsersRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode QueryUsersRequest to nil")
+	}
+	s.setDefaults()
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "limit":
+			if err := func() error {
+				s.Limit.Reset()
+				if err := s.Limit.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"limit\"")
+			}
+		case "page_token":
+			if err := func() error {
+				s.PageToken.Reset()
+				if err := s.PageToken.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"page_token\"")
+			}
+		case "sorting":
+			if err := func() error {
+				s.Sorting.Reset()
+				if err := s.Sorting.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"sorting\"")
+			}
+		case "filter":
+			if err := func() error {
+				s.Filter = make([]QueryUsersRequestFilterItem, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem QueryUsersRequestFilterItem
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Filter = append(s.Filter, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"filter\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode QueryUsersRequest")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *QueryUsersRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *QueryUsersRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *QueryUsersRequestFilterItem) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *QueryUsersRequestFilterItem) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("field")
+		s.Field.Encode(e)
+	}
+	{
+		if s.Value.Set {
+			e.FieldStart("value")
+			s.Value.Encode(e)
+		}
+	}
+	{
+		e.FieldStart("operation")
+		s.Operation.Encode(e)
+	}
+}
+
+var jsonFieldsNameOfQueryUsersRequestFilterItem = [3]string{
+	0: "field",
+	1: "value",
+	2: "operation",
+}
+
+// Decode decodes QueryUsersRequestFilterItem from json.
+func (s *QueryUsersRequestFilterItem) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode QueryUsersRequestFilterItem to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "field":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.Field.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"field\"")
+			}
+		case "value":
+			if err := func() error {
+				s.Value.Reset()
+				if err := s.Value.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"value\"")
+			}
+		case "operation":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				if err := s.Operation.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"operation\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode QueryUsersRequestFilterItem")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000101,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfQueryUsersRequestFilterItem) {
+					name = jsonFieldsNameOfQueryUsersRequestFilterItem[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *QueryUsersRequestFilterItem) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *QueryUsersRequestFilterItem) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *QueryUsersRequestSorting) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *QueryUsersRequestSorting) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("field")
+		s.Field.Encode(e)
+	}
+	{
+		e.FieldStart("direction")
+		s.Direction.Encode(e)
+	}
+}
+
+var jsonFieldsNameOfQueryUsersRequestSorting = [2]string{
+	0: "field",
+	1: "direction",
+}
+
+// Decode decodes QueryUsersRequestSorting from json.
+func (s *QueryUsersRequestSorting) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode QueryUsersRequestSorting to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "field":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.Field.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"field\"")
+			}
+		case "direction":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				if err := s.Direction.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"direction\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode QueryUsersRequestSorting")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfQueryUsersRequestSorting) {
+					name = jsonFieldsNameOfQueryUsersRequestSorting[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *QueryUsersRequestSorting) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *QueryUsersRequestSorting) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *QueryUsersResponse) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *QueryUsersResponse) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("users")
+		e.ArrStart()
+		for _, elem := range s.Users {
+			elem.Encode(e)
+		}
+		e.ArrEnd()
+	}
+	{
+		if s.NextPageToken.Set {
+			e.FieldStart("next_page_token")
+			s.NextPageToken.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfQueryUsersResponse = [2]string{
+	0: "users",
+	1: "next_page_token",
+}
+
+// Decode decodes QueryUsersResponse from json.
+func (s *QueryUsersResponse) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode QueryUsersResponse to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "users":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				s.Users = make([]User, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem User
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Users = append(s.Users, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"users\"")
+			}
+		case "next_page_token":
+			if err := func() error {
+				s.NextPageToken.Reset()
+				if err := s.NextPageToken.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"next_page_token\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode QueryUsersResponse")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfQueryUsersResponse) {
+					name = jsonFieldsNameOfQueryUsersResponse[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *QueryUsersResponse) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *QueryUsersResponse) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes QueryUsersUnauthorized as json.
+func (s *QueryUsersUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorDetails)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes QueryUsersUnauthorized from json.
+func (s *QueryUsersUnauthorized) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode QueryUsersUnauthorized to nil")
+	}
+	var unwrapped ErrorDetails
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = QueryUsersUnauthorized(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *QueryUsersUnauthorized) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *QueryUsersUnauthorized) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -64932,6 +65792,52 @@ func (s *UserDeletedEventDelegationType) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes UserFilterField as json.
+func (s UserFilterField) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes UserFilterField from json.
+func (s *UserFilterField) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode UserFilterField to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch UserFilterField(v) {
+	case UserFilterFieldCreatedAt:
+		*s = UserFilterFieldCreatedAt
+	case UserFilterFieldID:
+		*s = UserFilterFieldID
+	case UserFilterFieldSchema:
+		*s = UserFilterFieldSchema
+	case UserFilterFieldStatus:
+		*s = UserFilterFieldStatus
+	case UserFilterFieldLifecycleOwnerTeamID:
+		*s = UserFilterFieldLifecycleOwnerTeamID
+	default:
+		*s = UserFilterField(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s UserFilterField) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *UserFilterField) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes UserID as json.
 func (s UserID) Encode(e *jx.Encoder) {
 	unwrapped := string(s)
@@ -66364,6 +67270,52 @@ func (s UserSchemaProperties) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *UserSchemaProperties) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes UserSortField as json.
+func (s UserSortField) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes UserSortField from json.
+func (s *UserSortField) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode UserSortField to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch UserSortField(v) {
+	case UserSortFieldCreatedAt:
+		*s = UserSortFieldCreatedAt
+	case UserSortFieldID:
+		*s = UserSortFieldID
+	case UserSortFieldSchema:
+		*s = UserSortFieldSchema
+	case UserSortFieldStatus:
+		*s = UserSortFieldStatus
+	case UserSortFieldLifecycleOwnerTeamID:
+		*s = UserSortFieldLifecycleOwnerTeamID
+	default:
+		*s = UserSortField(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s UserSortField) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *UserSortField) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/api/generated/oas_operations_gen.go
+++ b/api/generated/oas_operations_gen.go
@@ -52,6 +52,7 @@ const (
 	QueryProjectsOperation                 OperationName = "QueryProjects"
 	QuerySessionsOperation                 OperationName = "QuerySessions"
 	QueryTeamsOperation                    OperationName = "QueryTeams"
+	QueryUsersOperation                    OperationName = "QueryUsers"
 	RevokeMySessionOperation               OperationName = "RevokeMySession"
 	RevokeSessionOperation                 OperationName = "RevokeSession"
 	SetUserPasswordOperation               OperationName = "SetUserPassword"

--- a/api/generated/oas_request_decoders_gen.go
+++ b/api/generated/oas_request_decoders_gen.go
@@ -1404,6 +1404,85 @@ func (s *Server) decodeQueryTeamsRequest(r *http.Request) (
 	}
 }
 
+func (s *Server) decodeQueryUsersRequest(r *http.Request) (
+	req *QueryUsersRequest,
+	rawBody []byte,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = errors.Join(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = errors.Join(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, rawBody, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, rawBody, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		defer func() {
+			_ = r.Body.Close()
+		}()
+		if err != nil {
+			return req, rawBody, close, err
+		}
+
+		// Reset the body to allow for downstream reading.
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
+
+		if len(buf) == 0 {
+			return req, rawBody, close, validate.ErrBodyRequired
+		}
+
+		rawBody = append(rawBody, buf...)
+		d := jx.DecodeBytes(buf)
+
+		var request QueryUsersRequest
+		if err := func() error {
+			if err := request.Decode(d); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, rawBody, close, err
+		}
+		if err := func() error {
+			if err := request.Validate(); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return req, rawBody, close, errors.Wrap(err, "validate")
+		}
+		return &request, rawBody, close, nil
+	default:
+		return req, rawBody, close, validate.InvalidContentType(ct)
+	}
+}
+
 func (s *Server) decodeSetUserPasswordRequest(r *http.Request) (
 	req *SetUserPasswordRequest,
 	rawBody []byte,

--- a/api/generated/oas_request_encoders_gen.go
+++ b/api/generated/oas_request_encoders_gen.go
@@ -262,6 +262,20 @@ func encodeQueryTeamsRequest(
 	return nil
 }
 
+func encodeQueryUsersRequest(
+	req *QueryUsersRequest,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		req.Encode(e)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
 func encodeSetUserPasswordRequest(
 	req *SetUserPasswordRequest,
 	r *http.Request,

--- a/api/generated/oas_response_decoders_gen.go
+++ b/api/generated/oas_response_decoders_gen.go
@@ -8057,6 +8057,203 @@ func decodeQueryTeamsResponse(resp *http.Response) (res QueryTeamsRes, _ error) 
 	return res, nil
 }
 
+func decodeQueryUsersResponse(resp *http.Response) (res QueryUsersRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response QueryUsersResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 400:
+		// Code 400.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response QueryUsersBadRequest
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response QueryUsersUnauthorized
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 403:
+		// Code 403.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response QueryUsersForbidden
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	// Default response.
+	res, err := func() (res QueryUsersRes, err error) {
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response QueryUsersErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &QueryUsersErrorResponseStatusCode{
+				StatusCode: resp.StatusCode,
+				Response:   response,
+			}, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}()
+	if err != nil {
+		return res, errors.Wrapf(err, "default (code %d)", resp.StatusCode)
+	}
+	return res, nil
+}
+
 func decodeRevokeMySessionResponse(resp *http.Response) (res RevokeMySessionRes, _ error) {
 	switch resp.StatusCode {
 	case 204:

--- a/api/generated/oas_response_encoders_gen.go
+++ b/api/generated/oas_response_encoders_gen.go
@@ -3834,6 +3834,98 @@ func encodeQueryTeamsResponse(response QueryTeamsRes, w http.ResponseWriter, spa
 	}
 }
 
+func encodeQueryUsersResponse(response QueryUsersRes, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *QueryUsersResponse:
+		if err := func() error {
+			if err := response.Validate(); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrap(err, "validate")
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *QueryUsersBadRequest:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *QueryUsersUnauthorized:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *QueryUsersForbidden:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(403)
+		span.SetStatus(codes.Error, http.StatusText(403))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *QueryUsersErrorResponseStatusCode:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		code := response.StatusCode
+		if code == 0 {
+			// Set default status code.
+			code = http.StatusOK
+		}
+		w.WriteHeader(code)
+		if st := http.StatusText(code); code >= http.StatusBadRequest {
+			span.SetStatus(codes.Error, st)
+		} else {
+			span.SetStatus(codes.Ok, st)
+		}
+
+		e := new(jx.Encoder)
+		response.Response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		if code >= http.StatusInternalServerError {
+			return errors.Wrapf(ht.ErrInternalServerErrorResponse, "code: %d, message: %s", code, http.StatusText(code))
+		}
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
 func encodeRevokeMySessionResponse(response RevokeMySessionRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
 	case *RevokeMySessionNoContent:

--- a/api/generated/oas_router_gen.go
+++ b/api/generated/oas_router_gen.go
@@ -20,7 +20,7 @@ var (
 	rn47AllowedHeaders = map[string]string{
 		"POST": "Authorization,Content-Type",
 	}
-	rn60AllowedHeaders = map[string]string{
+	rn61AllowedHeaders = map[string]string{
 		"POST": "Authorization,Content-Type,Idempotency-Key",
 	}
 	rn14AllowedHeaders = map[string]string{
@@ -42,7 +42,7 @@ var (
 	rn10AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
-	rn57AllowedHeaders = map[string]string{
+	rn58AllowedHeaders = map[string]string{
 		"POST": "Content-Type,Origin",
 	}
 	rn11AllowedHeaders = map[string]string{
@@ -108,6 +108,9 @@ var (
 		"GET":  "Authorization",
 		"POST": "Authorization,Content-Type",
 	}
+	rn55AllowedHeaders = map[string]string{
+		"POST": "Authorization,Content-Type",
+	}
 	rn2AllowedHeaders = map[string]string{
 		"DELETE": "Authorization",
 		"GET":    "Authorization",
@@ -121,7 +124,7 @@ var (
 	rn27AllowedHeaders = map[string]string{
 		"POST": "Authorization,Content-Type",
 	}
-	rn56AllowedHeaders = map[string]string{
+	rn57AllowedHeaders = map[string]string{
 		"PUT": "Authorization,Content-Type",
 	}
 	rn51AllowedHeaders = map[string]string{
@@ -317,7 +320,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 										default:
 											s.notAllowed(w, r, notAllowedParams{
 												allowedMethods: "POST",
-												allowedHeaders: rn60AllowedHeaders,
+												allowedHeaders: rn61AllowedHeaders,
 												acceptPost:     "application/json",
 												acceptPatch:    "",
 											})
@@ -566,7 +569,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "POST",
-									allowedHeaders: rn57AllowedHeaders,
+									allowedHeaders: rn58AllowedHeaders,
 									acceptPost:     "application/json",
 									acceptPatch:    "",
 								})
@@ -1313,6 +1316,32 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 
 						elem = origElem
+					case 'q': // Prefix: "query"
+						origElem := elem
+						if l := len("query"); len(elem) >= l && elem[0:l] == "query" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch r.Method {
+							case "POST":
+								s.handleQueryUsersRequest([0]string{}, elemIsEscaped, w, r)
+							default:
+								s.notAllowed(w, r, notAllowedParams{
+									allowedMethods: "POST",
+									allowedHeaders: rn55AllowedHeaders,
+									acceptPost:     "application/json",
+									acceptPatch:    "",
+								})
+							}
+
+							return
+						}
+
+						elem = origElem
 					}
 					// Param: "user_id"
 					// Match until "/"
@@ -1480,7 +1509,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									default:
 										s.notAllowed(w, r, notAllowedParams{
 											allowedMethods: "PUT",
-											allowedHeaders: rn56AllowedHeaders,
+											allowedHeaders: rn57AllowedHeaders,
 											acceptPost:     "",
 											acceptPatch:    "",
 										})
@@ -2780,6 +2809,32 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								r.operationID = "getMyUser"
 								r.operationGroup = ""
 								r.pathPattern = "/users/me"
+								r.args = args
+								r.count = 0
+								return r, true
+							default:
+								return
+							}
+						}
+
+						elem = origElem
+					case 'q': // Prefix: "query"
+						origElem := elem
+						if l := len("query"); len(elem) >= l && elem[0:l] == "query" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch method {
+							case "POST":
+								r.name = QueryUsersOperation
+								r.summary = "Query users"
+								r.operationID = "queryUsers"
+								r.operationGroup = ""
+								r.pathPattern = "/users/query"
 								r.args = args
 								r.count = 0
 								return r, true

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -20391,6 +20391,7 @@ type ListUsersErrorResponse struct {
 	Type                 ListUsersErrorResponseType // switch on this field
 	AuthUnauthorized     AuthUnauthorized
 	Internal             Internal
+	NotImplemented       NotImplemented
 	ReqInvalid           ReqInvalid
 	UserNotFound         UserNotFound
 	UserPermissionDenied UserPermissionDenied
@@ -20403,6 +20404,7 @@ type ListUsersErrorResponseType string
 const (
 	AuthUnauthorizedListUsersErrorResponse     ListUsersErrorResponseType = "auth.unauthorized"
 	InternalListUsersErrorResponse             ListUsersErrorResponseType = "internal"
+	NotImplementedListUsersErrorResponse       ListUsersErrorResponseType = "not_implemented"
 	ReqInvalidListUsersErrorResponse           ListUsersErrorResponseType = "req.invalid"
 	UserNotFoundListUsersErrorResponse         ListUsersErrorResponseType = "user.not_found"
 	UserPermissionDeniedListUsersErrorResponse ListUsersErrorResponseType = "user.permission_denied"
@@ -20415,6 +20417,11 @@ func (s ListUsersErrorResponse) IsAuthUnauthorized() bool {
 
 // IsInternal reports whether ListUsersErrorResponse is Internal.
 func (s ListUsersErrorResponse) IsInternal() bool { return s.Type == InternalListUsersErrorResponse }
+
+// IsNotImplemented reports whether ListUsersErrorResponse is NotImplemented.
+func (s ListUsersErrorResponse) IsNotImplemented() bool {
+	return s.Type == NotImplementedListUsersErrorResponse
+}
 
 // IsReqInvalid reports whether ListUsersErrorResponse is ReqInvalid.
 func (s ListUsersErrorResponse) IsReqInvalid() bool {
@@ -20470,6 +20477,27 @@ func (s ListUsersErrorResponse) GetInternal() (v Internal, ok bool) {
 func NewInternalListUsersErrorResponse(v Internal) ListUsersErrorResponse {
 	var s ListUsersErrorResponse
 	s.SetInternal(v)
+	return s
+}
+
+// SetNotImplemented sets ListUsersErrorResponse to NotImplemented.
+func (s *ListUsersErrorResponse) SetNotImplemented(v NotImplemented) {
+	s.Type = NotImplementedListUsersErrorResponse
+	s.NotImplemented = v
+}
+
+// GetNotImplemented returns NotImplemented and true boolean if ListUsersErrorResponse is NotImplemented.
+func (s ListUsersErrorResponse) GetNotImplemented() (v NotImplemented, ok bool) {
+	if !s.IsNotImplemented() {
+		return v, false
+	}
+	return s.NotImplemented, true
+}
+
+// NewNotImplementedListUsersErrorResponse returns new ListUsersErrorResponse from NotImplemented.
+func NewNotImplementedListUsersErrorResponse(v NotImplemented) ListUsersErrorResponse {
+	var s ListUsersErrorResponse
+	s.SetNotImplemented(v)
 	return s
 }
 
@@ -27708,6 +27736,52 @@ func (o OptQueryTeamsRequestSorting) Or(d QueryTeamsRequestSorting) QueryTeamsRe
 	return d
 }
 
+// NewOptQueryUsersRequestSorting returns new OptQueryUsersRequestSorting with value set to v.
+func NewOptQueryUsersRequestSorting(v QueryUsersRequestSorting) OptQueryUsersRequestSorting {
+	return OptQueryUsersRequestSorting{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptQueryUsersRequestSorting is optional QueryUsersRequestSorting.
+type OptQueryUsersRequestSorting struct {
+	Value QueryUsersRequestSorting
+	Set   bool
+}
+
+// IsSet returns true if OptQueryUsersRequestSorting was set.
+func (o OptQueryUsersRequestSorting) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptQueryUsersRequestSorting) Reset() {
+	var v QueryUsersRequestSorting
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptQueryUsersRequestSorting) SetTo(v QueryUsersRequestSorting) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptQueryUsersRequestSorting) Get() (v QueryUsersRequestSorting, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptQueryUsersRequestSorting) Or(d QueryUsersRequestSorting) QueryUsersRequestSorting {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptReqInvalidDetails returns new OptReqInvalidDetails with value set to v.
 func NewOptReqInvalidDetails(v ReqInvalidDetails) OptReqInvalidDetails {
 	return OptReqInvalidDetails{
@@ -32637,6 +32711,372 @@ func (*QueryTeamsTooManyRequests) queryTeamsRes() {}
 type QueryTeamsUnauthorized ErrorDetails
 
 func (*QueryTeamsUnauthorized) queryTeamsRes() {}
+
+type QueryUsersBadRequest ErrorDetails
+
+func (*QueryUsersBadRequest) queryUsersRes() {}
+
+// QueryUsersErrorResponse represents sum type.
+type QueryUsersErrorResponse struct {
+	Type                 QueryUsersErrorResponseType // switch on this field
+	AuthUnauthorized     AuthUnauthorized
+	Internal             Internal
+	NotImplemented       NotImplemented
+	ReqInvalid           ReqInvalid
+	UserNotFound         UserNotFound
+	UserPermissionDenied UserPermissionDenied
+}
+
+// QueryUsersErrorResponseType is oneOf type of QueryUsersErrorResponse.
+type QueryUsersErrorResponseType string
+
+// Possible values for QueryUsersErrorResponseType.
+const (
+	AuthUnauthorizedQueryUsersErrorResponse     QueryUsersErrorResponseType = "auth.unauthorized"
+	InternalQueryUsersErrorResponse             QueryUsersErrorResponseType = "internal"
+	NotImplementedQueryUsersErrorResponse       QueryUsersErrorResponseType = "not_implemented"
+	ReqInvalidQueryUsersErrorResponse           QueryUsersErrorResponseType = "req.invalid"
+	UserNotFoundQueryUsersErrorResponse         QueryUsersErrorResponseType = "user.not_found"
+	UserPermissionDeniedQueryUsersErrorResponse QueryUsersErrorResponseType = "user.permission_denied"
+)
+
+// IsAuthUnauthorized reports whether QueryUsersErrorResponse is AuthUnauthorized.
+func (s QueryUsersErrorResponse) IsAuthUnauthorized() bool {
+	return s.Type == AuthUnauthorizedQueryUsersErrorResponse
+}
+
+// IsInternal reports whether QueryUsersErrorResponse is Internal.
+func (s QueryUsersErrorResponse) IsInternal() bool { return s.Type == InternalQueryUsersErrorResponse }
+
+// IsNotImplemented reports whether QueryUsersErrorResponse is NotImplemented.
+func (s QueryUsersErrorResponse) IsNotImplemented() bool {
+	return s.Type == NotImplementedQueryUsersErrorResponse
+}
+
+// IsReqInvalid reports whether QueryUsersErrorResponse is ReqInvalid.
+func (s QueryUsersErrorResponse) IsReqInvalid() bool {
+	return s.Type == ReqInvalidQueryUsersErrorResponse
+}
+
+// IsUserNotFound reports whether QueryUsersErrorResponse is UserNotFound.
+func (s QueryUsersErrorResponse) IsUserNotFound() bool {
+	return s.Type == UserNotFoundQueryUsersErrorResponse
+}
+
+// IsUserPermissionDenied reports whether QueryUsersErrorResponse is UserPermissionDenied.
+func (s QueryUsersErrorResponse) IsUserPermissionDenied() bool {
+	return s.Type == UserPermissionDeniedQueryUsersErrorResponse
+}
+
+// SetAuthUnauthorized sets QueryUsersErrorResponse to AuthUnauthorized.
+func (s *QueryUsersErrorResponse) SetAuthUnauthorized(v AuthUnauthorized) {
+	s.Type = AuthUnauthorizedQueryUsersErrorResponse
+	s.AuthUnauthorized = v
+}
+
+// GetAuthUnauthorized returns AuthUnauthorized and true boolean if QueryUsersErrorResponse is AuthUnauthorized.
+func (s QueryUsersErrorResponse) GetAuthUnauthorized() (v AuthUnauthorized, ok bool) {
+	if !s.IsAuthUnauthorized() {
+		return v, false
+	}
+	return s.AuthUnauthorized, true
+}
+
+// NewAuthUnauthorizedQueryUsersErrorResponse returns new QueryUsersErrorResponse from AuthUnauthorized.
+func NewAuthUnauthorizedQueryUsersErrorResponse(v AuthUnauthorized) QueryUsersErrorResponse {
+	var s QueryUsersErrorResponse
+	s.SetAuthUnauthorized(v)
+	return s
+}
+
+// SetInternal sets QueryUsersErrorResponse to Internal.
+func (s *QueryUsersErrorResponse) SetInternal(v Internal) {
+	s.Type = InternalQueryUsersErrorResponse
+	s.Internal = v
+}
+
+// GetInternal returns Internal and true boolean if QueryUsersErrorResponse is Internal.
+func (s QueryUsersErrorResponse) GetInternal() (v Internal, ok bool) {
+	if !s.IsInternal() {
+		return v, false
+	}
+	return s.Internal, true
+}
+
+// NewInternalQueryUsersErrorResponse returns new QueryUsersErrorResponse from Internal.
+func NewInternalQueryUsersErrorResponse(v Internal) QueryUsersErrorResponse {
+	var s QueryUsersErrorResponse
+	s.SetInternal(v)
+	return s
+}
+
+// SetNotImplemented sets QueryUsersErrorResponse to NotImplemented.
+func (s *QueryUsersErrorResponse) SetNotImplemented(v NotImplemented) {
+	s.Type = NotImplementedQueryUsersErrorResponse
+	s.NotImplemented = v
+}
+
+// GetNotImplemented returns NotImplemented and true boolean if QueryUsersErrorResponse is NotImplemented.
+func (s QueryUsersErrorResponse) GetNotImplemented() (v NotImplemented, ok bool) {
+	if !s.IsNotImplemented() {
+		return v, false
+	}
+	return s.NotImplemented, true
+}
+
+// NewNotImplementedQueryUsersErrorResponse returns new QueryUsersErrorResponse from NotImplemented.
+func NewNotImplementedQueryUsersErrorResponse(v NotImplemented) QueryUsersErrorResponse {
+	var s QueryUsersErrorResponse
+	s.SetNotImplemented(v)
+	return s
+}
+
+// SetReqInvalid sets QueryUsersErrorResponse to ReqInvalid.
+func (s *QueryUsersErrorResponse) SetReqInvalid(v ReqInvalid) {
+	s.Type = ReqInvalidQueryUsersErrorResponse
+	s.ReqInvalid = v
+}
+
+// GetReqInvalid returns ReqInvalid and true boolean if QueryUsersErrorResponse is ReqInvalid.
+func (s QueryUsersErrorResponse) GetReqInvalid() (v ReqInvalid, ok bool) {
+	if !s.IsReqInvalid() {
+		return v, false
+	}
+	return s.ReqInvalid, true
+}
+
+// NewReqInvalidQueryUsersErrorResponse returns new QueryUsersErrorResponse from ReqInvalid.
+func NewReqInvalidQueryUsersErrorResponse(v ReqInvalid) QueryUsersErrorResponse {
+	var s QueryUsersErrorResponse
+	s.SetReqInvalid(v)
+	return s
+}
+
+// SetUserNotFound sets QueryUsersErrorResponse to UserNotFound.
+func (s *QueryUsersErrorResponse) SetUserNotFound(v UserNotFound) {
+	s.Type = UserNotFoundQueryUsersErrorResponse
+	s.UserNotFound = v
+}
+
+// GetUserNotFound returns UserNotFound and true boolean if QueryUsersErrorResponse is UserNotFound.
+func (s QueryUsersErrorResponse) GetUserNotFound() (v UserNotFound, ok bool) {
+	if !s.IsUserNotFound() {
+		return v, false
+	}
+	return s.UserNotFound, true
+}
+
+// NewUserNotFoundQueryUsersErrorResponse returns new QueryUsersErrorResponse from UserNotFound.
+func NewUserNotFoundQueryUsersErrorResponse(v UserNotFound) QueryUsersErrorResponse {
+	var s QueryUsersErrorResponse
+	s.SetUserNotFound(v)
+	return s
+}
+
+// SetUserPermissionDenied sets QueryUsersErrorResponse to UserPermissionDenied.
+func (s *QueryUsersErrorResponse) SetUserPermissionDenied(v UserPermissionDenied) {
+	s.Type = UserPermissionDeniedQueryUsersErrorResponse
+	s.UserPermissionDenied = v
+}
+
+// GetUserPermissionDenied returns UserPermissionDenied and true boolean if QueryUsersErrorResponse is UserPermissionDenied.
+func (s QueryUsersErrorResponse) GetUserPermissionDenied() (v UserPermissionDenied, ok bool) {
+	if !s.IsUserPermissionDenied() {
+		return v, false
+	}
+	return s.UserPermissionDenied, true
+}
+
+// NewUserPermissionDeniedQueryUsersErrorResponse returns new QueryUsersErrorResponse from UserPermissionDenied.
+func NewUserPermissionDeniedQueryUsersErrorResponse(v UserPermissionDenied) QueryUsersErrorResponse {
+	var s QueryUsersErrorResponse
+	s.SetUserPermissionDenied(v)
+	return s
+}
+
+// QueryUsersErrorResponseStatusCode wraps QueryUsersErrorResponse with StatusCode.
+type QueryUsersErrorResponseStatusCode struct {
+	StatusCode int
+	Response   QueryUsersErrorResponse
+}
+
+// GetStatusCode returns the value of StatusCode.
+func (s *QueryUsersErrorResponseStatusCode) GetStatusCode() int {
+	return s.StatusCode
+}
+
+// GetResponse returns the value of Response.
+func (s *QueryUsersErrorResponseStatusCode) GetResponse() QueryUsersErrorResponse {
+	return s.Response
+}
+
+// SetStatusCode sets the value of StatusCode.
+func (s *QueryUsersErrorResponseStatusCode) SetStatusCode(val int) {
+	s.StatusCode = val
+}
+
+// SetResponse sets the value of Response.
+func (s *QueryUsersErrorResponseStatusCode) SetResponse(val QueryUsersErrorResponse) {
+	s.Response = val
+}
+
+func (*QueryUsersErrorResponseStatusCode) queryUsersRes() {}
+
+type QueryUsersForbidden ErrorDetails
+
+func (*QueryUsersForbidden) queryUsersRes() {}
+
+// Request to query the users of a project.
+// Ref: #
+type QueryUsersRequest struct {
+	Limit OptLimit `json:"limit"`
+	// Token to retrieve the next page of results. Must be sent with the same
+	// `sorting` as the request that issued the token. Omitting `sorting` reuses
+	// the default sort and only succeeds when that default matches the token.
+	PageToken OptNilPageToken             `json:"page_token"`
+	Sorting   OptQueryUsersRequestSorting `json:"sorting"`
+	// Filter criteria for querying users. Criteria are combined with AND.
+	Filter []QueryUsersRequestFilterItem `json:"filter"`
+}
+
+// GetLimit returns the value of Limit.
+func (s *QueryUsersRequest) GetLimit() OptLimit {
+	return s.Limit
+}
+
+// GetPageToken returns the value of PageToken.
+func (s *QueryUsersRequest) GetPageToken() OptNilPageToken {
+	return s.PageToken
+}
+
+// GetSorting returns the value of Sorting.
+func (s *QueryUsersRequest) GetSorting() OptQueryUsersRequestSorting {
+	return s.Sorting
+}
+
+// GetFilter returns the value of Filter.
+func (s *QueryUsersRequest) GetFilter() []QueryUsersRequestFilterItem {
+	return s.Filter
+}
+
+// SetLimit sets the value of Limit.
+func (s *QueryUsersRequest) SetLimit(val OptLimit) {
+	s.Limit = val
+}
+
+// SetPageToken sets the value of PageToken.
+func (s *QueryUsersRequest) SetPageToken(val OptNilPageToken) {
+	s.PageToken = val
+}
+
+// SetSorting sets the value of Sorting.
+func (s *QueryUsersRequest) SetSorting(val OptQueryUsersRequestSorting) {
+	s.Sorting = val
+}
+
+// SetFilter sets the value of Filter.
+func (s *QueryUsersRequest) SetFilter(val []QueryUsersRequestFilterItem) {
+	s.Filter = val
+}
+
+type QueryUsersRequestFilterItem struct {
+	// The field to filter by.
+	Field     UserFilterField `json:"field"`
+	Value     OptFilterValue  `json:"value"`
+	Operation FilterOperation `json:"operation"`
+}
+
+// GetField returns the value of Field.
+func (s *QueryUsersRequestFilterItem) GetField() UserFilterField {
+	return s.Field
+}
+
+// GetValue returns the value of Value.
+func (s *QueryUsersRequestFilterItem) GetValue() OptFilterValue {
+	return s.Value
+}
+
+// GetOperation returns the value of Operation.
+func (s *QueryUsersRequestFilterItem) GetOperation() FilterOperation {
+	return s.Operation
+}
+
+// SetField sets the value of Field.
+func (s *QueryUsersRequestFilterItem) SetField(val UserFilterField) {
+	s.Field = val
+}
+
+// SetValue sets the value of Value.
+func (s *QueryUsersRequestFilterItem) SetValue(val OptFilterValue) {
+	s.Value = val
+}
+
+// SetOperation sets the value of Operation.
+func (s *QueryUsersRequestFilterItem) SetOperation(val FilterOperation) {
+	s.Operation = val
+}
+
+type QueryUsersRequestSorting struct {
+	// The field to sort by.
+	Field UserSortField `json:"field"`
+	// The direction to sort by.
+	Direction SortDirection `json:"direction"`
+}
+
+// GetField returns the value of Field.
+func (s *QueryUsersRequestSorting) GetField() UserSortField {
+	return s.Field
+}
+
+// GetDirection returns the value of Direction.
+func (s *QueryUsersRequestSorting) GetDirection() SortDirection {
+	return s.Direction
+}
+
+// SetField sets the value of Field.
+func (s *QueryUsersRequestSorting) SetField(val UserSortField) {
+	s.Field = val
+}
+
+// SetDirection sets the value of Direction.
+func (s *QueryUsersRequestSorting) SetDirection(val SortDirection) {
+	s.Direction = val
+}
+
+// Paginated list of users.
+// Ref: #
+type QueryUsersResponse struct {
+	Users []User `json:"users"`
+	// Token to pass as `page_token` in the next request to fetch the following page.
+	// Absent when there are no more results.
+	NextPageToken OptNilPageToken `json:"next_page_token"`
+}
+
+// GetUsers returns the value of Users.
+func (s *QueryUsersResponse) GetUsers() []User {
+	return s.Users
+}
+
+// GetNextPageToken returns the value of NextPageToken.
+func (s *QueryUsersResponse) GetNextPageToken() OptNilPageToken {
+	return s.NextPageToken
+}
+
+// SetUsers sets the value of Users.
+func (s *QueryUsersResponse) SetUsers(val []User) {
+	s.Users = val
+}
+
+// SetNextPageToken sets the value of NextPageToken.
+func (s *QueryUsersResponse) SetNextPageToken(val OptNilPageToken) {
+	s.NextPageToken = val
+}
+
+func (*QueryUsersResponse) queryUsersRes() {}
+
+type QueryUsersUnauthorized ErrorDetails
+
+func (*QueryUsersUnauthorized) queryUsersRes() {}
 
 // Merged schema.
 // Ref: #
@@ -41157,6 +41597,81 @@ func (s *UserDeletedEventDelegationType) UnmarshalText(data []byte) error {
 	}
 }
 
+// Field to filter users by:
+// - `created_at`: RFC3339 timestamp
+// - `id`: user id
+// - `schema`: the schema the user's attributes satisfy, matched against the
+// value the user carries as `schema`
+// - `status`: one of `active`, `suspended`, `deactivated`, `pending_purge`
+// - `lifecycle_owner_team_id`: the team that owns the user's identity
+// lifecycle — who may deprovision them (ADR 024). This is not team
+// participation: a user's roster is a separate collection, read at
+// `GET /users/{user_id}/teams`. The column is nullable for self-owned users,
+// and a null filter value is rejected, so self-owned users cannot be selected
+// by this field.
+// Ref: #
+type UserFilterField string
+
+const (
+	UserFilterFieldCreatedAt            UserFilterField = "created_at"
+	UserFilterFieldID                   UserFilterField = "id"
+	UserFilterFieldSchema               UserFilterField = "schema"
+	UserFilterFieldStatus               UserFilterField = "status"
+	UserFilterFieldLifecycleOwnerTeamID UserFilterField = "lifecycle_owner_team_id"
+)
+
+// AllValues returns all UserFilterField values.
+func (UserFilterField) AllValues() []UserFilterField {
+	return []UserFilterField{
+		UserFilterFieldCreatedAt,
+		UserFilterFieldID,
+		UserFilterFieldSchema,
+		UserFilterFieldStatus,
+		UserFilterFieldLifecycleOwnerTeamID,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s UserFilterField) MarshalText() ([]byte, error) {
+	switch s {
+	case UserFilterFieldCreatedAt:
+		return []byte(s), nil
+	case UserFilterFieldID:
+		return []byte(s), nil
+	case UserFilterFieldSchema:
+		return []byte(s), nil
+	case UserFilterFieldStatus:
+		return []byte(s), nil
+	case UserFilterFieldLifecycleOwnerTeamID:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *UserFilterField) UnmarshalText(data []byte) error {
+	switch UserFilterField(data) {
+	case UserFilterFieldCreatedAt:
+		*s = UserFilterFieldCreatedAt
+		return nil
+	case UserFilterFieldID:
+		*s = UserFilterFieldID
+		return nil
+	case UserFilterFieldSchema:
+		*s = UserFilterFieldSchema
+		return nil
+	case UserFilterFieldStatus:
+		*s = UserFilterFieldStatus
+		return nil
+	case UserFilterFieldLifecycleOwnerTeamID:
+		*s = UserFilterFieldLifecycleOwnerTeamID
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
 type UserID string
 
 // Merged schema.
@@ -41719,6 +42234,74 @@ func (s *UserSchemaProperties) init() UserSchemaProperties {
 		*s = m
 	}
 	return m
+}
+
+// Field to sort users by. Only stored columns are sortable: the keyset cursor
+// holds the last row's sort values, so a value computed per request would skip
+// or duplicate rows between pages.
+// Sorting by `lifecycle_owner_team_id` groups self-owned users together, since
+// the column is null for them.
+// Ref: #
+type UserSortField string
+
+const (
+	UserSortFieldCreatedAt            UserSortField = "created_at"
+	UserSortFieldID                   UserSortField = "id"
+	UserSortFieldSchema               UserSortField = "schema"
+	UserSortFieldStatus               UserSortField = "status"
+	UserSortFieldLifecycleOwnerTeamID UserSortField = "lifecycle_owner_team_id"
+)
+
+// AllValues returns all UserSortField values.
+func (UserSortField) AllValues() []UserSortField {
+	return []UserSortField{
+		UserSortFieldCreatedAt,
+		UserSortFieldID,
+		UserSortFieldSchema,
+		UserSortFieldStatus,
+		UserSortFieldLifecycleOwnerTeamID,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s UserSortField) MarshalText() ([]byte, error) {
+	switch s {
+	case UserSortFieldCreatedAt:
+		return []byte(s), nil
+	case UserSortFieldID:
+		return []byte(s), nil
+	case UserSortFieldSchema:
+		return []byte(s), nil
+	case UserSortFieldStatus:
+		return []byte(s), nil
+	case UserSortFieldLifecycleOwnerTeamID:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *UserSortField) UnmarshalText(data []byte) error {
+	switch UserSortField(data) {
+	case UserSortFieldCreatedAt:
+		*s = UserSortFieldCreatedAt
+		return nil
+	case UserSortFieldID:
+		*s = UserSortFieldID
+		return nil
+	case UserSortFieldSchema:
+		*s = UserSortFieldSchema
+		return nil
+	case UserSortFieldStatus:
+		*s = UserSortFieldStatus
+		return nil
+	case UserSortFieldLifecycleOwnerTeamID:
+		*s = UserSortFieldLifecycleOwnerTeamID
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
 
 // One entry of a user's team roster: a team the user belongs to, with the

--- a/api/generated/oas_security_gen.go
+++ b/api/generated/oas_security_gen.go
@@ -180,6 +180,9 @@ var oauth2ScopesOAuth2 = map[string][]string{
 	QueryTeamsOperation: []string{
 		"team.read",
 	},
+	QueryUsersOperation: []string{
+		"user.read",
+	},
 	RevokeSessionOperation: []string{
 		"session.delete",
 	},

--- a/api/generated/oas_server_gen.go
+++ b/api/generated/oas_server_gen.go
@@ -420,6 +420,15 @@ type Handler interface {
 	//
 	// POST /teams/query
 	QueryTeams(ctx context.Context, req *QueryTeamsRequest, params QueryTeamsParams) (QueryTeamsRes, error)
+	// QueryUsers implements queryUsers operation.
+	//
+	// Returns the users of a project, paginated with a cursor.
+	// The project comes from the credential, not from a parameter: the operation
+	// is bound to the token's own project by construction. This is why it takes
+	// no `project_id`, unlike the other query endpoints.
+	//
+	// POST /users/query
+	QueryUsers(ctx context.Context, req *QueryUsersRequest) (QueryUsersRes, error)
 	// RevokeMySession implements revokeMySession operation.
 	//
 	// Logs out by permanently deleting the session.

--- a/api/generated/oas_unimplemented_gen.go
+++ b/api/generated/oas_unimplemented_gen.go
@@ -563,6 +563,18 @@ func (UnimplementedHandler) QueryTeams(ctx context.Context, req *QueryTeamsReque
 	return r, ht.ErrNotImplemented
 }
 
+// QueryUsers implements queryUsers operation.
+//
+// Returns the users of a project, paginated with a cursor.
+// The project comes from the credential, not from a parameter: the operation
+// is bound to the token's own project by construction. This is why it takes
+// no `project_id`, unlike the other query endpoints.
+//
+// POST /users/query
+func (UnimplementedHandler) QueryUsers(ctx context.Context, req *QueryUsersRequest) (r QueryUsersRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // RevokeMySession implements revokeMySession operation.
 //
 // Logs out by permanently deleting the session.

--- a/api/generated/oas_validators_gen.go
+++ b/api/generated/oas_validators_gen.go
@@ -5213,6 +5213,205 @@ func (s *QueryTeamsResponse) Validate() error {
 	return nil
 }
 
+func (s *QueryUsersRequest) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.Limit.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "limit",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.Sorting.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "sorting",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Filter {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "filter",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *QueryUsersRequestFilterItem) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Field.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "field",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.Value.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "value",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.Operation.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "operation",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *QueryUsersRequestSorting) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Field.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "field",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.Direction.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "direction",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *QueryUsersResponse) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if s.Users == nil {
+			return errors.New("nil is invalid value")
+		}
+		var failures []validate.FieldError
+		for i, elem := range s.Users {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "users",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *RequestAPIEvent) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -6962,6 +7161,23 @@ func (s UserDeletedEventDelegationType) Validate() error {
 	}
 }
 
+func (s UserFilterField) Validate() error {
+	switch s {
+	case "created_at":
+		return nil
+	case "id":
+		return nil
+	case "schema":
+		return nil
+	case "status":
+		return nil
+	case "lifecycle_owner_team_id":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
 func (s UserID) Validate() error {
 	alias := (string)(s)
 	if err := (validate.String{
@@ -7261,6 +7477,23 @@ func (s UserSchemaProperties) Validate() error {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s UserSortField) Validate() error {
+	switch s {
+	case "created_at":
+		return nil
+	case "id":
+		return nil
+	case "schema":
+		return nil
+	case "status":
+		return nil
+	case "lifecycle_owner_team_id":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s *UserTeam) Validate() error {

--- a/api/openapi/endpoints/users/query/methods.yaml
+++ b/api/openapi/endpoints/users/query/methods.yaml
@@ -1,0 +1,48 @@
+post:
+  operationId: queryUsers
+  summary: Query users
+  description: |
+    Returns the users of a project, paginated with a cursor.
+
+    The project comes from the credential, not from a parameter: the operation
+    is bound to the token's own project by construction. This is why it takes
+    no `project_id`, unlike the other query endpoints.
+  tags:
+    - Users
+  security:
+    - oauth2:
+        - user.read
+  requestBody:
+    description: Request to query the users of a project.
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: query-users-request.yaml
+  responses:
+    '200':
+      description: The list of users was returned successfully
+      content:
+        application/json:
+          schema:
+            $ref: query-users-response.yaml
+    '400':
+      description: Invalid request (e.g., unknown filter field or unusable value).
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/error-details.yaml
+    '401':
+      description: Missing or invalid credentials.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/error-details.yaml
+    '403':
+      description: Insufficient permissions.
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/error-details.yaml
+    default:
+      $ref: queryUsers-error-response.yaml

--- a/api/openapi/endpoints/users/query/query-users-request.yaml
+++ b/api/openapi/endpoints/users/query/query-users-request.yaml
@@ -1,0 +1,41 @@
+type: object
+description: Request to query the users of a project.
+properties:
+  limit:
+    $ref: ../../../components/schemas/limit.yaml
+  page_token:
+    description: |
+      Token to retrieve the next page of results. Must be sent with the same
+      `sorting` as the request that issued the token. Omitting `sorting` reuses
+      the default sort and only succeeds when that default matches the token.
+    oneOf:
+      - $ref: ../../../components/schemas/page-token.yaml
+      - type: 'null'
+  sorting:
+    type: object
+    required:
+      - field
+      - direction
+    properties:
+      field:
+        $ref: user-sort-field.yaml
+        description: The field to sort by.
+      direction:
+        $ref: ../../../components/schemas/sort-direction.yaml
+        description: The direction to sort by.
+  filter:
+    type: array
+    description: Filter criteria for querying users. Criteria are combined with AND.
+    items:
+      type: object
+      required:
+        - field
+        - operation
+      properties:
+        field:
+          $ref: user-filter-field.yaml
+          description: The field to filter by.
+        value:
+          $ref: ../../../components/schemas/filter-value.yaml
+        operation:
+          $ref: ../../../components/schemas/filter-operation.yaml

--- a/api/openapi/endpoints/users/query/query-users-response.yaml
+++ b/api/openapi/endpoints/users/query/query-users-response.yaml
@@ -1,0 +1,16 @@
+type: object
+description: Paginated list of users.
+required:
+  - users
+properties:
+  users:
+    type: array
+    items:
+      $ref: ../user.yaml
+  next_page_token:
+    description: |
+      Token to pass as `page_token` in the next request to fetch the following page.
+      Absent when there are no more results.
+    oneOf:
+      - $ref: ../../../components/schemas/page-token.yaml
+      - type: 'null'

--- a/api/openapi/endpoints/users/query/queryUsers-error-response.yaml
+++ b/api/openapi/endpoints/users/query/queryUsers-error-response.yaml
@@ -4,21 +4,21 @@ content:
   application/json:
     schema:
       oneOf:
-        - $ref: '../../components/schemas/errors/auth-unauthorized.yaml'
-        - $ref: '../../components/schemas/errors/internal.yaml'
-        - $ref: '../../components/schemas/errors/not_implemented.yaml'
-        - $ref: '../../components/schemas/errors/req-invalid.yaml'
-        - $ref: '../../components/schemas/errors/user-not_found.yaml'
-        - $ref: '../../components/schemas/errors/user-permission_denied.yaml'
+        - $ref: '../../../components/schemas/errors/auth-unauthorized.yaml'
+        - $ref: '../../../components/schemas/errors/internal.yaml'
+        - $ref: '../../../components/schemas/errors/not_implemented.yaml'
+        - $ref: '../../../components/schemas/errors/req-invalid.yaml'
+        - $ref: '../../../components/schemas/errors/user-not_found.yaml'
+        - $ref: '../../../components/schemas/errors/user-permission_denied.yaml'
       discriminator:
         propertyName: code
         mapping:
-          auth.unauthorized: '../../components/schemas/errors/auth-unauthorized.yaml'
-          internal: '../../components/schemas/errors/internal.yaml'
-          not_implemented: '../../components/schemas/errors/not_implemented.yaml'
-          req.invalid: '../../components/schemas/errors/req-invalid.yaml'
-          user.not_found: '../../components/schemas/errors/user-not_found.yaml'
-          user.permission_denied: '../../components/schemas/errors/user-permission_denied.yaml'
+          auth.unauthorized: '../../../components/schemas/errors/auth-unauthorized.yaml'
+          internal: '../../../components/schemas/errors/internal.yaml'
+          not_implemented: '../../../components/schemas/errors/not_implemented.yaml'
+          req.invalid: '../../../components/schemas/errors/req-invalid.yaml'
+          user.not_found: '../../../components/schemas/errors/user-not_found.yaml'
+          user.permission_denied: '../../../components/schemas/errors/user-permission_denied.yaml'
     examples:
       auth.unauthorized:
         summary: auth.unauthorized

--- a/api/openapi/endpoints/users/query/user-filter-field.yaml
+++ b/api/openapi/endpoints/users/query/user-filter-field.yaml
@@ -1,0 +1,20 @@
+type: string
+description: |
+  Field to filter users by:
+  - `created_at`: RFC3339 timestamp
+  - `id`: user id
+  - `schema`: the schema the user's attributes satisfy, matched against the
+    value the user carries as `schema`
+  - `status`: one of `active`, `suspended`, `deactivated`, `pending_purge`
+  - `lifecycle_owner_team_id`: the team that owns the user's identity
+    lifecycle — who may deprovision them (ADR 024). This is not team
+    participation: a user's roster is a separate collection, read at
+    `GET /users/{user_id}/teams`. The column is nullable for self-owned users,
+    and a null filter value is rejected, so self-owned users cannot be selected
+    by this field.
+enum:
+  - created_at
+  - id
+  - schema
+  - status
+  - lifecycle_owner_team_id

--- a/api/openapi/endpoints/users/query/user-sort-field.yaml
+++ b/api/openapi/endpoints/users/query/user-sort-field.yaml
@@ -1,0 +1,14 @@
+type: string
+description: |
+  Field to sort users by. Only stored columns are sortable: the keyset cursor
+  holds the last row's sort values, so a value computed per request would skip
+  or duplicate rows between pages.
+
+  Sorting by `lifecycle_owner_team_id` groups self-owned users together, since
+  the column is null for them.
+enum:
+  - created_at
+  - id
+  - schema
+  - status
+  - lifecycle_owner_team_id

--- a/api/openapi/openapi-spec.yaml
+++ b/api/openapi/openapi-spec.yaml
@@ -55,6 +55,8 @@ paths:
     $ref: endpoints/readyz/methods.yaml
   /users:
     $ref: endpoints/users/methods.yaml
+  /users/query:
+    $ref: endpoints/users/query/methods.yaml
   /users/{user_id}:
     $ref: endpoints/users/by_id/methods.yaml
   /users/{user_id}/passkeys:

--- a/docs/adrs/027-cursor-based-pagination.md
+++ b/docs/adrs/027-cursor-based-pagination.md
@@ -9,6 +9,9 @@
 > `GET /users` takes `limit` + `page_token`, and the storage layer implements
 > keyset pagination via `ListOptions`/`CursorToken`. *(2026-08-22: `GET /schemas`,
 > the last offset/limit holdout, now pages by cursor — #924.)*
+> *(2026-08-26: `POST /users/query` joins the structured-query contract. It is
+> the first one with no `project_id` parameter — the users list takes its
+> project from the credential.)*
 
 ## Decision
 

--- a/docs/design/api/resource-map.md
+++ b/docs/design/api/resource-map.md
@@ -95,7 +95,11 @@ Create/list with explicit scope:
 ```http
 POST /users?project_id=…        # body: { schema, attributes: { email, ... } }
 GET  /users?limit=…&page_token=…   # cursor-paginated list
+POST /users/query               # structured filters + cursor pagination (ADR 031)
 ```
+
+`POST /users/query` takes no `project_id`, unlike the other query endpoints:
+the users list is bound to the token's own project by construction.
 
 `DELETE /users/{id}` deactivates/tombstones the user, revokes sessions, tokens,
 and credentials, and deactivates memberships. Teams and resources the user

--- a/docs/design/api/system-permission-catalog.md
+++ b/docs/design/api/system-permission-catalog.md
@@ -167,7 +167,7 @@ the corresponding resource permission.
 | Permission | Endpoints | Notes |
 |---|---|---|
 | `user.create` | `POST /users` | |
-| `user.read` | `GET /users`, `GET /users/{id}` | Get + list; full representation for now. |
+| `user.read` | `POST /users/query`, `GET /users`, `GET /users/{id}` | Get + list; full representation for now. `POST /users/query` is the structured-filter list (ADR 031) and, unlike the other query endpoints, takes no `project_id` — the credential's project is the only authority. |
 | `user.write` | `PATCH /users/{id}`, non-credential action verbs (e.g. `verify_email`) | Profile / attribute edits. Does **not** include setting another user's password — see `user.set_password`. `PATCH /users/{id}` is **not yet exposed**. |
 | `user.set_password` | `PUT /users/{id}/password` | **Credential-tier, account-takeover-grade.** Admin sets/resets *another* user's password. Held separately so a profile-editor / help-desk role can hold `user.write` without it. OpenAPI tags this endpoint `user.write` today (see [Drift notes](#drift-notes)). Reserve `user.reset_mfa` / similar for future admin factor-reset endpoints. |
 | `user.delete` | `DELETE /users/{id}` | **Not yet exposed**. |

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -97,6 +97,57 @@ func (h *Handler) ListUsers(ctx context.Context, params api.ListUsersParams) (ap
 	return resp, nil
 }
 
+// QueryUsers is the structured-filter list (ADR 031). Like ListUsers it takes
+// no project parameter: the oauth2 principal is the only authority for which
+// project's users are served, so the scope check is what keeps a browser-plane
+// preview secret out.
+func (h *Handler) QueryUsers(ctx context.Context, req *api.QueryUsersRequest) (api.QueryUsersRes, error) {
+	scopeCtx, _ := GetScopeContext(ctx)
+	ctx, err := h.requireProjectListAccess(ctx, scopeCtx.ProjectID, userAccess, domain.ResourceKindUser)
+	if err != nil {
+		return nil, err
+	}
+
+	users, err := h.userService.ListUsers(ctx, mapQueryUsersToService(scopeCtx.ProjectID, req))
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &api.QueryUsersResponse{
+		Users: make([]api.User, 0, len(users.Items)),
+	}
+	if users.NextPageToken != "" {
+		resp.NextPageToken = api.NewOptNilPageToken(api.PageToken(users.NextPageToken))
+	}
+	for _, user := range users.Items {
+		u, err := domainUserToApiUser(user)
+		if err != nil {
+			return nil, err
+		}
+		resp.Users = append(resp.Users, *u)
+	}
+
+	return resp, nil
+}
+
+func mapQueryUsersToService(projectID string, req *api.QueryUsersRequest) service.ListUsersInput {
+	input := service.ListUsersInput{
+		ProjectID: projectID,
+		// The decoder fills this with the schema's default (20) when the body
+		// omits it, and the schema floors it at 1; the service still normalizes,
+		// which is what bounds callers that reach it without going through HTTP.
+		Limit:     int(req.Limit.Or(0)),
+		PageToken: string(req.PageToken.Or("")),
+	}
+	if sorting, ok := req.Sorting.Get(); ok {
+		input.Sorting = sortingToService(sorting.Field, sorting.Direction)
+	}
+	for _, filter := range req.Filter {
+		input.Filters = append(input.Filters, filterToService(filter.Field, filter.Operation, filter.Value))
+	}
+	return input
+}
+
 func (h *Handler) ListUserPasskeys(ctx context.Context, params api.ListUserPasskeysParams) (api.ListUserPasskeysRes, error) {
 	projectID, err := h.requireResourceAccess(ctx, string(params.UserID), userAccess, opRead)
 	if err != nil {

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -3,12 +3,21 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/zitadel/nextgen/internal/audit"
 	"github.com/zitadel/nextgen/internal/crypto"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/storage/database"
+)
+
+const (
+	userFieldCreatedAt            = "created_at"
+	userFieldID                   = "id"
+	userFieldSchema               = "schema"
+	userFieldStatus               = "status"
+	userFieldLifecycleOwnerTeamID = "lifecycle_owner_team_id"
 )
 
 // ---- Input types -------------------------------------------------------------
@@ -45,6 +54,8 @@ type ListUsersInput struct {
 	ProjectID string
 	PageToken string
 	Limit     int
+	Sorting   *Sorting // optional; defaults to createdAt desc
+	Filters   []Filter
 }
 
 type ListPasskeysInput struct {
@@ -192,18 +203,29 @@ func (s *userService) DeleteUser(ctx context.Context, input DeleteUserInput) err
 }
 
 func (s *userService) ListUsers(ctx context.Context, input ListUsersInput) (*ListUsersOutput, error) {
+	filters := make([]database.Filter[domain.UserField], 0, len(input.Filters)+1)
+	filters = append(filters, database.Equal(database.Col(domain.UserFieldProjectID), input.ProjectID))
+	for _, f := range input.Filters {
+		filter, err := userFilter(f)
+		if err != nil {
+			return nil, err
+		}
+		filters = append(filters, filter)
+	}
+
+	// Newest-first by default, unlike the ascending default the other list
+	// services use: the users list is read as "who signed up recently".
+	orderBy, err := listOrderBy(input.Sorting, domain.UserFieldCreatedAt, database.OrderDesc, userField, domain.UserFieldID)
+	if err != nil {
+		return nil, err
+	}
+
 	result, err := s.v2Pool.Statements().ListUsers(ctx, &database.ListOptions[domain.UserField]{
-		Filter: database.Equal(database.Col(domain.UserFieldProjectID), input.ProjectID),
+		Filter: database.And(filters...),
 		Pagination: database.Page[domain.UserField]{
-			Limit:  uint32(normalizeLimit(input.Limit)),
-			Cursor: []byte(input.PageToken),
-			OrderBy: database.OrderBy[domain.UserField]{
-				Columns: []database.Column[domain.UserField]{
-					database.Col(domain.UserFieldCreatedAt),
-					database.Col(domain.UserFieldID),
-				},
-				Direction: database.OrderDesc,
-			},
+			Limit:   uint32(normalizeLimit(input.Limit)),
+			Cursor:  []byte(input.PageToken),
+			OrderBy: orderBy,
 		},
 	}, UserQueryOptions{})
 	if err != nil {
@@ -214,6 +236,85 @@ func (s *userService) ListUsers(ctx context.Context, input ListUsersInput) (*Lis
 		Items:         result.Items,
 		NextPageToken: string(result.NextCursor),
 	}, nil
+}
+
+// userFilter maps an API filter predicate to a storage filter. Operations the
+// v2 filter layer cannot express return [domain.ErrNotImplemented];
+// invalid field/operation/value combinations return [domain.ErrRequestInvalid].
+func userFilter(f Filter) (database.Filter[domain.UserField], error) {
+	switch f.Field {
+	case userFieldCreatedAt:
+		return createdAtFilter(f.Operation, database.Col(domain.UserFieldCreatedAt), f.Value)
+	case userFieldID:
+		value, err := stringFilterValue(f)
+		if err != nil {
+			return nil, err
+		}
+		return stringFilter(f.Operation, database.Col(domain.UserFieldID), value)
+	case userFieldSchema:
+		value, err := stringFilterValue(f)
+		if err != nil {
+			return nil, err
+		}
+		return stringFilter(f.Operation, database.Col(domain.UserFieldSchemaURL), value)
+	case userFieldStatus:
+		value, err := stringFilterValue(f)
+		if err != nil {
+			return nil, err
+		}
+		return userStatusFilter(f.Operation, value)
+	case userFieldLifecycleOwnerTeamID:
+		// The column is null for self-owned users. `= NULL` matches nothing in
+		// SQL, so a null value would quietly return an empty page; reject it
+		// instead. Selecting self-owned users needs an is-null filter the
+		// storage layer does not have yet.
+		value, err := stringFilterValue(f)
+		if err != nil {
+			return nil, err
+		}
+		return stringFilter(f.Operation, database.Col(domain.UserFieldLifecycleOwnerTeamID), value)
+	default:
+		return nil, domain.ErrRequestInvalid().WithDetails(fmt.Sprintf("unknown field %q", f.Field))
+	}
+}
+
+// userStatusFilter filters on the user's lifecycle status.
+func userStatusFilter(op, status string) (database.Filter[domain.UserField], error) {
+	switch op {
+	case filterOpEquals:
+	case filterOpNotEquals:
+		// todo: update when the operation is supported
+		return nil, domain.ErrNotImplemented().WithDetails(fmt.Sprintf("operation %q is not supported", op))
+	case filterOpContains, filterOpNotContains, filterOpLessThan, filterOpGreaterThan, filterOpLessThanOrEqual, filterOpGreaterThanOrEqual:
+		return nil, domain.ErrRequestInvalid().WithDetails(fmt.Sprintf("operation %q is not valid for this field", op))
+	default:
+		return nil, domain.ErrRequestInvalid().WithDetails(fmt.Sprintf("unknown operation %q", op))
+	}
+
+	switch domain.UserStatus(status) {
+	case domain.UserStatusActive, domain.UserStatusSuspended, domain.UserStatusDeactivated, domain.UserStatusPendingPurge:
+		return database.Equal(database.Col(domain.UserFieldStatus), status), nil
+	default:
+		return nil, domain.ErrRequestInvalid().WithDetails(fmt.Sprintf("unknown status %q", status))
+	}
+}
+
+// userField maps an API field name to its [domain.UserField] for sorting.
+func userField(field string) (domain.UserField, error) {
+	switch field {
+	case userFieldCreatedAt:
+		return domain.UserFieldCreatedAt, nil
+	case userFieldID:
+		return domain.UserFieldID, nil
+	case userFieldSchema:
+		return domain.UserFieldSchemaURL, nil
+	case userFieldStatus:
+		return domain.UserFieldStatus, nil
+	case userFieldLifecycleOwnerTeamID:
+		return domain.UserFieldLifecycleOwnerTeamID, nil
+	default:
+		return domain.UserFieldUnspecified, domain.ErrRequestInvalid().WithDetails(fmt.Sprintf("unknown field %q", field))
+	}
 }
 
 func (s *userService) ListPasskeys(ctx context.Context, input ListPasskeysInput) (passkeys []*domain.UserPasskey, nextPage string, err error) {

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -1,0 +1,221 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+	servicemocks "github.com/zitadel/nextgen/internal/service/mocks"
+	"github.com/zitadel/nextgen/internal/storage/database"
+)
+
+func TestUserService_ListUsers_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   service.ListUsersInput
+		wantErr error
+	}{
+		{
+			name: "unknown filter field is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "owner", Operation: "equals", Value: "x"}},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "unknown sort field is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Sorting:   &service.Sorting{Field: "owner", Direction: "asc"},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "unknown sort direction is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Sorting:   &service.Sorting{Field: "created_at", Direction: "sideways"},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "non-string id value is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "id", Operation: "equals", Value: 42}},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "ordering operation on schema is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "schema", Operation: "greater_than", Value: "sch_1"}},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "not_equals on id not implemented",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "id", Operation: "not_equals", Value: "usr_1"}},
+			},
+			wantErr: domain.ErrNotImplemented(),
+		},
+		{
+			name: "unknown status value is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "status", Operation: "equals", Value: "retired"}},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "contains on status is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "status", Operation: "contains", Value: "act"}},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "not_equals on status not implemented",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "status", Operation: "not_equals", Value: "active"}},
+			},
+			wantErr: domain.ErrNotImplemented(),
+		},
+		{
+			// The column is null for self-owned users and `= NULL` matches
+			// nothing, so a null value must be refused rather than silently
+			// returning an empty page.
+			name: "null lifecycle owner value is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "lifecycle_owner_team_id", Operation: "equals", Value: nil}},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "unparseable created_at value is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "created_at", Operation: "equals", Value: "not-a-time"}},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "non-string created_at value is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "created_at", Operation: "equals", Value: 42}},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Validation fails before storage is reached, so no ListUsers
+			// expectation is set and gomock would flag an unexpected call.
+			svc, _ := newMockedUserService(t)
+
+			out, err := svc.ListUsers(t.Context(), tc.input)
+			require.ErrorIs(t, err, tc.wantErr)
+			assert.Nil(t, out)
+		})
+	}
+}
+
+func TestUserService_ListUsers_TranslatesQuery(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults to created_at desc with id as tiebreaker", func(t *testing.T) {
+		t.Parallel()
+
+		svc, stmts := newMockedUserService(t)
+		var got *database.ListOptions[domain.UserField]
+		stmts.EXPECT().
+			ListUsers(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts *database.ListOptions[domain.UserField], _ service.UserQueryOptions) (*database.ListResult[*domain.User], error) {
+				got = opts
+				return &database.ListResult[*domain.User]{}, nil
+			})
+
+		_, err := svc.ListUsers(t.Context(), service.ListUsersInput{ProjectID: "proj_1"})
+		require.NoError(t, err)
+
+		require.Equal(t, database.OrderDesc, got.Pagination.OrderBy.Direction)
+		require.Len(t, got.Pagination.OrderBy.Columns, 2)
+		assert.Equal(t, domain.UserFieldCreatedAt, got.Pagination.OrderBy.Columns[0].Field())
+		assert.Equal(t, domain.UserFieldID, got.Pagination.OrderBy.Columns[1].Field())
+	})
+
+	t.Run("sorting overrides the default and keeps the id tiebreaker", func(t *testing.T) {
+		t.Parallel()
+
+		svc, stmts := newMockedUserService(t)
+		var got *database.ListOptions[domain.UserField]
+		stmts.EXPECT().
+			ListUsers(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts *database.ListOptions[domain.UserField], _ service.UserQueryOptions) (*database.ListResult[*domain.User], error) {
+				got = opts
+				return &database.ListResult[*domain.User]{}, nil
+			})
+
+		_, err := svc.ListUsers(t.Context(), service.ListUsersInput{
+			ProjectID: "proj_1",
+			Sorting:   &service.Sorting{Field: "status", Direction: "asc"},
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, database.OrderAsc, got.Pagination.OrderBy.Direction)
+		require.Len(t, got.Pagination.OrderBy.Columns, 2)
+		assert.Equal(t, domain.UserFieldStatus, got.Pagination.OrderBy.Columns[0].Field())
+		assert.Equal(t, domain.UserFieldID, got.Pagination.OrderBy.Columns[1].Field())
+	})
+
+	t.Run("every filter field maps and reaches storage", func(t *testing.T) {
+		t.Parallel()
+
+		svc, stmts := newMockedUserService(t)
+		stmts.EXPECT().
+			ListUsers(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&database.ListResult[*domain.User]{}, nil)
+
+		_, err := svc.ListUsers(t.Context(), service.ListUsersInput{
+			ProjectID: "proj_1",
+			Filters: []service.Filter{
+				{Field: "created_at", Operation: "greater_than", Value: time.Now().UTC().Format(time.RFC3339)},
+				{Field: "id", Operation: "equals", Value: "usr_1"},
+				{Field: "schema", Operation: "contains", Value: "sch_"},
+				{Field: "status", Operation: "equals", Value: "active"},
+				{Field: "lifecycle_owner_team_id", Operation: "equals", Value: "team_1"},
+			},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func newMockedUserService(t *testing.T) (service.UserService, *servicemocks.MockAllStatements) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	pool := servicemocks.NewMockPool(ctrl)
+	stmts := servicemocks.NewMockAllStatements(ctrl)
+	pool.EXPECT().Statements().Return(stmts).AnyTimes()
+
+	return service.NewUserService(service.NewPool(pool), nil, nil), stmts
+}


### PR DESCRIPTION
## Summary

This PR adds `POST /users/query`, following the structure defined on [ADR 031](https://github.com/zitadel/nextgen/blob/main/docs/adrs/031-openapi-querying.md), alongside the existing `GET /users` which will be removed on upcoming PR. 


<img width="964" height="599" alt="Screenshot 2026-08-27 at 10 47 23" src="https://github.com/user-attachments/assets/a07f2fbe-2f06-41b4-9783-8a1dd443873d" />

Filter and sort by `created_at`, `id`, `schema`, `status`, or `lifecycle_owner_team_id`, with the same cursor contract as `POST /sessions/query` and `POST /teams/query`.