### PR TITLE
feat(api): filter users by team

### DIFF
--- a/.changeset/filter-users-by-team.md
+++ b/.changeset/filter-users-by-team.md
@@ -1,0 +1,11 @@
+---
+"@zitadel/server": minor
+---
+
+Filter users by team: `POST /users/query` accepts a `team_id` filter field,
+restricting the result to users holding an active membership in that team.
+`equals` only, and it may be given once. It is filterable but not sortable.
+
+As everywhere on the user endpoints, `team_id` is membership, not lifecycle
+ownership — `lifecycle_owner_team_id` is a separate filter field answering a
+different question: which team may deprovision the user.

--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -65411,6 +65411,8 @@ func (s *UserFilterField) Decode(d *jx.Decoder) error {
 		*s = UserFilterFieldSchema
 	case UserFilterFieldStatus:
 		*s = UserFilterFieldStatus
+	case UserFilterFieldTeamID:
+		*s = UserFilterFieldTeamID
 	case UserFilterFieldLifecycleOwnerTeamID:
 		*s = UserFilterFieldLifecycleOwnerTeamID
 	default:

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -41358,12 +41358,21 @@ func (s *UserDeletedEventDelegationType) UnmarshalText(data []byte) error {
 // - `schema`: the schema the user's attributes satisfy, matched against the
 // value the user carries as `schema`
 // - `status`: one of `active`, `suspended`, `deactivated`, `pending_purge`
+// - `team_id`: restricts the result to users holding an **active** membership
+// in that team. A user who has been invited but has not accepted does not
+// match. `equals` is the only operation, and the field may be given once —
+// this names one team, not a set.
 // - `lifecycle_owner_team_id`: the team that owns the user's identity
-// lifecycle — who may deprovision them (ADR 024). This is not team
-// participation: a user's roster is a separate collection, read at
-// `GET /users/{user_id}/teams`. The column is nullable for self-owned users,
-// and a null filter value is rejected, so self-owned users cannot be selected
-// by this field.
+// lifecycle. The column is nullable for self-owned users, and a null filter
+// value is rejected, so self-owned users cannot be selected by this field.
+// **The two team fields answer different questions.** `team_id` is membership:
+// which team the user collaborates in, readable per user at
+// `GET /users/{user_id}/teams`. `lifecycle_owner_team_id` is ownership: which
+// team may deprovision the user. A user can belong to many teams while owning
+// their own lifecycle, so the two disagree often and neither implies the other
+// (ADR 024).
+// `team_id` is filterable but not sortable — it is not a column on the user, so
+// it is absent from the sort-field enum.
 // Ref: #
 type UserFilterField string
 
@@ -41372,6 +41381,7 @@ const (
 	UserFilterFieldID                   UserFilterField = "id"
 	UserFilterFieldSchema               UserFilterField = "schema"
 	UserFilterFieldStatus               UserFilterField = "status"
+	UserFilterFieldTeamID               UserFilterField = "team_id"
 	UserFilterFieldLifecycleOwnerTeamID UserFilterField = "lifecycle_owner_team_id"
 )
 
@@ -41382,6 +41392,7 @@ func (UserFilterField) AllValues() []UserFilterField {
 		UserFilterFieldID,
 		UserFilterFieldSchema,
 		UserFilterFieldStatus,
+		UserFilterFieldTeamID,
 		UserFilterFieldLifecycleOwnerTeamID,
 	}
 }
@@ -41396,6 +41407,8 @@ func (s UserFilterField) MarshalText() ([]byte, error) {
 	case UserFilterFieldSchema:
 		return []byte(s), nil
 	case UserFilterFieldStatus:
+		return []byte(s), nil
+	case UserFilterFieldTeamID:
 		return []byte(s), nil
 	case UserFilterFieldLifecycleOwnerTeamID:
 		return []byte(s), nil
@@ -41418,6 +41431,9 @@ func (s *UserFilterField) UnmarshalText(data []byte) error {
 		return nil
 	case UserFilterFieldStatus:
 		*s = UserFilterFieldStatus
+		return nil
+	case UserFilterFieldTeamID:
+		*s = UserFilterFieldTeamID
 		return nil
 	case UserFilterFieldLifecycleOwnerTeamID:
 		*s = UserFilterFieldLifecycleOwnerTeamID

--- a/api/generated/oas_validators_gen.go
+++ b/api/generated/oas_validators_gen.go
@@ -7131,6 +7131,8 @@ func (s UserFilterField) Validate() error {
 		return nil
 	case "status":
 		return nil
+	case "team_id":
+		return nil
 	case "lifecycle_owner_team_id":
 		return nil
 	default:

--- a/api/openapi/endpoints/users/query/user-filter-field.yaml
+++ b/api/openapi/endpoints/users/query/user-filter-field.yaml
@@ -6,15 +6,27 @@ description: |
   - `schema`: the schema the user's attributes satisfy, matched against the
     value the user carries as `schema`
   - `status`: one of `active`, `suspended`, `deactivated`, `pending_purge`
+  - `team_id`: restricts the result to users holding an **active** membership
+    in that team. A user who has been invited but has not accepted does not
+    match. `equals` is the only operation, and the field may be given once —
+    this names one team, not a set.
   - `lifecycle_owner_team_id`: the team that owns the user's identity
-    lifecycle — who may deprovision them (ADR 024). This is not team
-    participation: a user's roster is a separate collection, read at
-    `GET /users/{user_id}/teams`. The column is nullable for self-owned users,
-    and a null filter value is rejected, so self-owned users cannot be selected
-    by this field.
+    lifecycle. The column is nullable for self-owned users, and a null filter
+    value is rejected, so self-owned users cannot be selected by this field.
+
+  **The two team fields answer different questions.** `team_id` is membership:
+  which team the user collaborates in, readable per user at
+  `GET /users/{user_id}/teams`. `lifecycle_owner_team_id` is ownership: which
+  team may deprovision the user. A user can belong to many teams while owning
+  their own lifecycle, so the two disagree often and neither implies the other
+  (ADR 024).
+
+  `team_id` is filterable but not sortable — it is not a column on the user, so
+  it is absent from the sort-field enum.
 enum:
   - created_at
   - id
   - schema
   - status
+  - team_id
   - lifecycle_owner_team_id

--- a/apps/console/src/components/app-shell/ContextSwitcher.tsx
+++ b/apps/console/src/components/app-shell/ContextSwitcher.tsx
@@ -54,10 +54,10 @@ export function ContextSwitcher() {
 
             - **no current team.** Neither `GET /sessions/me` nor the runtime
               document carries one, so there is nothing to show as selected.
-            - **nothing is team-scoped.** `POST /users/query` takes no `team_id`, and the
-              users and schemas lists are scoped by project, so choosing a team
-              would change nothing on screen. `team_id` exists only as an optional
-              param on create and get-by-id calls.
+            - **nothing is team-scoped yet.** `POST /users/query` now accepts a
+              `team_id` filter, but the console does not send one, and the
+              schemas list is still project-scoped — so choosing a team would
+              change nothing on screen until the users list passes it through.
 
           Restore this when a current team is resolvable and the list reads accept
           it. The plan badge has since been dropped from the design; if it returns,

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -17,6 +17,7 @@ const (
 	userFieldID                   = "id"
 	userFieldSchema               = "schema"
 	userFieldStatus               = "status"
+	userFieldTeamID               = "team_id"
 	userFieldLifecycleOwnerTeamID = "lifecycle_owner_team_id"
 )
 
@@ -203,9 +204,14 @@ func (s *userService) DeleteUser(ctx context.Context, input DeleteUserInput) err
 }
 
 func (s *userService) ListUsers(ctx context.Context, input ListUsersInput) (*ListUsersOutput, error) {
-	filters := make([]database.Filter[domain.UserField], 0, len(input.Filters)+1)
+	columnFilters, queryOpts, err := splitUserFilters(input.Filters)
+	if err != nil {
+		return nil, err
+	}
+
+	filters := make([]database.Filter[domain.UserField], 0, len(columnFilters)+1)
 	filters = append(filters, database.Equal(database.Col(domain.UserFieldProjectID), input.ProjectID))
-	for _, f := range input.Filters {
+	for _, f := range columnFilters {
 		filter, err := userFilter(f)
 		if err != nil {
 			return nil, err
@@ -227,7 +233,7 @@ func (s *userService) ListUsers(ctx context.Context, input ListUsersInput) (*Lis
 			Cursor:  []byte(input.PageToken),
 			OrderBy: orderBy,
 		},
-	}, UserQueryOptions{})
+	}, queryOpts)
 	if err != nil {
 		return nil, mapListError(err, "failed to list users from database")
 	}
@@ -238,9 +244,44 @@ func (s *userService) ListUsers(ctx context.Context, input ListUsersInput) (*Lis
 	}, nil
 }
 
+// splitUserFilters separates the predicates that compile to a filter on the
+// users row from the one that does not. Team membership lives in another
+// table and reaches the query as [UserQueryOptions.MembershipTeamID], which
+// the dialects compile to an EXISTS clause — the same shape
+// [UserQueryOptions.Attributes] already uses for the EAV match.
+func splitUserFilters(filters []Filter) ([]Filter, UserQueryOptions, error) {
+	var (
+		columns []Filter
+		opts    UserQueryOptions
+	)
+	for _, f := range filters {
+		if f.Field != userFieldTeamID {
+			columns = append(columns, f)
+			continue
+		}
+		// The storage option holds one team and ADR 031 ANDs filters, so a
+		// second value would silently win over the first. Refuse instead.
+		if opts.MembershipTeamID != nil {
+			return nil, UserQueryOptions{}, domain.ErrRequestInvalid().
+				WithDetails(fmt.Sprintf("%s may only be given once", userFieldTeamID))
+		}
+		if f.Operation != filterOpEquals {
+			return nil, UserQueryOptions{}, domain.ErrRequestInvalid().
+				WithDetails(fmt.Sprintf("operation %q is not valid for %s", f.Operation, userFieldTeamID))
+		}
+		teamID, err := stringFilterValue(f)
+		if err != nil {
+			return nil, UserQueryOptions{}, err
+		}
+		opts.MembershipTeamID = &teamID
+	}
+	return columns, opts, nil
+}
+
 // userFilter maps an API filter predicate to a storage filter. Operations the
 // v2 filter layer cannot express return [domain.ErrNotImplemented];
 // invalid field/operation/value combinations return [domain.ErrRequestInvalid].
+// [splitUserFilters] has already taken team_id out.
 func userFilter(f Filter) (database.Filter[domain.UserField], error) {
 	switch f.Field {
 	case userFieldCreatedAt:
@@ -312,6 +353,11 @@ func userField(field string) (domain.UserField, error) {
 		return domain.UserFieldStatus, nil
 	case userFieldLifecycleOwnerTeamID:
 		return domain.UserFieldLifecycleOwnerTeamID, nil
+	case userFieldTeamID:
+		// Not a column on the user: the keyset cursor is built from the last
+		// row's sort values, and there is no membership value on that row.
+		return domain.UserFieldUnspecified, domain.ErrRequestInvalid().
+			WithDetails(fmt.Sprintf("%s can be filtered but not sorted", userFieldTeamID))
 	default:
 		return domain.UserFieldUnspecified, domain.ErrRequestInvalid().WithDetails(fmt.Sprintf("unknown field %q", field))
 	}

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -107,6 +107,43 @@ func TestUserService_ListUsers_ValidationErrors(t *testing.T) {
 			wantErr: domain.ErrRequestInvalid(),
 		},
 		{
+			name: "team_id cannot be sorted by",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Sorting:   &service.Sorting{Field: "team_id", Direction: "asc"},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			// The storage option holds one team and filters are ANDed, so a
+			// second value would silently win over the first.
+			name: "team_id given twice is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters: []service.Filter{
+					{Field: "team_id", Operation: "equals", Value: "team_1"},
+					{Field: "team_id", Operation: "equals", Value: "team_2"},
+				},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "contains on team_id is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "team_id", Operation: "contains", Value: "team_"}},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
+			name: "non-string team_id value is invalid",
+			input: service.ListUsersInput{
+				ProjectID: "proj_1",
+				Filters:   []service.Filter{{Field: "team_id", Operation: "equals", Value: 42}},
+			},
+			wantErr: domain.ErrRequestInvalid(),
+		},
+		{
 			name: "unparseable created_at value is invalid",
 			input: service.ListUsersInput{
 				ProjectID: "proj_1",
@@ -202,10 +239,57 @@ func TestUserService_ListUsers_TranslatesQuery(t *testing.T) {
 				{Field: "id", Operation: "equals", Value: "usr_1"},
 				{Field: "schema", Operation: "contains", Value: "sch_"},
 				{Field: "status", Operation: "equals", Value: "active"},
-				{Field: "lifecycle_owner_team_id", Operation: "equals", Value: "team_1"},
+				{Field: "team_id", Operation: "equals", Value: "team_1"},
+				{Field: "lifecycle_owner_team_id", Operation: "equals", Value: "team_2"},
 			},
 		})
 		require.NoError(t, err)
+	})
+
+	// Membership is not a column on the user, so it must not become a
+	// database.Filter — it reaches storage as the EXISTS option instead.
+	t.Run("team_id reaches storage as a query option, not a filter", func(t *testing.T) {
+		t.Parallel()
+
+		svc, stmts := newMockedUserService(t)
+		var gotOpts service.UserQueryOptions
+		var gotList *database.ListOptions[domain.UserField]
+		stmts.EXPECT().
+			ListUsers(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, opts *database.ListOptions[domain.UserField], q service.UserQueryOptions) (*database.ListResult[*domain.User], error) {
+				gotList = opts
+				gotOpts = q
+				return &database.ListResult[*domain.User]{}, nil
+			})
+
+		_, err := svc.ListUsers(t.Context(), service.ListUsersInput{
+			ProjectID: "proj_1",
+			Filters:   []service.Filter{{Field: "team_id", Operation: "equals", Value: "team_1"}},
+		})
+		require.NoError(t, err)
+
+		require.NotNil(t, gotOpts.MembershipTeamID)
+		assert.Equal(t, "team_1", *gotOpts.MembershipTeamID)
+		// Only the implicit project predicate is left on the row filter.
+		assert.NotNil(t, gotList.Filter)
+	})
+
+	t.Run("no membership filter leaves the query option unset", func(t *testing.T) {
+		t.Parallel()
+
+		svc, stmts := newMockedUserService(t)
+		var gotOpts service.UserQueryOptions
+		stmts.EXPECT().
+			ListUsers(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *database.ListOptions[domain.UserField], q service.UserQueryOptions) (*database.ListResult[*domain.User], error) {
+				gotOpts = q
+				return &database.ListResult[*domain.User]{}, nil
+			})
+
+		_, err := svc.ListUsers(t.Context(), service.ListUsersInput{ProjectID: "proj_1"})
+		require.NoError(t, err)
+
+		assert.Nil(t, gotOpts.MembershipTeamID)
 	})
 }
 


### PR DESCRIPTION
## Summary

`POST /users/query` accepts a `team_id` filter field, restricting the result to users holding an active membership in that team.

No storage work. The `EXISTS` clause already existed in all three dialects behind `UserQueryOptions.MembershipTeamID` — it was only reachable from `GET /users/{user_id}`. This exposes it on the list.

## Three decisions

**It cannot be a `database.Filter`.** That machinery binds to columns on the users row via `v2user.Schema`; membership lives in `team_memberships`. `splitUserFilters` routes it to `UserQueryOptions` instead — the same shape `UserQueryOptions.Attributes` already uses for the EAV match, which compiles to an `EXISTS` clause right beside this one. Some user predicates travel out-of-band; that is the existing pattern, not a new one.

**Filterable, not sortable.** It is absent from `user-sort-field.yaml`, and `userField` refuses it explicitly with that reason rather than letting it fall into the unknown-field case. The keyset cursor is built from the last row's sort values and there is no membership value on that row — the same argument `session-sort-field.yaml` already makes for `state`. This is what the separate filter/sort enums in #981 were for.

**Given twice, it is refused.** The storage option holds one team and ADR 031 ANDs filters, so a second value would silently win over the first. Rejecting beats picking.

## Naming

`team_id`, matching the parameter everywhere else. It sits next to `lifecycle_owner_team_id` in the same enum, which is exactly where the two are easiest to confuse, so the enum description carries the distinction in full: `team_id` is membership (which team the user collaborates in), `lifecycle_owner_team_id` is ownership (which team may deprovision them). They disagree often and neither implies the other — ADR 024, amended in #980.

Only **active** memberships match, consistent with `GET /users/{user_id}?team_id=`. A pending invitee does not appear.

## Notes

Stacked on #982 → #981 → #980. Next PR adds `expand: ["teams"]` plus ADR 056.
