### PR TITLE
feat: resolve the flow identifier from the schema designation

### DIFF
--- a/.changeset/flow-identifier-designation.md
+++ b/.changeset/flow-identifier-designation.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": minor
+---
+
+Login flows resolve the identifier from the schema's designation: a flow field carries the identifier challenge only when it names the schema-root `x-identifier` property. Other unique properties keep their uniqueness for storage but are no longer treated as login identifiers.

--- a/.changeset/flow-identifier-designation.md
+++ b/.changeset/flow-identifier-designation.md
@@ -1,5 +1,6 @@
 ---
 "@zitadel/server": minor
+"@zitadel/config": minor
 ---
 
 Login flows resolve the identifier from the schema's designation: a flow field carries the identifier challenge only when it names the schema-root `x-identifier` property. Other unique properties keep their uniqueness for storage but are no longer treated as login identifiers.

--- a/api/openapi/endpoints/flow_definitions/examples_test.go
+++ b/api/openapi/endpoints/flow_definitions/examples_test.go
@@ -24,6 +24,7 @@ var exampleUserSchema = []byte(`{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/schemas/flow-engine-examples-user.json",
   "type": "object",
+  "x-identifier": "email",
   "required": ["email"],
   "x-auth-methods": {
     "password": { "enabled": true },

--- a/internal/domain/flow_definition_validator_test.go
+++ b/internal/domain/flow_definition_validator_test.go
@@ -38,6 +38,7 @@ var tenantUserSchemaNoAuthMethod = []byte(`{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tenant.com/schemas/no-auth-methods.json",
   "type": "object",
+  "x-identifier": "email",
   "required": ["email"],
   "properties": {
     "email": { "type": "string", "format": "email", "x-unique": "team" }
@@ -48,6 +49,7 @@ var tenantUserSchemaEmptyAuthMethod = []byte(`{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tenant.com/schemas/empty-auth-methods.json",
   "type": "object",
+  "x-identifier": "email",
   "required": ["email"],
   "x-auth-methods": {},
   "properties": {
@@ -59,6 +61,7 @@ var tenantUserSchemaDisabledAuthMethod = []byte(`{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tenant.com/schemas/disabled-auth-user.json",
   "type": "object",
+  "x-identifier": "email",
   "required": ["email"],
   "x-auth-methods": {
     "password": { "enabled": false }
@@ -72,6 +75,7 @@ var userSchemaIDAndPassword = []byte(`{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tenant.com/schemas/idpw-user.json",
   "type": "object",
+  "x-identifier": "email",
   "required": ["email"],
   "x-auth-methods": {
     "password": { "enabled": true }
@@ -85,6 +89,7 @@ var userSchemaPasskeyEnabled = []byte(`{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tenant.com/schemas/passkey-user.json",
   "type": "object",
+  "x-identifier": "email",
   "required": ["email"],
   "x-auth-methods": {
     "password": { "enabled": true },
@@ -99,6 +104,7 @@ var userSchemaPasskeyDisabled = []byte(`{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tenant.com/schemas/passkey-disabled-user.json",
   "type": "object",
+  "x-identifier": "email",
   "required": ["email"],
   "x-auth-methods": {
     "password": { "enabled": true },

--- a/internal/domain/flow_field_resolver.go
+++ b/internal/domain/flow_field_resolver.go
@@ -9,8 +9,8 @@ import (
 
 // FlowFieldResolver maps property names referenced by a flow step to
 // fully-resolved [FlowField] payloads, surfaces the implicit transition
-// outcomes the schema implies (a property with `x-unique` set implies a
-// `user_not_found` outcome), and validates submitted values against the
+// outcomes the schema implies (the designated `x-identifier` property
+// implies a `user_not_found` outcome), and validates submitted values against the
 // schema-derived rules.
 //
 // The contract is shaped to the user meta-schema at
@@ -85,10 +85,10 @@ type FlowField struct {
 
 	// Challenge names the auth-attempt challenge the field maps to, or
 	// [FlowFieldChallengeNone] when the field carries neither an
-	// identifier nor a credential proof. Derivation paths: a non-empty
-	// `x-unique` annotation on the property surfaces as
-	// [FlowFieldChallengeIdentifier] (any uniquely-keyed property can
-	// identify a user); the reserved `x-auth-methods#password` field
+	// identifier nor a credential proof. Derivation paths: the field
+	// naming the schema's designated identifier (the schema-root
+	// `x-identifier` path, ADR 058) surfaces as
+	// [FlowFieldChallengeIdentifier]; the reserved `x-auth-methods#password` field
 	// name combined with `x-auth-methods.password.enabled = true` at
 	// the schema root surfaces as [FlowFieldChallengePassword]. Other
 	// credential kinds (passkey, magic_link, sso, otp) do not have
@@ -103,8 +103,8 @@ type FlowField struct {
 // FlowFieldChallenge names the auth-attempt challenge a field maps
 // to. Values mirror the keys of `x-auth-methods` in the user
 // meta-schema (api/openapi/endpoints/schemas/user-schema.yaml).
-// `identifier` is sourced from a non-empty `x-unique` scope on the
-// property; `password` is sourced from the reserved
+// `identifier` is sourced from the schema-root `x-identifier`
+// designation; `password` is sourced from the reserved
 // `x-auth-methods#password` field name combined with
 // `x-auth-methods.password.enabled` at the schema root. The remaining
 // credential values (passkey, magic_link, sso, otp) have no

--- a/internal/domain/flow_field_resolver_schema.go
+++ b/internal/domain/flow_field_resolver_schema.go
@@ -31,7 +31,8 @@ type SchemaResolver interface {
 //   - `x-unique` (non-empty) → [FlowField.Unique]
 //   - the schema-root `x-identifier` designation → the designated field
 //     carries [FlowFieldChallengeIdentifier] +
-//     [FlowImplicitOutcomeUserNotFound]
+//     [FlowImplicitOutcomeUserNotFound] +
+//     [FlowImplicitOutcomeUserAlreadyExists]
 //   - `x-auth-methods#<method>` field name → credential challenge for
 //     that method (e.g. `x-auth-methods#password` → password)
 type SchemaFieldResolver struct{}

--- a/internal/domain/flow_field_resolver_schema.go
+++ b/internal/domain/flow_field_resolver_schema.go
@@ -28,8 +28,10 @@ type SchemaResolver interface {
 //   - `required` membership at every level of the field's path →
 //     [FlowField.Required]
 //   - `minLength`, `maxLength`, `format` → [FlowFieldValidation]
-//   - `x-unique` (non-empty) → [FlowFieldChallengeIdentifier] +
-//     [FlowImplicitOutcomeUserNotFound] + [FlowField.Unique]
+//   - `x-unique` (non-empty) → [FlowField.Unique]
+//   - the schema-root `x-identifier` designation → the designated field
+//     carries [FlowFieldChallengeIdentifier] +
+//     [FlowImplicitOutcomeUserNotFound]
 //   - `x-auth-methods#<method>` field name → credential challenge for
 //     that method (e.g. `x-auth-methods#password` → password)
 type SchemaFieldResolver struct{}
@@ -47,6 +49,7 @@ func (r *SchemaFieldResolver) Resolve(schema *jsonschema.Schema, stepName string
 	if err != nil {
 		return FlowResolvedFields{}, fmt.Errorf("flow field resolver: read x-auth-methods: %w", err)
 	}
+	identifier := root.String(SchemaAnnotationIdentifier)
 
 	fields := make([]FlowField, 0, len(fieldNames))
 	implicit := make(map[string][]string)
@@ -60,7 +63,7 @@ func (r *SchemaFieldResolver) Resolve(schema *jsonschema.Schema, stepName string
 		case field.IsAuthMethod():
 			ff, err = resolveAuthMethodField(authMethods, field, stepName)
 		default:
-			ff, err = resolveUserPropertyField(root, field, stepName)
+			ff, err = resolveUserPropertyField(root, field, stepName, identifier)
 		}
 		if err != nil {
 			return FlowResolvedFields{}, err
@@ -83,7 +86,7 @@ func (r *SchemaFieldResolver) Resolve(schema *jsonschema.Schema, stepName string
 // [ErrFlowFieldNotScalar] when it lands on an object or array, and
 // [ErrFlowFieldUnsupportedType] when the JSON `type` keyword is an
 // ambiguous union.
-func resolveUserPropertyField(root schemaReader, field Field, stepName string) (FlowField, error) {
+func resolveUserPropertyField(root schemaReader, field Field, stepName, identifier string) (FlowField, error) {
 	prop, required, err := walkUserProperty(root, field)
 	if err != nil {
 		return FlowField{}, err
@@ -100,7 +103,7 @@ func resolveUserPropertyField(root schemaReader, field Field, stepName string) (
 		Name:      field.String(),
 		TextKey:   stepName + ".field." + field.String(),
 		Type:      fieldType,
-		Challenge: deriveIdentifierChallenge(unique),
+		Challenge: deriveIdentifierChallenge(field, identifier),
 		Unique:    unique,
 		Required:  required,
 	}
@@ -207,10 +210,13 @@ func deriveAuthMethodType(field Field) (FlowFieldType, error) {
 }
 
 // deriveIdentifierChallenge surfaces [FlowFieldChallengeIdentifier]
-// when the property has any non-empty `x-unique` scope. Any uniquely-
-// keyed property can identify a user.
-func deriveIdentifierChallenge(unique AttributeUniqueness) FlowFieldChallenge {
-	if unique != AttributeUniquenessUnspecified {
+// when the field names the schema's designated identifier (the
+// schema-root `x-identifier` path). Any other property — unique or not —
+// carries no identifier challenge: uniqueness is data integrity,
+// identification is a designation (ADR 058 §5, retiring the "any
+// `x-unique` property can identify" rule).
+func deriveIdentifierChallenge(field Field, identifier string) FlowFieldChallenge {
+	if identifier != "" && field.String() == identifier {
 		return FlowFieldChallengeIdentifier
 	}
 	return FlowFieldChallengeNone

--- a/internal/domain/flow_field_resolver_schema_test.go
+++ b/internal/domain/flow_field_resolver_schema_test.go
@@ -56,6 +56,7 @@ const defaultSchemaContent string = `{
 		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"type": "object",
 		"x-auth-methods": { "password": { "enabled": true }, "passkey": { "enabled": true } },
+		"x-identifier": "email",
 		"required": ["email", "username", "given_name", "family_name"],
 		"properties": {
 			"email":       { "type": "string", "format": "email", "maxLength": 320, "x-unique": "team" },
@@ -146,9 +147,10 @@ func TestSchemaFieldResolver_Resolve(t *testing.T) {
 			},
 		},
 		{
-			name: "x-unique=team surfaces identifier challenge plus implicit outcomes",
+			name: "the designated identifier surfaces the challenge plus implicit outcomes",
 			schema: `{
 				"type": "object",
+				"x-identifier": "email",
 				"properties": {
 					"email": { "type": "string", "format": "email", "x-unique": "team" }
 				}
@@ -170,7 +172,7 @@ func TestSchemaFieldResolver_Resolve(t *testing.T) {
 			},
 		},
 		{
-			name: "x-unique=project surfaces project-scoped uniqueness",
+			name: "x-unique alone carries uniqueness but no identifier challenge",
 			schema: `{
 				"type": "object",
 				"properties": {
@@ -182,14 +184,13 @@ func TestSchemaFieldResolver_Resolve(t *testing.T) {
 			want: domain.FlowResolvedFields{
 				Fields: []domain.FlowField{
 					{
-						Name:      "handle",
-						TextKey:   "step.field.handle",
-						Type:      domain.FlowFieldTypeText,
-						Challenge: domain.FlowFieldChallengeIdentifier,
-						Unique:    domain.AttributeUniquenessProject,
+						Name:    "handle",
+						TextKey: "step.field.handle",
+						Type:    domain.FlowFieldTypeText,
+						Unique:  domain.AttributeUniquenessProject,
 					},
 				},
-				ImplicitOutcomes: map[string][]string{"handle": identifierOutcomes},
+				ImplicitOutcomes: map[string][]string{},
 			},
 		},
 		{
@@ -266,6 +267,7 @@ func TestSchemaFieldResolver_Resolve(t *testing.T) {
 			name: "mixed user-property and auth-method fields preserve input order",
 			schema: `{
 				"type": "object",
+				"x-identifier": "email",
 				"x-auth-methods": { "password": { "enabled": true } },
 				"properties": {
 					"email": { "type": "string", "format": "email", "x-unique": "team" }
@@ -450,21 +452,50 @@ func TestSchemaFieldResolver_Resolve(t *testing.T) {
 			},
 		},
 		{
-			name:   "x-unique on a nested leaf makes it an identifier",
+			name: "a designated nested leaf is an identifier",
+			schema: `{
+				"type": "object",
+				"x-identifier": "account.email",
+				"properties": {
+					"account": {
+						"type": "object",
+						"properties": {
+							"email": { "type": "string", "format": "email", "x-unique": "project" }
+						}
+					}
+				}
+			}`,
+			step:   "identifier",
+			fields: []domain.Field{"account.email"},
+			want: domain.FlowResolvedFields{
+				Fields: []domain.FlowField{
+					{
+						Name:       "account.email",
+						TextKey:    "identifier.field.account.email",
+						Type:       domain.FlowFieldTypeEmail,
+						Challenge:  domain.FlowFieldChallengeIdentifier,
+						Unique:     domain.AttributeUniquenessProject,
+						Validation: &domain.FlowFieldValidation{Format: "email"},
+					},
+				},
+				ImplicitOutcomes: map[string][]string{"account.email": identifierOutcomes},
+			},
+		},
+		{
+			name:   "an undesignated nested unique leaf carries no challenge",
 			schema: nestedSchemaContent,
 			step:   "profile",
 			fields: []domain.Field{"address.zip"},
 			want: domain.FlowResolvedFields{
 				Fields: []domain.FlowField{
 					{
-						Name:      "address.zip",
-						TextKey:   "profile.field.address.zip",
-						Type:      domain.FlowFieldTypeText,
-						Challenge: domain.FlowFieldChallengeIdentifier,
-						Unique:    domain.AttributeUniquenessProject,
+						Name:    "address.zip",
+						TextKey: "profile.field.address.zip",
+						Type:    domain.FlowFieldTypeText,
+						Unique:  domain.AttributeUniquenessProject,
 					},
 				},
-				ImplicitOutcomes: map[string][]string{"address.zip": identifierOutcomes},
+				ImplicitOutcomes: map[string][]string{},
 			},
 		},
 		{

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -753,16 +753,21 @@ func anyVisitedStepOnSuccess(def *FlowDefinition, state *FlowState, current *Flo
 	return false
 }
 
-// identifierFieldValues returns every identifier-class field with a collected
+// uniqueFieldValues returns every uniquely-keyed field with a collected
 // value, in field order and deduplicated by name across the given resolved
-// sets. Every x-unique property resolves as an identifier field, so this is
-// the candidate list for locating the owner of a conflicting unique value.
-func identifierFieldValues(values map[string]any, resolvedSets ...FlowResolvedFields) [][2]string {
+// sets. Conflict re-resolution is about uniqueness, not identification
+// (ADR 058): the race was lost on some unique attribute, designated or
+// not, so the candidate list keys on FlowField.Unique — the designated
+// identifier alone would miss an undesignated unique attribute (a taken
+// username beside a fresh email). The lookup behind SubmitIdentifier goes
+// through the unique-attributes registry, so probing any unique attribute
+// is well-defined regardless of designation.
+func uniqueFieldValues(values map[string]any, resolvedSets ...FlowResolvedFields) [][2]string {
 	var out [][2]string
 	seen := map[string]bool{}
 	for _, resolved := range resolvedSets {
 		for _, field := range resolved.Fields {
-			if field.Challenge != FlowFieldChallengeIdentifier || seen[field.Name] {
+			if field.Unique == AttributeUniquenessUnspecified || seen[field.Name] {
 				continue
 			}
 			raw, present := values[field.Name]
@@ -877,14 +882,14 @@ func (r *FlowStateMachineRuntime) processPasskey(pc *processCtx, resolved FlowRe
 				// existing user on the attempt before routing — and the
 				// downstream password step requires a persisted user factor —
 				// so re-resolve the conflicting owner here to land in the
-				// same state. Every x-unique property resolves as an
-				// identifier-class field, so trying each collected one finds
-				// the owner even when the race was lost on a non-identifier
-				// unique attribute (e.g. a fresh email but a taken phone).
+				// same state. Trying every collected uniquely-keyed field
+				// finds the owner even when the race was lost on an
+				// undesignated unique attribute (e.g. a fresh email but a
+				// taken phone).
 				clearUserBoundState(state)
-				candidates := identifierFieldValues(state.CollectedData.UserData, passkeyResolved)
+				candidates := uniqueFieldValues(state.CollectedData.UserData, passkeyResolved)
 				if visited, verr := r.resolveVisitedFields(pc); verr == nil {
-					candidates = identifierFieldValues(state.CollectedData.UserData, passkeyResolved, visited)
+					candidates = uniqueFieldValues(state.CollectedData.UserData, passkeyResolved, visited)
 				}
 				for _, candidate := range candidates {
 					userID, rerr := r.authAttempts.SubmitIdentifier(ctx, FlowSubmitIdentifierInput{

--- a/internal/domain/flow_state_machine.go
+++ b/internal/domain/flow_state_machine.go
@@ -1208,13 +1208,22 @@ func (r *FlowStateMachineRuntime) resolveStepFields(ctx context.Context, state *
 // progress, not just the current step.
 func (r *FlowStateMachineRuntime) resolveVisitedFields(pc *processCtx) (FlowResolvedFields, error) {
 	ctx, def, state, current := pc.ctx, pc.def, pc.state, pc.currentStep
+	// First-encounter order, not map order: consumers walk these fields
+	// positionally (uniqueFieldValues promises field order), so the union
+	// must be deterministic — visited steps in history order, fields in
+	// their step order.
 	seen := map[Field]struct{}{}
+	names := make([]Field, 0, 8)
 	collect := func(s *FlowDefinitionStep) {
 		if s == nil {
 			return
 		}
 		for _, f := range s.Fields {
+			if _, ok := seen[f]; ok {
+				continue
+			}
 			seen[f] = struct{}{}
+			names = append(names, f)
 		}
 	}
 	for _, name := range state.History {
@@ -1223,12 +1232,8 @@ func (r *FlowStateMachineRuntime) resolveVisitedFields(pc *processCtx) (FlowReso
 		}
 	}
 	collect(current)
-	if len(seen) == 0 {
+	if len(names) == 0 {
 		return FlowResolvedFields{}, nil
-	}
-	names := make([]Field, 0, len(seen))
-	for n := range seen {
-		names = append(names, n)
 	}
 	schema, err := r.schemas.Resolve(ctx, r.schemaStore, state.ProjectID, state.UserSchemaURL, nil)
 	if err != nil {

--- a/packages/config/src/validate.test.ts
+++ b/packages/config/src/validate.test.ts
@@ -71,6 +71,18 @@ describe("validateFlowDefinition — valid flows", () => {
     expect(validateFlowDefinition(flow())).toEqual([]);
   });
 
+  it("does not treat an undesignated unique field as an identifier", () => {
+    // Mirrors the Go resolver (ADR 057): x-unique alone no longer carries
+    // the identifier challenge, so the login path loses its identifier and
+    // the on_success manifest fails upstream.
+    const undesignated = structuredClone(schema);
+    delete undesignated["x-identifier"];
+    const msgs = messages(errors(validateFlowDefinition(flow(), undesignated)));
+    expect(msgs.some((m) => m.includes('requires "identifier" to be collected upstream'))).toBe(
+      true,
+    );
+  });
+
   it("accepts a login-only flow without user_not_found (no register purpose)", () => {
     const def = flow();
     def.purposes = { login: "identifier" };

--- a/packages/config/src/validate.ts
+++ b/packages/config/src/validate.ts
@@ -713,10 +713,11 @@ function resolveFieldChallenge(
     };
   }
 
-  // Mirrors deriveUnique + deriveIdentifierChallenge: any recognized
-  // non-empty x-unique scope makes the property an identifier.
-  const unique = property["x-unique"];
-  if (unique === "project" || unique === "team") {
+  // Mirrors deriveIdentifierChallenge: the field naming the schema-root
+  // `x-identifier` designation is the identifier (ADR 057); other
+  // properties — unique or not — carry no identifier challenge.
+  const identifier = schema["x-identifier"];
+  if (typeof identifier === "string" && identifier !== "" && field === identifier) {
     return { challenge: "identifier" };
   }
   return { challenge: null };


### PR DESCRIPTION
## Summary

Second half of ADR 058 Phase A, **stacked on #987** (retargets to `main` when that merges).

The field resolver derived `FlowFieldChallengeIdentifier` from *any* non-empty `x-unique` scope — the rule #142 introduced when the original `x-identifier` annotation was dropped. With the designation back:

- A flow field carries the identifier challenge (and the `user_not_found` / `user_already_exists` implicit outcomes) **only when it names the schema-root `x-identifier` path** — top-level or nested, same dotted addressing as attribute rows.
- Other unique properties keep `FlowField.Unique` for storage-side uniqueness but become plain collected fields — registration can gather unique values that are not login identifiers. Uniqueness is data integrity; identification is a designation.
- **Passkey conflict re-resolution is re-keyed on uniqueness** (`uniqueFieldValues`, was `identifierFieldValues`): the owner-pinning walk after a lost registration race depends on probing *every* collected unique attribute, designated or not — keying it on the identifier challenge would have missed a taken username beside a fresh email. The lookup behind `SubmitIdentifier` goes through the unique-attributes registry, so probing any unique attribute is well-defined regardless of designation.
- The **TypeScript mirror** (`packages/config/src/validate.ts`, the CLI-side flow validator) switches identically, with a test pinning that an undesignated unique field no longer satisfies the login path's identifier manifest.
- **No flow-definition validation change needed**: a non-designated field simply stops being an identifier field, and `user_not_found` remains a valid reserved transition key.

Shipped presets are unaffected: `default-login` and `passkey-first` both collect `email`, which the default schema designates (#987). No flow-definition shapes change, so no `@zitadel/api-mock` fixture updates per its parity rule.

## Validation

- Resolver cases pin both directions (designated top-level and nested leaves are identifiers; `x-unique` alone carries uniqueness but no challenge, at both depths).
- `TestFlowStateMachine_Process_PasskeyRegisterConflictOnSecondUniqueField` (main's owner-pinning feature) passes repeatedly on this branch after the re-key. The flake that test showed on `main` (#1058) is root-caused and fixed here too: `resolveVisitedFields` resolved its field union in map order, so the probe order the sister function promises ("field order") was random per run — the union now keeps first-encounter order (fixes #1058).
- Full untagged `go test ./internal/... ./api/...` green; flow state machine and flow-definition validator suites run against designating schemas.

## Release notes / changeset

`.changeset/flow-identifier-designation.md` — minor for `@zitadel/server`.

## Notes

- Behavioral change by design (pre-release): a tenant flow offering a unique-but-undesignated field as its login input stops resolving users through it; the schema author designates that property to restore it.
- With this, Phase A is complete; Phase B (direct-API `IdentifierProof` resolution against the designation) builds on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)