### PR TITLE
refactor: read schema annotations through the domain constants

### DIFF
--- a/internal/domain/attribute.go
+++ b/internal/domain/attribute.go
@@ -180,11 +180,11 @@ func (attrs *CreateAttributes) fromMap(m map[string]any, schema map[string]any, 
 			}
 		default:
 			var unique AttributeUniqueness
-			strUnique, _ := maputil.GetNested[string](schema, []string{"properties", key, "x-unique"})
+			strUnique, _ := maputil.GetNested[string](schema, []string{"properties", key, SchemaAnnotationUnique})
 			switch strUnique {
-			case "project":
+			case SchemaUniqueScopeProject:
 				unique = AttributeUniquenessProject
-			case "team":
+			case SchemaUniqueScopeTeam:
 				unique = AttributeUniquenessTeam
 			}
 			attr, err := NewCreateAttribute(fullKey, value, unique)

--- a/internal/domain/flow_definition.go
+++ b/internal/domain/flow_definition.go
@@ -182,7 +182,7 @@ type FlowDefinitionAudience struct {
 // authMethodPrefix marks a step.fields entry as referring to an entry
 // under the user schema's `x-auth-methods` keyword (e.g.
 // "x-auth-methods#password") rather than to a user property.
-const authMethodPrefix = "x-auth-methods#"
+const authMethodPrefix = SchemaAnnotationAuthMethods + "#"
 
 // Field carries the raw field name from a flow-definition step.
 type Field string

--- a/internal/domain/flow_field_resolver_schema.go
+++ b/internal/domain/flow_field_resolver_schema.go
@@ -224,10 +224,10 @@ func deriveIdentifierChallenge(field Field, identifier string) FlowFieldChalleng
 }
 
 func deriveUnique(prop schemaReader) AttributeUniqueness {
-	switch prop.String("x-unique") {
-	case "project":
+	switch prop.String(SchemaAnnotationUnique) {
+	case SchemaUniqueScopeProject:
 		return AttributeUniquenessProject
-	case "team":
+	case SchemaUniqueScopeTeam:
 		return AttributeUniquenessTeam
 	}
 	return AttributeUniquenessUnspecified
@@ -506,7 +506,7 @@ func (r schemaReader) collectRequiredPaths(prefix AttributeKey, materialized, ou
 // absent. An error is returned only when the keyword is present but
 // shaped differently than expected.
 func (r schemaReader) AuthMethods() (xAuthMethodsReader, error) {
-	v, ok := r.s.LookupKeyword("x-auth-methods")
+	v, ok := r.s.LookupKeyword(SchemaAnnotationAuthMethods)
 	if !ok {
 		return xAuthMethodsReader{}, nil
 	}


### PR DESCRIPTION
Top of the ADR 058 Phase A stack (#987 ← #988 ← this).

## Summary

Migrates the pre-existing literal spellings of the schema annotations to the constants #987 introduced (`SchemaAnnotationUnique`, `SchemaAnnotationAuthMethods`, `SchemaUniqueScopeProject`/`Team`, `SchemaAnnotationIdentifier`/`Display`):

- attribute uniqueness stamping (`CreateAttributesFromMap`)
- the flow field resolver's uniqueness and auth-methods readers
- the `x-auth-methods#` field-name prefix

(The designation validator's own literals moved into #987 itself after review — new code uses the constants from birth; this PR migrates only pre-existing usage.)

Deliberately out of scope: the dialect-side uniqueness scope literals (`uniquenessScopeLiteral` and SQL enum labels) — those are database enum labels that happen to share spelling with the schema keyword values, not schema-document reads; coupling them to the schema constants would tie a wire vocabulary to a storage encoding.

## Validation

No behavior change — constants compile to the same strings. Full untagged `go test ./internal/...` green, `gofmt` clean.

## Release notes / changeset

No changeset — internal refactor, ships nothing user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)