### PR TITLE
feat(api): gate a user's team memberships behind team_membership.read

### DIFF
--- a/.changeset/gate-membership-reads.md
+++ b/.changeset/gate-membership-reads.md
@@ -1,0 +1,12 @@
+---
+"@zitadel/server": minor
+---
+
+Reading a user's team memberships now requires `team_membership.read` on top of
+`user.read`, on every surface that serves them: `GET /users/{user_id}/teams`,
+and `POST /users/query` when `expand` asks for `teams` or a filter selects on
+`team_id`. Requesting any of them without it answers `403` rather than quietly
+omitting the data or serving the filtered page.
+
+Granular scopes are not minted yet, so an operator project secret satisfies the
+requirement for now; browser-plane preview secrets do not.

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -41405,6 +41405,7 @@ func (s *UserDeletedEventDelegationType) UnmarshalText(data []byte) error {
 // `GET /users/{user_id}/teams`.
 // Membership is team participation, not lifecycle ownership — the
 // owning team stays at `metadata.lifecycle_owner_team_id` (ADR 024).
+// Requires `team_membership.read` in addition to `user.read`.
 // Ref: #
 type UserExpand string
 
@@ -41461,6 +41462,8 @@ func (s *UserExpand) UnmarshalText(data []byte) error {
 // (ADR 024).
 // `team_id` is filterable but not sortable — it is not a column on the user, so
 // it is absent from the sort-field enum.
+// Filtering on `team_id` requires `team_membership.read` in addition to
+// `user.read`: it reads the same memberships that `expand: ["teams"]` embeds.
 // Ref: #
 type UserFilterField string
 

--- a/api/generated/oas_security_gen.go
+++ b/api/generated/oas_security_gen.go
@@ -163,7 +163,7 @@ var oauth2ScopesOAuth2 = map[string][]string{
 	},
 	ListUserTeamsOperation: []string{
 		"user.read",
-		"team.read",
+		"team_membership.read",
 	},
 	PatchProjectOperation: []string{
 		"project.write",

--- a/api/openapi/endpoints/users/by_id/teams/methods.yaml
+++ b/api/openapi/endpoints/users/by_id/teams/methods.yaml
@@ -22,7 +22,7 @@ get:
   security:
     - oauth2:
         - user.read
-        - team.read
+        - team_membership.read
   responses:
     '200':
       description: The teams of a user are returned

--- a/api/openapi/endpoints/users/query/methods.yaml
+++ b/api/openapi/endpoints/users/query/methods.yaml
@@ -9,6 +9,10 @@ post:
     no `project_id`, unlike the other query endpoints.
   tags:
     - Users
+  # user.read alone: scopes in one requirement are ANDed, and
+  # team_membership.read is needed only when the body asks for memberships —
+  # `expand: ["teams"]` or a `team_id` filter — a condition OpenAPI cannot
+  # express. `user-expand.yaml` and `user-filter-field.yaml` state it.
   security:
     - oauth2:
         - user.read

--- a/api/openapi/endpoints/users/query/user-expand.yaml
+++ b/api/openapi/endpoints/users/query/user-expand.yaml
@@ -11,5 +11,7 @@ description: |
 
     Membership is team participation, not lifecycle ownership — the
     owning team stays at `metadata.lifecycle_owner_team_id` (ADR 024).
+
+  Requires `team_membership.read` in addition to `user.read`.
 enum:
   - teams

--- a/api/openapi/endpoints/users/query/user-filter-field.yaml
+++ b/api/openapi/endpoints/users/query/user-filter-field.yaml
@@ -23,6 +23,9 @@ description: |
 
   `team_id` is filterable but not sortable — it is not a column on the user, so
   it is absent from the sort-field enum.
+
+  Filtering on `team_id` requires `team_membership.read` in addition to
+  `user.read`: it reads the same memberships that `expand: ["teams"]` embeds.
 enum:
   - created_at
   - id

--- a/api/openapi/security/oauth2.yaml
+++ b/api/openapi/security/oauth2.yaml
@@ -15,6 +15,7 @@ flows:
       team.read: Permission to read teams
       team.write: Permission to create and manage teams
       team.delete: Permission to delete teams
+      team_membership.read: Permission to read team memberships
       flow_definition.read: Permission to read flow definitions
       flow_definition.write: Permission to create and manage flow definitions
       flow_definition.delete: Permission to delete flow definitions
@@ -54,6 +55,7 @@ flows:
       team.read: Permission to read teams
       team.write: Permission to create and manage teams
       team.delete: Permission to delete teams
+      team_membership.read: Permission to read team memberships
       flow_definition.read: Permission to read flow definitions
       flow_definition.write: Permission to create and manage flow definitions
       flow_definition.delete: Permission to delete flow definitions

--- a/docs/design/api/system-permission-catalog.md
+++ b/docs/design/api/system-permission-catalog.md
@@ -190,7 +190,7 @@ their **own** password/factors is self-service (`/me`-gated), **not**
 | Permission | Endpoints | Notes |
 |---|---|---|
 | `team_membership.create` | `POST /teams/{id}/memberships`, `POST /team_memberships` | Prefer nested create; flat create with `team_id` in body is legacy. |
-| `team_membership.read` | `GET /teams/{id}/memberships`, `GET /team_memberships/{id}` | |
+| `team_membership.read` | `GET /teams/{id}/memberships`, `GET /team_memberships/{id}`, `GET /users/{id}/teams`, `POST /users/query` with `expand: ["teams"]` or a `team_id` filter | Required on top of `user.read` for the user-side membership reads: reading users is not reading memberships. The `team_id` filter is gated with the expansion — it answers "who is in this team" a page at a time, which is the same read. **Drift ([ADR 036](../../adrs/036-api-credential-planes.md)):** granular scopes are not minted yet and memberships have no RSI kind, so an operator project secret satisfies this interim — preview secrets do not. Tighten when #420 lands. |
 | `team_membership.write` | `PATCH /team_memberships/{id}` | Role changes within a membership (replaces old `team.roles.assign`). |
 | `team_membership.delete` | `DELETE /team_memberships/{id}` | |
 

--- a/internal/api/authz.go
+++ b/internal/api/authz.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"slices"
 
 	"github.com/zitadel/nextgen/internal/authz/resolver"
 	"github.com/zitadel/nextgen/internal/domain"
@@ -312,6 +313,24 @@ func hasOperatorProjectWrite(granted []string) bool {
 		}
 	}
 	return false
+}
+
+// requireMembershipRead gates the membership reads — `expand: ["teams"]` and a
+// `team_id` filter on the users query, and GET /users/{user_id}/teams — because
+// reading users is not reading team memberships (system-permission-catalog.md).
+//
+// The operator fallback is interim: no token carries team_membership.read yet
+// (ADR 036), so requiring it outright would reject every caller.
+// TODO(#420): drop it once granular scopes are minted.
+func requireMembershipRead(ctx context.Context) error {
+	scope, ok := GetScopeContext(ctx)
+	if ok && (slices.Contains(scope.Scope, "team_membership.read") || hasOperatorProjectWrite(scope.Scope)) {
+		return nil
+	}
+	// The sentinel's own message names the project secret, which is not what
+	// this gate is about; WithMessage keeps the code so errors.Is still matches.
+	return domain.ErrUserPermissionDenied().
+		WithMessage("reading a user's team memberships requires team_membership.read")
 }
 
 func mapAuthzDecision(dec resolver.Decision, res resourceAccess, op accessOp) error {

--- a/internal/api/authz_internal_test.go
+++ b/internal/api/authz_internal_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/zitadel/nextgen/internal/authz/resolver"
@@ -149,6 +150,48 @@ func TestHasOperatorProjectWrite(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := hasOperatorProjectWrite(tt.granted); got != tt.want {
 				t.Fatalf("hasOperatorProjectWrite(%v) = %v, want %v", tt.granted, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequireMembershipRead(t *testing.T) {
+	withScopes := func(scopes ...string) context.Context {
+		return WithScopeContext(context.Background(), ScopeContext{
+			ProjectID:     "proj_a",
+			Scope:         scopes,
+			PrincipalType: domain.AuthzPrincipalTypeSKProj,
+			PrincipalID:   "proj_a",
+		})
+	}
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		wantErr bool
+	}{
+		{"granular scope", withScopes("user.read", "team_membership.read"), false},
+		// Interim until #420: requiring the scope outright would reject everyone.
+		{"operator secret", withScopes("project.write", "project.read"), false},
+		{"preview secret", withScopes("project.read"), true},
+		{"no credential", context.Background(), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireMembershipRead(tt.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("requireMembershipRead() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				return
+			}
+			// The sentinel's own message names the project secret; a denial
+			// here has to say what is actually missing.
+			var de domain.Error
+			if !errors.As(err, &de) {
+				t.Fatalf("error is not a domain.Error: %v", err)
+			}
+			if !strings.Contains(de.Message, "team_membership.read") {
+				t.Fatalf("message %q does not name the missing permission", de.Message)
 			}
 		})
 	}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"slices"
 
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
@@ -69,7 +70,18 @@ func (h *Handler) QueryUsers(ctx context.Context, req *api.QueryUsersRequest) (a
 		return nil, err
 	}
 
-	users, err := h.userService.ListUsers(ctx, mapQueryUsersToService(scopeCtx.ProjectID, req))
+	input := mapQueryUsersToService(scopeCtx.ProjectID, req)
+	// Expanding answers 403 rather than a silently missing property: a caller
+	// could not tell that from "this user has no teams". Filtering on team_id
+	// reads the same memberships by a different route — it answers "who is in
+	// this team", one page at a time — so it takes the same gate.
+	if input.IncludeTeams || filtersOnTeamID(req.Filter) {
+		if err := requireMembershipRead(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	users, err := h.userService.ListUsers(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -114,6 +126,16 @@ func mapQueryUsersToService(projectID string, req *api.QueryUsersRequest) servic
 	return input
 }
 
+// filtersOnTeamID reports whether the request selects users by team membership.
+// The service turns that filter into a storage option rather than a column
+// predicate, so it is read off the request here rather than off the mapped
+// input.
+func filtersOnTeamID(filters []api.QueryUsersRequestFilterItem) bool {
+	return slices.ContainsFunc(filters, func(f api.QueryUsersRequestFilterItem) bool {
+		return f.Field == api.UserFilterFieldTeamID
+	})
+}
+
 func (h *Handler) ListUserPasskeys(ctx context.Context, params api.ListUserPasskeysParams) (api.ListUserPasskeysRes, error) {
 	projectID, err := h.requireResourceAccess(ctx, string(params.UserID), userAccess, opRead)
 	if err != nil {
@@ -155,6 +177,10 @@ func (h *Handler) ListUserPasskeys(ctx context.Context, params api.ListUserPassk
 func (h *Handler) ListUserTeams(ctx context.Context, params api.ListUserTeamsParams) (api.ListUserTeamsRes, error) {
 	projectID, err := h.requireResourceAccess(ctx, string(params.UserID), userAccess, opRead)
 	if err != nil {
+		return nil, err
+	}
+	// Same permission as the embedded read, or this becomes the way around it.
+	if err := requireMembershipRead(ctx); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/user_internal_test.go
+++ b/internal/api/user_internal_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"testing"
+
+	api "github.com/zitadel/nextgen/api/generated"
+)
+
+// The membership gate on POST /users/query keys off this, so a field that reads
+// like a team but is not a membership must not trip it: lifecycle_owner_team_id
+// is a column on the user and carries no membership read (ADR 024).
+func TestFiltersOnTeamID(t *testing.T) {
+	filter := func(fields ...api.UserFilterField) []api.QueryUsersRequestFilterItem {
+		items := make([]api.QueryUsersRequestFilterItem, 0, len(fields))
+		for _, field := range fields {
+			items = append(items, api.QueryUsersRequestFilterItem{Field: field})
+		}
+		return items
+	}
+
+	tests := []struct {
+		name    string
+		filters []api.QueryUsersRequestFilterItem
+		want    bool
+	}{
+		{"no filters", nil, false},
+		{"unrelated field", filter(api.UserFilterFieldStatus), false},
+		{"lifecycle owner is not membership", filter(api.UserFilterFieldLifecycleOwnerTeamID), false},
+		{"team id", filter(api.UserFilterFieldTeamID), true},
+		{"team id among others", filter(api.UserFilterFieldStatus, api.UserFilterFieldTeamID), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filtersOnTeamID(tt.filters); got != tt.want {
+				t.Fatalf("filtersOnTeamID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Reading a user's team memberships now requires `team_membership.read` on top of `user.read`, on every surface that serves them:

- `GET /users/{user_id}/teams`
- `POST /users/query` when `expand` asks for `teams`
- `POST /users/query` when a filter selects on `team_id`

This completes [ADR 059](../blob/users-expand-teams/docs/adrs/059-expanding-embedded-objects.md) rule 8 — *expansion never widens authorization* — for the expansion added in #984.

The `team_id` filter is gated with the expansion because it is the same read by a different route: paging a filtered query answers "who is in this team" one page at a time. `lifecycle_owner_team_id` stays ungated — it is a column on the user, not a membership, and is already served on every user (ADR 024).
