### PR TITLE
feat(console): label flow definitions with their user schema

### DIFF
--- a/.changeset/console-flow-schema-name.md
+++ b/.changeset/console-flow-schema-name.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+The console's login flows directory shows which user schema each flow definition uses, labelled with the schema's own name instead of leaving it out. A schema that no longer resolves is shown by id rather than blanking the row.

--- a/apps/console/src/routes/_authed/flow-definitions/flow-definitions.spec.tsx
+++ b/apps/console/src/routes/_authed/flow-definitions/flow-definitions.spec.tsx
@@ -15,6 +15,28 @@ vi.mock("@/auth/session", async (importOriginal) => {
 vi.stubEnv("VITE_CONSOLE_API_BASE", "http://localhost/api");
 
 const FLOWS_URL = "http://localhost/api/flow_definitions";
+const SCHEMAS_URL = "http://localhost/api/schemas";
+
+/** One populated flow definition, pinning schema `sch_1`. */
+function flowDefinitionsResponse() {
+  return {
+    flow_definitions: [
+      {
+        id: "flow_1",
+        project_id: "proj_1",
+        flow_definition: {
+          name: "Login",
+          status: "active",
+          user_schema: "sch_1",
+          purposes: { login: "identifier" },
+          steps: [{ name: "identifier" }],
+        },
+        created_at: "2026-01-01",
+        updated_at: "2026-01-02",
+      },
+    ],
+  };
+}
 
 const server = setupServer();
 
@@ -43,29 +65,55 @@ describe("login flows list states", () => {
   });
 
   it("renders a row and summary counts when populated", async () => {
+    server.use(http.get(FLOWS_URL, () => HttpResponse.json(flowDefinitionsResponse())));
+    await renderAt("/flow-definitions");
+    expect(await screen.findByRole("link", { name: "Login" })).toBeInTheDocument();
+  });
+
+  // The flow stores an opaque, revision-specific schema id; the directory
+  // labels the row with the schema's own name (#940).
+  it("labels the row with the referenced schema's name", async () => {
     server.use(
-      http.get(FLOWS_URL, () =>
-        HttpResponse.json({
-          flow_definitions: [
+      http.get(FLOWS_URL, () => HttpResponse.json(flowDefinitionsResponse())),
+      http.get(SCHEMAS_URL, ({ request }) => {
+        // Only the referenced ids are asked for, not the whole project.
+        expect(new URL(request.url).searchParams.getAll("id")).toEqual(["sch_1"]);
+        return HttpResponse.json({
+          schemas: [
             {
-              id: "flow_1",
-              project_id: "proj_1",
-              flow_definition: {
-                name: "Login",
-                status: "active",
-                user_schema: "sch_1",
-                purposes: { login: "identifier" },
-                steps: [{ name: "identifier" }],
-              },
-              created_at: "2026-01-01",
-              updated_at: "2026-01-02",
+              id: "sch_1",
+              schema: { title: "Consumer", objectType: "consumer" },
+              metadata: { created_at: "2026-01-01" },
             },
           ],
-        }),
+        });
+      }),
+    );
+    await renderAt("/flow-definitions");
+    expect(await screen.findByText("Consumer")).toBeInTheDocument();
+    expect(screen.queryByText("sch_1")).not.toBeInTheDocument();
+  });
+
+  // A schema that was deleted — or never returned — still has to render a row.
+  it("falls back to the raw id when the schema is not in the response", async () => {
+    server.use(
+      http.get(FLOWS_URL, () => HttpResponse.json(flowDefinitionsResponse())),
+      http.get(SCHEMAS_URL, () => HttpResponse.json({ schemas: [] })),
+    );
+    await renderAt("/flow-definitions");
+    expect(await screen.findByText("sch_1")).toBeInTheDocument();
+  });
+
+  it("still renders the page when the schemas request fails", async () => {
+    server.use(
+      http.get(FLOWS_URL, () => HttpResponse.json(flowDefinitionsResponse())),
+      http.get(SCHEMAS_URL, () =>
+        HttpResponse.json({ code: "internal", message: "boom" }, { status: 500 }),
       ),
     );
     await renderAt("/flow-definitions");
     expect(await screen.findByRole("link", { name: "Login" })).toBeInTheDocument();
+    expect(screen.getByText("sch_1")).toBeInTheDocument();
   });
 
   it("renders the error boundary when the request fails", async () => {

--- a/apps/console/src/routes/_authed/flow-definitions/index.tsx
+++ b/apps/console/src/routes/_authed/flow-definitions/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import type { ListFlowDefinitions200 } from "@zitadel/api/generated/model";
 
 import { StatusBadge } from "@/components/status-badge";
+import { type UserSchema, schemaDisplayName } from "@/lib/schema";
 
 import { api } from "../../../api/zitadel";
 import { getConsoleProjectId } from "../../../runtime/runtime";
@@ -8,12 +10,44 @@ import { ContentGrid, Page } from "../../../components/layout";
 import { DataTable, PageHeader, TableLink } from "../../../components/resource-page";
 
 export const Route = createFileRoute("/_authed/flow-definitions/")({
-  loader: () => api.listFlowDefinitions({ project_id: getConsoleProjectId() }),
+  loader: async () => {
+    const projectId = getConsoleProjectId();
+    const { flow_definitions: definitions } = await api.listFlowDefinitions({
+      project_id: projectId,
+    });
+    return { definitions, schemaNames: await schemaNames(projectId, definitions) };
+  },
   component: FlowDefinitionsList,
 });
 
+/**
+ * Display names for the schemas the listed flows pin, keyed by id.
+ *
+ * Fetched by id, and only the referenced ones: a flow keeps the schema revision
+ * it was created with, so a `revisions: latest` list would miss every flow
+ * pointing at a superseded one. The ids come from the flow list, which is why
+ * this runs after it rather than alongside it.
+ *
+ * Best-effort — an id the response does not carry (a deleted schema) or a
+ * failed list leaves the row labelled with the id itself, which is still true.
+ */
+async function schemaNames(
+  projectId: string,
+  definitions: ListFlowDefinitions200["flow_definitions"],
+): Promise<Map<string, string>> {
+  const ids = [...new Set(definitions.map((definition) => definition.flow_definition.user_schema))];
+  if (ids.length === 0) return new Map();
+  const listed = await api.listSchemas({ project_id: projectId, id: ids }).catch(() => undefined);
+  return new Map(
+    listed?.schemas.map((entry) => [
+      entry.id,
+      schemaDisplayName(entry.schema as UserSchema, entry.id),
+    ]),
+  );
+}
+
 function FlowDefinitionsList() {
-  const { flow_definitions: definitions } = Route.useLoaderData();
+  const { definitions, schemaNames } = Route.useLoaderData();
   const active = definitions.filter(
     (definition) => definition.flow_definition.status === "active",
   ).length;
@@ -46,6 +80,19 @@ function FlowDefinitionsList() {
                 {definition.flow_definition.name}
               </TableLink>
             ),
+          },
+          {
+            header: "User schema",
+            cell: (definition) => {
+              const id = definition.flow_definition.user_schema;
+              // An unresolved schema shows its id rather than an empty cell —
+              // mono and muted so it reads as an identifier, not a name.
+              return (
+                schemaNames.get(id) ?? (
+                  <span className="font-mono text-xs text-muted-foreground">{id}</span>
+                )
+              );
+            },
           },
           {
             header: "Status",


### PR DESCRIPTION
Closes #940. Stacked on #1053; merge that first.

The flows directory now labels each flow definition with its user schema's display name instead of nothing. The loader collects the distinct `user_schema` ids from the flow list and resolves them with a single `listSchemas` call using the new `id` filter from #1053, then derives names with the existing `schemaDisplayName` helper (`title`, else `objectType`, else id).

A row never breaks on an unresolvable schema: a deleted schema, an id the response did not contain, and a failed schemas fetch all fall back to the raw id rendered muted/mono. The fetch itself is catch-and-degraded, so the page renders even when `listSchemas` errors.

<details>
<summary>Details and tests</summary>

- One new "User schema" column in `apps/console/src/routes/_authed/flow-definitions/index.tsx`; a single code path where the map lookup falls back to the id.
- Fetching by explicit ids (rather than `revisions: latest`) matters because schema revisions are id-distinct and a flow pins the id it was created with, so flows referencing non-latest revisions are the common case over time.
- Spec cases added to `flow-definitions.spec.tsx`: resolved name shown; schema absent from the response leaves the raw id; `listSchemas` rejecting still renders the page with ids.
- `moon run console:test` (Node 24): 121 tests green; typecheck and lint clean.

</details>

Follow-ups deliberately out of scope: the rest of the directory row (purposes, step tags, last-changed, the orphaned console half of #939) and switching the users directory's per-schema `getSchemaById` fan-out to the new id filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)