### PR TITLE
feat(login): offer a passkey after password registration

### DIFF
--- a/.changeset/passkey-upsell-step.md
+++ b/.changeset/passkey-upsell-step.md
@@ -1,0 +1,6 @@
+---
+"@zitadel/config": minor
+"@zitadel/server": minor
+---
+
+The default login flow gains a `passkey-upsell` step between `register-password` and `done`. A user who has just set a password is offered a passkey (`passkey_register`) with a `skip` action beside it, so registration no longer ends on the password step. The copy already existed in the orchestrator's locales; only the flow definition was missing it. Tenants running an ejected flow definition are unaffected — the step is added to `defaults/default-login.json`, not injected at runtime — and `@zitadel/api-mock` mirrors it.

--- a/.changeset/testkit-absorbs-passkey-upsell.md
+++ b/.changeset/testkit-absorbs-passkey-upsell.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/testing": minor
+---
+
+`registerWithPassword` now clears the passkey upsell the default flow shows after a password is set, so a caller still lands on their signed-in surface rather than on an intermediate step. Suites that added their own skip handling after `registerWithPassword` should drop it — the two race each other. A flow that routes `register-password` straight to `done` is unaffected: the helper only clicks a `skip` action that is actually rendered, and never waits for one.

--- a/apps/cli-journey-e2e/src/user-journey.spec.ts
+++ b/apps/cli-journey-e2e/src/user-journey.spec.ts
@@ -49,7 +49,6 @@ if (preset === "password-first") {
     }
     await gotoLogin(page);
     await registerWithPassword(page, { email, password, profile: registrationProfile });
-    await skipPasskeyUpsellIfVisible(page);
     await expectSignedIn(page);
     await expectSessionCookie(page);
 

--- a/apps/demo-next-e2e/src-real/registration.spec.ts
+++ b/apps/demo-next-e2e/src-real/registration.spec.ts
@@ -1,5 +1,3 @@
-import type { Page } from "@playwright/test";
-
 import { expect, registerWithPassword, test } from "@zitadel/testing/playwright";
 
 /**
@@ -12,7 +10,6 @@ test("a fresh identity registers through the real flow", async ({ page, seed, zi
 
   await page.goto("/login");
   await registerWithPassword(page, { email: who.email, password: who.password });
-  await skipPasskeyUpsellIfVisible(page);
 
   await page.waitForURL(/\/admin(?:[/?#]|$)/, { timeout: 30_000 });
 
@@ -24,16 +21,3 @@ test("a fresh identity registers through the real flow", async ({ page, seed, zi
   const created = users.find((user) => user.attributes.email === who.email);
   expect(created).toBeDefined();
 });
-
-async function skipPasskeyUpsellIfVisible(page: Page): Promise<void> {
-  const skip = page.getByRole("button", { name: /skip for now/i });
-  const outcome = await Promise.race([
-    skip.waitFor({ state: "visible", timeout: 30_000 }).then(() => "upsell" as const),
-    page
-      .waitForURL(/\/admin(?:[/?#]|$)/, { timeout: 30_000 })
-      .then(() => "done" as const),
-  ]);
-  if (outcome === "upsell") {
-    await skip.click();
-  }
-}

--- a/docs/design/idp/schemas/default-login.scaffold.json
+++ b/docs/design/idp/schemas/default-login.scaffold.json
@@ -155,10 +155,36 @@
       "on_success": "create_user",
       "transitions": {
         "submit": {
-          "target": "done"
+          "target": "passkey-upsell"
         },
         "user_already_exists": {
           "target": "sso-conflict"
+        }
+      }
+    },
+    {
+      "name": "passkey-upsell",
+      "fields": [],
+      "actions": [
+        {
+          "name": "passkey_register",
+          "kind": "passkey_register",
+          "primary": true,
+          "text_key": "passkey-upsell.action.passkey_register"
+        },
+        {
+          "name": "skip",
+          "kind": "navigate",
+          "primary": false,
+          "text_key": "passkey-upsell.action.skip"
+        }
+      ],
+      "transitions": {
+        "passkey_register": {
+          "target": "done"
+        },
+        "skip": {
+          "target": "done"
         }
       }
     },

--- a/internal/api/integration_test/project_test.go
+++ b/internal/api/integration_test/project_test.go
@@ -188,12 +188,21 @@ func TestCreateProjectProvisionsDefaultLoginFlow(t *testing.T) {
 	assert.Equal(t, []domain.Field{"x-auth-methods#password"}, registerPasswordStep.Fields)
 	require.NotNil(t, registerPasswordStep.OnSuccess)
 	assert.Equal(t, domain.FlowOnSuccessCreateUser, *registerPasswordStep.OnSuccess)
-	// Registration completes directly — no passkey upsell step; passkey
-	// registration is offered up front on the register step instead.
-	assert.Equal(t, "done", registerPasswordStep.Transitions[domain.FlowActionSubmit].Target)
+	// Setting a password hands off to the upsell rather than finishing, so a
+	// user who registered with a password is still offered a passkey. The
+	// register step keeps offering one up front for anyone who wants it there.
+	assert.Equal(t, "passkey-upsell", registerPasswordStep.Transitions[domain.FlowActionSubmit].Target)
 
-	_, ok = flowDef.FindStep("passkey-upsell")
-	assert.False(t, ok)
+	// Both ways out of the upsell finish the flow — taking the passkey and
+	// declining it. Without the skip transition a user who does not want one
+	// has no way off this step.
+	upsellStep, ok := flowDef.FindStep("passkey-upsell")
+	require.True(t, ok)
+	assert.Empty(t, upsellStep.Fields)
+	assert.Contains(t, actionNames(upsellStep.Actions), domain.FlowActionPasskeyRegister)
+	assert.Contains(t, actionNames(upsellStep.Actions), "skip")
+	assert.Equal(t, "done", upsellStep.Transitions[domain.FlowActionPasskeyRegister].Target)
+	assert.Equal(t, "done", upsellStep.Transitions["skip"].Target)
 }
 
 func TestCreateProjectSkipsDefaultLoginFlow(t *testing.T) {

--- a/packages/api-mock/src/fixtures/default-conformance.spec.ts
+++ b/packages/api-mock/src/fixtures/default-conformance.spec.ts
@@ -25,6 +25,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   identifierStep,
+  passkeyUpsellStep,
   passwordStep,
   registerPasswordStep,
   registerStep,
@@ -48,6 +49,7 @@ const FIXTURES = {
   password: passwordStep,
   register: registerStep,
   "register-password": registerPasswordStep,
+  "passkey-upsell": passkeyUpsellStep,
 } as const;
 
 /** ADR 022: the engine injects `back` on steps with a predecessor. */

--- a/packages/api-mock/src/fixtures/login.ts
+++ b/packages/api-mock/src/fixtures/login.ts
@@ -266,19 +266,22 @@ export function recoverStep(input: StepFixtureInput): CreateFlow201 {
 }
 
 /**
- * Passkey enrolment upsell — prompts the user to set up a passkey after a
- * successful credential sign-in. Figma `6594:630`.
+ * Passkey enrolment upsell — offers a passkey once the account exists, which
+ * in the default flow is straight after `register-password`.
  */
 export function passkeyUpsellStep(input: StepFixtureInput): CreateFlow201 {
   return wrap(input, {
     name: "passkey-upsell",
-    texts: { title_key: "passkey-upsell.title" },
+    texts: {
+      title_key: "passkey-upsell.title",
+      description_key: "passkey-upsell.description",
+    },
     fields: [],
     actions: [
       {
-        name: "setup",
+        name: "passkey_register",
         kind: "passkey_register",
-        text_key: "passkey-upsell.action.setup",
+        text_key: "passkey-upsell.action.passkey_register",
         primary: true,
       },
       { name: "skip", kind: "navigate", text_key: "passkey-upsell.action.skip" },

--- a/packages/api-mock/src/flow-machine.ts
+++ b/packages/api-mock/src/flow-machine.ts
@@ -24,13 +24,10 @@
  *                            password   --SUBMIT(submit)--> done
  *                                       --SUBMIT(back)----> identifier
  *                                       --SUBMIT(passkey)--> passkey-login
- *      \--START(register)--> register --SUBMIT--> register-password --SUBMIT--> done
+ *      \--START(register)--> register --SUBMIT--> register-password
  *                                     --SUBMIT(sign_in)--> identifier
+ *                            register-password --SUBMIT--> passkey-upsell
  *
- *   passkey-upsell / passkey-setup -- legacy upsell pair; the default flow no
- *               longer routes through them (passkey registration is offered
- *               up front instead). Kept so tests can target them directly
- *               via actor injection.
  *   passkey-upsell --SUBMIT(skip)--> done
  *   passkey-upsell --SUBMIT(*)----> passkey-setup --SUBMIT--> done
  *   passkey-login --SUBMIT--> done
@@ -200,7 +197,7 @@ export const flowMachine = createMachine({
             target: "register",
             actions: [rotateToken],
           },
-          { target: "done", actions: [captureFields, rotateToken] },
+          { target: "passkey-upsell", actions: [captureFields, rotateToken] },
         ],
       },
     },

--- a/packages/api-mock/src/index.spec.ts
+++ b/packages/api-mock/src/index.spec.ts
@@ -117,7 +117,7 @@ describe("setupMockHandlers", () => {
     expect(start.session_token).not.toBe(submit.session_token);
   });
 
-  test("routes register through two-step sign-up to done", async () => {
+  test("routes register through two-step sign-up and the passkey upsell to done", async () => {
     const start = await createFlow({ purpose: "register", project_id: PROJECT_ID });
     expect(start.step.name).toBe("register");
     expect(start.step.fields?.some((f) => f.name === "email")).toBe(true);
@@ -139,10 +139,20 @@ describe("setupMockHandlers", () => {
     // definition declares `x-auth-methods#password` on both.
     expect(passwordStep.step.fields?.map((f) => f.name)).toEqual([PASSWORD_FIELD]);
 
-    const done = await submitFlowStep(passwordStep.id, {
+    // The account exists from here, so the flow offers a passkey before
+    // finishing rather than dropping the user straight into `done`.
+    const upsell = await submitFlowStep(passwordStep.id, {
       session_token: passwordStep.session_token,
       action: "submit",
       fields: { [PASSWORD_FIELD]: "hunter2" },
+    });
+    expect(upsell.step.name).toBe("passkey-upsell");
+    expect(upsell.step.fields ?? []).toEqual([]);
+    expect(upsell.step.actions?.map((a) => a.name)).toEqual(["passkey_register", "skip"]);
+
+    const done = await submitFlowStep(upsell.id, {
+      session_token: upsell.session_token,
+      action: "skip",
     });
     expect(done.step.name).toBe("done");
     expect(done.step.complete).toBe("show");

--- a/packages/config/defaults/default-login.json
+++ b/packages/config/defaults/default-login.json
@@ -134,10 +134,36 @@
       "on_success": "create_user",
       "transitions": {
         "submit": {
-          "target": "done"
+          "target": "passkey-upsell"
         },
         "user_already_exists": {
           "target": "password"
+        }
+      }
+    },
+    {
+      "name": "passkey-upsell",
+      "fields": [],
+      "actions": [
+        {
+          "name": "passkey_register",
+          "kind": "passkey_register",
+          "primary": true,
+          "text_key": "passkey-upsell.action.passkey_register"
+        },
+        {
+          "name": "skip",
+          "kind": "navigate",
+          "primary": false,
+          "text_key": "passkey-upsell.action.skip"
+        }
+      ],
+      "transitions": {
+        "passkey_register": {
+          "target": "done"
+        },
+        "skip": {
+          "target": "done"
         }
       }
     },

--- a/packages/testing/src/flows.ts
+++ b/packages/testing/src/flows.ts
@@ -194,11 +194,15 @@ export async function loginWithPasskey(page: Page, options: { email?: string } =
 
 /**
  * Register a new user with a password: enter the (unknown) identifier,
- * advance into the registration step, continue on the password path, and
- * submit the password. Ends when the final submit is clicked — assert your
- * app's signed-in surface afterwards. Flows that route through steps the
- * default flow does not (e.g. a passkey upsell) need caller-side handling
- * after this returns.
+ * advance into the registration step, continue on the password path, submit
+ * the password, and clear the passkey enrolment offer the default flow shows
+ * once the account exists. Ends with the account created and the flow past its
+ * last interstitial — assert your app's signed-in surface afterwards.
+ *
+ * A flow that skips the offer entirely (a preset that drops the step, or one
+ * routing `register-password` straight to `done`) needs nothing extra; a test
+ * that wants to assert the offer itself should drive the steps directly rather
+ * than through this helper.
  */
 export async function registerWithPassword(
   page: Page,
@@ -213,6 +217,25 @@ export async function registerWithPassword(
   }
   await password_.fill(password);
   await flowAction(page, "submit").click();
+  await skipPasskeyUpsellIfPresent(page);
+}
+
+/**
+ * Take the `skip` action on the passkey enrolment offer, if this flow shows
+ * one. Waiting for the password control to go first means the next step has
+ * already rendered, so the offer is either on screen or not part of this flow
+ * — no polling race, and no timeout paid by flows that go straight to `done`.
+ */
+async function skipPasskeyUpsellIfPresent(page: Page): Promise<void> {
+  await passwordField(page)
+    .waitFor({ state: "hidden", timeout: 30_000 })
+    .catch(() => {
+      // A completing flow navigates away, detaching the whole widget.
+    });
+  const skip = flowAction(page, "skip");
+  if (await skip.isVisible().catch(() => false)) {
+    await skip.click();
+  }
 }
 
 /**

--- a/packages/testing/tests/unit/flows.test.ts
+++ b/packages/testing/tests/unit/flows.test.ts
@@ -223,7 +223,24 @@ describe("registration ceremonies", () => {
       { op: "click", target: action("submit") },
       { op: "fill", target: PASSWORD, value: "pw" },
       { op: "click", target: action("submit") },
+      // The default flow offers a passkey once the account exists; the helper
+      // clears it so callers still land on their signed-in surface.
+      { op: "click", target: action("skip") },
     ]);
+  });
+
+  it("registerWithPassword leaves a flow that offers no passkey upsell untouched", async () => {
+    const fake = fakePage(
+      (target) => defaultFlowVisibility(target) && !target.includes("zitadel-action-skip"),
+    );
+    await registerWithPassword(fake.page, { email: "new@example.test", password: "pw" });
+
+    // No trailing skip: a preset that routes `register-password` straight to
+    // `done` has nothing to clear, and the helper must not wait on one.
+    expect(fake.ops.filter((op) => op.op === "click").at(-1)).toEqual({
+      op: "click",
+      target: action("submit"),
+    });
   });
 
   it("registerWithPasskey takes the registration step's passkey action", async () => {


### PR DESCRIPTION
## Summary

- The default login flow gains a `passkey-upsell` step. `register-password` submits into it instead of to `done`, and it offers `passkey_register` with `skip` beside it — both terminal. Setting a password no longer ends registration before a passkey is offered; the register step keeps offering one up front for anyone who wants it there.
- New projects get it at seed time. The Go seed embeds `packages/config/defaults/default-login.json` through `configdefaults.DefaultLoginFlowDefinition()`, so the flow definition is the only source that needs to change. Existing projects keep whatever definition is already in their database; there is no migration, and a tenant can edit theirs.
- The copy and the mock's state machine have carried this chain since #116 — the orchestrator locales document `register → register-password → passkey-upsell → done` and define all six strings, and `@zitadel/api-mock` already had the state. Only the flow definition never caught up.
- `@zitadel/testing`'s `registerWithPassword` now clears the offer, so callers land on their signed-in surface. The two suites that carried their own skip handling after it drop it — the two race each other.
- The social-login scaffold under `docs/design/idp/schemas/` mirrors the shipped default and is drift-tested against it, so it gains the same step.
- Replaces #915, which was raised from a branch that had fallen behind both main and its own remote.

## Validation

- `moon run config:test api-mock:test testing:test`
- `moon run config:typecheck api-mock:typecheck testing:typecheck`
- `go build ./...`
- `go test ./api/openapi/endpoints/flow_definitions/... ./internal/domain/...`
- Not run: `TestCreateProjectProvisionsDefaultLoginFlow`, which this PR rewrites. It is behind the `postgres_integration` / `spanner_integration` build tags and needs a real database, so it is CI-gated.

## Release notes / changeset

- Changeset: `.changeset/passkey-upsell-step.md` — registering with a password now offers a passkey before finishing. Lists `@zitadel/server`.
- Changeset: `.changeset/testkit-absorbs-passkey-upsell.md` — `@zitadel/testing`'s `registerWithPassword` clears the new step.

## Notes

- Split out of #913 so the behaviour change is reviewed on its own rather than inside a visual diff.
- The passkey registration this step triggers is the attempt-based path that landed in #949/#950/#951; the flow definition is what was missing.
