### PR TITLE
feat(console): add the project claim page

### DIFF
--- a/.changeset/console-claim-page.md
+++ b/.changeset/console-claim-page.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": minor
+---
+
+The console serves the project claim page at `/claim`: a developer opening a claim link authenticates through the platform login widget and the project is attached to their personal team, with explicit outcomes for an expired, already-claimed, or unauthorized challenge instead of a redirect loop.

--- a/apps/console/src/lib/claim.ts
+++ b/apps/console/src/lib/claim.ts
@@ -1,0 +1,95 @@
+import { ApiError } from "@zitadel/api/runtime/fetch";
+
+import { api } from "../api/zitadel";
+import { describeError } from "./api-error";
+
+/**
+ * What one completion attempt came to. A discriminated union rather than a
+ * thrown error because every branch is a screen state the claim page renders,
+ * not an exception: the contract enumerates them (`claim/complete` in
+ * `api/openapi/endpoints/projects/by_id/claim/complete/methods.yaml`).
+ */
+export type ClaimOutcome =
+  | { kind: "claimed"; teamId: string; claimedAt: string }
+  /** 409 — single-use, first-claim-wins; `details` names the owning team. */
+  | { kind: "already_claimed"; message: string; teamId?: string; dashboardUrl?: string }
+  /** 410 — the challenge aged out; only `claim/init` (the CLI) can mint a new one. */
+  | { kind: "expired"; message: string }
+  /** 403 — the session user has no active personal team to attach the project to. */
+  | { kind: "no_personal_team"; message: string }
+  /** 400/404 — the challenge id is malformed or unknown. */
+  | { kind: "invalid_challenge"; message: string }
+  /**
+   * 401 — the cookie is gone, **or** the session does not belong to the
+   * platform project. The server deliberately collapses both into the public
+   * `auth.unauthorized` verdict (`verifyClaimSession`, ADR 046 §2), so the
+   * browser cannot tell them apart — which is why the page must not answer
+   * this by silently re-running sign-in: on a deployment without a platform
+   * project (`platform.bootstrap_project` off — the local testkit today),
+   * every completion 401s and re-signing-in just loops.
+   */
+  | { kind: "unauthenticated" }
+  /** 429, 5xx, network — nothing the page can name; retryable. */
+  | { kind: "error"; message: string };
+
+/**
+ * Spend a claim challenge: `POST /projects/{project_id}/claim/complete`,
+ * authenticated by the `__nextgen_session` cookie.
+ *
+ * Deliberately the **single** place the completion request is made (#615):
+ * when ADR 053 adds the `X-Zitadel-CSRF` requirement it lands in this call
+ * alone, and if ADR 054 grows the contract a team-selection parameter, the
+ * body grows here. Callers render the outcome; they do not build the request.
+ */
+export async function completeProjectClaim(
+  projectId: string,
+  challengeId: string,
+): Promise<ClaimOutcome> {
+  try {
+    const result = await api.completeClaim(
+      projectId,
+      { challenge_id: challengeId },
+      // Same-origin by design (Console ADR 0002), but say `include` like the
+      // session helpers do rather than leaning on the browser default.
+      { credentials: "include" },
+    );
+    return { kind: "claimed", teamId: result.team_id, claimedAt: result.claimed_at };
+  } catch (cause) {
+    if (cause instanceof ApiError) {
+      // ADR 030: the API owns the human-facing copy; render it verbatim.
+      const message = describeError(cause, "The claim could not be completed.");
+      switch (cause.status) {
+        case 401:
+          return { kind: "unauthenticated" };
+        case 403:
+          return { kind: "no_personal_team", message };
+        case 400:
+        case 404:
+          return { kind: "invalid_challenge", message };
+        case 409:
+          return { kind: "already_claimed", message, ...alreadyClaimedDetails(cause.body) };
+        case 410:
+          return { kind: "expired", message };
+        default:
+          return { kind: "error", message };
+      }
+    }
+    return { kind: "error", message: describeError(cause, "The claim could not be completed.") };
+  }
+}
+
+/**
+ * The 409 body's `details` block (`already-claimed-response.yaml`): the owning
+ * team and its dashboard. Read defensively — the base error schema does not
+ * require it, and a missing block costs the link, not the screen.
+ */
+function alreadyClaimedDetails(body: unknown): { teamId?: string; dashboardUrl?: string } {
+  if (!body || typeof body !== "object") return {};
+  const details = (body as Record<string, unknown>).details;
+  if (!details || typeof details !== "object") return {};
+  const record = details as Record<string, unknown>;
+  return {
+    teamId: typeof record.team_id === "string" ? record.team_id : undefined,
+    dashboardUrl: typeof record.dashboard_url === "string" ? record.dashboard_url : undefined,
+  };
+}

--- a/apps/console/src/lib/claim.ts
+++ b/apps/console/src/lib/claim.ts
@@ -15,8 +15,20 @@ export type ClaimOutcome =
   | { kind: "already_claimed"; message: string; teamId?: string; dashboardUrl?: string }
   /** 410 — the challenge aged out; only `claim/init` (the CLI) can mint a new one. */
   | { kind: "expired"; message: string }
-  /** 403 — the session user has no active personal team to attach the project to. */
+  /**
+   * 403 `claim.no_personal_team` — no membership at all. The contract is
+   * explicit that this one clears itself: the next sign-in provisions the team
+   * (the exchange-time ensure), so the page may honestly offer a retry.
+   */
   | { kind: "no_personal_team"; message: string }
+  /**
+   * 403 `claim.personal_team_not_active` — the membership exists but is not
+   * active, and the contract is equally explicit that provisioning will *not*
+   * clear it. `membershipStatus` (`removed` | `inactive` | `pending`) is the
+   * only thing that says who has to do what; it rides an otherwise untyped
+   * details object, so it is read defensively and may be absent.
+   */
+  | { kind: "personal_team_not_active"; message: string; membershipStatus?: string }
   /** 400/404 — the challenge id is malformed or unknown. */
   | { kind: "invalid_challenge"; message: string }
   /**
@@ -62,7 +74,7 @@ export async function completeProjectClaim(
         case 401:
           return { kind: "unauthenticated" };
         case 403:
-          return { kind: "no_personal_team", message };
+          return personalTeamOutcome(message, cause.body);
         case 400:
         case 404:
           return { kind: "invalid_challenge", message };
@@ -92,4 +104,37 @@ function alreadyClaimedDetails(body: unknown): { teamId?: string; dashboardUrl?:
     teamId: typeof record.team_id === "string" ? record.team_id : undefined,
     dashboardUrl: typeof record.dashboard_url === "string" ? record.dashboard_url : undefined,
   };
+}
+
+/**
+ * Splits the 403's two codes (`completeClaim` declares them as a `oneOf`).
+ * They differ in the only thing the developer cares about: whether signing in
+ * again fixes it.
+ *
+ * An unrecognised code degrades to the recoverable branch rather than the dead
+ * end — the server never said this account is permanently stuck, and offering a
+ * retry that fails is kinder than refusing one that would have worked.
+ */
+function personalTeamOutcome(message: string, body: unknown): ClaimOutcome {
+  const record = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  if (record.code === "claim.personal_team_not_active") {
+    return {
+      kind: "personal_team_not_active",
+      message,
+      membershipStatus: membershipStatus(record),
+    };
+  }
+  return { kind: "no_personal_team", message };
+}
+
+/**
+ * `details.membership_status` from the not-active 403. The details object is
+ * documented but untyped, so read it the same way `alreadyClaimedDetails` reads
+ * its block: a missing value costs the remedy sentence, not the screen.
+ */
+function membershipStatus(body: Record<string, unknown>): string | undefined {
+  const details = body.details;
+  if (!details || typeof details !== "object") return undefined;
+  const value = (details as Record<string, unknown>).membership_status;
+  return typeof value === "string" ? value : undefined;
 }

--- a/apps/console/src/routeTree.gen.ts
+++ b/apps/console/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthedRouteImport } from './routes/_authed'
+import { Route as ClaimIndexRouteImport } from './routes/claim/index'
 import { Route as AuthedIndexRouteImport } from './routes/_authed/index'
 import { Route as AuthedUsersIndexRouteImport } from './routes/_authed/users/index'
 import { Route as AuthedTeamsIndexRouteImport } from './routes/_authed/teams/index'
@@ -33,6 +34,11 @@ const LoginRoute = LoginRouteImport.update({
 } as any)
 const AuthedRoute = AuthedRouteImport.update({
   id: '/_authed',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ClaimIndexRoute = ClaimIndexRouteImport.update({
+  id: '/claim/',
+  path: '/claim/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthedIndexRoute = AuthedIndexRouteImport.update({
@@ -111,6 +117,7 @@ const AuthedFlowDefinitionsDefinitionIdRoute =
 export interface FileRoutesByFullPath {
   '/': typeof AuthedIndexRoute
   '/login': typeof LoginRoute
+  '/claim/': typeof ClaimIndexRoute
   '/flow-definitions/$definitionId': typeof AuthedFlowDefinitionsDefinitionIdRoute
   '/projects/$projectId': typeof AuthedProjectsProjectIdRoute
   '/schemas/$schemaId': typeof AuthedSchemasSchemaIdRoute
@@ -128,6 +135,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/': typeof AuthedIndexRoute
+  '/claim': typeof ClaimIndexRoute
   '/flow-definitions/$definitionId': typeof AuthedFlowDefinitionsDefinitionIdRoute
   '/projects/$projectId': typeof AuthedProjectsProjectIdRoute
   '/schemas/$schemaId': typeof AuthedSchemasSchemaIdRoute
@@ -147,6 +155,7 @@ export interface FileRoutesById {
   '/_authed': typeof AuthedRouteWithChildren
   '/login': typeof LoginRoute
   '/_authed/': typeof AuthedIndexRoute
+  '/claim/': typeof ClaimIndexRoute
   '/_authed/flow-definitions/$definitionId': typeof AuthedFlowDefinitionsDefinitionIdRoute
   '/_authed/projects/$projectId': typeof AuthedProjectsProjectIdRoute
   '/_authed/schemas/$schemaId': typeof AuthedSchemasSchemaIdRoute
@@ -166,6 +175,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/login'
+    | '/claim/'
     | '/flow-definitions/$definitionId'
     | '/projects/$projectId'
     | '/schemas/$schemaId'
@@ -183,6 +193,7 @@ export interface FileRouteTypes {
   to:
     | '/login'
     | '/'
+    | '/claim'
     | '/flow-definitions/$definitionId'
     | '/projects/$projectId'
     | '/schemas/$schemaId'
@@ -201,6 +212,7 @@ export interface FileRouteTypes {
     | '/_authed'
     | '/login'
     | '/_authed/'
+    | '/claim/'
     | '/_authed/flow-definitions/$definitionId'
     | '/_authed/projects/$projectId'
     | '/_authed/schemas/$schemaId'
@@ -219,6 +231,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   AuthedRoute: typeof AuthedRouteWithChildren
   LoginRoute: typeof LoginRoute
+  ClaimIndexRoute: typeof ClaimIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -235,6 +248,13 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: '/'
       preLoaderRoute: typeof AuthedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/claim/': {
+      id: '/claim/'
+      path: '/claim'
+      fullPath: '/claim/'
+      preLoaderRoute: typeof ClaimIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authed/': {
@@ -379,6 +399,7 @@ const AuthedRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   AuthedRoute: AuthedRouteWithChildren,
   LoginRoute: LoginRoute,
+  ClaimIndexRoute: ClaimIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/console/src/routes/claim/claim.spec.tsx
+++ b/apps/console/src/routes/claim/claim.spec.tsx
@@ -165,13 +165,42 @@ describe("claim page", () => {
     expect(screen.getByText(/terminal/i)).toBeInTheDocument();
   });
 
-  it("explains a 403 — the session user has no personal team", async () => {
+  it("offers a retry on claim.no_personal_team — the contract says it self-clears", async () => {
+    // `claim.no_personal_team` means no membership at all, and the 403's own
+    // contract text says the next sign-in provisions one. Dead-ending here
+    // would tell a developer to give up on the recoverable case.
     fetchSession.mockResolvedValue(makeTestSession());
     stubComplete(() =>
       HttpResponse.json(
         {
-          code: "claim-no_personal_team",
+          code: "claim.no_personal_team",
           message: "The session user has no active personal team in the platform project.",
+        },
+        { status: 403 },
+      ),
+    );
+    await renderAt(CLAIM_PATH);
+
+    expect(
+      await screen.findByRole("heading", { name: "Your account has no team yet" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The session user has no active personal team in the platform project."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  it("dead-ends claim.personal_team_not_active and names the remedy", async () => {
+    // The mirror case: the membership exists but is not active, which
+    // provisioning will not fix. `membership_status` decides the copy —
+    // `removed` is about the user's access, not the team's.
+    fetchSession.mockResolvedValue(makeTestSession());
+    stubComplete(() =>
+      HttpResponse.json(
+        {
+          code: "claim.personal_team_not_active",
+          message: "The user's personal team in the platform project is not active.",
+          details: { membership_status: "removed" },
         },
         { status: 403 },
       ),
@@ -181,9 +210,26 @@ describe("claim page", () => {
     expect(
       await screen.findByRole("heading", { name: "This account cannot claim projects" }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText("The session user has no active personal team in the platform project."),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Restoring this account's access/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Try again" })).not.toBeInTheDocument();
+  });
+
+  it("drops a dashboard link that is not http(s)", async () => {
+    fetchSession.mockResolvedValue(makeTestSession());
+    stubComplete(() =>
+      HttpResponse.json(
+        {
+          code: "proj-already_claimed",
+          message: "The project is already claimed by a team.",
+          details: { team_id: "team_other", dashboard_url: "javascript:alert(1)" },
+        },
+        { status: 409 },
+      ),
+    );
+    await renderAt(CLAIM_PATH);
+
+    expect(await screen.findByRole("heading", { name: "Already claimed" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /dashboard/i })).not.toBeInTheDocument();
   });
 
   it("dead-ends a 401 instead of re-running sign-in", async () => {

--- a/apps/console/src/routes/claim/claim.spec.tsx
+++ b/apps/console/src/routes/claim/claim.spec.tsx
@@ -1,0 +1,247 @@
+import { RouterProvider, createMemoryHistory } from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeTestSession } from "../../auth/session.fixture";
+import { createAppRouter } from "../../router";
+
+/**
+ * The claim page (#615): `claim/init` hands the CLI a URL of the form
+ * `<console>/claim?challenge_id=…&project_id=…`; the browser leg signs the
+ * developer in against the platform project and spends the challenge via
+ * `claim/complete`, cookie-authenticated.
+ *
+ * Same module-boundary mocks as `auth-guard.spec`: the auth module because the
+ * screen branches on the session, the widget because `<zitadel-login>` drives
+ * real flow requests on mount, which a jsdom spec neither needs nor supports.
+ */
+const fetchSession = vi.fn();
+
+vi.mock("@/auth/session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/auth/session")>();
+  return {
+    ...actual,
+    fetchSession: (...args: []) => fetchSession(...args),
+  };
+});
+
+vi.mock("@zitadel/sdk-react", () => ({
+  ZitadelLogin: (props: {
+    postSignInUrl?: string;
+    theme?: string;
+    project?: { projectId?: string };
+  }) => (
+    <div
+      data-testid="zitadel-login"
+      data-post-sign-in-url={props.postSignInUrl}
+      data-project-id={props.project?.projectId}
+    />
+  ),
+}));
+
+const PROJECT_ID = "proj_claimme";
+const CHALLENGE_ID = "chal_1";
+const CLAIM_PATH = `/claim?challenge_id=${CHALLENGE_ID}&project_id=${PROJECT_ID}`;
+
+// A path pattern rather than an absolute URL: this spec imports the router
+// statically, so `api/zitadel.ts` binds its base before any `stubEnv`.
+const COMPLETE_PATTERN = `*/api/projects/${PROJECT_ID}/claim/complete`;
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterAll(() => server.close());
+
+beforeEach(() => {
+  fetchSession.mockReset();
+  // The widget renders only when a project id resolves (ADR 0004 §§2–3);
+  // pin the dev override so the unauthenticated branch exercises it.
+  vi.stubEnv("VITE_CONSOLE_PROJECT_ID", "proj_platform");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  server.resetHandlers();
+});
+
+async function renderAt(path: string) {
+  const router = createAppRouter({ history: createMemoryHistory({ initialEntries: [path] }) });
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+/** Records completion calls and answers them with `respond`. */
+function stubComplete(respond: () => Response) {
+  const bodies: unknown[] = [];
+  server.use(
+    http.post(COMPLETE_PATTERN, async ({ request }) => {
+      bodies.push(await request.json());
+      return respond();
+    }),
+  );
+  return bodies;
+}
+
+describe("claim page", () => {
+  it("prompts an unauthenticated visitor to sign in, returning to the claim URL", async () => {
+    fetchSession.mockResolvedValue(null);
+    await renderAt(CLAIM_PATH);
+
+    const widget = await screen.findByTestId("zitadel-login");
+    // The widget's terminal step is a full-document navigation; pointing it
+    // back at the claim URL (params included) is what resumes the claim with
+    // the cookie in place.
+    expect(widget.dataset.postSignInUrl).toContain("/claim");
+    expect(widget.dataset.postSignInUrl).toContain(`challenge_id=${CHALLENGE_ID}`);
+    expect(widget.dataset.postSignInUrl).toContain(`project_id=${PROJECT_ID}`);
+    // Identity lives in the console's platform project, not the project being
+    // claimed (ADR 0004).
+    expect(widget.dataset.projectId).toBe("proj_platform");
+  });
+
+  it("completes the claim exactly once for a signed-in visit and shows success", async () => {
+    fetchSession.mockResolvedValue(makeTestSession());
+    const bodies = stubComplete(() =>
+      HttpResponse.json({
+        project_id: PROJECT_ID,
+        team_id: "team_personal",
+        claimed_at: "2026-08-24T10:00:00Z",
+      }),
+    );
+    await renderAt(CLAIM_PATH);
+
+    expect(await screen.findByRole("heading", { name: "Project claimed" })).toBeInTheDocument();
+    // The challenge is single-use (first-claim-wins): one visit must spend it
+    // exactly once, whatever React re-renders happen around the effect.
+    expect(bodies).toEqual([{ challenge_id: CHALLENGE_ID }]);
+    // The CLI is polling `claim/status`; the page says so instead of
+    // pretending the browser is the end of the story.
+    expect(screen.getByText(/terminal/i)).toBeInTheDocument();
+  });
+
+  it("shows the owning team's dashboard when the project is already claimed", async () => {
+    fetchSession.mockResolvedValue(makeTestSession());
+    stubComplete(() =>
+      HttpResponse.json(
+        {
+          code: "proj-already_claimed",
+          message: "The project is already claimed by a team.",
+          details: {
+            team_id: "team_other",
+            dashboard_url: "https://console.example/teams/team_other",
+          },
+        },
+        { status: 409 },
+      ),
+    );
+    await renderAt(CLAIM_PATH);
+
+    expect(await screen.findByRole("heading", { name: "Already claimed" })).toBeInTheDocument();
+    // ADR 030: the API owns the error copy; it is rendered verbatim.
+    expect(screen.getByText("The project is already claimed by a team.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /dashboard/i })).toHaveAttribute(
+      "href",
+      "https://console.example/teams/team_other",
+    );
+  });
+
+  it("prompts a restart when the challenge has expired", async () => {
+    fetchSession.mockResolvedValue(makeTestSession());
+    stubComplete(() =>
+      HttpResponse.json(
+        { code: "proj-claim_expired", message: "The claim challenge has expired." },
+        { status: 410 },
+      ),
+    );
+    await renderAt(CLAIM_PATH);
+
+    expect(await screen.findByRole("heading", { name: "Claim link expired" })).toBeInTheDocument();
+    expect(screen.getByText("The claim challenge has expired.")).toBeInTheDocument();
+    // The fix is a fresh challenge from `claim/init`, which only the CLI can
+    // mint — the page says where to go rather than offering a dead retry.
+    expect(screen.getByText(/terminal/i)).toBeInTheDocument();
+  });
+
+  it("explains a 403 — the session user has no personal team", async () => {
+    fetchSession.mockResolvedValue(makeTestSession());
+    stubComplete(() =>
+      HttpResponse.json(
+        {
+          code: "claim-no_personal_team",
+          message: "The session user has no active personal team in the platform project.",
+        },
+        { status: 403 },
+      ),
+    );
+    await renderAt(CLAIM_PATH);
+
+    expect(
+      await screen.findByRole("heading", { name: "This account cannot claim projects" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The session user has no active personal team in the platform project."),
+    ).toBeInTheDocument();
+  });
+
+  it("dead-ends a 401 instead of re-running sign-in", async () => {
+    // The loader just confirmed an active session, so a 401 from
+    // `claim/complete` is the server's opaque wrong-plane verdict (no platform
+    // project, or a foreign-project session — `verifyClaimSession` collapses
+    // both into public `auth.unauthorized`). Re-embedding the widget mints the
+    // same session again and loops forever — the local dev backend boots
+    // without a platform project, which is exactly how the loop was found.
+    fetchSession.mockResolvedValue(makeTestSession());
+    stubComplete(() =>
+      HttpResponse.json(
+        { code: "auth.unauthorized", message: "Missing or invalid session token." },
+        { status: 401 },
+      ),
+    );
+    await renderAt(CLAIM_PATH);
+
+    expect(
+      await screen.findByRole("heading", { name: "Your session can't complete this claim" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("zitadel-login")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  it("offers a retry on an unexpected failure, spending one call per attempt", async () => {
+    fetchSession.mockResolvedValue(makeTestSession());
+    let calls = 0;
+    server.use(
+      http.post(COMPLETE_PATTERN, () => {
+        calls += 1;
+        return calls === 1
+          ? HttpResponse.json({ code: "internal", message: "Something broke." }, { status: 500 })
+          : HttpResponse.json({
+              project_id: PROJECT_ID,
+              team_id: "team_personal",
+              claimed_at: "2026-08-24T10:00:00Z",
+            });
+      }),
+    );
+    await renderAt(CLAIM_PATH);
+
+    expect(
+      await screen.findByRole("heading", { name: "The claim did not complete" }),
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(await screen.findByRole("heading", { name: "Project claimed" })).toBeInTheDocument();
+    expect(calls).toBe(2);
+  });
+
+  it("rejects a claim URL with missing parameters without spending anything", async () => {
+    fetchSession.mockResolvedValue(makeTestSession());
+    const bodies = stubComplete(() => HttpResponse.json({}));
+    await renderAt("/claim?project_id=proj_only");
+
+    expect(
+      await screen.findByRole("heading", { name: "This claim link is not valid" }),
+    ).toBeInTheDocument();
+    expect(bodies).toHaveLength(0);
+  });
+});

--- a/apps/console/src/routes/claim/index.tsx
+++ b/apps/console/src/routes/claim/index.tsx
@@ -80,7 +80,17 @@ function ClaimScreen() {
 
   return (
     <ClaimShell>
-      <CompleteClaim projectId={project_id} challengeId={challenge_id} />
+      {/*
+        Keyed: CompleteClaim gates its single-use spend behind a ref, so a
+        client-side navigation to a *different* claim URL would otherwise reuse
+        the spent-once state and show the previous outcome. The key remounts it
+        instead, which resets the gate without weakening it.
+      */}
+      <CompleteClaim
+        key={`${project_id}:${challenge_id}`}
+        projectId={project_id}
+        challengeId={challenge_id}
+      />
     </ClaimShell>
   );
 }
@@ -192,17 +202,19 @@ function CompleteClaim({ projectId, challengeId }: { projectId: string; challeng
           </Button>
         </StateCard>
       );
-    case "already_claimed":
+    case "already_claimed": {
+      const dashboardUrl = safeHttpUrl(outcome.dashboardUrl);
       return (
         <StateCard title="Already claimed">
           <p className={BODY_TEXT}>{outcome.message}</p>
-          {outcome.dashboardUrl && (
+          {dashboardUrl && (
             <Button asChild variant="outline" className="mx-auto w-fit">
-              <a href={outcome.dashboardUrl}>Open the owning team&rsquo;s dashboard</a>
+              <a href={dashboardUrl}>Open the owning team&rsquo;s dashboard</a>
             </Button>
           )}
         </StateCard>
       );
+    }
     case "expired":
       return (
         <StateCard title="Claim link expired">
@@ -213,9 +225,27 @@ function CompleteClaim({ projectId, challengeId }: { projectId: string; challeng
         </StateCard>
       );
     case "no_personal_team":
+      // The contract states this code clears itself: the next sign-in
+      // provisions the team. A retry is therefore honest here — unlike the
+      // not-active case below, where retrying can only fail again.
+      return (
+        <StateCard title="Your account has no team yet">
+          <p className={BODY_TEXT}>{outcome.message}</p>
+          <p className={BODY_TEXT}>
+            Signing in again normally provisions one. Retry, or reopen the link from your terminal.
+          </p>
+          <Button onClick={run} variant="outline" className="mx-auto w-fit">
+            Try again
+          </Button>
+        </StateCard>
+      );
+    case "personal_team_not_active":
+      // Deliberately no retry: the membership exists and is not active, and
+      // the contract says provisioning will not change that. Only a person can.
       return (
         <StateCard title="This account cannot claim projects">
           <p className={BODY_TEXT}>{outcome.message}</p>
+          <p className={BODY_TEXT}>{membershipRemedy(outcome.membershipStatus)}</p>
         </StateCard>
       );
     case "invalid_challenge":
@@ -253,5 +283,40 @@ function CompleteClaim({ projectId, challengeId }: { projectId: string; challeng
           </Button>
         </StateCard>
       );
+  }
+}
+
+/**
+ * Renders only http(s). The value comes from an error body — our own API,
+ * declared `format: uri` — so this is defence in depth, but React will happily
+ * render a `javascript:` href, and the sibling field is already read
+ * defensively. A rejected URL costs the button, not the screen.
+ */
+function safeHttpUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value, window.location.origin);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * What actually unblocks each membership state, from the 403's contract text.
+ * `removed` is the counter-intuitive one: deactivating a *user* cascades to
+ * their memberships without touching the team, so the fix is the account's
+ * access rather than the team's.
+ */
+function membershipRemedy(status: string | undefined): string {
+  switch (status) {
+    case "removed":
+      return "The membership was withdrawn. Restoring this account's access is what unblocks the claim — the team itself may well still be active.";
+    case "inactive":
+      return "The membership is suspended. An administrator has to reactivate it before this account can claim a project.";
+    case "pending":
+      return "There is an invitation waiting to be accepted. Accept it, then reopen the claim link.";
+    default:
+      return "Ask an administrator to restore this account's team membership, then reopen the claim link.";
   }
 }

--- a/apps/console/src/routes/claim/index.tsx
+++ b/apps/console/src/routes/claim/index.tsx
@@ -1,0 +1,257 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ZitadelLogin, type ZitadelProject } from "@zitadel/sdk-react";
+import { Loader2 } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { apiBase } from "../../api/zitadel";
+import { fetchSession } from "../../auth/session";
+import { ZitadelMark } from "../../components/app-shell/icons";
+import { type ClaimOutcome, completeProjectClaim } from "../../lib/claim";
+import { getConsoleProjectId, getPublishableKey } from "../../runtime/runtime";
+import { useTheme } from "../../theme";
+
+/**
+ * The claim page (#615, Claim H1) — the browser leg of a project claim.
+ *
+ * `claim/init` hands the CLI a URL of the form
+ * `<console>/claim?challenge_id=…&project_id=…`. The developer lands here,
+ * signs in or registers against the **platform project** — the console's own
+ * identity project (ADR 0004), not the project being claimed — and the page
+ * spends the challenge via `claim/complete`, authenticated by the
+ * `__nextgen_session` cookie. The CLI meanwhile polls `claim/status`, so
+ * success here is what unblocks the terminal.
+ *
+ * A top-level route outside `_authed` on purpose: an unauthenticated visitor
+ * is the normal case, and bouncing them to `/login` would lose the claim
+ * context. The sign-in widget renders inline instead (the same embedding as
+ * `login.tsx`), with `postSignInUrl` pointing back at this URL — the widget's
+ * terminal step is a full-document navigation, so the page reboots with the
+ * cookie in place and completes the claim.
+ *
+ * Visual design for this page is still being refined; the layout mirrors the
+ * login screen's centered column with token-correct styling until the frames
+ * exist.
+ */
+export const Route = createFileRoute("/claim/")({
+  validateSearch: (search: Record<string, unknown>): ClaimSearch => ({
+    challenge_id: typeof search.challenge_id === "string" ? search.challenge_id : undefined,
+    project_id: typeof search.project_id === "string" ? search.project_id : undefined,
+  }),
+  // A read, not the completion: the mutation lives in the component so loader
+  // re-runs (preloads, invalidations) can never spend the single-use challenge.
+  loader: async () => ({ session: await fetchSession() }),
+  component: ClaimScreen,
+});
+
+export interface ClaimSearch {
+  challenge_id?: string;
+  project_id?: string;
+}
+
+const HEADING = "text-foreground font-serif text-xl";
+const BODY_TEXT = "text-muted-foreground text-sm";
+
+function ClaimScreen() {
+  const { challenge_id, project_id } = Route.useSearch();
+  const { session } = Route.useLoaderData();
+
+  if (!challenge_id || !project_id) {
+    return (
+      <ClaimShell>
+        <StateCard title="This claim link is not valid">
+          <p className={BODY_TEXT}>
+            The link is missing its claim parameters. Copy the URL from your terminal again, or
+            re-run the claim to mint a fresh one.
+          </p>
+        </StateCard>
+      </ClaimShell>
+    );
+  }
+
+  if (!session) {
+    return (
+      <ClaimShell>
+        <ClaimLogin challengeId={challenge_id} projectId={project_id} />
+      </ClaimShell>
+    );
+  }
+
+  return (
+    <ClaimShell>
+      <CompleteClaim projectId={project_id} challengeId={challenge_id} />
+    </ClaimShell>
+  );
+}
+
+/** The login screen's centered column (`login.tsx`), reused for every state. */
+function ClaimShell({ children }: { children: ReactNode }) {
+  return (
+    <main className="flex min-h-svh flex-col items-center justify-center gap-8 bg-background px-4 py-10">
+      <ZitadelMark size={40} className="text-foreground" aria-hidden />
+      <h1 className="sr-only">Claim your project</h1>
+      {children}
+    </main>
+  );
+}
+
+function StateCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="flex max-w-md flex-col gap-3 text-center">
+      <h2 className={HEADING}>{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The sign-in/registration leg: the embedded widget against the platform
+ * project, exactly as `login.tsx` builds it (per-element project handle —
+ * see that file for why attributes would lose to the app-wide
+ * `configureZitadel()`). `purpose="login"` runs the project's default login
+ * flow, whose definition owns the registration affordance; a claim-specific
+ * flow would attach here via the widget's flow key once one exists.
+ */
+function ClaimLogin({ challengeId, projectId }: { challengeId: string; projectId: string }) {
+  const { resolved: theme } = useTheme();
+  const consoleProjectId = getConsoleProjectId();
+  const publishableKey = getPublishableKey();
+
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  const params = new URLSearchParams({ challenge_id: challengeId, project_id: projectId });
+  const postSignInUrl = `${base}/claim?${params.toString()}`;
+
+  const project = useMemo<ZitadelProject | undefined>(
+    () =>
+      consoleProjectId
+        ? Object.freeze({ projectId: consoleProjectId, proxyPath: apiBase, publishableKey })
+        : undefined,
+    [consoleProjectId, publishableKey],
+  );
+
+  if (!project) {
+    return (
+      <StateCard title="No project yet">
+        <p className={BODY_TEXT}>
+          This deployment has nothing to sign in to yet, so the claim cannot start. Finish the setup
+          in your terminal, then reopen the claim link.
+        </p>
+      </StateCard>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <p className={BODY_TEXT}>Sign in or create an account to claim your project.</p>
+      <ZitadelLogin project={project} purpose="login" theme={theme} postSignInUrl={postSignInUrl} />
+    </div>
+  );
+}
+
+/**
+ * The completion leg. The challenge is single-use and first-claim-wins, so
+ * one visit must spend it exactly once: the ref gates the effect against
+ * re-renders and double-mounts, and only the explicit `Try again` button can
+ * start another attempt.
+ */
+function CompleteClaim({ projectId, challengeId }: { projectId: string; challengeId: string }) {
+  const [outcome, setOutcome] = useState<ClaimOutcome | null>(null);
+  const startedRef = useRef(false);
+
+  const run = useCallback(() => {
+    setOutcome(null);
+    void completeProjectClaim(projectId, challengeId).then(setOutcome);
+  }, [projectId, challengeId]);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    run();
+  }, [run]);
+
+  if (!outcome) {
+    return (
+      <div className="text-muted-foreground flex items-center gap-2 text-sm" role="status">
+        <Loader2 className="size-4 animate-spin" aria-hidden />
+        Claiming your project…
+      </div>
+    );
+  }
+
+  switch (outcome.kind) {
+    case "claimed":
+      return (
+        <StateCard title="Project claimed">
+          <p className={BODY_TEXT}>
+            The project now belongs to your personal team. You can return to your terminal — the CLI
+            picks the claim up on its own.
+          </p>
+          <Button asChild className="mx-auto w-fit">
+            <Link to="/">Open the console</Link>
+          </Button>
+        </StateCard>
+      );
+    case "already_claimed":
+      return (
+        <StateCard title="Already claimed">
+          <p className={BODY_TEXT}>{outcome.message}</p>
+          {outcome.dashboardUrl && (
+            <Button asChild variant="outline" className="mx-auto w-fit">
+              <a href={outcome.dashboardUrl}>Open the owning team&rsquo;s dashboard</a>
+            </Button>
+          )}
+        </StateCard>
+      );
+    case "expired":
+      return (
+        <StateCard title="Claim link expired">
+          <p className={BODY_TEXT}>{outcome.message}</p>
+          <p className={BODY_TEXT}>
+            Run the claim again from your terminal to mint a fresh link — this one is done.
+          </p>
+        </StateCard>
+      );
+    case "no_personal_team":
+      return (
+        <StateCard title="This account cannot claim projects">
+          <p className={BODY_TEXT}>{outcome.message}</p>
+        </StateCard>
+      );
+    case "invalid_challenge":
+      return (
+        <StateCard title="This claim link is not valid">
+          <p className={BODY_TEXT}>{outcome.message}</p>
+        </StateCard>
+      );
+    case "unauthenticated":
+      // NOT the sign-in widget again. The loader confirmed an active session
+      // moments ago, so this 401 is almost never a lost cookie — it is the
+      // server's deliberately opaque verdict for a session that cannot claim
+      // (most often: it does not belong to the platform project, e.g. a
+      // deployment running without `platform.bootstrap_project`, which is how
+      // the local testkit boots today). Re-running sign-in mints the same
+      // session and loops forever; an honest dead-end beats a treadmill.
+      return (
+        <StateCard title="Your session can't complete this claim">
+          <p className={BODY_TEXT}>
+            The server did not accept the signed-in session for this claim. On a deployment without
+            a platform project, claims cannot complete; otherwise your session may have expired
+            mid-claim — reopen the link from your terminal and sign in again.
+          </p>
+          <Button onClick={run} variant="outline" className="mx-auto w-fit">
+            Try again
+          </Button>
+        </StateCard>
+      );
+    case "error":
+      return (
+        <StateCard title="The claim did not complete">
+          <p className={BODY_TEXT}>{outcome.message}</p>
+          <Button onClick={run} variant="outline" className="mx-auto w-fit">
+            Try again
+          </Button>
+        </StateCard>
+      );
+  }
+}


### PR DESCRIPTION
## Summary

<img width="433" height="587" alt="Screenshot 2026-09-01 at 09 14 24" src="https://github.com/user-attachments/assets/1f3cdbc1-a99d-4714-bb19-ddba246a5238" />
<img width="631" height="439" alt="Screenshot 2026-09-01 at 09 14 49" src="https://github.com/user-attachments/assets/344da668-f18b-46f5-b5ef-6384f0d4e8aa" />

- Closes #615 (Claim H1) — the browser leg of a project claim. `claim/init` hands the CLI a `<console>/claim?challenge_id=…&project_id=…` URL; the developer lands here, signs in or registers against the **platform** project (the console's own identity project, ADR 0004 — not the project being claimed), and the page spends the challenge via `claim/complete` on the `__nextgen_session` cookie. The CLI polls `claim/status`, so success here is what unblocks the terminal.
- **A top-level route outside `_authed`, deliberately.** An unauthenticated visitor is the normal case; bouncing them to `/login` would drop the claim context. The sign-in widget renders inline instead (same embedding as `login.tsx`) with `postSignInUrl` pointing back at the claim URL — the widget's terminal step is a full-document navigation, so the page reboots with the cookie in place and completes.
- **One call site for the mutation.** `completeProjectClaim` in `lib/claim.ts` is the only place the completion request is built, returning a `ClaimOutcome` discriminated union rather than throwing: every HTTP status the contract enumerates (400/401/403/404/409/410/429) is a screen state, not an exception. When ADR 053 adds `X-Zitadel-CSRF` it lands in that one function; if ADR 054 grows a team-selection parameter, the body grows there.
- **The 401 is a dead end, and that is the fix.** `verifyClaimSession` collapses "no cookie" and "session is not in the platform project" into the same opaque `auth.unauthorized` (ADR 046 §2), so the browser cannot tell them apart. The page therefore does **not** answer a 401 by re-rendering the sign-in widget: the loader confirmed a live session moments earlier, so re-signing-in mints the same session and loops forever — which is exactly the symptom seen locally on a deployment without `platform.bootstrap_project`. It renders an honest card with a `Try again` button instead.
- **The challenge is spent exactly once per visit.** The route loader only *reads* the session — the mutation lives in the component, so loader re-runs (preloads, invalidations) can never spend a single-use challenge — and a ref gates the effect against re-renders and StrictMode double-mounts. Only the explicit `Try again` button starts another attempt.
- Missing or malformed `challenge_id`/`project_id` short-circuits before any request; a deployment with no console project renders a "nothing to sign in to yet" card rather than a broken widget.

## Validation
- `pnpm vitest run src/routes/claim` in `apps/console` — 8 tests: unauthenticated visitor gets the widget with a return URL; a signed-in visit completes exactly once and shows success; 409 renders the owning team's dashboard link; 410 prompts a restart; 403 explains the missing personal team; **401 dead-ends instead of re-running sign-in** (the regression guard for the loop); an unexpected failure offers retry and spends one call per attempt; a URL with missing parameters spends nothing.
- `tsc --noEmit -p tsconfig.json` on `apps/console` — clean against current `main` (i.e. after the API regeneration and the backend claim work that has since landed).
- `pnpm exec oxlint` / `pnpm exec oxfmt --check` on the changed files.
- Manually exercised locally against a real `claim/init` challenge: the pre-fix build reproduced the sign-in loop; this build ends on the 401 card instead.
- Not run: an end-to-end claim that reaches `claimed`. That needs a flow-capable platform project (`platform.bootstrap_project` plus the #527 provisioner), which the local testkit does not boot today — the reason the 401 branch is the one reachable locally.

## Release notes / changeset
- Changeset: `.changeset/console-claim-page.md` — the console serves the project claim page at `/claim`, with explicit outcomes for expired, already-claimed and unauthorized challenges instead of a redirect loop. Lists `@zitadel/server` (the console ships embedded in the server container).

## Notes
- **The backend half is already in `main`.** The personal-team ensure now runs on session exchange, so the `no_personal_team` (403) branch should be unreachable for anyone who signs in. The state is kept regardless: the contract still enumerates the status, and a page that renders a documented error honestly is cheaper than one that assumes it cannot happen.
- The 401 copy names "a deployment without a platform project" as the likely cause. That is accurate today; once the #527 provisioner makes a bootstrapped platform project the norm, this copy should be revisited — a 401 will then far more often be a genuinely expired session.
- Visual design is provisional: no Figma frames exist for this screen yet, so the layout mirrors the login column with token-correct styling. Worth a follow-up once the frames land.
- `purpose="login"` runs the project's default login flow, whose definition owns the registration affordance. A claim-specific flow would attach through the widget's flow key if one is ever defined.
- `routeTree.gen.ts` changes are plugin-generated from the new route file, not hand-edited.
