### PR TITLE
fix(api): preserve transition purpose for embedded flow definitions

### DIFF
--- a/.changeset/fix-flow-transition-purpose.md
+++ b/.changeset/fix-flow-transition-purpose.md
@@ -2,6 +2,6 @@
 "@zitadel/server": patch
 ---
 
-Fix flow-definition upload dropping each transition's `purpose` field, which
-left the login flow's Sign Up link unable to switch the flow into
-registration mode.
+Fix embedded default-login-flow seeding dropping each transition's `purpose`
+field, which left the login flow's Sign Up link unable to switch the flow
+into registration mode.

--- a/.changeset/fix-flow-transition-purpose.md
+++ b/.changeset/fix-flow-transition-purpose.md
@@ -1,0 +1,7 @@
+---
+"@zitadel/server": patch
+---
+
+Fix flow-definition upload dropping each transition's `purpose` field, which
+left the login flow's Sign Up link unable to switch the flow into
+registration mode.

--- a/api/openapi/endpoints/flow_definitions/embed.go
+++ b/api/openapi/endpoints/flow_definitions/embed.go
@@ -142,20 +142,42 @@ func convertStepTransitions(transitions api.OptFlowDefinitionStepTransitions) (m
 			return nil, err
 		}
 
+		purpose, err := convertStepTransitionPurpose(transition.GetPurpose())
+		if err != nil {
+			return nil, err
+		}
+
 		ret[name] = domain.FlowStepTransition{
-			Action: action,
-			Target: transition.GetTarget(),
+			Action:  action,
+			Target:  transition.GetTarget(),
+			Purpose: purpose,
 		}
 	}
 	return ret, nil
 }
 
-func convertStepTransitionAction(action api.OptNilFlowDefinitionStepTransitionsItemAction) (*domain.FlowDefinitionTransitionAction, error) {
-	if !action.IsSet() {
+func convertStepTransitionPurpose(purpose api.OptNilFlowDefinitionStepTransitionsItemPurpose) (*domain.FlowDefinitionPurpose, error) {
+	// Get() is false for absent and explicit-null values alike; IsSet() alone
+	// would map an explicit `null` to the zero enum and fail the conversion.
+	value, ok := purpose.Get()
+	if !ok {
 		return nil, nil
 	}
 
-	ret, err := domain.FlowDefinitionTransitionActionString(string(action.Value))
+	ret, err := domain.FlowDefinitionPurposeString(string(value))
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+func convertStepTransitionAction(action api.OptNilFlowDefinitionStepTransitionsItemAction) (*domain.FlowDefinitionTransitionAction, error) {
+	value, ok := action.Get()
+	if !ok {
+		return nil, nil
+	}
+
+	ret, err := domain.FlowDefinitionTransitionActionString(string(value))
 	if err != nil {
 		return nil, err
 	}

--- a/api/openapi/endpoints/flow_definitions/examples_test.go
+++ b/api/openapi/endpoints/flow_definitions/examples_test.go
@@ -136,4 +136,25 @@ func TestDefaultLoginFlowDefinition(t *testing.T) {
 
 	_, err = domain.ValidateFlowDefinition(&userSchema, *defs[0])
 	require.NoError(t, err)
+
+	// Regression guard for #1084: convertStepTransitions must preserve each
+	// transition's purpose through the upload path, or the Sign Up / Sign In
+	// navigations lose their re-purposing and the engine desyncs.
+	var identifierStep, registerStep *domain.FlowDefinitionStep
+	for i, step := range defs[0].Steps {
+		switch step.Name {
+		case "identifier":
+			identifierStep = &defs[0].Steps[i]
+		case "register":
+			registerStep = &defs[0].Steps[i]
+		}
+	}
+	require.NotNil(t, identifierStep, "default-login.json must have an identifier step")
+	require.NotNil(t, registerStep, "default-login.json must have a register step")
+
+	require.NotNil(t, identifierStep.Transitions["register"].Purpose, "identifier->register transition must preserve purpose")
+	require.Equal(t, domain.FlowDefinitionPurposeRegister, *identifierStep.Transitions["register"].Purpose)
+
+	require.NotNil(t, registerStep.Transitions["sign_in"].Purpose, "register->sign_in transition must preserve purpose")
+	require.Equal(t, domain.FlowDefinitionPurposeLogin, *registerStep.Transitions["sign_in"].Purpose)
 }

--- a/api/openapi/endpoints/flow_definitions/examples_test.go
+++ b/api/openapi/endpoints/flow_definitions/examples_test.go
@@ -138,8 +138,9 @@ func TestDefaultLoginFlowDefinition(t *testing.T) {
 	require.NoError(t, err)
 
 	// Regression guard for #1084: convertStepTransitions must preserve each
-	// transition's purpose through the upload path, or the Sign Up / Sign In
-	// navigations lose their re-purposing and the engine desyncs.
+	// transition's purpose through embedded default-flow seeding, or the
+	// Sign Up / Sign In navigations lose their re-purposing and the engine
+	// desyncs.
 	var identifierStep, registerStep *domain.FlowDefinitionStep
 	for i, step := range defs[0].Steps {
 		switch step.Name {


### PR DESCRIPTION
## Summary

Fixes #1084. `convertStepTransitions` in `api/openapi/endpoints/flow_definitions/embed.go` never copied the wire-documented per-transition `purpose` field into `domain.FlowStepTransition`, so every flow definition converted through the embed path (used by `internal/service/project.go` to seed each new project's default login flow) silently lost its purpose overrides. On the seeded default-login flow that meant the Sign up navigate never flipped `FlowState.CurrentPurpose` to `register`, and the next identifier submit misread a fresh email as a real `user_not_found` failure, dead-ending registration.

- Add `convertStepTransitionPurpose`, mirroring the existing `convertStepTransitionAction`, and wire `Purpose` into the built transition.
- Use ogen `Get()` instead of `IsSet()` + `.Value` in both transition helpers, so a schema-legal explicit `"purpose": null` (or `"action": null`) reads as unset instead of failing enum conversion on the zero value. This matches the null-handling pattern the HTTP upload handler already documents in [internal/api/flow_definition.go](https://github.com/zitadel/nextgen/blob/deb08c83be2e30bd4014efd6486554871bd4dfeb/internal/api/flow_definition.go#L207-L221).
- Regression test in `examples_test.go` asserts the two purpose-carrying transitions of [default-login.json](https://github.com/zitadel/nextgen/blob/deb08c83be2e30bd4014efd6486554871bd4dfeb/packages/config/defaults/default-login.json#L46-L49) survive the real conversion path (`DefaultLoginFlowDefinitions` -> `convertSteps` -> `convertStepTransitions`), not a hand-built domain object.

The other two `FlowStepTransition` construction sites already preserve `purpose` (HTTP handler and storage round-trip); the embed path was the only gap. The engine consumes the field at [flow_state_machine.go#L482-L506](https://github.com/zitadel/nextgen/blob/deb08c83be2e30bd4014efd6486554871bd4dfeb/internal/domain/flow_state_machine.go#L481-L507), so preserving it is sufficient to fix the user-facing bug.

## Validation

- `go test ./api/openapi/endpoints/flow_definitions/` (8 passed; includes the new #1084 regression guard and the existing example round-trips)
- Live repro path from #1084 (fresh instance, console login, Sign up, new email, Continue with password) was verified broken before the fix during the end-to-end claim journey; the regression test pins the conversion-level cause.

## Release notes / changeset

- Changeset: `.changeset/fix-flow-transition-purpose.md` (`@zitadel/server` patch): flow-definition upload no longer drops each transition's `purpose` field.

## Notes

- Stacked on #1078 (`cnsl-project-claim`), which is the base branch; only commit deb08c83b belongs to this PR. Merge #1078 first, then retarget or let GitHub auto-retarget this one to main.
- The `user_not_found`-as-visible-copy issue mentioned in #1084 is not addressed here; with purpose preserved, the Sign up path no longer produces that error at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrJHufA9FMetvLuZy7EY9a