### PR TITLE
feat: user-ref resolution plumbing (ADR 058 §3–§4)

### DIFF
--- a/.changeset/user-ref-plumbing.md
+++ b/.changeset/user-ref-plumbing.md
@@ -1,0 +1,9 @@
+---
+"@zitadel/server": patch
+---
+
+Internal plumbing for ADR 058 §3/§4: the `user-ref` resolution primitives
+(designation readers, `domain.ResolveUserRef`, and the batched
+`(project_id, user_ids) → refs` resolution port) and the inert `user-ref`
+wire component. No endpoint behavior changes yet — session adoption ships
+separately.

--- a/api/openapi/components/schemas/user-ref.yaml
+++ b/api/openapi/components/schemas/user-ref.yaml
@@ -1,0 +1,37 @@
+type: object
+title: UserRef
+description: |
+  A resolved reference to a user (ADR 058 §3). Fields are role-named, not
+  property-named, so responses can mix users from different schemas.
+  `identifier` and `display` are resolved independently from the user
+  schema's `x-identifier` and `x-display` designations, live at read time.
+  Clients render `display`, falling back to `identifier`, then `user_id`.
+required:
+  - user_id
+properties:
+  user_id:
+    $ref: ./user-id.yaml
+    description: The referenced user's id. Always present.
+  identifier:
+    type: string
+    description: |
+      The current value of the schema's designated identifier
+      (`x-identifier`). Absent when the schema designates no identifier or
+      the user carries no value for it.
+    example: ada@example.com
+  identifier_property:
+    type: string
+    description: |
+      The schema property `identifier` came from, so clients can reach the
+      property's schema for semantics (a mailto link, a field label)
+      instead of guessing from the value. Present exactly when
+      `identifier` is.
+    example: email
+  display:
+    type: string
+    description: |
+      The `x-display` rendering — the designated properties' values joined
+      in list order. Purely presentational, with no source attribution.
+      Absent when the schema designates no display properties or the user
+      carries no values for them.
+    example: Ada Lovelace

--- a/internal/domain/schema_designation.go
+++ b/internal/domain/schema_designation.go
@@ -1,12 +1,47 @@
 package domain
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/zitadel/nextgen/internal/maputil"
 )
+
+// DesignatedIdentifier reads the root x-identifier designation from a raw
+// schema document. It returns "" for a document that designates nothing —
+// including one that is not a JSON object, since designation validity is
+// enforced when the schema is created ([validateUserSchemaDesignations]) and
+// readers treat anything unreadable as undesignated.
+func DesignatedIdentifier(document []byte) string {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(document, &root); err != nil {
+		return ""
+	}
+	var identifier string
+	if err := json.Unmarshal(root[SchemaAnnotationIdentifier], &identifier); err != nil {
+		return ""
+	}
+	return identifier
+}
+
+// DesignatedDisplay reads the root x-display designation from a raw schema
+// document: the ordered property paths whose values render the user's
+// display name (ADR 058 §2). Same reader contract as
+// [DesignatedIdentifier] — anything unreadable, including non-string
+// entries, reads as undesignated.
+func DesignatedDisplay(document []byte) []string {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(document, &root); err != nil {
+		return nil
+	}
+	var entries []string
+	if err := json.Unmarshal(root[SchemaAnnotationDisplay], &entries); err != nil {
+		return nil
+	}
+	return entries
+}
 
 // ErrSchemaDesignationInvalid reports an x-identifier / x-display designation
 // the user meta-schema cannot check itself (ADR 058 §1–§2): the named

--- a/internal/domain/user_ref.go
+++ b/internal/domain/user_ref.go
@@ -1,0 +1,81 @@
+package domain
+
+import (
+	"strconv"
+	"strings"
+)
+
+// UserRef is the resolved reference to a user carried by user-linked
+// resources (ADR 058 §3). Fields are role-named, not property-named, so
+// responses can mix users from different schemas. An empty field means
+// absent on the wire; Identifier and Display resolve independently of each
+// other, and clients render Display → Identifier → UserID.
+type UserRef struct {
+	UserID string
+	// Identifier is the current value of the schema's designated identifier
+	// (x-identifier). Empty when the schema designates nothing or the user
+	// lacks the value.
+	Identifier string
+	// IdentifierProperty names the schema property Identifier came from, so
+	// clients can reach the property's schema for semantics instead of
+	// guessing from the value. Set exactly when Identifier is.
+	IdentifierProperty string
+	// Display is the x-display rendering: the designated properties' values
+	// joined in list order. Purely presentational — no source attribution.
+	Display string
+}
+
+// ResolveUserRef derives the user's reference from their schema document's
+// designations. Attribute values are read from the user's loaded attributes:
+// designation paths are dot-joined leaf paths, matching the EAV flattening
+// of [AttributeKey], so entries address attribute keys verbatim. The user's
+// attributes must be hydrated with at least the designated keys (see
+// [DesignatedAttributeKeys]).
+func ResolveUserRef(user *User, schemaDocument []byte) UserRef {
+	ref := UserRef{UserID: user.ID}
+	if property := DesignatedIdentifier(schemaDocument); property != "" {
+		if value := scalarAttributeString(user, property); value != "" {
+			ref.Identifier = value
+			ref.IdentifierProperty = property
+		}
+	}
+	parts := make([]string, 0, 2)
+	for _, path := range DesignatedDisplay(schemaDocument) {
+		if value := scalarAttributeString(user, path); value != "" {
+			parts = append(parts, value)
+		}
+	}
+	ref.Display = strings.Join(parts, " ")
+	return ref
+}
+
+// scalarAttributeString renders the attribute at the designated path for the
+// wire. Designated properties declare exactly one non-null scalar type
+// ([declaresScalarType]), so string, number, and boolean are the shapes a
+// valid document can put here; anything else reads as absent.
+func scalarAttributeString(user *User, path string) string {
+	value, ok := user.Attributes.Get(AttributeKey(path))
+	if !ok {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(v)
+	}
+	return ""
+}
+
+// DesignatedAttributeKeys returns the attribute keys a schema document's
+// designations read — the hydration set a batch ref resolution needs
+// (ADR 058 §3a: rows hydrate only the designated attribute keys).
+func DesignatedAttributeKeys(schemaDocument []byte) []string {
+	var keys []string
+	if property := DesignatedIdentifier(schemaDocument); property != "" {
+		keys = append(keys, property)
+	}
+	return append(keys, DesignatedDisplay(schemaDocument)...)
+}

--- a/internal/domain/user_ref_test.go
+++ b/internal/domain/user_ref_test.go
@@ -1,0 +1,102 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+func TestDesignationReaders(t *testing.T) {
+	document := []byte(`{
+		"type": "object",
+		"x-identifier": "email",
+		"x-display": ["givenName", "familyName"]
+	}`)
+	assert.Equal(t, "email", domain.DesignatedIdentifier(document))
+	assert.Equal(t, []string{"givenName", "familyName"}, domain.DesignatedDisplay(document))
+	assert.Equal(t, []string{"email", "givenName", "familyName"}, domain.DesignatedAttributeKeys(document))
+
+	undesignated := []byte(`{"type": "object"}`)
+	assert.Empty(t, domain.DesignatedIdentifier(undesignated))
+	assert.Nil(t, domain.DesignatedDisplay(undesignated))
+	assert.Nil(t, domain.DesignatedAttributeKeys(undesignated))
+
+	// Unreadable shapes read as undesignated — validity is enforced at
+	// schema creation, not by readers.
+	for name, doc := range map[string]string{
+		"malformed":             `{`,
+		"non-object":            `true`,
+		"non-string identifier": `{"x-identifier": ["email"]}`,
+		"non-string display":    `{"x-display": ["givenName", 3]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Empty(t, domain.DesignatedIdentifier([]byte(doc)))
+			assert.Nil(t, domain.DesignatedDisplay([]byte(doc)))
+		})
+	}
+}
+
+func TestResolveUserRef(t *testing.T) {
+	user := func(attrs map[string]any) *domain.User {
+		return &domain.User{ID: "user-1", Attributes: domain.AttributesFromMap(attrs)}
+	}
+
+	tests := []struct {
+		name     string
+		document string
+		user     *domain.User
+		want     domain.UserRef
+	}{
+		{
+			name:     "identifier and display resolve independently",
+			document: `{"x-identifier": "email", "x-display": ["givenName", "familyName"]}`,
+			user:     user(map[string]any{"email": "ada@example.com", "givenName": "Ada", "familyName": "Lovelace"}),
+			want: domain.UserRef{
+				UserID: "user-1", Identifier: "ada@example.com",
+				IdentifierProperty: "email", Display: "Ada Lovelace",
+			},
+		},
+		{
+			name:     "no designation degrades to the id",
+			document: `{"type": "object"}`,
+			user:     user(map[string]any{"email": "ada@example.com"}),
+			want:     domain.UserRef{UserID: "user-1"},
+		},
+		{
+			name:     "display without identifier",
+			document: `{"x-display": ["givenName"]}`,
+			user:     user(map[string]any{"givenName": "Ada"}),
+			want:     domain.UserRef{UserID: "user-1", Display: "Ada"},
+		},
+		{
+			name:     "identifier without value stays absent with its property",
+			document: `{"x-identifier": "email", "x-display": ["givenName"]}`,
+			user:     user(map[string]any{"givenName": "Ada"}),
+			want:     domain.UserRef{UserID: "user-1", Display: "Ada"},
+		},
+		{
+			name:     "absent display parts are skipped, not rendered empty",
+			document: `{"x-display": ["givenName", "familyName"]}`,
+			user:     user(map[string]any{"familyName": "Lovelace"}),
+			want:     domain.UserRef{UserID: "user-1", Display: "Lovelace"},
+		},
+		{
+			name:     "dot-path display entry addresses the flattened leaf",
+			document: `{"x-display": ["profile.nickname"]}`,
+			user:     user(map[string]any{"profile": map[string]any{"nickname": "ada"}}),
+			want:     domain.UserRef{UserID: "user-1", Display: "ada"},
+		},
+		{
+			name:     "non-string scalar identifier renders for the wire",
+			document: `{"x-identifier": "employeeNumber"}`,
+			user:     user(map[string]any{"employeeNumber": float64(4211)}),
+			want:     domain.UserRef{UserID: "user-1", Identifier: "4211", IdentifierProperty: "employeeNumber"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, domain.ResolveUserRef(tt.user, []byte(tt.document)))
+		})
+	}
+}

--- a/internal/service/user_ref.go
+++ b/internal/service/user_ref.go
@@ -38,6 +38,12 @@ func (r StatementsUserRefResolver) ResolveUserRefs(ctx context.Context, projectI
 		return map[string]domain.UserRef{}, nil
 	}
 
+	// Both queries below are nested reads keyed on rows the caller already
+	// holds (the page's user ids, the project's schemas) — not management
+	// lists — so the authz list-filter tripwire and any inherited filter are
+	// deliberately skipped, the same choice GetUser makes (#839).
+	ctx = WithAuthzListUnrestricted(ctx)
+
 	documents, attributeKeys, err := r.designatingSchemas(ctx, projectID)
 	if err != nil {
 		return nil, err
@@ -47,10 +53,7 @@ func (r StatementsUserRefResolver) ResolveUserRefs(ctx context.Context, projectI
 	for _, userID := range userIDs {
 		idFilters = append(idFilters, database.Equal(database.Col(domain.UserFieldID), userID))
 	}
-	// By-id lookup shape: the ids come from rows the caller already read, so
-	// the management list gate does not apply (same deliberate choice as
-	// GetUser, #839).
-	listed, err := r.Pool.Statements().ListUsers(WithAuthzListUnrestricted(ctx), &database.ListOptions[domain.UserField]{
+	listed, err := r.Pool.Statements().ListUsers(ctx, &database.ListOptions[domain.UserField]{
 		Filter: database.And(
 			database.Equal(database.Col(domain.UserFieldProjectID), projectID),
 			database.Or(idFilters...),

--- a/internal/service/user_ref.go
+++ b/internal/service/user_ref.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"context"
+	"slices"
+
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/storage/database"
+)
+
+// UserRefResolver is the batch resolution port of ADR 058 §4: it hydrates
+// user references for a page of user IDs with one batched attribute query —
+// list endpoints must not resolve per row. Missing users are simply absent
+// from the result; their refs degrade to the user id at the caller.
+type UserRefResolver interface {
+	ResolveUserRefs(ctx context.Context, projectID string, userIDs []string) (map[string]domain.UserRef, error)
+}
+
+// refSchemaPageSize pages the user-schema listing during ref resolution.
+// Projects hold few schemas; paging is correctness, not tuning.
+const refSchemaPageSize = 100
+
+// StatementsUserRefResolver resolves refs against the statement surface.
+type StatementsUserRefResolver struct {
+	Pool StatementPool
+}
+
+var _ UserRefResolver = StatementsUserRefResolver{}
+
+// ResolveUserRefs loads the project's user-schema documents (every stored
+// revision — users pin the schema URL they were created under, so each
+// revision's own designations govern its users), lists the requested users
+// in one call hydrating only the designated attribute keys, and maps each
+// user through its schema's designations.
+func (r StatementsUserRefResolver) ResolveUserRefs(ctx context.Context, projectID string, userIDs []string) (map[string]domain.UserRef, error) {
+	userIDs = slices.Compact(slices.Sorted(slices.Values(userIDs)))
+	if len(userIDs) == 0 {
+		return map[string]domain.UserRef{}, nil
+	}
+
+	documents, attributeKeys, err := r.designatingSchemas(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	idFilters := make([]database.Filter[domain.UserField], 0, len(userIDs))
+	for _, userID := range userIDs {
+		idFilters = append(idFilters, database.Equal(database.Col(domain.UserFieldID), userID))
+	}
+	// By-id lookup shape: the ids come from rows the caller already read, so
+	// the management list gate does not apply (same deliberate choice as
+	// GetUser, #839).
+	listed, err := r.Pool.Statements().ListUsers(WithAuthzListUnrestricted(ctx), &database.ListOptions[domain.UserField]{
+		Filter: database.And(
+			database.Equal(database.Col(domain.UserFieldProjectID), projectID),
+			database.Or(idFilters...),
+		),
+		Pagination: database.Page[domain.UserField]{
+			Limit: uint32(len(userIDs)),
+			OrderBy: database.OrderBy[domain.UserField]{
+				Columns:   []database.Column[domain.UserField]{database.Col(domain.UserFieldID)},
+				Direction: database.OrderAsc,
+			},
+		},
+	}, UserQueryOptions{AttributeKeys: attributeKeys})
+	if err != nil {
+		return nil, err
+	}
+
+	refs := make(map[string]domain.UserRef, len(listed.Items))
+	for _, user := range listed.Items {
+		refs[user.ID] = domain.ResolveUserRef(user, documents[user.SchemaURL])
+	}
+	return refs, nil
+}
+
+// designatingSchemas returns the project's user-schema documents by URL and
+// the union of attribute keys their designations read — the hydration set
+// for the batched user query. A user whose schema URL is not stored (or
+// designates nothing) resolves to a bare user-id ref.
+func (r StatementsUserRefResolver) designatingSchemas(ctx context.Context, projectID string) (map[string][]byte, []string, error) {
+	stmts := r.Pool.Statements()
+	list := func(cursor []byte) (*database.ListResult[*domain.JSONSchema], error) {
+		return stmts.ListJSONSchemas(ctx, &database.ListOptions[domain.JSONSchemaField]{
+			Filter: database.And(
+				database.Equal(database.Col(domain.JSONSchemaFieldProjectID), projectID),
+				database.Equal(database.Col(domain.JSONSchemaFieldKind), domain.JSONSchemaKindUserSchema.String()),
+			),
+			Pagination: database.Page[domain.JSONSchemaField]{
+				Limit:  refSchemaPageSize,
+				Cursor: cursor,
+				OrderBy: database.OrderBy[domain.JSONSchemaField]{
+					Columns:   []database.Column[domain.JSONSchemaField]{database.Col(domain.JSONSchemaFieldURL)},
+					Direction: database.OrderAsc,
+				},
+			},
+		}, JSONSchemaQueryOptions{})
+	}
+	first, err := list(nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	documents := make(map[string][]byte)
+	var attributeKeys []string
+	for schema, err := range first.Iterate(list) {
+		if err != nil {
+			return nil, nil, err
+		}
+		documents[schema.URL] = schema.Schema
+		for _, key := range domain.DesignatedAttributeKeys(schema.Schema) {
+			if !slices.Contains(attributeKeys, key) {
+				attributeKeys = append(attributeKeys, key)
+			}
+		}
+	}
+	if attributeKeys == nil {
+		// AttributeKeys nil means "hydrate everything"; no designation
+		// anywhere means nothing to read — hydrate a key no property can
+		// use so the query returns no attribute rows.
+		attributeKeys = []string{""}
+	}
+	return documents, attributeKeys, nil
+}

--- a/internal/service/user_ref.go
+++ b/internal/service/user_ref.go
@@ -116,10 +116,11 @@ func (r StatementsUserRefResolver) designatingSchemas(ctx context.Context, proje
 			}
 		}
 	}
-	if attributeKeys == nil {
-		// AttributeKeys nil means "hydrate everything"; no designation
-		// anywhere means nothing to read — hydrate a key no property can
-		// use so the query returns no attribute rows.
+	if len(attributeKeys) == 0 {
+		// Empty AttributeKeys — nil or not — means "hydrate everything"
+		// (UserQueryOptions contract); no designation anywhere means
+		// nothing to read, so hydrate a key no property can use and the
+		// query returns no attribute rows.
 		attributeKeys = []string{""}
 	}
 	return documents, attributeKeys, nil

--- a/internal/service/user_ref_test.go
+++ b/internal/service/user_ref_test.go
@@ -1,0 +1,132 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+	"github.com/zitadel/nextgen/internal/service/mocks"
+	"github.com/zitadel/nextgen/internal/storage/database"
+	"go.uber.org/mock/gomock"
+)
+
+func TestStatementsUserRefResolver_ResolveUserRefs(t *testing.T) {
+	newResolver := func(t *testing.T, stmts *mocks.MockAllStatements) service.StatementsUserRefResolver {
+		t.Helper()
+		ctrl := gomock.NewController(t)
+		pool := mocks.NewMockPool(ctrl)
+		pool.EXPECT().Statements().Return(stmts).AnyTimes()
+		return service.StatementsUserRefResolver{Pool: service.NewPool(pool)}
+	}
+
+	userSchema := func(schemaURL, document string) *domain.JSONSchema {
+		return &domain.JSONSchema{
+			ProjectID: "proj",
+			URL:       schemaURL,
+			Kind:      domain.JSONSchemaKindUserSchema,
+			Schema:    []byte(document),
+		}
+	}
+
+	expectSchemas := func(stmts *mocks.MockAllStatements, schemas ...*domain.JSONSchema) {
+		stmts.EXPECT().ListJSONSchemas(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&database.ListResult[*domain.JSONSchema]{Items: schemas}, nil)
+	}
+
+	t.Run("resolves a mixed-schema page with one batched query", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stmts := mocks.NewMockAllStatements(ctrl)
+		expectSchemas(stmts,
+			userSchema("https://s/human", `{"x-identifier":"email","x-display":["givenName","familyName"]}`),
+			userSchema("https://s/admin", `{"x-identifier":"username"}`),
+		)
+		var gotKeys []string
+		stmts.EXPECT().ListUsers(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *database.ListOptions[domain.UserField], opts service.UserQueryOptions) (*database.ListResult[*domain.User], error) {
+				gotKeys = opts.AttributeKeys
+				return &database.ListResult[*domain.User]{Items: []*domain.User{
+					{ProjectID: "proj", SchemaURL: "https://s/human", ID: "user-1", Attributes: domain.AttributesFromMap(map[string]any{
+						"email": "ada@example.com", "givenName": "Ada", "familyName": "Lovelace",
+					})},
+					{ProjectID: "proj", SchemaURL: "https://s/admin", ID: "user-2", Attributes: domain.AttributesFromMap(map[string]any{
+						"username": "root",
+					})},
+				}}, nil
+			})
+
+		refs, err := newResolver(t, stmts).ResolveUserRefs(t.Context(), "proj", []string{"user-2", "user-1", "user-2"})
+
+		require.NoError(t, err)
+		assert.Equal(t, map[string]domain.UserRef{
+			"user-1": {UserID: "user-1", Identifier: "ada@example.com", IdentifierProperty: "email", Display: "Ada Lovelace"},
+			"user-2": {UserID: "user-2", Identifier: "root", IdentifierProperty: "username"},
+		}, refs)
+		assert.ElementsMatch(t, []string{"email", "givenName", "familyName", "username"}, gotKeys,
+			"hydration must be limited to the union of designated keys")
+	})
+
+	t.Run("missing users are absent from the result", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stmts := mocks.NewMockAllStatements(ctrl)
+		expectSchemas(stmts, userSchema("https://s/human", `{"x-identifier":"email"}`))
+		stmts.EXPECT().ListUsers(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&database.ListResult[*domain.User]{Items: []*domain.User{
+				{ProjectID: "proj", SchemaURL: "https://s/human", ID: "user-1", Attributes: domain.AttributesFromMap(map[string]any{"email": "a@example.com"})},
+			}}, nil)
+
+		refs, err := newResolver(t, stmts).ResolveUserRefs(t.Context(), "proj", []string{"user-1", "user-gone"})
+
+		require.NoError(t, err)
+		assert.Len(t, refs, 1)
+		assert.NotContains(t, refs, "user-gone")
+	})
+
+	t.Run("user of an unstored schema resolves to a bare ref", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stmts := mocks.NewMockAllStatements(ctrl)
+		expectSchemas(stmts, userSchema("https://s/human", `{"x-identifier":"email"}`))
+		stmts.EXPECT().ListUsers(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&database.ListResult[*domain.User]{Items: []*domain.User{
+				{ProjectID: "proj", SchemaURL: "https://s/builtin", ID: "user-3", Attributes: domain.AttributesFromMap(map[string]any{"email": "b@example.com"})},
+			}}, nil)
+
+		refs, err := newResolver(t, stmts).ResolveUserRefs(t.Context(), "proj", []string{"user-3"})
+
+		require.NoError(t, err)
+		assert.Equal(t, domain.UserRef{UserID: "user-3"}, refs["user-3"])
+	})
+
+	t.Run("no designations anywhere hydrates no attribute rows", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stmts := mocks.NewMockAllStatements(ctrl)
+		expectSchemas(stmts, userSchema("https://s/passkey", `{"type":"object"}`))
+		var gotKeys []string
+		stmts.EXPECT().ListUsers(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *database.ListOptions[domain.UserField], opts service.UserQueryOptions) (*database.ListResult[*domain.User], error) {
+				gotKeys = opts.AttributeKeys
+				return &database.ListResult[*domain.User]{Items: []*domain.User{
+					{ProjectID: "proj", SchemaURL: "https://s/passkey", ID: "user-4"},
+				}}, nil
+			})
+
+		refs, err := newResolver(t, stmts).ResolveUserRefs(t.Context(), "proj", []string{"user-4"})
+
+		require.NoError(t, err)
+		assert.Equal(t, domain.UserRef{UserID: "user-4"}, refs["user-4"])
+		assert.Equal(t, []string{""}, gotKeys,
+			"nil would hydrate everything; the sentinel key hydrates nothing")
+	})
+
+	t.Run("empty id set short-circuits without queries", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stmts := mocks.NewMockAllStatements(ctrl)
+
+		refs, err := newResolver(t, stmts).ResolveUserRefs(t.Context(), "proj", nil)
+
+		require.NoError(t, err)
+		assert.Empty(t, refs)
+	})
+}


### PR DESCRIPTION
## Phase C of ADR 058 — split out of #1085 for review focus

The resolution plumbing behind user refs, with **zero observable behavior change** — #1085 (sessions adoption, the #869 fix) stacks directly on this.

### What's in it

1. **Domain** — `domain.UserRef` + `ResolveUserRef` (ADR 058 §3: role-named fields, identifier/display resolved independently, clients render `display → identifier → user_id`), and the raw-document designation readers `DesignatedIdentifier`/`DesignatedDisplay`/`DesignatedAttributeKeys`. Designation paths are dot-joined leaf paths and address the EAV-flattened attribute keys verbatim.
2. **Service** — `StatementsUserRefResolver`, the §4 batch port: `(project_id, user_ids) → refs`, one by-ids user query per page hydrating only the union of designated attribute keys (§3a); every stored schema revision contributes its own designation; missing users are absent from the result. **Authz note:** resolution runs `WithAuthzListUnrestricted` — both queries are nested reads keyed on rows the caller already holds, not management lists (the `GetUser`/#839 pattern); without it the #838 list-filter tripwire 500s every resolving read.
3. **Wire** — the `user-ref` component (`{user_id, identifier, identifier_property, display}`), inert until a response references it (#1085 does).

### Notes for review

- `DesignatedIdentifier` is duplicated on #1074 (Phase B, parallel track); whichever merges second rebases the duplicate away.
- The `AttributeKeys: [""]` sentinel (hydrate nothing when no schema designates) behaves identically in all three dialects — postgres `key = ANY`, sqlite/spanner key-IN.
- Changeset is a `@zitadel/server` patch describing internal plumbing; the behavior-changing changeset rides #1085.

Part of #869 / ADR 058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)