### PR TITLE
feat: user responses and console surfaces carry the derived identity

### DIFF
--- a/.changeset/user-envelope-identity.md
+++ b/.changeset/user-envelope-identity.md
@@ -9,6 +9,9 @@ resolved live from each user's own schema designations
 (`x-identifier`/`x-display`) on every read path — query users (one batch
 resolution per page), get by id, `users/me`, and the create read-back.
 Clients render `display`, falling back to `identifier`, then `id`, with
-zero designation logic of their own; the console's users list gains a
-leading identity column on exactly that chain and its convention-based
-display-name guesser is removed.
+zero designation logic of their own. The embedded console (shipped inside
+`@zitadel/server`) renders them: the users list gains a leading **User**
+identity column on exactly that chain plus a dedicated role-named
+**Identifier** column (platform-derived, outside the schema-driven column
+set), the user detail heads with the identity, and the console's
+convention-based display-name guesser is removed.

--- a/.changeset/user-envelope-identity.md
+++ b/.changeset/user-envelope-identity.md
@@ -1,0 +1,14 @@
+---
+"@zitadel/server": minor
+"@zitadel/api": minor
+---
+
+User responses carry the derived identity of ADR 058 §3a: the envelope
+gains read-only `identifier`, `identifier_property`, and `display`,
+resolved live from each user's own schema designations
+(`x-identifier`/`x-display`) on every read path — query users (one batch
+resolution per page), get by id, `users/me`, and the create read-back.
+Clients render `display`, falling back to `identifier`, then `id`, with
+zero designation logic of their own; the console's users list gains a
+leading identity column on exactly that chain and its convention-based
+display-name guesser is removed.

--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -70655,6 +70655,24 @@ func (s *User) encodeFields(e *jx.Encoder) {
 		s.Metadata.Encode(e)
 	}
 	{
+		if s.Identifier.Set {
+			e.FieldStart("identifier")
+			s.Identifier.Encode(e)
+		}
+	}
+	{
+		if s.IdentifierProperty.Set {
+			e.FieldStart("identifier_property")
+			s.IdentifierProperty.Encode(e)
+		}
+	}
+	{
+		if s.Display.Set {
+			e.FieldStart("display")
+			s.Display.Encode(e)
+		}
+	}
+	{
 		if s.Teams != nil {
 			e.FieldStart("teams")
 			e.ArrStart()
@@ -70672,13 +70690,16 @@ func (s *User) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfUser = [6]string{
+var jsonFieldsNameOfUser = [9]string{
 	0: "id",
 	1: "schema",
 	2: "attributes",
 	3: "metadata",
-	4: "teams",
-	5: "teams_truncated",
+	4: "identifier",
+	5: "identifier_property",
+	6: "display",
+	7: "teams",
+	8: "teams_truncated",
 }
 
 // Decode decodes User from json.
@@ -70686,7 +70707,7 @@ func (s *User) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode User to nil")
 	}
-	var requiredBitSet [1]uint8
+	var requiredBitSet [2]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -70732,6 +70753,36 @@ func (s *User) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"metadata\"")
 			}
+		case "identifier":
+			if err := func() error {
+				s.Identifier.Reset()
+				if err := s.Identifier.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"identifier\"")
+			}
+		case "identifier_property":
+			if err := func() error {
+				s.IdentifierProperty.Reset()
+				if err := s.IdentifierProperty.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"identifier_property\"")
+			}
+		case "display":
+			if err := func() error {
+				s.Display.Reset()
+				if err := s.Display.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"display\"")
+			}
 		case "teams":
 			if err := func() error {
 				s.Teams = make([]UserTeam, 0)
@@ -70768,8 +70819,9 @@ func (s *User) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [1]uint8{
+	for i, mask := range [2]uint8{
 		0b00001111,
+		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -44592,6 +44592,21 @@ type User struct {
 	// names and types are determined entirely by that schema.
 	Attributes UserAttributes `json:"attributes"`
 	Metadata   UserMetadata   `json:"metadata"`
+	// The current value of the user schema's designated identifier
+	// (`x-identifier`), resolved live at read time. Absent when the schema
+	// designates no identifier or the user carries no value for it.
+	Identifier OptString `json:"identifier"`
+	// The schema property `identifier` came from, so clients can reach the
+	// property's schema for semantics (a mailto link, a field label)
+	// instead of guessing from the value. Present exactly when
+	// `identifier` is.
+	IdentifierProperty OptString `json:"identifier_property"`
+	// The `x-display` rendering — the designated properties' values joined
+	// in list order, resolved live at read time. Purely presentational.
+	// Absent when the schema designates no display properties or the user
+	// carries no values for them. Clients render `display`, falling back
+	// to `identifier`, then `id`.
+	Display OptString `json:"display"`
 	// The user's team memberships, present only when the request asked for them with
 	// `expand: ["teams"]` (ADR 059). Absent means it was not requested; `[]`
 	// means the user has none.
@@ -44625,6 +44640,21 @@ func (s *User) GetMetadata() UserMetadata {
 	return s.Metadata
 }
 
+// GetIdentifier returns the value of Identifier.
+func (s *User) GetIdentifier() OptString {
+	return s.Identifier
+}
+
+// GetIdentifierProperty returns the value of IdentifierProperty.
+func (s *User) GetIdentifierProperty() OptString {
+	return s.IdentifierProperty
+}
+
+// GetDisplay returns the value of Display.
+func (s *User) GetDisplay() OptString {
+	return s.Display
+}
+
 // GetTeams returns the value of Teams.
 func (s *User) GetTeams() []UserTeam {
 	return s.Teams
@@ -44653,6 +44683,21 @@ func (s *User) SetAttributes(val UserAttributes) {
 // SetMetadata sets the value of Metadata.
 func (s *User) SetMetadata(val UserMetadata) {
 	s.Metadata = val
+}
+
+// SetIdentifier sets the value of Identifier.
+func (s *User) SetIdentifier(val OptString) {
+	s.Identifier = val
+}
+
+// SetIdentifierProperty sets the value of IdentifierProperty.
+func (s *User) SetIdentifierProperty(val OptString) {
+	s.IdentifierProperty = val
+}
+
+// SetDisplay sets the value of Display.
+func (s *User) SetDisplay(val OptString) {
+	s.Display = val
 }
 
 // SetTeams sets the value of Teams.

--- a/api/openapi/endpoints/users/user.yaml
+++ b/api/openapi/endpoints/users/user.yaml
@@ -36,6 +36,38 @@ properties:
   metadata:
     readOnly: true
     $ref: user-metadata.yaml
+  # The derived identity fields of ADR 058 §3a: the same resolution that
+  # produces the `user-ref` component (components/schemas/user-ref.yaml),
+  # inlined on the envelope — `user_id` is omitted since the envelope has
+  # `id`. Refs and derived label fields ride the resource's own read
+  # permission (ADR 059 rule 8), so they carry no expand gate.
+  identifier:
+    readOnly: true
+    type: string
+    description: |
+      The current value of the user schema's designated identifier
+      (`x-identifier`), resolved live at read time. Absent when the schema
+      designates no identifier or the user carries no value for it.
+    example: ada@example.com
+  identifier_property:
+    readOnly: true
+    type: string
+    description: |
+      The schema property `identifier` came from, so clients can reach the
+      property's schema for semantics (a mailto link, a field label)
+      instead of guessing from the value. Present exactly when
+      `identifier` is.
+    example: email
+  display:
+    readOnly: true
+    type: string
+    description: |
+      The `x-display` rendering — the designated properties' values joined
+      in list order, resolved live at read time. Purely presentational.
+      Absent when the schema designates no display properties or the user
+      carries no values for them. Clients render `display`, falling back
+      to `identifier`, then `id`.
+    example: Ada Lovelace
   teams:
     readOnly: true
     type: array

--- a/apps/console/src/components/delete-user-dialog.spec.tsx
+++ b/apps/console/src/components/delete-user-dialog.spec.tsx
@@ -125,7 +125,7 @@ describe("delete user dialog", () => {
     // row is gone from the invalidated list.
     expect(await screen.findByText("Maya Patel deleted")).toBeInTheDocument();
     await waitFor(() =>
-      // The row's link is its first schema-driven column, not a combined name.
+      // The row's link lives on the User identity column.
       expect(screen.queryByRole("link", { name: "Maya Patel" })).not.toBeInTheDocument(),
     );
   });

--- a/apps/console/src/components/delete-user-dialog.spec.tsx
+++ b/apps/console/src/components/delete-user-dialog.spec.tsx
@@ -19,6 +19,11 @@ const USERS_QUERY_URL = `${USERS_URL}/query`;
 const USER = {
   id: "user_1",
   schema: "sch_business",
+  // The dialog's label comes from the envelope's resolved identity
+  // (ADR 058), not from attribute derivation.
+  display: "Maya Patel",
+  identifier: "maya@acme.com",
+  identifier_property: "email",
   attributes: { givenName: "Maya", familyName: "Patel", email: "maya@acme.com" },
 };
 const server = setupServer();
@@ -121,7 +126,7 @@ describe("delete user dialog", () => {
     expect(await screen.findByText("Maya Patel deleted")).toBeInTheDocument();
     await waitFor(() =>
       // The row's link is its first schema-driven column, not a combined name.
-      expect(screen.queryByRole("link", { name: "maya@acme.com" })).not.toBeInTheDocument(),
+      expect(screen.queryByRole("link", { name: "Maya Patel" })).not.toBeInTheDocument(),
     );
   });
 
@@ -150,7 +155,7 @@ describe("delete user dialog", () => {
     // found: opening the dialog from inside the row menu left the menu open
     // underneath, and its `aria-hidden` on the rest of the page outlived the
     // dialog — so the list was invisible to assistive tech after cancelling.
-    expect(screen.getByRole("link", { name: "maya@acme.com" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Maya Patel" })).toBeInTheDocument();
   });
 
   it("keeps the dialog open and shows the server's message when the delete fails", async () => {

--- a/apps/console/src/lib/user.ts
+++ b/apps/console/src/lib/user.ts
@@ -15,26 +15,24 @@ export function userAttributes(user: Record<string, unknown>): Record<string, un
 }
 
 /**
- * The user's human-readable name, mirroring the platform's identity contract
- * (`User.DisplayName` in `internal/domain/user.go` — the same derivation behind
- * `GET /sessions/me`'s `name`): an explicit `name` wins, otherwise the given and
- * family parts joined. The shipped presets spell them camelCase
- * (`packages/config/defaults/*.json`); snake_case stays accepted for schemas
- * authored that way.
+ * The user's rendered identity per ADR 058: the envelope's derived `display`,
+ * falling back to `identifier`, then the id. The fields are resolved by the
+ * server from the schema's own `x-identifier`/`x-display` designations, so
+ * the console carries zero designation logic — the convention-guessing
+ * `userDisplayName` this replaces is gone with the platform's own resolver.
  *
- * User schemas are free-form and `queryUsers` returns the attribute tree verbatim,
- * so this reads only the conventional identity keys and returns `undefined` when
- * a schema names its properties differently. Callers fall back to the email and
- * then the id — inventing a name from an unrelated attribute is worse than
- * having none.
- *
- * Takes the attributes object, not the whole user: `name` is a schema property.
+ * Takes the whole user record: `display`/`identifier` are envelope fields,
+ * not schema properties.
  */
-export function userDisplayName(attributes: Record<string, unknown>): string | undefined {
-  const explicit = field(attributes, "name");
-  if (explicit) return explicit;
-  const given = field(attributes, "givenName") ?? field(attributes, "given_name");
-  const family = field(attributes, "familyName") ?? field(attributes, "family_name");
-  const joined = [given, family].filter(Boolean).join(" ");
-  return joined || undefined;
+export function userIdentity(user: Record<string, unknown>): string {
+  return field(user, "display") ?? field(user, "identifier") ?? (field(user, "id") ?? "");
+}
+
+/**
+ * The muted secondary line shown next to the identity: the identifier, but
+ * only when a display name is the primary (rendering the identifier twice
+ * says nothing).
+ */
+export function userIdentitySecondary(user: Record<string, unknown>): string | undefined {
+  return field(user, "display") ? field(user, "identifier") : undefined;
 }

--- a/apps/console/src/lib/user.ts
+++ b/apps/console/src/lib/user.ts
@@ -28,10 +28,15 @@ export function userIdentity(user: Record<string, unknown>): string {
   return field(user, "display") ?? field(user, "identifier") ?? (field(user, "id") ?? "");
 }
 
+/** The envelope's designated identifier value, when the schema designates one. */
+export function userIdentifier(user: Record<string, unknown>): string | undefined {
+  return field(user, "identifier");
+}
+
 /**
- * The muted secondary line shown next to the identity: the identifier, but
- * only when a display name is the primary (rendering the identifier twice
- * says nothing).
+ * The muted secondary line shown under a heading: the identifier, but only
+ * when a display name is the primary (rendering the identifier twice says
+ * nothing). The users list shows the identifier as its own column instead.
  */
 export function userIdentitySecondary(user: Record<string, unknown>): string | undefined {
   return field(user, "display") ? field(user, "identifier") : undefined;

--- a/apps/console/src/lib/user.ts
+++ b/apps/console/src/lib/user.ts
@@ -24,8 +24,8 @@ export function userAttributes(user: Record<string, unknown>): Record<string, un
  * Takes the whole user record: `display`/`identifier` are envelope fields,
  * not schema properties.
  */
-export function userIdentity(user: Record<string, unknown>): string {
-  return field(user, "display") ?? field(user, "identifier") ?? (field(user, "id") ?? "");
+export function userIdentity(user: Record<string, unknown>): string | undefined {
+  return field(user, "display") ?? field(user, "identifier") ?? field(user, "id");
 }
 
 /** The envelope's designated identifier value, when the schema designates one. */

--- a/apps/console/src/routes/_authed/users/$userId.tsx
+++ b/apps/console/src/routes/_authed/users/$userId.tsx
@@ -84,7 +84,7 @@ function UserDetail() {
   const router = useRouter();
   const attributes = userAttributes(user);
   // The server-resolved identity chain (ADR 058): display → identifier → id.
-  const name = userIdentity(user) || userId;
+  const name = userIdentity(user) ?? userId;
   const secondary = userIdentitySecondary(user);
   const fields = schema ? schemaFields(schema) : [];
   const metadata = userMetadata(user);

--- a/apps/console/src/routes/_authed/users/$userId.tsx
+++ b/apps/console/src/routes/_authed/users/$userId.tsx
@@ -17,7 +17,7 @@ import { api } from "../../../api/zitadel";
 import { formatDate } from "../../../lib/date";
 import { displayValue, field } from "../../../lib/record";
 import { type UserSchema, schemaDisplayName, schemaFields } from "../../../lib/schema";
-import { userAttributes, userDisplayName } from "../../../lib/user";
+import { userAttributes, userIdentity, userIdentitySecondary } from "../../../lib/user";
 
 /**
  * User detail (Figma `467:44362`, `Filled` and `Authentication` variants).
@@ -83,16 +83,21 @@ function UserDetail() {
   const { userId } = Route.useParams();
   const router = useRouter();
   const attributes = userAttributes(user);
-  const name = userDisplayName(attributes) ?? field(attributes, "email") ?? userId;
+  // The server-resolved identity chain (ADR 058): display → identifier → id.
+  const name = userIdentity(user) || userId;
+  const secondary = userIdentitySecondary(user);
   const fields = schema ? schemaFields(schema) : [];
   const metadata = userMetadata(user);
 
   return (
     <div className={PAGE}>
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="flex flex-wrap items-center gap-3">
-          <h1 className={HEADING}>{name}</h1>
-          {metadata.status && <StatusBadge status={metadata.status} />}
+        <div className="flex flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className={HEADING}>{name}</h1>
+            {metadata.status && <StatusBadge status={metadata.status} />}
+          </div>
+          {secondary && <p className="text-muted-foreground text-sm">{secondary}</p>}
         </div>
         <Card className="gap-0 rounded-xl py-0">
           {/* Stacked below `sm`, in a row above it — the mobile frame

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -33,7 +33,7 @@ import { StatusBadge } from "@/components/status-badge";
 import { api } from "../../../api/zitadel";
 import { displayValue, field } from "../../../lib/record";
 import { type SchemaField, type UserSchema, schemaColumns } from "../../../lib/schema";
-import { userAttributes, userDisplayName } from "../../../lib/user";
+import { userAttributes, userIdentity, userIdentitySecondary } from "../../../lib/user";
 
 export const Route = createFileRoute("/_authed/users/")({
   // `User`, not `Users`: the sidebar frame's row carries `lucide/User`, the
@@ -87,8 +87,14 @@ async function columnsForUsers(users: Record<string, unknown>[]): Promise<Schema
 
 interface UserRow {
   id: string;
-  /** Display name for the row menu and the delete dialog — not a column. */
+  /**
+   * The rendered identity (display → identifier → id, ADR 058) — the User
+   * column's primary line, the row menu's accessible name, and the delete
+   * dialog's heading.
+   */
   name: string;
+  /** The identifier as the User column's muted second line, only when the display is the primary. */
+  secondary?: string;
   /** Rendered cell values, keyed by schema property. */
   values: Record<string, string>;
   /** `metadata.status`, absent on a record the server has not stamped. */
@@ -214,9 +220,12 @@ function UsersScreen() {
     const needle = query.trim().toLowerCase();
     return users.map((user, index) => toUserRow(user, index, columns)).filter((row) => {
       if (needle === "") return true;
-      return [row.id, ...columns.map((column) => row.values[column.key] ?? "")].some((value) =>
-        value.toLowerCase().includes(needle),
-      );
+      return [
+        row.id,
+        row.name,
+        row.secondary ?? "",
+        ...columns.map((column) => row.values[column.key] ?? ""),
+      ].some((value) => value.toLowerCase().includes(needle));
     });
   }, [users, query, columns]);
 
@@ -265,6 +274,7 @@ function UsersScreen() {
         <Table className="text-xs">
           <TableHeader>
             <TableRow className="border-border border-b hover:bg-transparent">
+              <ResourceHeadCell>User</ResourceHeadCell>
               {columns.map((column) => (
                 <ResourceHeadCell key={column.key}>{column.label}</ResourceHeadCell>
               ))}
@@ -277,7 +287,7 @@ function UsersScreen() {
             {rows.length === 0 ? (
               <TableRow className="border-0 hover:bg-transparent">
                 <TableCell
-                  colSpan={columns.length + 2}
+                  colSpan={columns.length + 3}
                   className="text-muted-foreground h-24 text-center"
                 >
                   {users.length === 0 ? "No users yet." : "No users match the current filters."}
@@ -286,26 +296,30 @@ function UsersScreen() {
             ) : (
               rows.map((user) => (
                 <TableRow key={user.id} className="hover:bg-muted/40 border-0">
-                  {columns.map((column, index) => (
+                  {/* The User column renders the server-resolved identity
+                      (display → identifier → id, ADR 058 §3a) and carries the
+                      link to the detail screen — schema-driven columns cannot
+                      promise a meaningful leading value, this cell always can. */}
+                  <TableCell className={`${RESOURCE_CELL} max-w-[280px] text-sm`}>
+                    <Link
+                      to="/users/$userId"
+                      params={{ userId: user.id }}
+                      className="text-foreground block truncate font-medium underline-offset-2 hover:underline"
+                    >
+                      {user.name}
+                    </Link>
+                    {user.secondary && (
+                      <span className="text-muted-foreground block truncate text-xs">
+                        {user.secondary}
+                      </span>
+                    )}
+                  </TableCell>
+                  {columns.map((column) => (
                     <TableCell
                       key={column.key}
                       className={`${RESOURCE_CELL} text-muted-foreground max-w-[280px] truncate text-sm`}
                     >
-                      {/* The first column carries the link to the detail screen.
-                          There is no separate name column to hang it on — the
-                          design's columns are the schema's own properties, and
-                          which one comes first depends on the schema. */}
-                      {index === 0 ? (
-                        <Link
-                          to="/users/$userId"
-                          params={{ userId: user.id }}
-                          className="text-foreground truncate font-medium underline-offset-2 hover:underline"
-                        >
-                          {user.values[column.key] || user.id}
-                        </Link>
-                      ) : (
-                        (user.values[column.key] ?? "—")
-                      )}
+                      {user.values[column.key] ?? "—"}
                     </TableCell>
                   ))}
                   <TableCell className={RESOURCE_CELL}>
@@ -366,10 +380,11 @@ function toUserRow(
   return {
     id,
     values,
-    // Used for the row menu's accessible name and the delete dialog's heading,
-    // not as a column. Falls back to the email and then the id: a `minimal`
-    // schema defines only `email`, so a name is genuinely absent, not missing.
-    name: userDisplayName(attributes) ?? field(attributes, "email") ?? id,
+    // The server-resolved identity chain (ADR 058): display → identifier →
+    // id. Also the row menu's accessible name and the delete dialog's
+    // heading, so every surface labels the user identically.
+    name: userIdentity(user) || id,
+    secondary: userIdentitySecondary(user),
     status: userStatus(user),
   };
 }

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -290,7 +290,7 @@ function UsersScreen() {
             {rows.length === 0 ? (
               <TableRow className="border-0 hover:bg-transparent">
                 <TableCell
-                  colSpan={columns.length + 4}
+                  colSpan={columns.length + 5}
                   className="text-muted-foreground h-24 text-center"
                 >
                   {users.length === 0 ? "No users yet." : "No users match the current filters."}

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -33,7 +33,7 @@ import { StatusBadge } from "@/components/status-badge";
 import { api } from "../../../api/zitadel";
 import { displayValue, field } from "../../../lib/record";
 import { type SchemaField, type UserSchema, schemaColumns } from "../../../lib/schema";
-import { userAttributes, userIdentity, userIdentitySecondary } from "../../../lib/user";
+import { userAttributes, userIdentifier, userIdentity } from "../../../lib/user";
 
 export const Route = createFileRoute("/_authed/users/")({
   // `User`, not `Users`: the sidebar frame's row carries `lucide/User`, the
@@ -89,12 +89,14 @@ interface UserRow {
   id: string;
   /**
    * The rendered identity (display → identifier → id, ADR 058) — the User
-   * column's primary line, the row menu's accessible name, and the delete
-   * dialog's heading.
+   * column, the row menu's accessible name, and the delete dialog's heading.
    */
   name: string;
-  /** The identifier as the User column's muted second line, only when the display is the primary. */
-  secondary?: string;
+  /** The designated identifier — its own column: platform-derived like Status
+   * and ID, so it sits outside the schema-driven set (D4). */
+  identifier?: string;
+  /** The schema property the identifier came from (e.g. "email"), as the cell's tooltip. */
+  identifierProperty?: string;
   /** Rendered cell values, keyed by schema property. */
   values: Record<string, string>;
   /** `metadata.status`, absent on a record the server has not stamped. */
@@ -223,7 +225,7 @@ function UsersScreen() {
       return [
         row.id,
         row.name,
-        row.secondary ?? "",
+        row.identifier ?? "",
         ...columns.map((column) => row.values[column.key] ?? ""),
       ].some((value) => value.toLowerCase().includes(needle));
     });
@@ -275,6 +277,7 @@ function UsersScreen() {
           <TableHeader>
             <TableRow className="border-border border-b hover:bg-transparent">
               <ResourceHeadCell>User</ResourceHeadCell>
+              <ResourceHeadCell>Identifier</ResourceHeadCell>
               {columns.map((column) => (
                 <ResourceHeadCell key={column.key}>{column.label}</ResourceHeadCell>
               ))}
@@ -287,7 +290,7 @@ function UsersScreen() {
             {rows.length === 0 ? (
               <TableRow className="border-0 hover:bg-transparent">
                 <TableCell
-                  colSpan={columns.length + 3}
+                  colSpan={columns.length + 4}
                   className="text-muted-foreground h-24 text-center"
                 >
                   {users.length === 0 ? "No users yet." : "No users match the current filters."}
@@ -308,11 +311,16 @@ function UsersScreen() {
                     >
                       {user.name}
                     </Link>
-                    {user.secondary && (
-                      <span className="text-muted-foreground block truncate text-xs">
-                        {user.secondary}
-                      </span>
-                    )}
+                  </TableCell>
+                  {/* The designated identifier (x-identifier) — role-named, so a
+                      mixed-schema list reads down one column whether a row's
+                      identifier is an email or a loginname; the tooltip names
+                      the property it came from. */}
+                  <TableCell
+                    className={`${RESOURCE_CELL} text-muted-foreground max-w-[280px] truncate text-sm`}
+                    title={user.identifierProperty}
+                  >
+                    {user.identifier ?? "—"}
                   </TableCell>
                   {columns.map((column) => (
                     <TableCell
@@ -384,7 +392,8 @@ function toUserRow(
     // id. Also the row menu's accessible name and the delete dialog's
     // heading, so every surface labels the user identically.
     name: userIdentity(user) || id,
-    secondary: userIdentitySecondary(user),
+    identifier: userIdentifier(user),
+    identifierProperty: field(user, "identifier_property"),
     status: userStatus(user),
   };
 }

--- a/apps/console/src/routes/_authed/users/index.tsx
+++ b/apps/console/src/routes/_authed/users/index.tsx
@@ -391,7 +391,7 @@ function toUserRow(
     // The server-resolved identity chain (ADR 058): display → identifier →
     // id. Also the row menu's accessible name and the delete dialog's
     // heading, so every surface labels the user identically.
-    name: userIdentity(user) || id,
+    name: userIdentity(user) ?? id,
     identifier: userIdentifier(user),
     identifierProperty: field(user, "identifier_property"),
     status: userStatus(user),

--- a/apps/console/src/routes/_authed/users/user-detail.spec.tsx
+++ b/apps/console/src/routes/_authed/users/user-detail.spec.tsx
@@ -41,6 +41,10 @@ function stub({
   user = {
     id: USER_ID,
     schema: "sch_business",
+    // The heading renders the envelope's resolved identity (ADR 058):
+    // this schema designates email and no display properties.
+    identifier: "maya@acme.com",
+    identifier_property: "email",
     attributes: { email: "maya@acme.com", companyName: "Acme" },
     metadata: { status: "active", created_at: "2026-07-12T09:00:00Z", updated_at: "2026-07-12T09:00:00Z" },
   },
@@ -101,6 +105,8 @@ describe("user detail", () => {
         HttpResponse.json({
           id: USER_ID,
           schema: "sch_business",
+          identifier: "maya@acme.com",
+          identifier_property: "email",
           attributes: { email: "maya@acme.com", headcount: 42, verified: false },
         }),
       ),
@@ -156,11 +162,33 @@ describe("user detail", () => {
     expect(screen.getByText(expected)).toBeInTheDocument();
   });
 
+  it("leads with the display and subtitles the identifier when both resolve", async () => {
+    stub({
+      user: {
+        id: USER_ID,
+        schema: "sch_business",
+        identifier: "maya@acme.com",
+        identifier_property: "email",
+        display: "Maya Patel",
+        attributes: { email: "maya@acme.com" },
+      },
+    });
+    await renderDetail();
+    expect(await screen.findByRole("heading", { name: "Maya Patel" })).toBeInTheDocument();
+    expect(screen.getAllByText("maya@acme.com").length).toBeGreaterThanOrEqual(1);
+  });
+
   it("omits status and created on a record the server has not stamped", async () => {
     // `metadata` sits on an otherwise open record, so a user written before it
     // existed simply has none. Nothing is invented for it.
     stub({
-      user: { id: USER_ID, schema: "sch_business", attributes: { email: "maya@acme.com" } },
+      user: {
+        id: USER_ID,
+        schema: "sch_business",
+        identifier: "maya@acme.com",
+        identifier_property: "email",
+        attributes: { email: "maya@acme.com" },
+      },
     });
     await renderDetail();
     await screen.findByRole("heading", { name: "maya@acme.com" });

--- a/apps/console/src/routes/_authed/users/users.spec.tsx
+++ b/apps/console/src/routes/_authed/users/users.spec.tsx
@@ -65,7 +65,7 @@ describe("users screen", () => {
     await renderUsers();
     expect(await screen.findByRole("heading", { name: "Users" })).toBeInTheDocument();
     // The User column leads with the resolved display and carries the link;
-    // the identifier renders as its muted second line. Schema-driven
+    // the identifier has its own column (asserted below). Schema-driven
     // attribute columns follow (design `277:288291`, decisions log D4).
     expect(await screen.findByRole("link", { name: "Maya Patel" })).toBeInTheDocument();
     // The designated identifier is its own platform-derived column (like

--- a/apps/console/src/routes/_authed/users/users.spec.tsx
+++ b/apps/console/src/routes/_authed/users/users.spec.tsx
@@ -44,11 +44,14 @@ describe("users screen", () => {
       http.post(USERS_QUERY_URL, () =>
         HttpResponse.json({
           users: [
-            // The shipped `consumer`/`business` presets spell the name parts
-            // camelCase; `queryUsers` returns the schema's attribute tree verbatim.
+            // The envelope carries the server-resolved identity (ADR 058
+            // §3a); `attributes` stays the schema's verbatim tree.
             {
               id: "user_1",
               schema: "sch_business",
+              identifier: "maya.patel@acme.com",
+              identifier_property: "email",
+              display: "Maya Patel",
               attributes: {
                 givenName: "Maya",
                 familyName: "Patel",
@@ -61,10 +64,13 @@ describe("users screen", () => {
     );
     await renderUsers();
     expect(await screen.findByRole("heading", { name: "Users" })).toBeInTheDocument();
-    // Columns are the schema's properties (design `277:288291`, decisions log
-    // D4), so there is no combined "Name" column — the first property carries
-    // the link to the detail screen.
-    expect(await screen.findByRole("link", { name: "maya.patel@acme.com" })).toBeInTheDocument();
+    // The User column leads with the resolved display and carries the link;
+    // the identifier renders as its muted second line. Schema-driven
+    // attribute columns follow (design `277:288291`, decisions log D4).
+    expect(await screen.findByRole("link", { name: "Maya Patel" })).toBeInTheDocument();
+    // The identifier appears twice by design: the User column's secondary
+    // line and the schema's own email column.
+    expect(screen.getAllByText("maya.patel@acme.com").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Maya")).toBeInTheDocument();
     expect(screen.getByText("Patel")).toBeInTheDocument();
   });
@@ -139,64 +145,64 @@ describe("users screen", () => {
     );
     await renderUsers();
 
-    // `schemaFields` orders properties by key, so `companyName` is the first
-    // column and therefore the linked one. The user without a company falls back
-    // to its id rather than rendering an empty link.
-    expect(await screen.findByRole("link", { name: "Acme" })).toBeInTheDocument();
+    // The link lives on the User identity column now. Neither fixture
+    // carries envelope identity, so both rows degrade to their id — the
+    // schema-driven cells render values and placeholders unchanged.
+    expect(await screen.findByRole("link", { name: "user_1" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "user_2" })).toBeInTheDocument();
+    expect(within(screen.getByRole("table")).getByText("Acme")).toBeInTheDocument();
     expect(within(screen.getByRole("table")).getByText("min@acme.com")).toBeInTheDocument();
   });
 
-  it("derives the display name the way the platform does", async () => {
-    // Mirrors `User.DisplayName` (internal/domain/user.go): explicit `name`
-    // wins, else the given/family parts joined, with snake_case accepted for
-    // schemas authored that way. A partial name must not render a stray space.
+  it("renders the server-resolved identity chain, never deriving from attributes", async () => {
+    // ADR 058: the envelope's display → identifier → id, resolved by the
+    // server from the schema's own designations. The console carries zero
+    // derivation logic — attributes that *look* like identity (name,
+    // givenName, username) are never read.
     server.use(
       http.post(USERS_QUERY_URL, () =>
         HttpResponse.json({
           users: [
             {
               id: "user_1",
-              attributes: {
-                name: "Ada L.",
-                givenName: "Ada",
-                familyName: "Lovelace",
-                email: "a@x.com",
-              },
+              identifier: "a@x.com",
+              identifier_property: "email",
+              display: "Ada L.",
+              attributes: { name: "WRONG name attr", givenName: "Ada", email: "a@x.com" },
             },
-            { id: "user_2", attributes: { given_name: "Grace", family_name: "Hopper", email: "g@x.com" } },
-            { id: "user_3", attributes: { givenName: "Radia", email: "r@x.com" } },
+            {
+              id: "user_2",
+              identifier: "g@x.com",
+              identifier_property: "email",
+              attributes: { given_name: "Grace", family_name: "Hopper", email: "g@x.com" },
+            },
+            { id: "user_3", attributes: { username: "nope", givenName: "Radia", email: "r@x.com" } },
           ],
         }),
       ),
     );
     await renderUsers();
-    // The derived name is no longer a column; it names the row's actions and
-    // titles the delete dialog, which is where a wrong derivation would show.
+    // Display when designated; identifier when not; the id when the schema
+    // designates nothing. The identity also names the row's actions, which
+    // titles the delete dialog.
     expect(await screen.findByRole("button", { name: "Actions for Ada L." })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Actions for Grace Hopper" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Actions for Radia" })).toBeInTheDocument();
-  });
-
-  it("ignores non-identity attributes when deriving the name", async () => {
-    // Regression: the screen used to read a `username` property that no shipped
-    // schema defines, so every row silently fell back to the email. Reading an
-    // unrelated attribute as the name is worse than having none.
-    server.use(
-      http.post(USERS_QUERY_URL, () =>
-        HttpResponse.json({ users: [{ id: "user_1", attributes: { username: "nope", email: "kenji@acme.com" } }] }),
-      ),
-    );
-    await renderUsers();
-    expect(
-      await screen.findByRole("button", { name: "Actions for kenji@acme.com" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Actions for g@x.com" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Actions for user_3" })).toBeInTheDocument();
+    // The `name` attribute still renders as a schema-driven column value —
+    // the assertions above prove it is never *promoted* to the identity.
   });
 
   it("shows the user id alongside the schema's own attributes", async () => {
     server.use(
       http.post(USERS_QUERY_URL, () =>
-        HttpResponse.json({ users: [{ id: "user_1", attributes: { email: "kenji@acme.com", status: "Blocked" } }] }),
+        HttpResponse.json({
+          users: [{
+            id: "user_1",
+            identifier: "kenji@acme.com",
+            identifier_property: "email",
+            attributes: { email: "kenji@acme.com", status: "Blocked" },
+          }],
+        }),
       ),
     );
     await renderUsers();

--- a/apps/console/src/routes/_authed/users/users.spec.tsx
+++ b/apps/console/src/routes/_authed/users/users.spec.tsx
@@ -68,8 +68,9 @@ describe("users screen", () => {
     // the identifier renders as its muted second line. Schema-driven
     // attribute columns follow (design `277:288291`, decisions log D4).
     expect(await screen.findByRole("link", { name: "Maya Patel" })).toBeInTheDocument();
-    // The identifier appears twice by design: the User column's secondary
-    // line and the schema's own email column.
+    // The designated identifier is its own platform-derived column (like
+    // Status and ID), role-named so mixed-schema lists read down one column.
+    expect(screen.getByRole("columnheader", { name: "Identifier" })).toBeInTheDocument();
     expect(screen.getAllByText("maya.patel@acme.com").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Maya")).toBeInTheDocument();
     expect(screen.getByText("Patel")).toBeInTheDocument();

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -205,6 +205,7 @@ func run(ctx context.Context, cfg Config, userFiles []string) error {
 		serviceDBPool,
 		schemaStore,
 		passwordHasher,
+		service.StatementsUserRefResolver{Pool: serviceDBPool},
 	)
 
 	// The platform project's registration side effect (#527): every flow-created

--- a/internal/api/integration_test/helpers/user.go
+++ b/internal/api/integration_test/helpers/user.go
@@ -22,6 +22,7 @@ func (h *Harness) EnsureUserService(t *testing.T) service.UserService {
 			h.EnsureServiceDB(t),
 			h.EnsureSchemaStore(t),
 			h.EnsureHasher(t),
+			service.StatementsUserRefResolver{Pool: h.EnsureServiceDB(t)},
 		)
 	}
 	return h.userService.value

--- a/internal/api/integration_test/user_identity_test.go
+++ b/internal/api/integration_test/user_identity_test.go
@@ -1,0 +1,102 @@
+//go:build postgres_integration || spanner_integration
+
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	api "github.com/zitadel/nextgen/api/generated"
+	apischemas "github.com/zitadel/nextgen/api/openapi/endpoints/schemas"
+	"github.com/zitadel/nextgen/internal/api/integration_test/helpers"
+	"github.com/zitadel/nextgen/internal/service"
+)
+
+// TestUserResponses_CarryDerivedIdentity pins ADR 058 §3a end to end: user
+// responses carry the derived identifier/identifier_property/display fields,
+// resolved live from each user's own schema designations, with no expand
+// gate (ADR 059 rule 8).
+func TestUserResponses_CarryDerivedIdentity(t *testing.T) {
+	t.Parallel()
+
+	project, err := harness.EnsureProjectService(t).Create(t.Context(), helpers.ProjectName(), nil, true)
+	require.NoError(t, err)
+
+	// A schema designating both identifier and display, alongside the seeded
+	// default (which designates email and no display properties).
+	displaySchemaURL := harness.CreateUserSchema(t, project, `{
+		"title": "IdentityEnvelopeSchema",
+		"metaSchema": "https://test.example.schemas.com/schemas/user-schema.json",
+		"$id": "https://identity-envelope.example.com/schemas/human-user.json",
+		"kind": "user-schema",
+		"type": "object",
+		"x-identifier": "email",
+		"x-display": ["givenName", "familyName"],
+		"x-auth-methods": {"password": {"enabled": true}},
+		"properties": {
+			"email": {"type": "string", "format": "email", "x-unique": "project"},
+			"givenName": {"type": "string"},
+			"familyName": {"type": "string"}
+		}
+	}`)
+
+	users := harness.EnsureUserService(t)
+	displayUser, err := users.CreateUser(t.Context(), service.CreateUserInput{
+		ProjectID: project.ID,
+		SchemaURL: displaySchemaURL,
+		Attributes: map[string]any{
+			"email":      "grace@identity.example.com",
+			"givenName":  "Grace",
+			"familyName": "Hopper",
+		},
+	})
+	require.NoError(t, err)
+
+	// The create read-back already carries the resolution.
+	require.NotNil(t, displayUser.Ref)
+	assert.Equal(t, "Grace Hopper", displayUser.Ref.Display)
+
+	defaultUser, err := users.CreateUser(t.Context(), service.CreateUserInput{
+		ProjectID:  project.ID,
+		SchemaURL:  apischemas.DefaultHumanUserSchemaURL(helpers.BuiltinSchemaBaseURL),
+		Attributes: map[string]any{"email": "plain@identity.example.com"},
+	})
+	require.NoError(t, err)
+
+	client, err := helpers.NewApiClient(harness.EnsureTestServer(t).URL)
+	require.NoError(t, err)
+	harness.SetProjectSecretOnApiClient(t, client, project)
+
+	t.Run("query rows carry each schema's own resolution", func(t *testing.T) {
+		res, err := client.QueryUsers(t.Context(), &api.QueryUsersRequest{})
+		require.NoError(t, err)
+		page, ok := res.(*api.QueryUsersResponse)
+		require.True(t, ok, helpers.MustMarshal(t, res))
+
+		byID := map[string]api.User{}
+		for _, row := range page.Users {
+			byID[string(row.ID)] = row
+		}
+
+		display := byID[displayUser.ID]
+		assert.Equal(t, "grace@identity.example.com", display.Identifier.Value)
+		assert.Equal(t, "email", display.IdentifierProperty.Value)
+		assert.Equal(t, "Grace Hopper", display.Display.Value)
+
+		plain := byID[defaultUser.ID]
+		assert.Equal(t, "plain@identity.example.com", plain.Identifier.Value)
+		assert.Equal(t, "email", plain.IdentifierProperty.Value)
+		assert.False(t, plain.Display.Set, "the default schema designates no display properties")
+	})
+
+	t.Run("get by id carries the resolution", func(t *testing.T) {
+		res, err := client.GetUserByID(t.Context(), api.GetUserByIDParams{UserID: api.UserID(displayUser.ID)})
+		require.NoError(t, err)
+		got, ok := res.(*api.User)
+		require.True(t, ok, helpers.MustMarshal(t, res))
+		assert.Equal(t, "grace@identity.example.com", got.Identifier.Value)
+		assert.Equal(t, "Grace Hopper", got.Display.Value)
+	})
+}

--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -322,6 +322,19 @@ func domainUserToApiUser(user *domain.User) (*api.User, error) {
 		},
 	}
 
+	// The derived identity of ADR 058 §3a: identifier and identifier_property
+	// travel together, display independently; empty means absent on the wire
+	// (the userRefToAPI pairing rule).
+	if user.Ref != nil {
+		if user.Ref.Identifier != "" {
+			out.Identifier = api.NewOptString(user.Ref.Identifier)
+			out.IdentifierProperty = api.NewOptString(user.Ref.IdentifierProperty)
+		}
+		if user.Ref.Display != "" {
+			out.Display = api.NewOptString(user.Ref.Display)
+		}
+	}
+
 	// Nil means the read was not asked for memberships, so the property stays
 	// off the wire entirely; an empty non-nil slice means it was asked for and
 	// the user has none, which serializes as []. Every other caller of

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -63,6 +63,11 @@ type User struct {
 	// Attributes are populated by user read statements.
 	Attributes Attributes
 
+	// Ref is the derived identity of ADR 058 §3a, resolved live from the
+	// schema's x-identifier/x-display designations. Populated by service
+	// reads that resolve it; nil on plain statement-level reads.
+	Ref *UserRef
+
 	// Teams is the user's team memberships, populated only when the read asked
 	// for it. Nil means it was not asked for; empty means the user has none.
 	Teams []UserTeam

--- a/internal/service/auth_attempt_registration_integration_test.go
+++ b/internal/service/auth_attempt_registration_integration_test.go
@@ -236,7 +236,7 @@ func TestAuthAttemptService_PasskeyRegistration_integration(t *testing.T) {
 		hasher.EXPECT().Hash(gomock.Any()).Return("hashed:pw", nil)
 		handler := service.NewFlowCreateUserHandler(
 			hasher,
-			service.NewUserService(pool, pool.Statements(), hasher),
+			service.NewUserService(pool, pool.Statements(), hasher, service.StatementsUserRefResolver{Pool: pool}),
 			pool.Statements(),
 			pool,
 		)

--- a/internal/service/flow_create_user_with_password_handler_test.go
+++ b/internal/service/flow_create_user_with_password_handler_test.go
@@ -13,6 +13,7 @@ import (
 	domainmock "github.com/zitadel/nextgen/internal/domain/mock"
 	"github.com/zitadel/nextgen/internal/service"
 	servicemocks "github.com/zitadel/nextgen/internal/service/mocks"
+	"github.com/zitadel/nextgen/internal/storage/database"
 )
 
 const passwordHandlerTestSchema = `{
@@ -48,7 +49,10 @@ func newPasswordHandlerFixture(t *testing.T) *passwordHandlerFixture {
 	hasher := cryptomock.NewMockHasher(ctrl)
 
 	v2Pool.EXPECT().Statements().Return(stmts).AnyTimes()
-	userService := service.NewUserService(service.NewPool(v2Pool), schemaStore, hasher)
+	svcPool := service.NewPool(v2Pool)
+	stmts.EXPECT().ListJSONSchemas(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&database.ListResult[*domain.JSONSchema]{}, nil).AnyTimes()
+	userService := service.NewUserService(svcPool, schemaStore, hasher, service.StatementsUserRefResolver{Pool: svcPool})
 	handler := service.NewFlowCreateUserHandler(hasher, userService, schemaStore, v2Pool)
 
 	return &passwordHandlerFixture{

--- a/internal/service/session_test.go
+++ b/internal/service/session_test.go
@@ -34,6 +34,12 @@ func (s *refResolverStub) ResolveUserRefs(ctx context.Context, projectID string,
 	return s.resolveFunc(ctx, projectID, userIDs)
 }
 
+// ResolveRefsForUsers satisfies the widened port; the session service
+// resolves by id only, so any call here is a test failure.
+func (s *refResolverStub) ResolveRefsForUsers(context.Context, string, []*domain.User) (map[string]domain.UserRef, error) {
+	panic("unexpected refs.ResolveRefsForUsers call")
+}
+
 func sessionConfigForTest() service.SessionConfig {
 	return service.SessionConfig{DefaultTTL: time.Hour, MaxTTL: 24 * time.Hour}
 }

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -119,6 +119,7 @@ type userService struct {
 	v2Pool      StatementPool
 	schemaStore domain.JSONSchemaStore
 	hasher      crypto.Hasher
+	refs        UserRefResolver
 }
 
 // NewUserService returns the interface rather than *userService, deliberately
@@ -131,11 +132,13 @@ func NewUserService(
 	v2Pool StatementPool,
 	schemaStore domain.JSONSchemaStore,
 	hasher crypto.Hasher,
+	refs UserRefResolver,
 ) UserService {
 	return &userService{
 		v2Pool:      v2Pool,
 		schemaStore: schemaStore,
 		hasher:      hasher,
+		refs:        refs,
 	}
 }
 
@@ -199,8 +202,26 @@ func (s *userService) CreateUser(ctx context.Context, input CreateUserInput) (_ 
 			WithMessage("The user was created but could not be read back. Fetch it by id rather than retrying the create.").
 			WithDetails(domain.CreatedUserDetails{UserID: action.CreateUser.ID})
 	}
+	if err := s.attachUserRefs(ctx, input.ProjectID, user); err != nil {
+		return nil, err
+	}
 
 	return user, nil
+}
+
+// attachUserRefs resolves the derived identity (ADR 058 §3a) onto each
+// user's Ref — one batch per page, per §4.
+func (s *userService) attachUserRefs(ctx context.Context, projectID string, users ...*domain.User) error {
+	refs, err := s.refs.ResolveRefsForUsers(ctx, projectID, users)
+	if err != nil {
+		return domain.ErrInternal(err).WithMessage("failed to resolve user identities")
+	}
+	for _, user := range users {
+		if ref, ok := refs[user.ID]; ok {
+			user.Ref = &ref
+		}
+	}
+	return nil
 }
 
 func (s *userService) DeleteUser(ctx context.Context, input DeleteUserInput) error {
@@ -243,6 +264,9 @@ func (s *userService) ListUsers(ctx context.Context, input ListUsersInput) (*Lis
 	}, queryOpts)
 	if err != nil {
 		return nil, mapListError(err, "failed to list users from database")
+	}
+	if err := s.attachUserRefs(ctx, input.ProjectID, result.Items...); err != nil {
+		return nil, err
 	}
 
 	return &ListUsersOutput{
@@ -468,6 +492,9 @@ func (s *userService) GetUserByID(ctx context.Context, input GetUserInput) (*dom
 		}
 		return nil, domain.ErrInternal(err).WithMessage("failed to get user from database")
 	}
+	if err := s.attachUserRefs(ctx, input.ProjectID, user); err != nil {
+		return nil, err
+	}
 
 	return user, nil
 }
@@ -495,6 +522,9 @@ func (s *userService) GetMyUser(ctx context.Context, input GetMyUserInput) (*dom
 			return nil, domain.ErrUserNotFound()
 		}
 		return nil, domain.ErrInternal(err).WithMessage("failed to get user from database")
+	}
+	if err := s.attachUserRefs(ctx, sessionToken.ProjectID, user); err != nil {
+		return nil, err
 	}
 
 	return user, nil

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -202,8 +202,14 @@ func (s *userService) CreateUser(ctx context.Context, input CreateUserInput) (_ 
 			WithMessage("The user was created but could not be read back. Fetch it by id rather than retrying the create.").
 			WithDetails(domain.CreatedUserDetails{UserID: action.CreateUser.ID})
 	}
-	if err := s.attachUserRefs(ctx, input.ProjectID, user); err != nil {
-		return nil, err
+	// The identity ref is derived decoration and the create has already
+	// committed: a resolution failure must not fail the create — the caller
+	// would retry and hit the unique constraints — so the response simply
+	// carries no ref fields and clients fall back to the id (ADR 058).
+	if refs, err := s.refs.ResolveRefsForUsers(ctx, input.ProjectID, []*domain.User{user}); err == nil {
+		if ref, ok := refs[user.ID]; ok {
+			user.Ref = &ref
+		}
 	}
 
 	return user, nil

--- a/internal/service/user_ref.go
+++ b/internal/service/user_ref.go
@@ -14,6 +14,9 @@ import (
 // from the result; their refs degrade to the user id at the caller.
 type UserRefResolver interface {
 	ResolveUserRefs(ctx context.Context, projectID string, userIDs []string) (map[string]domain.UserRef, error)
+	// ResolveRefsForUsers resolves refs for users the caller already holds
+	// fully hydrated (ADR 058 §3a) — one schema-list query, no user query.
+	ResolveRefsForUsers(ctx context.Context, projectID string, users []*domain.User) (map[string]domain.UserRef, error)
 }
 
 // refSchemaPageSize pages the user-schema listing during ref resolution.
@@ -72,6 +75,29 @@ func (r StatementsUserRefResolver) ResolveUserRefs(ctx context.Context, projectI
 
 	refs := make(map[string]domain.UserRef, len(listed.Items))
 	for _, user := range listed.Items {
+		refs[user.ID] = domain.ResolveUserRef(user, documents[user.SchemaURL])
+	}
+	return refs, nil
+}
+
+// ResolveRefsForUsers maps already-listed users through their own schema's
+// designations (ADR 058 §3a). The callers' read paths hydrate the full
+// attribute document, a superset of the designated keys, so resolution
+// needs only the schema documents — one schema-list query per page, zero
+// additional user queries (§4: list endpoints must not resolve per row).
+// Users whose schema URL has no stored document resolve to a bare id ref.
+func (r StatementsUserRefResolver) ResolveRefsForUsers(ctx context.Context, projectID string, users []*domain.User) (map[string]domain.UserRef, error) {
+	refs := make(map[string]domain.UserRef, len(users))
+	if len(users) == 0 {
+		return refs, nil
+	}
+	// Nested read keyed on rows the caller already holds — not a management
+	// list; skip the authz list-filter tripwire like GetUser does (#839).
+	documents, _, err := r.designatingSchemas(WithAuthzListUnrestricted(ctx), projectID)
+	if err != nil {
+		return nil, err
+	}
+	for _, user := range users {
 		refs[user.ID] = domain.ResolveUserRef(user, documents[user.SchemaURL])
 	}
 	return refs, nil

--- a/internal/service/user_ref_test.go
+++ b/internal/service/user_ref_test.go
@@ -130,3 +130,55 @@ func TestStatementsUserRefResolver_ResolveUserRefs(t *testing.T) {
 		assert.Empty(t, refs)
 	})
 }
+
+func TestStatementsUserRefResolver_ResolveRefsForUsers(t *testing.T) {
+	newResolver := func(t *testing.T, stmts *mocks.MockAllStatements) service.StatementsUserRefResolver {
+		t.Helper()
+		ctrl := gomock.NewController(t)
+		pool := mocks.NewMockPool(ctrl)
+		pool.EXPECT().Statements().Return(stmts).AnyTimes()
+		return service.StatementsUserRefResolver{Pool: service.NewPool(pool)}
+	}
+
+	t.Run("resolves already-listed users without a user query", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stmts := mocks.NewMockAllStatements(ctrl)
+		// Only ListJSONSchemas may run — a ListUsers call would fail the
+		// mock: the callers already hold fully hydrated users (§3a).
+		stmts.EXPECT().ListJSONSchemas(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&database.ListResult[*domain.JSONSchema]{Items: []*domain.JSONSchema{{
+				ProjectID: "proj",
+				URL:       "https://s/human",
+				Kind:      domain.JSONSchemaKindUserSchema,
+				Schema:    []byte(`{"x-identifier":"email","x-display":["givenName"]}`),
+			}}}, nil)
+
+		users := []*domain.User{
+			{ProjectID: "proj", SchemaURL: "https://s/human", ID: "user-1", Attributes: domain.AttributesFromMap(map[string]any{
+				"email": "ada@example.com", "givenName": "Ada",
+			})},
+			{ProjectID: "proj", SchemaURL: "https://s/unstored", ID: "user-2", Attributes: domain.AttributesFromMap(map[string]any{
+				"email": "b@example.com",
+			})},
+		}
+		refs, err := newResolver(t, stmts).ResolveRefsForUsers(t.Context(), "proj", users)
+
+		require.NoError(t, err)
+		assert.Equal(t, domain.UserRef{
+			UserID: "user-1", Identifier: "ada@example.com",
+			IdentifierProperty: "email", Display: "Ada",
+		}, refs["user-1"])
+		assert.Equal(t, domain.UserRef{UserID: "user-2"}, refs["user-2"],
+			"a user of an unstored schema resolves to a bare id ref")
+	})
+
+	t.Run("empty input short-circuits without queries", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stmts := mocks.NewMockAllStatements(ctrl)
+
+		refs, err := newResolver(t, stmts).ResolveRefsForUsers(t.Context(), "proj", nil)
+
+		require.NoError(t, err)
+		assert.Empty(t, refs)
+	})
+}

--- a/internal/service/user_ref_test.go
+++ b/internal/service/user_ref_test.go
@@ -2,11 +2,13 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/nextgen/internal/domain"
+	domainmock "github.com/zitadel/nextgen/internal/domain/mock"
 	"github.com/zitadel/nextgen/internal/service"
 	"github.com/zitadel/nextgen/internal/service/mocks"
 	"github.com/zitadel/nextgen/internal/storage/database"
@@ -181,4 +183,48 @@ func TestStatementsUserRefResolver_ResolveRefsForUsers(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, refs)
 	})
+}
+
+func TestCreateUser_SurvivesRefResolutionFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	pool := mocks.NewMockPool(ctrl)
+	stmts := mocks.NewMockAllStatements(ctrl)
+	statementer := mocks.NewMockStatementer[service.AllStatements](ctrl)
+	pool.EXPECT().Statements().Return(stmts).AnyTimes()
+	pool.EXPECT().Transaction(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, fn func(context.Context, service.Statementer[service.AllStatements]) error) error {
+			return fn(ctx, statementer)
+		}).AnyTimes()
+	statementer.EXPECT().Statements().Return(stmts).AnyTimes()
+	stmts.EXPECT().InsertEvent(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	schemaStore := domainmock.NewMockJSONSchemaStore(ctrl)
+	schemaStore.EXPECT().GetJSONSchemaByID(gomock.Any(), "proj", gomock.Any()).Return(&domain.JSONSchema{
+		ProjectID: "proj",
+		URL:       "https://s/human",
+		Kind:      domain.JSONSchemaKindUserSchema,
+		Schema:    []byte(`{"type":"object","properties":{"email":{"type":"string"}}}`),
+	}, nil)
+	stmts.EXPECT().NewManagedID(gomock.Any()).Return("user_new", nil).AnyTimes()
+	stmts.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Return(nil)
+	stmts.EXPECT().GetUser(gomock.Any(), gomock.Any(), gomock.Any()).Return(&domain.User{
+		ProjectID: "proj", SchemaURL: "https://s/human", ID: "user_new",
+		Attributes: domain.AttributesFromMap(map[string]any{"email": "a@example.com"}),
+	}, nil)
+	// The create has committed; the decoration query failing must not fail
+	// the create — the response simply carries no ref.
+	stmts.EXPECT().ListJSONSchemas(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("schema listing down"))
+
+	svcPool := service.NewPool(pool)
+	svc := service.NewUserService(svcPool, schemaStore, nil, service.StatementsUserRefResolver{Pool: svcPool})
+	user, err := svc.CreateUser(t.Context(), service.CreateUserInput{
+		ProjectID:  "proj",
+		SchemaURL:  "https://s/human",
+		Attributes: map[string]any{"email": "a@example.com"},
+	})
+
+	require.NoError(t, err, "a ref-resolution failure must not fail the committed create")
+	require.NotNil(t, user)
+	assert.Nil(t, user.Ref)
 }

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -300,6 +300,11 @@ func newMockedUserService(t *testing.T) (service.UserService, *servicemocks.Mock
 	pool := servicemocks.NewMockPool(ctrl)
 	stmts := servicemocks.NewMockAllStatements(ctrl)
 	pool.EXPECT().Statements().Return(stmts).AnyTimes()
+	// Ref resolution lists the project's schemas on every read path; an empty
+	// listing resolves every user to a bare id ref without further queries.
+	stmts.EXPECT().ListJSONSchemas(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&database.ListResult[*domain.JSONSchema]{}, nil).AnyTimes()
 
-	return service.NewUserService(service.NewPool(pool), nil, nil), stmts
+	svcPool := service.NewPool(pool)
+	return service.NewUserService(svcPool, nil, nil, service.StatementsUserRefResolver{Pool: svcPool}), stmts
 }


### PR DESCRIPTION
## ADR 058 §3a — user envelope identity + console user surfaces

**Third in the stack: #1090 (plumbing) ← #1085 (sessions) ← this PR.** Fixes #956; also completes the identity half of the users-list build-out tracked in #630.

### API

The user envelope gains read-only `identifier`, `identifier_property`, `display` — the same resolution that produces session user refs, inlined (`user_id` omitted; the envelope has `id`). Per ADR 059 rule 8, derived label fields ride the resource's own read permission: **no expand gate**, unconditional on every user response (query, get by id, `users/me`, create read-back).

Resolution cost: the read paths already hydrate the full attribute document, so the new `ResolveRefsForUsers` port method adds **one schema-list query per page and zero user queries** (§4: never per row). Same `WithAuthzListUnrestricted` posture as the batch resolver (#839 pattern).

### Console

- **Users list**: a leading **User** identity column (`display → identifier → id`) carrying the row link, plus a dedicated role-named **Identifier** column — platform-derived like Status/ID, deliberately outside the schema-driven column set (D4/#630), scannable down a mixed-schema list whether a row's identifier is an email or a loginname (cell tooltip names the source property) (the link used to hang on whatever schema property happened to sort first, falling back to the raw ULID: exactly #956's complaint). Schema-driven columns, Status, and ID follow unchanged; search covers the identity.
- **Detail**: heading follows the same chain, identifier as subtitle under a display.
- **Deleted**: `userDisplayName` — the client-side convention guesser (name → givenName/familyName, camel+snake), the console twin of the Go resolver #1085 removes. Identity now comes only from the server's resolution; the console carries zero designation logic.

### Screenshots

The list against a real seeded instance — `Grace Hopper` lives under a schema designating `loginname`/`first_name`/`last_name` (no property the platform has ever hardcoded), `Ada Lovelace` under one designating `email` + display, the seeded rest under the shipped default (identifier only). **Before**: see the screenshots in #956 — these same rows degraded to raw ULIDs or guessed attributes.

<img width="1440" height="900" alt="956userslist" src="https://github.com/user-attachments/assets/d65e71c6-ea2e-4ba9-9cd5-8b2e61b0e30c" />

<img width="1440" height="900" alt="956userdetail" src="https://github.com/user-attachments/assets/e4964c49-ada9-4dd0-9d25-1e634dceb653" />

### Out of scope

How **schema-defined properties** render across mixed schemas (the unioned schema-driven columns and their `—` placeholders, e.g. cross-schema property normalization) stays with #630 — this PR only adds the platform-derived identity fields, which sit outside that column set like Status and ID.

### Tests

- Unit: `ResolveRefsForUsers` (no user query asserted via mock, unstored-schema bare ref, empty short-circuit); console suites rewritten off the convention cases onto the chain (display / identifier-only / id fallback), 122/122.
- Integration: `TestUserResponses_CarryDerivedIdentity` — query rows carry each schema's own resolution (display-designating schema vs the shipped default), get-by-id carries it; create read-back asserted at the service level. Runs in CI (no local Docker).
- console-e2e real specs unchanged by design: seeded users live under the default schema, so their labels stay the email (identifier).

### Not in this PR

The api-mock serves no users ("a users list read from it is a fiction" — apps/console/AGENTS.md), so no mock change; verify visually with `moon run console:dev-real`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

