### PR TITLE
fix(console): give CI test runs cold-cache headroom

### DIFF
--- a/apps/console/src/test-setup.ts
+++ b/apps/console/src/test-setup.ts
@@ -1,4 +1,12 @@
 import "@testing-library/jest-dom/vitest";
+import { configure } from "@testing-library/react";
+
+// Companion to the CI-only vitest testTimeout in vite.config.mts: the async
+// utils (findBy*, waitFor) default to 1s, which the cold-cache transform of
+// the first CI run eats before the screen under test ever renders.
+if (process.env.CI) {
+  configure({ asyncUtilTimeout: 5_000 });
+}
 
 // @ts-expect-error Needed for tests
 global.IS_REACT_ACT_ENVIRONMENT = true;

--- a/apps/console/vite.config.mts
+++ b/apps/console/vite.config.mts
@@ -76,6 +76,12 @@ export default defineConfig(({ command, mode, isPreview }) => ({
     passWithNoTests: true,
     globals: true,
     environment: "jsdom",
+    // CI's first run after a large change transforms the whole module graph
+    // cold, and that startup cost lands inside the first specs' clocks: the
+    // suite then fails en masse with ~5s findBy timeouts on screens that are
+    // green locally and on every warm rerun. Give CI the headroom; keep the
+    // tight local budget so a genuinely hung test still fails fast at a desk.
+    testTimeout: process.env.CI ? 20_000 : 5_000,
     setupFiles: ["./src/test-setup.ts"],
     include: ["src/**/*.spec.{ts,tsx}"],
     reporters: ["default"],


### PR DESCRIPTION
`console:test` has failed on the first CI run after every large rebase (observed three times on the ADR 058 stack), always with the same signature: many unrelated `_authed` screens failing at ~5s `findBy` timeouts, while the identical head passes locally (132/132) and on every warm rerun.

The cause is the cold module-graph transform on a fresh runner: its startup cost lands inside the first specs' async clocks. This bumps two budgets **under CI only** — vitest `testTimeout` 5s → 20s and testing-library's `asyncUtilTimeout` 1s → 5s — keeping the tight local budgets so a genuinely hung test still fails fast at a desk.

No test changes; verified the full console suite green in both modes (default and `CI=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)