### PR TITLE
fix(config): mint claim and dashboard URLs from a dedicated public base

### DIFF
--- a/.changeset/server-public-base.md
+++ b/.changeset/server-public-base.md
@@ -1,0 +1,5 @@
+---
+"@zitadel/server": patch
+---
+
+The server now mints claim and dashboard URLs from a dedicated `server.public_base` setting (env `NEXTGEN_SERVER_PUBLIC_BASE`, default `https://nextgen.zitadel.cloud`) instead of deriving them from the schema identity namespace. Deployments reachable at another origin — a local server most of all — set the new key and `zitadel claim` opens the right console instead of a dead `nextgen.com` address. A misconfigured base (query, fragment, userinfo, or a non-http(s) scheme) now fails at startup instead of leaking into every minted URL.

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -132,6 +132,11 @@ type ServerConfig struct {
 	ConsolePath    string `mapstructure:"console_path"`
 	LoginEnabled   bool   `mapstructure:"login_enabled"`
 	LoginPath      string `mapstructure:"login_path"`
+	// PublicBase is the origin this deployment is reachable at from a browser.
+	// It only feeds user-facing URLs (claim and dashboard); schema identity
+	// stays on schema.builtin_public_base, which is an identifier namespace,
+	// not an address.
+	PublicBase string `mapstructure:"public_base"`
 }
 
 type SchemaConfig struct {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -368,16 +368,25 @@ func run(ctx context.Context, cfg Config, userFiles []string) error {
 
 // consoleBaseURL joins the deployment's public base with the console mount
 // path. The public base may carry a path prefix (a proxy mounting the server
-// under a subpath); only a trailing slash is trimmed before the join.
+// under a subpath) but nothing else: query, fragment, or userinfo would leak
+// into every minted claim and dashboard URL, so misconfiguration fails at
+// startup instead. The result never ends in a slash — callers append paths.
 func consoleBaseURL(publicBase, consolePath string) (string, error) {
 	base, err := url.Parse(publicBase)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse server public base: %w", err)
 	}
-	if base.Scheme == "" || base.Host == "" {
-		return "", fmt.Errorf("server public base %q must be an absolute URL", publicBase)
+	if (base.Scheme != "http" && base.Scheme != "https") || base.Host == "" {
+		return "", fmt.Errorf("server public base %q must be an absolute http(s) URL", publicBase)
 	}
-	return strings.TrimRight(publicBase, "/") + consolePath, nil
+	if base.User != nil || base.RawQuery != "" || base.Fragment != "" {
+		return "", fmt.Errorf("server public base %q must carry only an origin and an optional path prefix", publicBase)
+	}
+	if consolePath != "" && !strings.HasPrefix(consolePath, "/") {
+		return "", fmt.Errorf("server console path %q must start with a slash", consolePath)
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + strings.TrimRight(consolePath, "/")
+	return base.String(), nil
 }
 
 // ----------------------------- CONFIG --------------------------------------

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -190,12 +190,13 @@ func run(ctx context.Context, cfg Config, userFiles []string) error {
 		nil,
 	)
 	teamService := service.NewTeamService(serviceDBPool)
-	// The claim and dashboard URLs hang off the console. builtin_public_base is
-	// the only public-origin config today and carries the /api/schemas path, so
-	// strip it down to the origin before appending the console path; a
-	// dedicated server public-base setting should replace this when cloud
-	// deployment configuration lands.
-	consoleBase := (&url.URL{Scheme: builtinPublicBase.Scheme, Host: builtinPublicBase.Host}).String() + cfg.Server.ConsolePath
+	// The claim and dashboard URLs hang off the console, reached at the
+	// deployment's public base (not at schema.builtin_public_base, which is an
+	// identifier namespace and must not follow the deployment address).
+	consoleBase, err := consoleBaseURL(cfg.Server.PublicBase, cfg.Server.ConsolePath)
+	if err != nil {
+		return err
+	}
 	claimService := service.NewClaimService(serviceDBPool, consoleBase, cfg.Platform.ResolvedProjectID())
 	grantService := service.NewGrantService(serviceDBPool, cfg.Platform.ResolvedProjectID())
 	brandingService := service.NewBrandingService(serviceDBPool)
@@ -365,6 +366,20 @@ func run(ctx context.Context, cfg Config, userFiles []string) error {
 	}
 }
 
+// consoleBaseURL joins the deployment's public base with the console mount
+// path. The public base may carry a path prefix (a proxy mounting the server
+// under a subpath); only a trailing slash is trimmed before the join.
+func consoleBaseURL(publicBase, consolePath string) (string, error) {
+	base, err := url.Parse(publicBase)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse server public base: %w", err)
+	}
+	if base.Scheme == "" || base.Host == "" {
+		return "", fmt.Errorf("server public base %q must be an absolute URL", publicBase)
+	}
+	return strings.TrimRight(publicBase, "/") + consolePath, nil
+}
+
 // ----------------------------- CONFIG --------------------------------------
 
 func loadConfig(configPath string) (Config, error) {
@@ -381,6 +396,7 @@ func loadConfig(configPath string) (Config, error) {
 	v.SetDefault("server.data_dir", dataDir)
 	v.SetDefault("server.console_enabled", true)
 	v.SetDefault("server.console_path", "/ui/console")
+	v.SetDefault("server.public_base", "https://nextgen.zitadel.cloud")
 	v.SetDefault("server.login_enabled", true)
 	v.SetDefault("server.login_path", "/ui/login")
 	// Default to argon2id (per ADR 029). Params follow the RFC 9106 second

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -28,6 +28,46 @@ func TestLoadConfigReadsPostgresDatabaseEnv(t *testing.T) {
 	assert.Equal(t, "postgresql://postgres@localhost:5432/nextgen?sslmode=disable", postgresConfig)
 }
 
+func TestConsoleBaseURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		publicBase string
+		want       string
+		wantErr    bool
+	}{
+		{name: "plain origin", publicBase: "http://localhost:8080", want: "http://localhost:8080/ui/console"},
+		{name: "trailing slash trimmed", publicBase: "https://nextgen.zitadel.cloud/", want: "https://nextgen.zitadel.cloud/ui/console"},
+		{name: "path prefix kept", publicBase: "https://proxy.example.com/nextgen", want: "https://proxy.example.com/nextgen/ui/console"},
+		{name: "missing scheme", publicBase: "localhost:8080", wantErr: true},
+		{name: "empty", publicBase: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := consoleBaseURL(tt.publicBase, "/ui/console")
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLoadConfigServerPublicBase(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "nextgen.yaml")
+	require.NoError(t, os.WriteFile(configPath, nil, 0o600))
+
+	cfg, err := loadConfig(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "https://nextgen.zitadel.cloud", cfg.Server.PublicBase)
+
+	t.Setenv("NEXTGEN_SERVER_PUBLIC_BASE", "http://localhost:9999")
+	cfg, err = loadConfig(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:9999", cfg.Server.PublicBase)
+}
+
 // TestLoadConfigDefaultsToArgon2id locks in the ADR 029 default: with no
 // password_hasher overrides, the built hasher produces argon2id hashes while
 // still verifying (and rehashing) pre-existing bcrypt hashes.

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -30,20 +30,31 @@ func TestLoadConfigReadsPostgresDatabaseEnv(t *testing.T) {
 
 func TestConsoleBaseURL(t *testing.T) {
 	tests := []struct {
-		name       string
-		publicBase string
-		want       string
-		wantErr    bool
+		name        string
+		publicBase  string
+		consolePath string
+		want        string
+		wantErr     bool
 	}{
 		{name: "plain origin", publicBase: "http://localhost:8080", want: "http://localhost:8080/ui/console"},
 		{name: "trailing slash trimmed", publicBase: "https://nextgen.zitadel.cloud/", want: "https://nextgen.zitadel.cloud/ui/console"},
 		{name: "path prefix kept", publicBase: "https://proxy.example.com/nextgen", want: "https://proxy.example.com/nextgen/ui/console"},
+		{name: "console path trailing slash trimmed", publicBase: "http://localhost:8080", consolePath: "/ui/console/", want: "http://localhost:8080/ui/console"},
 		{name: "missing scheme", publicBase: "localhost:8080", wantErr: true},
 		{name: "empty", publicBase: "", wantErr: true},
+		{name: "non-http scheme", publicBase: "ftp://example.com", wantErr: true},
+		{name: "query rejected", publicBase: "https://example.com?x=y", wantErr: true},
+		{name: "fragment rejected", publicBase: "https://example.com#frag", wantErr: true},
+		{name: "userinfo rejected", publicBase: "https://user:pass@example.com", wantErr: true},
+		{name: "console path without leading slash", publicBase: "http://localhost:8080", consolePath: "ui/console", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := consoleBaseURL(tt.publicBase, "/ui/console")
+			consolePath := tt.consolePath
+			if consolePath == "" {
+				consolePath = "/ui/console"
+			}
+			got, err := consoleBaseURL(tt.publicBase, consolePath)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/docs/operations/nextgen.example.yaml
+++ b/docs/operations/nextgen.example.yaml
@@ -20,6 +20,10 @@ server:
   console_path: /ui/console
   login_enabled: true
   login_path: /ui/login
+  # Public origin browsers reach this deployment at; feeds the claim and
+  # dashboard URLs. Set to http://localhost:8080 when running the server
+  # locally by hand (env: NEXTGEN_SERVER_PUBLIC_BASE).
+  public_base: https://nextgen.zitadel.cloud
 
 # Optional. When omitted, the server uses SQLite at <data_dir>/zitadel.db.
 # Configure exactly one dialect to override the default:


### PR DESCRIPTION
## Problem

`zitadel claim` against a local server opens the browser at `https://nextgen.com/ui/console/claim?...` (follow-up to #613). The CLI is innocent: it opens whatever `claim_url` the server returns. The server derives the console base from the origin of `schema.builtin_public_base`, whose default (`https://nextgen.com/api/schemas`) is a schema `$id` namespace, an identifier, not a reachable address. The code comment at the derivation site already asked for a dedicated public-base setting.

Repointing `schema.builtin_public_base` was not an option: it would silently rewrite every built-in schema `$id` per deployment.

## Change

- New `server.public_base` config key (default `https://nextgen.zitadel.cloud`), automatically settable as `NEXTGEN_SERVER_PUBLIC_BASE` through the existing viper env binding, with the usual env > yaml > default precedence.
- The claim service's console base is now built from it via a small validated helper (`consoleBaseURL`), so `claim_url` and both `dashboard_url` paths follow the deployment's real origin. Schema identity is untouched.
- Documented in `docs/operations/nextgen.example.yaml` (set it to `http://localhost:8080` for manual local runs).

## Tests

- `TestConsoleBaseURL`: origin join, trailing-slash trim, path-prefix support, invalid-URL errors.
- `TestLoadConfigServerPublicBase`: default value and env override.

## Stacked on top

The CLI half (injecting `NEXTGEN_SERVER_PUBLIC_BASE=http://localhost:<port>` when the CLI launches the local server, a claim-time mismatch warning, and a full-flow claim e2e) follows in a stacked PR based on this branch.

A separate follow-up will handle the `nextgen.com` to `nextgen.zitadel.cloud` identifier rename (schema `$id` namespace, flow schema URI, contract examples, fixtures); it is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw9u3S9YGZYf32meW62fwe