### PR TITLE
feat(cli): validate user-schema identity designations at plan time

### DIFF
--- a/.changeset/cli-designation-validation.md
+++ b/.changeset/cli-designation-validation.md
@@ -1,0 +1,13 @@
+---
+"@zitadel/config": minor
+"@zitadel/cli": minor
+---
+
+Validate user-schema identity designations at plan time. `schemaConfigSchema`
+now ports the server's designation rules (`x-identifier` must name a reachable
+scalar leaf carrying `x-unique: "project"`, `x-display` entries must name
+reachable scalar leaves, and a password-enabled schema must designate an
+identifier), so `zitadel plan`, `apply`, and `doctor` reject a schema file
+locally with the server's own error messages instead of letting apply fail
+with a 400. Unlike the server (fail-fast), the CLI reports every violation at
+once.

--- a/apps/cli/src/lib/sync/syncers.ts
+++ b/apps/cli/src/lib/sync/syncers.ts
@@ -99,9 +99,22 @@ class SchemaSyncer implements ResourceSyncer {
   validate(data: object): void {
     const result = schemaConfigSchema.safeParse(data);
     if (!result.success) {
-      throw new ZitadelError("E_VALIDATION", "Schema file is not a valid Zitadel schema body", {
-        details: { issues: result.error.issues },
-      });
+      // Fold every issue into the message: text-mode output prints only the
+      // message, so a bare "not valid" would leave the designation rules
+      // (ADR 058, mirrored from the server) invisible — the same rendering
+      // validatePlannedFlows uses.
+      const noun = result.error.issues.length === 1 ? "issue" : "issues";
+      throw new ZitadelError(
+        "E_VALIDATION",
+        `Schema file is not a valid Zitadel schema body (${result.error.issues.length} ${noun}):\n` +
+          result.error.issues
+            .map((issue) => `  - ${issue.path.join(".") || "/"}: ${issue.message}`)
+            .join("\n"),
+        {
+          hint: "These are the same rules the server enforces on apply.",
+          details: { issues: result.error.issues },
+        },
+      );
     }
     assertEnvRefs(data, this.env);
   }

--- a/apps/cli/tests/unit/commands/apply.test.ts
+++ b/apps/cli/tests/unit/commands/apply.test.ts
@@ -92,8 +92,9 @@ describe("apply command pre-flight", () => {
 const VALID_USER_SCHEMA = {
   kind: "user-schema",
   metaSchema: "https://nextgen.com/api/schemas/user-schema.json",
+  "x-identifier": "email",
   "x-auth-methods": { password: { enabled: true } },
-  properties: { email: { type: "string" } },
+  properties: { email: { type: "string", "x-unique": "project" } },
 };
 
 // VALID_FLOW deliberately references an env var for the pre-flight test

--- a/apps/cli/tests/unit/commands/doctor.test.ts
+++ b/apps/cli/tests/unit/commands/doctor.test.ts
@@ -16,8 +16,9 @@ const servers: Server[] = [];
 const VALID_USER_SCHEMA = {
   kind: "user-schema",
   metaSchema: "https://nextgen.com/api/schemas/user-schema.json",
+  "x-identifier": "email",
   "x-auth-methods": { password: { enabled: true } },
-  properties: { email: { type: "string" } },
+  properties: { email: { type: "string", "x-unique": "project" } },
 };
 
 async function doctor(cwd: string, extra: string[] = []) {

--- a/apps/cli/tests/unit/commands/doctor/checks.test.ts
+++ b/apps/cli/tests/unit/commands/doctor/checks.test.ts
@@ -353,6 +353,25 @@ describe("SchemaCheck", () => {
     const outcome = await new SchemaCheck().run(ctxFor(cwd));
     expect(outcome.status).toBe("fail");
   });
+
+  it("fails for a designation the server would reject, rendering path and message", async () => {
+    const cwd = await makeProject();
+    // Shape-valid user schema whose `x-identifier` names a property that does
+    // not exist — the server's designation validator (ported into
+    // `schemaConfigSchema`) rejects it, so doctor must too.
+    await writeFile(
+      join(cwd, ".zitadel/schemas/user.json"),
+      JSON.stringify({
+        ...VALID_USER_SCHEMA,
+        "x-identifier": "username",
+      }),
+    );
+    const outcome = await new SchemaCheck().run(ctxFor(cwd));
+    expect(outcome.status).toBe("fail");
+    expect(outcome.message).toContain(
+      'x-identifier schema designation invalid: "x-identifier" names unknown property "username"',
+    );
+  });
 });
 
 describe("DependencyCheck", () => {

--- a/apps/cli/tests/unit/commands/plan.test.ts
+++ b/apps/cli/tests/unit/commands/plan.test.ts
@@ -18,8 +18,9 @@ const SECRET = {
 const VALID_USER_SCHEMA = {
   kind: "user-schema",
   metaSchema: "https://nextgen.com/api/schemas/user-schema.json",
+  "x-identifier": "email",
   "x-auth-methods": { password: { enabled: true } },
-  properties: { email: { type: "string" } },
+  properties: { email: { type: "string", "x-unique": "project" } },
 };
 
 const VALID_FLOW = {

--- a/apps/cli/tests/unit/lib/sync/syncers.test.ts
+++ b/apps/cli/tests/unit/lib/sync/syncers.test.ts
@@ -62,10 +62,35 @@ describe("SchemaSyncer", () => {
       schema.validate({
         kind: "user-schema",
         metaSchema: "https://nextgen.com/api/schemas/user-schema.json",
+        "x-identifier": "email",
         "x-auth-methods": { password: { enabled: true } },
-        properties: { email: { type: "string" } },
+        properties: { email: { type: "string", "x-unique": "project" } },
       }),
     ).not.toThrow();
+  });
+
+  it("validate enforces the server's designation rules and names them in the message", () => {
+    // Mirrors validateUserSchemaDesignations (internal/domain/
+    // schema_designation.go): a password-enabled schema must designate an
+    // identifier, and the rendered message must carry the server's own
+    // wording — text-mode plan output prints only the message.
+    const [schema] = makeSyncers({ client, projectId: "proj-1", env: {}, cwd: "/tmp/zitadel-sync-test" });
+
+    let thrown: unknown;
+    try {
+      schema.validate({
+        kind: "user-schema",
+        metaSchema: "https://nextgen.com/api/schemas/user-schema.json",
+        "x-auth-methods": { password: { enabled: true } },
+        properties: { email: { type: "string" } },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ZitadelError);
+    expect((thrown as ZitadelError).message).toContain(
+      'password authentication is enabled but the schema designates no "x-identifier"',
+    );
   });
 
   it("validate throws E_VALIDATION on a malformed JSON Schema", () => {

--- a/packages/config/src/schema-validate.test.ts
+++ b/packages/config/src/schema-validate.test.ts
@@ -1,0 +1,379 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { SCHEMA_DESIGNATION_RULES, validateUserSchemaDesignations } from "./schema-validate.js";
+import { schemaConfigSchema } from "./schemas.js";
+
+/** A password-enabled document with the given root-level extras. */
+function doc(extra: Record<string, unknown>): Record<string, unknown> {
+  return {
+    type: "object",
+    "x-auth-methods": { password: { enabled: true } },
+    ...extra,
+  };
+}
+
+const emailLeaf = { type: "string", "x-unique": "project" };
+
+describe("validateUserSchemaDesignations", () => {
+  // Case-for-case mirror of TestTenantSchemaValidator_UserSchemaDesignations
+  // (internal/domain/schema_validator_test.go). `want` is the exact server
+  // detail string — client-visible end to end, asserted verbatim.
+  const cases: { name: string; schema: Record<string, unknown>; want?: string }[] = [
+    {
+      name: "identifier on a project-unique leaf",
+      schema: doc({ "x-identifier": "email", properties: { email: emailLeaf } }),
+    },
+    {
+      name: "identifier on a nested leaf path",
+      schema: doc({
+        "x-identifier": "contact.email",
+        properties: { contact: { type: "object", properties: { email: emailLeaf } } },
+      }),
+    },
+    {
+      name: "password enabled without a designation",
+      schema: doc({ properties: { email: emailLeaf } }),
+      want: 'schema designation invalid: password authentication is enabled but the schema designates no "x-identifier"',
+    },
+    {
+      name: "passkey-only schema needs no designation",
+      schema: {
+        type: "object",
+        "x-auth-methods": { passkey: { enabled: true } },
+        properties: { email: { type: "string" } },
+      },
+    },
+    {
+      name: "identifier naming an unknown property",
+      schema: doc({ "x-identifier": "username", properties: { email: emailLeaf } }),
+      want: 'schema designation invalid: "x-identifier" names unknown property "username"',
+    },
+    {
+      name: "identifier on a non-unique property",
+      schema: doc({ "x-identifier": "email", properties: { email: { type: "string" } } }),
+      want: 'schema designation invalid: "x-identifier" property "email" must carry x-unique "project", has ""',
+    },
+    {
+      name: "identifier on a team-unique property",
+      schema: doc({
+        "x-identifier": "email",
+        properties: { email: { type: "string", "x-unique": "team" } },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "email" must carry x-unique "project", has "team"',
+    },
+    {
+      name: "identifier hiding an object behind a $ref is indeterminate",
+      schema: doc({
+        "x-identifier": "profile",
+        properties: { profile: { $ref: "#/$defs/profile", "x-unique": "project" } },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "profile" must locally declare exactly one scalar type',
+    },
+    {
+      name: "identifier composed via allOf is indeterminate",
+      schema: doc({
+        "x-identifier": "handle",
+        properties: { handle: { allOf: [{ type: "string" }], "x-unique": "project" } },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "handle" must locally declare exactly one scalar type',
+    },
+    {
+      name: "identifier on a patternProperties object is not a leaf",
+      schema: doc({
+        "x-identifier": "tags",
+        properties: {
+          tags: { patternProperties: { ".*": { type: "string" } }, "x-unique": "project" },
+        },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "tags" must locally declare exactly one scalar type',
+    },
+    {
+      name: "identifier on an untyped property is indeterminate",
+      schema: doc({ "x-identifier": "email", properties: { email: { "x-unique": "project" } } }),
+      want: 'schema designation invalid: "x-identifier" property "email" must locally declare exactly one scalar type',
+    },
+    {
+      name: "allOf constraining a declared scalar stays a valid designation",
+      schema: doc({
+        "x-identifier": "email",
+        properties: { email: { type: "string", allOf: [{ minLength: 3 }], "x-unique": "project" } },
+      }),
+    },
+    {
+      name: "inert object-only keywords on a declared scalar stay valid",
+      schema: doc({
+        "x-identifier": "email",
+        properties: {
+          email: { type: "string", additionalProperties: false, "x-unique": "project" },
+        },
+      }),
+    },
+    {
+      name: "a nullable scalar union is a valid designation target",
+      schema: doc({
+        "x-identifier": "email",
+        properties: { email: { type: ["null", "string"], "x-unique": "project" } },
+      }),
+    },
+    {
+      name: "an all-scalar type union is rejected like the flow resolver rejects it",
+      schema: doc({
+        "x-identifier": "handle",
+        properties: { handle: { type: ["string", "integer"], "x-unique": "project" } },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "handle" must locally declare exactly one scalar type',
+    },
+    {
+      name: "a null-only type cannot identify anyone",
+      schema: doc({
+        "x-identifier": "ghost",
+        properties: { ghost: { type: "null", "x-unique": "project" } },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "ghost" must locally declare exactly one scalar type',
+    },
+    {
+      name: "a null-only union cannot identify anyone",
+      schema: doc({
+        "x-identifier": "ghost",
+        properties: { ghost: { type: ["null"], "x-unique": "project" } },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "ghost" must locally declare exactly one scalar type',
+    },
+    {
+      name: "a scalar-typed schema root cannot carry a designation",
+      schema: {
+        type: "string",
+        "x-auth-methods": { password: { enabled: true } },
+        "x-identifier": "email",
+        properties: { email: emailLeaf },
+      },
+      want: 'schema designation invalid: "x-identifier" path "email": the schema root is not an object',
+    },
+    {
+      name: "an intermediate segment on a scalar-typed parent is unreachable",
+      schema: doc({
+        "x-identifier": "contact.email",
+        properties: { contact: { type: "string", properties: { email: emailLeaf } } },
+      }),
+      want: 'schema designation invalid: "x-identifier" path "contact.email": segment "contact" is not an object',
+    },
+    {
+      name: "a nullable-object intermediate segment is reachable",
+      schema: doc({
+        "x-identifier": "contact.email",
+        properties: {
+          contact: { type: ["null", "object"], properties: { email: emailLeaf } },
+        },
+      }),
+    },
+    {
+      name: "identifier on an implicit object (properties without type)",
+      schema: doc({
+        "x-identifier": "contact",
+        properties: {
+          contact: { properties: { email: { type: "string" } }, "x-unique": "project" },
+        },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "contact" must locally declare exactly one scalar type',
+    },
+    {
+      name: "identifier on an array is not a leaf",
+      schema: doc({
+        "x-identifier": "emails",
+        properties: { emails: { type: "array", items: { type: "string" }, "x-unique": "project" } },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "emails" must locally declare exactly one scalar type',
+    },
+    {
+      name: "identifier on a nullable-object type union is not a leaf",
+      schema: doc({
+        "x-identifier": "profile",
+        properties: { profile: { type: ["null", "object"], "x-unique": "project" } },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "profile" must locally declare exactly one scalar type',
+    },
+    {
+      name: "identifier on an object is not a leaf",
+      schema: doc({
+        "x-identifier": "profile",
+        properties: { profile: { type: "object", "x-unique": "project" } },
+      }),
+      want: 'schema designation invalid: "x-identifier" property "profile" must locally declare exactly one scalar type',
+    },
+    {
+      name: "display on leaves without uniqueness",
+      schema: doc({
+        "x-identifier": "email",
+        "x-display": ["givenName", "familyName"],
+        properties: {
+          email: emailLeaf,
+          givenName: { type: "string" },
+          familyName: { type: "string" },
+        },
+      }),
+    },
+    {
+      name: "display naming an unknown property",
+      schema: doc({
+        "x-identifier": "email",
+        "x-display": ["nickname"],
+        properties: { email: emailLeaf },
+      }),
+      want: 'schema designation invalid: "x-display" names unknown property "nickname"',
+    },
+    {
+      name: "display entry must be a leaf",
+      schema: doc({
+        "x-identifier": "email",
+        "x-display": ["profile"],
+        properties: { email: emailLeaf, profile: { type: "object" } },
+      }),
+      want: 'schema designation invalid: "x-display" property "profile" must locally declare exactly one scalar type',
+    },
+  ];
+
+  for (const tt of cases) {
+    it(tt.name, () => {
+      const issues = validateUserSchemaDesignations(tt.schema);
+      if (tt.want === undefined) {
+        expect(issues, JSON.stringify(issues)).toEqual([]);
+      } else {
+        expect(issues.map((i) => i.message)).toContain(tt.want);
+      }
+    });
+  }
+
+  it("collects every issue instead of failing fast (documented Go divergence)", () => {
+    const issues = validateUserSchemaDesignations(
+      doc({
+        // No identifier while password is enabled AND two bad display entries.
+        "x-display": ["", "nickname"],
+        properties: { email: emailLeaf },
+      }),
+    );
+    expect(issues.map((i) => i.message)).toEqual([
+      'schema designation invalid: password authentication is enabled but the schema designates no "x-identifier"',
+      'schema designation invalid: "x-display" entries must be non-empty property paths',
+      'schema designation invalid: "x-display" names unknown property "nickname"',
+    ]);
+    expect(issues.map((i) => i.path)).toEqual([
+      ["x-auth-methods", "password", "enabled"],
+      ["x-display", 0],
+      ["x-display", 1],
+    ]);
+  });
+
+  it("skips a non-array x-display like the Go type assertion", () => {
+    expect(
+      validateUserSchemaDesignations(
+        doc({ "x-identifier": "email", "x-display": "email", properties: { email: emailLeaf } }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("schemaConfigSchema designation refine", () => {
+  it("rejects a password-enabled user schema without a designation", () => {
+    const result = schemaConfigSchema.safeParse({
+      kind: "user-schema",
+      metaSchema: "https://example.com/user-schema.json",
+      $id: "https://example.com/schemas/broken.json",
+      type: "object",
+      "x-auth-methods": { password: { enabled: true } },
+      properties: { email: { type: "string" } },
+    });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain(
+      "password authentication is enabled but the schema designates no",
+    );
+  });
+
+  it("passes a designating user schema", () => {
+    const result = schemaConfigSchema.safeParse({
+      kind: "user-schema",
+      metaSchema: "https://example.com/user-schema.json",
+      $id: "https://example.com/schemas/ok.json",
+      type: "object",
+      "x-identifier": "email",
+      "x-auth-methods": { password: { enabled: true } },
+      properties: { email: { type: "string", "x-unique": "project" } },
+    });
+    expect(result.success, JSON.stringify(result.error?.issues)).toBe(true);
+  });
+
+  it("leaves the schema-url union arm untouched", () => {
+    const result = schemaConfigSchema.safeParse({
+      kind: "schema-url",
+      url: "https://example.com/schemas/remote.json",
+    });
+    expect(result.success, JSON.stringify(result.error?.issues)).toBe(true);
+  });
+});
+
+describe("drift audit (Go designation validator)", () => {
+  const goSource = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../..",
+    "internal/domain/schema_designation.go",
+  );
+
+  it.skipIf(!existsSync(goSource))("every goRef function still exists in the Go source", () => {
+    const source = readFileSync(goSource, "utf8");
+    for (const [rule, { goRef }] of Object.entries(SCHEMA_DESIGNATION_RULES)) {
+      expect(source, `rule ${rule} → Go func ${goRef}`).toMatch(new RegExp(`func ${goRef}\\(`));
+    }
+  });
+
+  it.skipIf(!existsSync(goSource))("the Go validator gained no unported functions", () => {
+    const source = readFileSync(goSource, "utf8");
+    const goFuncs = [...source.matchAll(/^func (\w+)\(/gm)].map((m) => m[1]).sort();
+    const ported = Object.values(SCHEMA_DESIGNATION_RULES)
+      .map((rule) => rule.goRef)
+      .sort();
+    // Readers (DesignatedIdentifier, DesignatedDisplay, ...) resolve values at
+    // read time and enforce nothing — plan has no rule to mirror for them.
+    // NOT a place to park an unported rule: a new validation function here
+    // silently reopens the plan-passes/apply-fails gap this port closes.
+    const readers = goFuncs.filter(
+      (name) => name !== undefined && (name.startsWith("Designated") || name.startsWith("Resolve")),
+    );
+    expect(goFuncs).toEqual([...ported, ...readers].sort());
+  });
+
+  it.skipIf(!existsSync(goSource))("shared message literals still match the Go source", () => {
+    const source = readFileSync(goSource, "utf8");
+    for (const fragment of [
+      "schema designation invalid",
+      "password authentication is enabled but the schema designates no",
+      "names unknown property",
+      "must carry",
+      "is not an object",
+      "must locally declare exactly one scalar type",
+      "entries must be non-empty property paths",
+      "the schema root",
+    ]) {
+      expect(source).toContain(fragment);
+    }
+    // The scalar set and the annotation literals the messages embed.
+    for (const literal of ['"string", "number", "integer", "boolean"']) {
+      expect(source.replace(/\s+/g, " ")).toContain(literal.replace(/\s+/g, " "));
+    }
+  });
+
+  const annotationsSource = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../..",
+    "internal/domain/schema_annotations.go",
+  );
+
+  it.skipIf(!existsSync(annotationsSource))("annotation literals still match", () => {
+    const source = readFileSync(annotationsSource, "utf8");
+    for (const literal of ['"x-identifier"', '"x-display"', '"x-unique"', '"x-auth-methods"', '"project"']) {
+      expect(source).toContain(literal);
+    }
+  });
+});

--- a/packages/config/src/schema-validate.ts
+++ b/packages/config/src/schema-validate.ts
@@ -1,0 +1,235 @@
+/**
+ * Plan-time port of the server's user-schema designation validator
+ * (`validateUserSchemaDesignations` in `internal/domain/schema_designation.go`,
+ * ADR 058 §1–§2): the property named by `x-identifier` must exist as a
+ * reachable scalar leaf carrying project-scoped uniqueness, every `x-display`
+ * entry must name a reachable scalar leaf, and a password-enabled schema must
+ * designate an identifier. Without the port, `zitadel plan` accepts schema
+ * files the server rejects with a 400 on apply.
+ *
+ * Contract with the Go source (the same contract `validate.ts` holds for the
+ * flow validator):
+ *
+ * - Every rule id in {@link SCHEMA_DESIGNATION_RULES} names the Go function it
+ *   ports (`goRef`); a drift-audit test asserts those functions still exist
+ *   and that the shared message literals still match.
+ * - Error messages mirror the Go detail strings verbatim — they are
+ *   client-visible end to end, so a user who bypasses plan sees identical
+ *   text from the server.
+ * - Unlike the Go validator (fail-fast), this port collects every issue, the
+ *   flow port's documented divergence.
+ * - No skip escape hatch, deliberately: the branding refine (`schemas.ts`)
+ *   sets the precedent for schema-level rules, and this port is four small
+ *   functions with a case-for-case test mirror — plan must never accept what
+ *   apply would reject.
+ *
+ * Lifecycle: a local-first interim like the flow port; the designed successor
+ * is the server-side validate-only bundle endpoint (zitadel/nextgen#449).
+ */
+
+/**
+ * Rule registry: rule id → the Go function it ports. Kept separate from
+ * `FLOW_VALIDATION_RULES` — that registry's drift audit is exhaustive over
+ * `flow_definition_validator.go` and must not learn about this file.
+ */
+export const SCHEMA_DESIGNATION_RULES = {
+  "designation/password-requires-identifier": { goRef: "validateUserSchemaDesignations" },
+  "designation/leaf": { goRef: "designatedLeaf" },
+  "designation/object-shaped": { goRef: "isObjectShaped" },
+  "designation/scalar-type": { goRef: "declaresScalarType" },
+} as const;
+
+/** One designation violation; `path` addresses the offending keyword. */
+export interface DesignationIssue {
+  path: (string | number)[];
+  message: string;
+}
+
+const IDENTIFIER = "x-identifier";
+const DISPLAY = "x-display";
+const UNIQUE = "x-unique";
+const AUTH_METHODS = "x-auth-methods";
+const UNIQUE_SCOPE_PROJECT = "project";
+
+/** The Go sentinel every detail string is prefixed with (`%w:` rendering). */
+const PREFIX = "schema designation invalid";
+
+/** Go `%q` — double-quoted string. */
+function q(value: string): string {
+  return JSON.stringify(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Mirrors `maputil.GetNested[bool]` + the password trigger: every level is
+ * type-asserted, so a non-object `x-auth-methods` or non-boolean `enabled`
+ * reads as disabled.
+ */
+function passwordEnabled(schema: Record<string, unknown>): boolean {
+  if (!isPlainObject(schema[AUTH_METHODS])) return false;
+  const password = (schema[AUTH_METHODS] as Record<string, unknown>).password;
+  return isPlainObject(password) && password.enabled === true;
+}
+
+/**
+ * Validate the designation rules on a parsed user-schema document. Returns
+ * every violation; an empty array means the server-side validator would pass
+ * the document too. The caller gates on `kind === "user-schema"` — the
+ * `schema-url` union arm carries no document to check
+ * (`internal/domain/schema_validator.go` gates identically).
+ */
+export function validateUserSchemaDesignations(
+  schema: Record<string, unknown>,
+): DesignationIssue[] {
+  const issues: DesignationIssue[] = [];
+
+  const identifier = typeof schema[IDENTIFIER] === "string" ? (schema[IDENTIFIER] as string) : "";
+  const hasIdentifier = identifier !== "";
+
+  // Password verification is unreachable without a prior identifier (the flow
+  // state machine dispatches identifier before password). Passkey is
+  // deliberately NOT in this trigger: discoverable credentials identify the
+  // user through the assertion itself, so passkey-only (and API-managed)
+  // schemas legitimately designate nothing. magic_link, otp and sso are
+  // enable-able in the meta-schema but not in this trigger yet — ADR 058
+  // defers them; extend the trigger when the Go source does (the drift audit
+  // watches it).
+  if (passwordEnabled(schema) && !hasIdentifier) {
+    issues.push({
+      path: [AUTH_METHODS, "password", "enabled"],
+      message: `${PREFIX}: password authentication is enabled but the schema designates no ${q(IDENTIFIER)}`,
+    });
+  }
+
+  if (hasIdentifier) {
+    const leaf = designatedLeaf(schema, identifier, IDENTIFIER);
+    if ("message" in leaf) {
+      issues.push({ path: [IDENTIFIER], message: leaf.message });
+    } else {
+      const scope = typeof leaf.prop[UNIQUE] === "string" ? (leaf.prop[UNIQUE] as string) : "";
+      if (scope !== UNIQUE_SCOPE_PROJECT) {
+        issues.push({
+          path: [IDENTIFIER],
+          message: `${PREFIX}: ${q(IDENTIFIER)} property ${q(identifier)} must carry ${UNIQUE} ${q(UNIQUE_SCOPE_PROJECT)}, has ${q(scope)}`,
+        });
+      }
+    }
+  }
+
+  // Read as the Go type assertion does: anything but an array is silently
+  // skipped (the meta-schema types the keyword; this validator does not
+  // re-report shapes).
+  const display = schema[DISPLAY];
+  if (Array.isArray(display)) {
+    display.forEach((entry, i) => {
+      if (typeof entry !== "string" || entry === "") {
+        issues.push({
+          path: [DISPLAY, i],
+          message: `${PREFIX}: ${q(DISPLAY)} entries must be non-empty property paths`,
+        });
+        return;
+      }
+      const leaf = designatedLeaf(schema, entry, DISPLAY);
+      if ("message" in leaf) {
+        issues.push({ path: [DISPLAY, i], message: leaf.message });
+      }
+    });
+  }
+
+  return issues;
+}
+
+/**
+ * Resolve a dot-separated attribute path to its property schema. The root and
+ * every intermediate segment must be object-shaped — JSON Schema ignores a
+ * `properties` map on a scalar-typed parent, so a path through one could
+ * never exist on any valid user document — and the final segment must locally
+ * declare a scalar type. Mirrors `designatedLeaf` exactly, including that a
+ * missing `properties` map and a missing segment produce the same message,
+ * always quoting the full path.
+ */
+function designatedLeaf(
+  schema: Record<string, unknown>,
+  path: string,
+  keyword: string,
+): { prop: Record<string, unknown> } | { message: string } {
+  const unknown = { message: `${PREFIX}: ${q(keyword)} names unknown property ${q(path)}` };
+  let current: Record<string, unknown> = schema;
+  let parent = "the schema root";
+  for (const segment of path.split(".")) {
+    // The node being descended into must be able to hold object values —
+    // this covers the schema root too, whose type the meta-schema does not
+    // constrain.
+    if (!isObjectShaped(current)) {
+      return {
+        message: `${PREFIX}: ${q(keyword)} path ${q(path)}: ${parent} is not an object`,
+      };
+    }
+    const properties = current.properties;
+    if (!isPlainObject(properties)) {
+      return unknown;
+    }
+    // Own properties only: Go indexes a map, where an inherited name like
+    // `toString` is simply absent.
+    const next = Object.hasOwn(properties, segment) ? properties[segment] : undefined;
+    if (!isPlainObject(next)) {
+      return unknown;
+    }
+    current = next;
+    parent = `segment ${q(segment)}`;
+  }
+  if (!declaresScalarType(current)) {
+    return {
+      message: `${PREFIX}: ${q(keyword)} property ${q(path)} must locally declare exactly one scalar type`,
+    };
+  }
+  return { prop: current };
+}
+
+/**
+ * Whether a property schema can hold object values: no `type` declared (its
+ * `properties` map carries the intent), the type "object", or a union whose
+ * only non-null entry is "object".
+ */
+function isObjectShaped(prop: Record<string, unknown>): boolean {
+  const t = prop.type;
+  if (t === undefined) return true;
+  if (typeof t === "string") return t === "object";
+  if (Array.isArray(t)) {
+    let object = false;
+    for (const entry of t) {
+      if (entry === "object") object = true;
+      else if (entry !== "null") return false;
+    }
+    return object;
+  }
+  return false;
+}
+
+const SCALARS = new Set(["string", "number", "integer", "boolean"]);
+
+/**
+ * Whether a property schema locally proves its values are non-null scalars
+ * via the `type` keyword: one scalar type name, optionally in a union with
+ * "null" (the nullable idiom); exactly one non-null type. JSON Schema
+ * keywords are conjunctive, so a local scalar type cannot be widened by
+ * `$ref`, `allOf`, or any other keyword the property carries; without the
+ * local proof the shape is indeterminate.
+ */
+function declaresScalarType(prop: Record<string, unknown>): boolean {
+  const t = prop.type;
+  if (typeof t === "string") return SCALARS.has(t);
+  if (Array.isArray(t)) {
+    let nonNull = 0;
+    for (const entry of t) {
+      if (entry === "null") continue;
+      if (typeof entry !== "string" || !SCALARS.has(entry)) return false;
+      nonNull += 1;
+    }
+    return nonNull === 1;
+  }
+  return false;
+}

--- a/packages/config/src/schemas.ts
+++ b/packages/config/src/schemas.ts
@@ -6,8 +6,48 @@ import {
 import { z } from "zod";
 
 import { isCanonicalLoopbackHttpUrl } from "./branding-url.js";
+import { validateUserSchemaDesignations } from "./schema-validate.js";
 
-export const schemaConfigSchema = CreateSchemaBody;
+/**
+ * The generated wire shape plus the server's designation rules
+ * (`validateUserSchemaDesignations` in `internal/domain/schema_designation.go`,
+ * ADR 058 §1–§2), mirrored so plan rejects what apply would — the same
+ * doctrine as the branding refine below.
+ *
+ * The designation check runs on the RAW document, not the parsed output:
+ * the generated Zod strips schema keywords it does not model (`type` on
+ * property leaves, the root `type`) and injects annotation defaults, while
+ * the server stores and validates schema bytes verbatim (see SchemaSyncer's
+ * deliberate lack of `normalizeWrite`). Shape first, designations second —
+ * the server's own order (`schema_validator.go` runs the meta-schema before
+ * the designation rules); the `schema-url` union arm carries no document to
+ * check and is gated out identically.
+ */
+export const schemaConfigSchema = z
+  .custom<z.infer<typeof CreateSchemaBody>>(() => true)
+  .superRefine((raw, ctx) => {
+    const parsed = CreateSchemaBody.safeParse(raw);
+    if (!parsed.success) {
+      // Re-emitted as custom issues: zod's own issue objects are not
+      // assignable to addIssue's input type, and only path + message reach
+      // any renderer (doctor, the syncer's folded message).
+      for (const issue of parsed.error.issues) {
+        ctx.addIssue({
+          code: "custom",
+          path: issue.path as (string | number)[],
+          message: issue.message,
+        });
+      }
+      return;
+    }
+    if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+      const document = raw as Record<string, unknown>;
+      if (document.kind !== "user-schema") return;
+      for (const issue of validateUserSchemaDesignations(document)) {
+        ctx.addIssue({ code: "custom", path: issue.path, message: issue.message });
+      }
+    }
+  });
 export const flowConfigSchema = CreateFlowDefinitionBody.shape.flow_definition;
 export const createFlowDefinitionRequestSchema = CreateFlowDefinitionBody;
 


### PR DESCRIPTION
Ports the server's user-schema designation validator into `@zitadel/config`, so `zitadel plan`, `apply`, and `doctor` reject a schema file locally instead of letting `apply` fail with a 400 from the server.

Closes #1057

## What it validates

The same rules as `validateUserSchemaDesignations` (`internal/domain/schema_designation.go`, ADR 058 §1–§2):

- `x-identifier` must name a reachable scalar leaf carrying `x-unique: "project"`.
- Every `x-display` entry must name a reachable scalar leaf (dot-paths descend through object-shaped parents only).
- A password-enabled schema must designate an identifier (passkey deliberately not in the trigger — discoverable credentials identify the user through the assertion).

Error messages mirror the Go detail strings **verbatim**, so a user who bypasses plan sees identical text from the server. One documented divergence: the CLI collects every violation instead of failing fast.

## Design notes

- **The refine runs on the raw document, not the generated Zod's parse output.** `CreateSchemaBody`'s parse strips unmodeled keywords (leaf `type`, root `type`, `$id`) and injects defaults, which would break the scalar-leaf checks. `schemaConfigSchema` is now a `z.custom(...).superRefine` that checks shape first via `CreateSchemaBody.safeParse` (issues re-emitted), then designations on the raw document — the same order as the server's `schema_validator.go`, and the server stores the raw bytes verbatim anyway.
- **Drift audit**, same contract as the flow-validator port: `SCHEMA_DESIGNATION_RULES` maps each rule id to the Go function it ports; a test asserts those functions still exist in `internal/domain/schema_designation.go` and that the shared message literals still match. Verified it fires: typoing a `goRef` fails the audit.
- The test suite mirrors `TestTenantSchemaValidator_UserSchemaDesignations` case for case (27 cases), plus collect-all ordering and the wiring through `schemaConfigSchema`.
- `SchemaSyncer.validate` folds the issues into the thrown message (`validatePlannedFlows` pattern), and doctor's `SchemaCheck` renders `path message` per issue.
- Existing test fixtures that enabled password without designating an identifier were updated — the server would reject those documents on apply, which is exactly the gap this PR closes. The scaffolded default (`packages/config/defaults/default-human-user.json`) already designates correctly and passes.

## Follow-up

Like the flow port, this is a local-first interim; the designed successor is the server-side validate-only bundle endpoint (#449).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
