### PR TITLE
feat(api): read releases

### DIFF
--- a/.changeset/release-read-endpoints.md
+++ b/.changeset/release-read-endpoints.md
@@ -1,0 +1,8 @@
+---
+"@zitadel/server": minor
+"@zitadel/api": minor
+---
+
+Releases can now be read back over the API.
+
+`GET /releases` lists a project's releases newest first, carrying metadata only — the pinned set is omitted. `GET /releases/{release_id}` returns one release with the revisions it pins.

--- a/api/generated/oas_json_gen.go
+++ b/api/generated/oas_json_gen.go
@@ -39155,6 +39155,38 @@ func (s GetReleaseByIdErrorResponse) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case RelNotFoundGetReleaseByIdErrorResponse:
+		e.FieldStart("code")
+		e.Str("rel.not_found")
+		{
+			s := s.RelNotFound
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
+	case RelPermissionDeniedGetReleaseByIdErrorResponse:
+		e.FieldStart("code")
+		e.Str("rel.permission_denied")
+		{
+			s := s.RelPermissionDenied
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
 	case ReqInvalidGetReleaseByIdErrorResponse:
 		e.FieldStart("code")
 		e.Str("req.invalid")
@@ -39203,6 +39235,12 @@ func (s *GetReleaseByIdErrorResponse) Decode(d *jx.Decoder) error {
 				case "internal":
 					s.Type = InternalGetReleaseByIdErrorResponse
 					found = true
+				case "rel.not_found":
+					s.Type = RelNotFoundGetReleaseByIdErrorResponse
+					found = true
+				case "rel.permission_denied":
+					s.Type = RelPermissionDeniedGetReleaseByIdErrorResponse
+					found = true
 				case "req.invalid":
 					s.Type = ReqInvalidGetReleaseByIdErrorResponse
 					found = true
@@ -39226,6 +39264,14 @@ func (s *GetReleaseByIdErrorResponse) Decode(d *jx.Decoder) error {
 		}
 	case InternalGetReleaseByIdErrorResponse:
 		if err := s.Internal.Decode(d); err != nil {
+			return err
+		}
+	case RelNotFoundGetReleaseByIdErrorResponse:
+		if err := s.RelNotFound.Decode(d); err != nil {
+			return err
+		}
+	case RelPermissionDeniedGetReleaseByIdErrorResponse:
+		if err := s.RelPermissionDenied.Decode(d); err != nil {
 			return err
 		}
 	case ReqInvalidGetReleaseByIdErrorResponse:
@@ -43839,6 +43885,38 @@ func (s ListReleasesErrorResponse) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case RelNotFoundListReleasesErrorResponse:
+		e.FieldStart("code")
+		e.Str("rel.not_found")
+		{
+			s := s.RelNotFound
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
+	case RelPermissionDeniedListReleasesErrorResponse:
+		e.FieldStart("code")
+		e.Str("rel.permission_denied")
+		{
+			s := s.RelPermissionDenied
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+			{
+				if s.Details.Set {
+					e.FieldStart("details")
+					s.Details.Encode(e)
+				}
+			}
+		}
 	case ReqInvalidListReleasesErrorResponse:
 		e.FieldStart("code")
 		e.Str("req.invalid")
@@ -43887,6 +43965,12 @@ func (s *ListReleasesErrorResponse) Decode(d *jx.Decoder) error {
 				case "internal":
 					s.Type = InternalListReleasesErrorResponse
 					found = true
+				case "rel.not_found":
+					s.Type = RelNotFoundListReleasesErrorResponse
+					found = true
+				case "rel.permission_denied":
+					s.Type = RelPermissionDeniedListReleasesErrorResponse
+					found = true
 				case "req.invalid":
 					s.Type = ReqInvalidListReleasesErrorResponse
 					found = true
@@ -43910,6 +43994,14 @@ func (s *ListReleasesErrorResponse) Decode(d *jx.Decoder) error {
 		}
 	case InternalListReleasesErrorResponse:
 		if err := s.Internal.Decode(d); err != nil {
+			return err
+		}
+	case RelNotFoundListReleasesErrorResponse:
+		if err := s.RelNotFound.Decode(d); err != nil {
+			return err
+		}
+	case RelPermissionDeniedListReleasesErrorResponse:
+		if err := s.RelPermissionDenied.Decode(d); err != nil {
 			return err
 		}
 	case ReqInvalidListReleasesErrorResponse:

--- a/api/generated/oas_schemas_gen.go
+++ b/api/generated/oas_schemas_gen.go
@@ -21734,10 +21734,12 @@ func (*GetReadyOK) getReadyRes() {}
 
 // GetReleaseByIdErrorResponse represents sum type.
 type GetReleaseByIdErrorResponse struct {
-	Type             GetReleaseByIdErrorResponseType // switch on this field
-	AuthUnauthorized AuthUnauthorized
-	Internal         Internal
-	ReqInvalid       ReqInvalid
+	Type                GetReleaseByIdErrorResponseType // switch on this field
+	AuthUnauthorized    AuthUnauthorized
+	Internal            Internal
+	RelNotFound         RelNotFound
+	RelPermissionDenied RelPermissionDenied
+	ReqInvalid          ReqInvalid
 }
 
 // GetReleaseByIdErrorResponseType is oneOf type of GetReleaseByIdErrorResponse.
@@ -21745,9 +21747,11 @@ type GetReleaseByIdErrorResponseType string
 
 // Possible values for GetReleaseByIdErrorResponseType.
 const (
-	AuthUnauthorizedGetReleaseByIdErrorResponse GetReleaseByIdErrorResponseType = "auth.unauthorized"
-	InternalGetReleaseByIdErrorResponse         GetReleaseByIdErrorResponseType = "internal"
-	ReqInvalidGetReleaseByIdErrorResponse       GetReleaseByIdErrorResponseType = "req.invalid"
+	AuthUnauthorizedGetReleaseByIdErrorResponse    GetReleaseByIdErrorResponseType = "auth.unauthorized"
+	InternalGetReleaseByIdErrorResponse            GetReleaseByIdErrorResponseType = "internal"
+	RelNotFoundGetReleaseByIdErrorResponse         GetReleaseByIdErrorResponseType = "rel.not_found"
+	RelPermissionDeniedGetReleaseByIdErrorResponse GetReleaseByIdErrorResponseType = "rel.permission_denied"
+	ReqInvalidGetReleaseByIdErrorResponse          GetReleaseByIdErrorResponseType = "req.invalid"
 )
 
 // IsAuthUnauthorized reports whether GetReleaseByIdErrorResponse is AuthUnauthorized.
@@ -21758,6 +21762,16 @@ func (s GetReleaseByIdErrorResponse) IsAuthUnauthorized() bool {
 // IsInternal reports whether GetReleaseByIdErrorResponse is Internal.
 func (s GetReleaseByIdErrorResponse) IsInternal() bool {
 	return s.Type == InternalGetReleaseByIdErrorResponse
+}
+
+// IsRelNotFound reports whether GetReleaseByIdErrorResponse is RelNotFound.
+func (s GetReleaseByIdErrorResponse) IsRelNotFound() bool {
+	return s.Type == RelNotFoundGetReleaseByIdErrorResponse
+}
+
+// IsRelPermissionDenied reports whether GetReleaseByIdErrorResponse is RelPermissionDenied.
+func (s GetReleaseByIdErrorResponse) IsRelPermissionDenied() bool {
+	return s.Type == RelPermissionDeniedGetReleaseByIdErrorResponse
 }
 
 // IsReqInvalid reports whether GetReleaseByIdErrorResponse is ReqInvalid.
@@ -21804,6 +21818,48 @@ func (s GetReleaseByIdErrorResponse) GetInternal() (v Internal, ok bool) {
 func NewInternalGetReleaseByIdErrorResponse(v Internal) GetReleaseByIdErrorResponse {
 	var s GetReleaseByIdErrorResponse
 	s.SetInternal(v)
+	return s
+}
+
+// SetRelNotFound sets GetReleaseByIdErrorResponse to RelNotFound.
+func (s *GetReleaseByIdErrorResponse) SetRelNotFound(v RelNotFound) {
+	s.Type = RelNotFoundGetReleaseByIdErrorResponse
+	s.RelNotFound = v
+}
+
+// GetRelNotFound returns RelNotFound and true boolean if GetReleaseByIdErrorResponse is RelNotFound.
+func (s GetReleaseByIdErrorResponse) GetRelNotFound() (v RelNotFound, ok bool) {
+	if !s.IsRelNotFound() {
+		return v, false
+	}
+	return s.RelNotFound, true
+}
+
+// NewRelNotFoundGetReleaseByIdErrorResponse returns new GetReleaseByIdErrorResponse from RelNotFound.
+func NewRelNotFoundGetReleaseByIdErrorResponse(v RelNotFound) GetReleaseByIdErrorResponse {
+	var s GetReleaseByIdErrorResponse
+	s.SetRelNotFound(v)
+	return s
+}
+
+// SetRelPermissionDenied sets GetReleaseByIdErrorResponse to RelPermissionDenied.
+func (s *GetReleaseByIdErrorResponse) SetRelPermissionDenied(v RelPermissionDenied) {
+	s.Type = RelPermissionDeniedGetReleaseByIdErrorResponse
+	s.RelPermissionDenied = v
+}
+
+// GetRelPermissionDenied returns RelPermissionDenied and true boolean if GetReleaseByIdErrorResponse is RelPermissionDenied.
+func (s GetReleaseByIdErrorResponse) GetRelPermissionDenied() (v RelPermissionDenied, ok bool) {
+	if !s.IsRelPermissionDenied() {
+		return v, false
+	}
+	return s.RelPermissionDenied, true
+}
+
+// NewRelPermissionDeniedGetReleaseByIdErrorResponse returns new GetReleaseByIdErrorResponse from RelPermissionDenied.
+func NewRelPermissionDeniedGetReleaseByIdErrorResponse(v RelPermissionDenied) GetReleaseByIdErrorResponse {
+	var s GetReleaseByIdErrorResponse
+	s.SetRelPermissionDenied(v)
 	return s
 }
 
@@ -24325,10 +24381,12 @@ func (s *ListFlowDefinitionsPurpose) UnmarshalText(data []byte) error {
 
 // ListReleasesErrorResponse represents sum type.
 type ListReleasesErrorResponse struct {
-	Type             ListReleasesErrorResponseType // switch on this field
-	AuthUnauthorized AuthUnauthorized
-	Internal         Internal
-	ReqInvalid       ReqInvalid
+	Type                ListReleasesErrorResponseType // switch on this field
+	AuthUnauthorized    AuthUnauthorized
+	Internal            Internal
+	RelNotFound         RelNotFound
+	RelPermissionDenied RelPermissionDenied
+	ReqInvalid          ReqInvalid
 }
 
 // ListReleasesErrorResponseType is oneOf type of ListReleasesErrorResponse.
@@ -24336,9 +24394,11 @@ type ListReleasesErrorResponseType string
 
 // Possible values for ListReleasesErrorResponseType.
 const (
-	AuthUnauthorizedListReleasesErrorResponse ListReleasesErrorResponseType = "auth.unauthorized"
-	InternalListReleasesErrorResponse         ListReleasesErrorResponseType = "internal"
-	ReqInvalidListReleasesErrorResponse       ListReleasesErrorResponseType = "req.invalid"
+	AuthUnauthorizedListReleasesErrorResponse    ListReleasesErrorResponseType = "auth.unauthorized"
+	InternalListReleasesErrorResponse            ListReleasesErrorResponseType = "internal"
+	RelNotFoundListReleasesErrorResponse         ListReleasesErrorResponseType = "rel.not_found"
+	RelPermissionDeniedListReleasesErrorResponse ListReleasesErrorResponseType = "rel.permission_denied"
+	ReqInvalidListReleasesErrorResponse          ListReleasesErrorResponseType = "req.invalid"
 )
 
 // IsAuthUnauthorized reports whether ListReleasesErrorResponse is AuthUnauthorized.
@@ -24349,6 +24409,16 @@ func (s ListReleasesErrorResponse) IsAuthUnauthorized() bool {
 // IsInternal reports whether ListReleasesErrorResponse is Internal.
 func (s ListReleasesErrorResponse) IsInternal() bool {
 	return s.Type == InternalListReleasesErrorResponse
+}
+
+// IsRelNotFound reports whether ListReleasesErrorResponse is RelNotFound.
+func (s ListReleasesErrorResponse) IsRelNotFound() bool {
+	return s.Type == RelNotFoundListReleasesErrorResponse
+}
+
+// IsRelPermissionDenied reports whether ListReleasesErrorResponse is RelPermissionDenied.
+func (s ListReleasesErrorResponse) IsRelPermissionDenied() bool {
+	return s.Type == RelPermissionDeniedListReleasesErrorResponse
 }
 
 // IsReqInvalid reports whether ListReleasesErrorResponse is ReqInvalid.
@@ -24395,6 +24465,48 @@ func (s ListReleasesErrorResponse) GetInternal() (v Internal, ok bool) {
 func NewInternalListReleasesErrorResponse(v Internal) ListReleasesErrorResponse {
 	var s ListReleasesErrorResponse
 	s.SetInternal(v)
+	return s
+}
+
+// SetRelNotFound sets ListReleasesErrorResponse to RelNotFound.
+func (s *ListReleasesErrorResponse) SetRelNotFound(v RelNotFound) {
+	s.Type = RelNotFoundListReleasesErrorResponse
+	s.RelNotFound = v
+}
+
+// GetRelNotFound returns RelNotFound and true boolean if ListReleasesErrorResponse is RelNotFound.
+func (s ListReleasesErrorResponse) GetRelNotFound() (v RelNotFound, ok bool) {
+	if !s.IsRelNotFound() {
+		return v, false
+	}
+	return s.RelNotFound, true
+}
+
+// NewRelNotFoundListReleasesErrorResponse returns new ListReleasesErrorResponse from RelNotFound.
+func NewRelNotFoundListReleasesErrorResponse(v RelNotFound) ListReleasesErrorResponse {
+	var s ListReleasesErrorResponse
+	s.SetRelNotFound(v)
+	return s
+}
+
+// SetRelPermissionDenied sets ListReleasesErrorResponse to RelPermissionDenied.
+func (s *ListReleasesErrorResponse) SetRelPermissionDenied(v RelPermissionDenied) {
+	s.Type = RelPermissionDeniedListReleasesErrorResponse
+	s.RelPermissionDenied = v
+}
+
+// GetRelPermissionDenied returns RelPermissionDenied and true boolean if ListReleasesErrorResponse is RelPermissionDenied.
+func (s ListReleasesErrorResponse) GetRelPermissionDenied() (v RelPermissionDenied, ok bool) {
+	if !s.IsRelPermissionDenied() {
+		return v, false
+	}
+	return s.RelPermissionDenied, true
+}
+
+// NewRelPermissionDeniedListReleasesErrorResponse returns new ListReleasesErrorResponse from RelPermissionDenied.
+func NewRelPermissionDeniedListReleasesErrorResponse(v RelPermissionDenied) ListReleasesErrorResponse {
+	var s ListReleasesErrorResponse
+	s.SetRelPermissionDenied(v)
 	return s
 }
 

--- a/api/openapi/endpoints/releases/by_id/getReleaseById-error-response.yaml
+++ b/api/openapi/endpoints/releases/by_id/getReleaseById-error-response.yaml
@@ -6,12 +6,16 @@ content:
       oneOf:
         - $ref: '../../../components/schemas/errors/auth-unauthorized.yaml'
         - $ref: '../../../components/schemas/errors/internal.yaml'
+        - $ref: '../../../components/schemas/errors/rel-not_found.yaml'
+        - $ref: '../../../components/schemas/errors/rel-permission_denied.yaml'
         - $ref: '../../../components/schemas/errors/req-invalid.yaml'
       discriminator:
         propertyName: code
         mapping:
           auth.unauthorized: '../../../components/schemas/errors/auth-unauthorized.yaml'
           internal: '../../../components/schemas/errors/internal.yaml'
+          rel.not_found: '../../../components/schemas/errors/rel-not_found.yaml'
+          rel.permission_denied: '../../../components/schemas/errors/rel-permission_denied.yaml'
           req.invalid: '../../../components/schemas/errors/req-invalid.yaml'
     examples:
       auth.unauthorized:
@@ -24,6 +28,16 @@ content:
         value:
           code: internal
           message: 'An unexpected error occurred.'
+      rel.not_found:
+        summary: rel.not_found
+        value:
+          code: rel.not_found
+          message: 'release: not found'
+      rel.permission_denied:
+        summary: rel.permission_denied
+        value:
+          code: rel.permission_denied
+          message: 'release: requires an operator-grade token bound to the project (project.write or a release.* scope)'
       req.invalid:
         summary: req.invalid
         value:

--- a/api/openapi/endpoints/releases/listReleases-error-response.yaml
+++ b/api/openapi/endpoints/releases/listReleases-error-response.yaml
@@ -6,12 +6,16 @@ content:
       oneOf:
         - $ref: '../../components/schemas/errors/auth-unauthorized.yaml'
         - $ref: '../../components/schemas/errors/internal.yaml'
+        - $ref: '../../components/schemas/errors/rel-not_found.yaml'
+        - $ref: '../../components/schemas/errors/rel-permission_denied.yaml'
         - $ref: '../../components/schemas/errors/req-invalid.yaml'
       discriminator:
         propertyName: code
         mapping:
           auth.unauthorized: '../../components/schemas/errors/auth-unauthorized.yaml'
           internal: '../../components/schemas/errors/internal.yaml'
+          rel.not_found: '../../components/schemas/errors/rel-not_found.yaml'
+          rel.permission_denied: '../../components/schemas/errors/rel-permission_denied.yaml'
           req.invalid: '../../components/schemas/errors/req-invalid.yaml'
     examples:
       auth.unauthorized:
@@ -24,6 +28,16 @@ content:
         value:
           code: internal
           message: 'An unexpected error occurred.'
+      rel.not_found:
+        summary: rel.not_found
+        value:
+          code: rel.not_found
+          message: 'release: not found'
+      rel.permission_denied:
+        summary: rel.permission_denied
+        value:
+          code: rel.permission_denied
+          message: 'release: requires an operator-grade token bound to the project (project.write or a release.* scope)'
       req.invalid:
         summary: req.invalid
         value:

--- a/api/openapi/endpoints/releases/methods.yaml
+++ b/api/openapi/endpoints/releases/methods.yaml
@@ -224,8 +224,8 @@ get:
             lastPage:
               summary: The final page
               description: |
-                `next_page_token` is null when there are no further results.
-                Metadata fields the caller never supplied are null too.
+                `next_page_token` is absent when there are no further results.
+                Metadata fields the caller never supplied are null, not absent.
               value:
                 releases:
                   - id: rel_01KX2ZJ4B8C7F0N9WD3P2E4YM5
@@ -237,6 +237,5 @@ get:
                       created_at: '2026-07-13T08:00:00Z'
                       created_by: null
                       created_by_type: null
-                next_page_token: null
     default:
       $ref: listReleases-error-response.yaml

--- a/internal/api/integration_test/release_read_test.go
+++ b/internal/api/integration_test/release_read_test.go
@@ -1,0 +1,186 @@
+//go:build postgres_integration || spanner_integration
+
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	api "github.com/zitadel/nextgen/api/generated"
+	"github.com/zitadel/nextgen/internal/api/integration_test/helpers"
+	"github.com/zitadel/nextgen/internal/domain"
+)
+
+// createdRelease assembles one release and returns it, so the read tests do
+// not each repeat the fixture wiring.
+func createdRelease(t *testing.T, fixture releaseFixture, pointers []api.CreateReleasePointer, message string) api.Release {
+	t.Helper()
+	resp := fixture.create(t, &api.CreateReleaseRequest{
+		Pointers: pointers,
+		Message:  api.NewOptString(message),
+	})
+	require.IsType(t, &api.CreateReleaseCreated{}, resp, "create release: %s", helpers.MustMarshal(t, resp))
+	return api.Release(*resp.(*api.CreateReleaseCreated))
+}
+
+// TestGetReleaseById reads back a release with the set it pins.
+func TestGetReleaseById(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReleaseFixture(t)
+	created := createdRelease(t, fixture, fixture.pointers(), "initial import")
+
+	t.Run("returns the release with its pinned set", func(t *testing.T) {
+		resp, err := fixture.client.GetReleaseById(t.Context(), api.GetReleaseByIdParams{
+			ProjectID: api.ProjectID(fixture.project),
+			ReleaseID: created.ID,
+		})
+		require.NoError(t, err)
+		require.IsType(t, &api.Release{}, resp, "get release: %s", helpers.MustMarshal(t, resp))
+
+		// The response of the create and the read are the same object, so a
+		// caller that stored one can compare it against the other.
+		assert.Equal(t, created, *resp.(*api.Release))
+	})
+
+	t.Run("an unknown release id is a 404", func(t *testing.T) {
+		resp, err := fixture.client.GetReleaseById(t.Context(), api.GetReleaseByIdParams{
+			ProjectID: api.ProjectID(fixture.project),
+			ReleaseID: "rel_does_not_exist",
+		})
+		require.NoError(t, err)
+		status, code, _, ok := errorResponseParts(t, resp)
+		require.True(t, ok, "unexpected response shape: %s", helpers.MustMarshal(t, resp))
+		assert.Equal(t, http.StatusNotFound, status)
+		assert.Equal(t, domain.ErrReleaseNotFound().Code, code)
+	})
+}
+
+// A release of another project is unreachable rather than forbidden: the read
+// is filtered by the caller's project, so it answers exactly as an unknown id
+// does and is no existence oracle.
+func TestGetReleaseByIdIsProjectScoped(t *testing.T) {
+	t.Parallel()
+
+	mine := newReleaseFixture(t)
+	theirs := newReleaseFixture(t)
+
+	release := createdRelease(t, mine, mine.pointers(), "mine")
+
+	resp, err := theirs.client.GetReleaseById(t.Context(), api.GetReleaseByIdParams{
+		ProjectID: api.ProjectID(theirs.project),
+		ReleaseID: release.ID,
+	})
+	require.NoError(t, err)
+	status, code, _, ok := errorResponseParts(t, resp)
+	require.True(t, ok, "unexpected response shape: %s", helpers.MustMarshal(t, resp))
+	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, domain.ErrReleaseNotFound().Code, code)
+}
+
+// The list carries metadata only. Pointers are omitted rather than optional,
+// so a list entry can never be mistaken for a release that pins nothing.
+func TestListReleases(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReleaseFixture(t)
+	created := createdRelease(t, fixture, fixture.pointers(), "initial import")
+
+	resp, err := fixture.client.ListReleases(t.Context(), api.ListReleasesParams{
+		ProjectID: api.ProjectID(fixture.project),
+	})
+	require.NoError(t, err)
+	require.IsType(t, &api.ListReleasesResponse{}, resp, "list releases: %s", helpers.MustMarshal(t, resp))
+	listed := resp.(*api.ListReleasesResponse)
+
+	require.Len(t, listed.Releases, 1)
+	assert.Equal(t, created.ID, listed.Releases[0].ID)
+	assert.Equal(t, api.ProjectID(fixture.project), listed.Releases[0].ProjectID)
+	assert.Equal(t, "initial import", listed.Releases[0].Metadata.Message.Value)
+	assert.Equal(t, created.Metadata.CreatedAt, listed.Releases[0].Metadata.CreatedAt)
+}
+
+// The list is paginated even though a project usually holds few releases, so a
+// caller written against it keeps working as releases accumulate.
+func TestListReleasesPagesNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReleaseFixture(t)
+
+	// Three distinct pinned sets, so three distinct releases: the branding
+	// revision is what varies, since everything else the project holds is
+	// seeded once.
+	var want []api.ReleaseID
+	for _, revision := range []string{"1", "2", "3"} {
+		branding := publishBranding(t, fixture.client, fixture.project,
+			`<zl-page-shell data-rev="`+revision+`">{% mandatory_gates %}</zl-page-shell>`)
+		want = append(want, createdRelease(t, fixture, []api.CreateReleasePointer{
+			{Kind: api.ReleasePointerKindSchema, RevisionID: fixture.schemaURL},
+			{Kind: api.ReleasePointerKindBranding, RevisionID: branding},
+		}, "revision "+revision).ID)
+	}
+
+	first, err := fixture.client.ListReleases(t.Context(), api.ListReleasesParams{
+		ProjectID: api.ProjectID(fixture.project),
+		Limit:     api.NewOptLimit(2),
+	})
+	require.NoError(t, err)
+	require.IsType(t, &api.ListReleasesResponse{}, first, helpers.MustMarshal(t, first))
+	page := first.(*api.ListReleasesResponse)
+	require.Len(t, page.Releases, 2)
+	require.True(t, page.NextPageToken.Set, "expected a next_page_token on a short first page")
+
+	got := []api.ReleaseID{page.Releases[0].ID, page.Releases[1].ID}
+
+	second, err := fixture.client.ListReleases(t.Context(), api.ListReleasesParams{
+		ProjectID: api.ProjectID(fixture.project),
+		PageToken: api.NewOptPageToken(page.NextPageToken.Value),
+	})
+	require.NoError(t, err)
+	require.IsType(t, &api.ListReleasesResponse{}, second, helpers.MustMarshal(t, second))
+	for _, item := range second.(*api.ListReleasesResponse).Releases {
+		got = append(got, item.ID)
+	}
+
+	// Newest first, so the creation order reversed.
+	assert.Equal(t, []api.ReleaseID{want[2], want[1], want[0]}, got)
+}
+
+// The list is scoped to the caller's project, so another project's releases
+// are absent rather than filtered out of a shared result.
+func TestListReleasesIsProjectScoped(t *testing.T) {
+	t.Parallel()
+
+	mine := newReleaseFixture(t)
+	theirs := newReleaseFixture(t)
+
+	release := createdRelease(t, mine, mine.pointers(), "mine")
+	createdRelease(t, theirs, theirs.pointers(), "theirs")
+
+	resp, err := mine.client.ListReleases(t.Context(), api.ListReleasesParams{
+		ProjectID: api.ProjectID(mine.project),
+	})
+	require.NoError(t, err)
+	require.IsType(t, &api.ListReleasesResponse{}, resp, helpers.MustMarshal(t, resp))
+	listed := resp.(*api.ListReleasesResponse)
+
+	require.Len(t, listed.Releases, 1)
+	assert.Equal(t, release.ID, listed.Releases[0].ID)
+}
+
+func TestListReleasesUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	client, err := helpers.NewApiClient(harness.EnsureTestServer(t).URL)
+	require.NoError(t, err)
+
+	resp, err := client.ListReleases(t.Context(), api.ListReleasesParams{ProjectID: "proj_1234"})
+	require.NoError(t, err)
+	status, code, _, ok := errorResponseParts(t, resp)
+	require.True(t, ok, "unexpected response shape: %s", helpers.MustMarshal(t, resp))
+	assert.Equal(t, http.StatusUnauthorized, status)
+	assert.Equal(t, domain.ErrAuthUnauthorized(nil).Code, code)
+}

--- a/internal/api/integration_test/release_read_test.go
+++ b/internal/api/integration_test/release_read_test.go
@@ -141,9 +141,14 @@ func TestListReleasesPagesNewestFirst(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.IsType(t, &api.ListReleasesResponse{}, second, helpers.MustMarshal(t, second))
-	for _, item := range second.(*api.ListReleasesResponse).Releases {
+	last := second.(*api.ListReleasesResponse)
+	for _, item := range last.Releases {
 		got = append(got, item.ID)
 	}
+
+	// The final page omits the token rather than sending it as null, which is
+	// what the schema documents and what every other list endpoint does.
+	assert.False(t, last.NextPageToken.Set, "expected no next_page_token on the final page")
 
 	// Newest first, so the creation order reversed.
 	assert.Equal(t, []api.ReleaseID{want[2], want[1], want[0]}, got)

--- a/internal/api/release.go
+++ b/internal/api/release.go
@@ -58,6 +58,51 @@ func (h *Handler) CreateRelease(ctx context.Context, req *api.CreateReleaseReque
 	return &reused, nil
 }
 
+func (h *Handler) GetReleaseById(ctx context.Context, params api.GetReleaseByIdParams) (api.GetReleaseByIdRes, error) {
+	// Releases are addressed by a path id, but the read is scoped to the
+	// project the caller named, so a release of another project reads as an
+	// unknown id rather than a forbidden one and is no existence oracle.
+	if err := h.requireProjectAccess(ctx, string(params.ProjectID), releaseAccess, opRead); err != nil {
+		return nil, err
+	}
+
+	entity, err := h.releaseService.Get(ctx, string(params.ProjectID), string(params.ReleaseID))
+	if err != nil {
+		return nil, err
+	}
+	release := toAPIRelease(entity)
+	return &release, nil
+}
+
+func (h *Handler) ListReleases(ctx context.Context, params api.ListReleasesParams) (api.ListReleasesRes, error) {
+	ctx, err := h.requireProjectListAccess(ctx, string(params.ProjectID), releaseAccess, domain.ResourceKindRelease)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := h.releaseService.List(ctx, service.ListReleasesInput{
+		ProjectID: string(params.ProjectID),
+		PageToken: string(params.PageToken.Value),
+		Limit:     int(params.Limit.Value),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resp := api.ListReleasesResponse{Releases: make([]api.ReleaseSummary, len(result.Items))}
+	for i, entity := range result.Items {
+		resp.Releases[i] = api.ReleaseSummary{
+			ID:        api.ReleaseID(entity.ID),
+			ProjectID: api.ProjectID(entity.ProjectID),
+			Metadata:  toAPIReleaseMetadata(entity),
+		}
+	}
+	if result.NextPageToken != "" {
+		resp.NextPageToken = api.NewOptNilPageToken(api.PageToken(result.NextPageToken))
+	}
+	return &resp, nil
+}
+
 /* ---------------- CONVERTERS ---------------- */
 
 func toAPIRelease(entity *domain.Release) api.Release {

--- a/internal/api/release_internal_test.go
+++ b/internal/api/release_internal_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/nextgen/internal/domain"
-	"github.com/zitadel/nextgen/internal/service"
 )
 
 // Pins the release resource-flavored answers through the resolver gate. The
@@ -59,62 +58,18 @@ func TestReleaseAccessRow(t *testing.T) {
 		assertDomainCode(t, requireProjectAccess(operator, narrow, "proj_a", releaseAccess, opWrite),
 			domain.ErrReleasePermissionDenied().Code)
 	})
-}
 
-// Listing narrows rather than refusing when the credential holds a foothold in
-// the project but not the permission, so a partial view is a page of the
-// releases the caller may see instead of a 403.
-func TestReleaseListAccess(t *testing.T) {
-	stmts := stubAuthzStmts{}
-	operator := WithScopeContext(context.Background(), ScopeContext{
-		ProjectID:     "proj_a",
-		Scope:         []string{"project.write", "project.read"},
-		PrincipalType: domain.AuthzPrincipalTypeSKProj,
-		PrincipalID:   "proj_a",
+	// Listing runs a different gate, so the codes it refuses with are worth
+	// pinning too. How that gate narrows a partial view is machinery every
+	// resource shares, and TestRequireProjectListAccess already covers it.
+	t.Run("listing refuses with the same release-flavored codes", func(t *testing.T) {
+		_, err := requireProjectListAccess(operator, stmts, "proj_b", releaseAccess, domain.ResourceKindRelease)
+		assertDomainCode(t, err, domain.ErrReleaseNotFound().Code)
+
+		_, err = requireProjectListAccess(preview, stmts, "proj_a", releaseAccess, domain.ResourceKindRelease)
+		assertDomainCode(t, err, domain.ErrReleasePermissionDenied().Code)
+
+		_, err = requireProjectListAccess(context.Background(), stmts, "proj_a", releaseAccess, domain.ResourceKindRelease)
+		assertDomainCode(t, err, domain.ErrReleaseNotFound().Code)
 	})
-	preview := WithScopeContext(context.Background(), ScopeContext{
-		ProjectID:     "proj_a",
-		Scope:         []string{"project.read"},
-		PrincipalType: domain.AuthzPrincipalTypeSKProj,
-		PrincipalID:   "proj_a",
-	})
-
-	ctx, err := requireProjectListAccess(operator, stmts, "proj_a", releaseAccess, domain.ResourceKindRelease)
-	if err != nil {
-		t.Fatalf("project-wide Allow should proceed: %v", err)
-	}
-	if !service.AuthzListSkipOncePending(ctx) {
-		t.Fatal("Allow must stamp a one-shot EXISTS skip")
-	}
-	if _, ok := service.AuthzListFilterFromContext(ctx); ok {
-		t.Fatal("Allow must not attach EXISTS")
-	}
-
-	deny := false
-	foothold := true
-	narrow := stubAuthzStmts{allowCheck: &deny, foothold: &foothold}
-	ctx, err = requireProjectListAccess(operator, narrow, "proj_a", releaseAccess, domain.ResourceKindRelease)
-	if err != nil {
-		t.Fatalf("Forbidden with foothold should proceed for partial-view lists: %v", err)
-	}
-	filter, ok := service.AuthzListFilterFromContext(ctx)
-	if !ok {
-		t.Fatal("Forbidden must attach the EXISTS list filter")
-	}
-	// The kind is what scopes the filter to releases; the wrong one here would
-	// silently filter the list against another resource's scope rows.
-	if filter.ResourceKind != domain.ResourceKindRelease {
-		t.Fatalf("filter kind = %q, want release", filter.ResourceKind)
-	}
-
-	// Reads miss rather than deny, so the list is no oracle for projects the
-	// caller cannot see.
-	_, err = requireProjectListAccess(operator, stmts, "proj_b", releaseAccess, domain.ResourceKindRelease)
-	assertDomainCode(t, err, domain.ErrReleaseNotFound().Code)
-
-	_, err = requireProjectListAccess(preview, stmts, "proj_a", releaseAccess, domain.ResourceKindRelease)
-	assertDomainCode(t, err, domain.ErrReleasePermissionDenied().Code)
-
-	_, err = requireProjectListAccess(context.Background(), stmts, "proj_a", releaseAccess, domain.ResourceKindRelease)
-	assertDomainCode(t, err, domain.ErrReleaseNotFound().Code)
 }

--- a/internal/api/release_internal_test.go
+++ b/internal/api/release_internal_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
 )
 
 // Pins the release resource-flavored answers through the resolver gate. The
@@ -58,4 +59,62 @@ func TestReleaseAccessRow(t *testing.T) {
 		assertDomainCode(t, requireProjectAccess(operator, narrow, "proj_a", releaseAccess, opWrite),
 			domain.ErrReleasePermissionDenied().Code)
 	})
+}
+
+// Listing narrows rather than refusing when the credential holds a foothold in
+// the project but not the permission, so a partial view is a page of the
+// releases the caller may see instead of a 403.
+func TestReleaseListAccess(t *testing.T) {
+	stmts := stubAuthzStmts{}
+	operator := WithScopeContext(context.Background(), ScopeContext{
+		ProjectID:     "proj_a",
+		Scope:         []string{"project.write", "project.read"},
+		PrincipalType: domain.AuthzPrincipalTypeSKProj,
+		PrincipalID:   "proj_a",
+	})
+	preview := WithScopeContext(context.Background(), ScopeContext{
+		ProjectID:     "proj_a",
+		Scope:         []string{"project.read"},
+		PrincipalType: domain.AuthzPrincipalTypeSKProj,
+		PrincipalID:   "proj_a",
+	})
+
+	ctx, err := requireProjectListAccess(operator, stmts, "proj_a", releaseAccess, domain.ResourceKindRelease)
+	if err != nil {
+		t.Fatalf("project-wide Allow should proceed: %v", err)
+	}
+	if !service.AuthzListSkipOncePending(ctx) {
+		t.Fatal("Allow must stamp a one-shot EXISTS skip")
+	}
+	if _, ok := service.AuthzListFilterFromContext(ctx); ok {
+		t.Fatal("Allow must not attach EXISTS")
+	}
+
+	deny := false
+	foothold := true
+	narrow := stubAuthzStmts{allowCheck: &deny, foothold: &foothold}
+	ctx, err = requireProjectListAccess(operator, narrow, "proj_a", releaseAccess, domain.ResourceKindRelease)
+	if err != nil {
+		t.Fatalf("Forbidden with foothold should proceed for partial-view lists: %v", err)
+	}
+	filter, ok := service.AuthzListFilterFromContext(ctx)
+	if !ok {
+		t.Fatal("Forbidden must attach the EXISTS list filter")
+	}
+	// The kind is what scopes the filter to releases; the wrong one here would
+	// silently filter the list against another resource's scope rows.
+	if filter.ResourceKind != domain.ResourceKindRelease {
+		t.Fatalf("filter kind = %q, want release", filter.ResourceKind)
+	}
+
+	// Reads miss rather than deny, so the list is no oracle for projects the
+	// caller cannot see.
+	_, err = requireProjectListAccess(operator, stmts, "proj_b", releaseAccess, domain.ResourceKindRelease)
+	assertDomainCode(t, err, domain.ErrReleaseNotFound().Code)
+
+	_, err = requireProjectListAccess(preview, stmts, "proj_a", releaseAccess, domain.ResourceKindRelease)
+	assertDomainCode(t, err, domain.ErrReleasePermissionDenied().Code)
+
+	_, err = requireProjectListAccess(context.Background(), stmts, "proj_a", releaseAccess, domain.ResourceKindRelease)
+	assertDomainCode(t, err, domain.ErrReleaseNotFound().Code)
 }

--- a/internal/service/mocks/service.mock.go
+++ b/internal/service/mocks/service.mock.go
@@ -12428,6 +12428,84 @@ func (c *MockReleaseServiceCreateCall) DoAndReturn(f func(context.Context, servi
 	return c
 }
 
+// Get mocks base method.
+func (m *MockReleaseService) Get(ctx context.Context, projectID, id string) (*domain.Release, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, projectID, id)
+	ret0, _ := ret[0].(*domain.Release)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockReleaseServiceMockRecorder) Get(ctx, projectID, id any) *MockReleaseServiceGetCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockReleaseService)(nil).Get), ctx, projectID, id)
+	return &MockReleaseServiceGetCall{Call: call}
+}
+
+// MockReleaseServiceGetCall wrap *gomock.Call
+type MockReleaseServiceGetCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockReleaseServiceGetCall) Return(arg0 *domain.Release, arg1 error) *MockReleaseServiceGetCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockReleaseServiceGetCall) Do(f func(context.Context, string, string) (*domain.Release, error)) *MockReleaseServiceGetCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockReleaseServiceGetCall) DoAndReturn(f func(context.Context, string, string) (*domain.Release, error)) *MockReleaseServiceGetCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// List mocks base method.
+func (m *MockReleaseService) List(ctx context.Context, input service.ListReleasesInput) (*service.ListReleasesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", ctx, input)
+	ret0, _ := ret[0].(*service.ListReleasesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockReleaseServiceMockRecorder) List(ctx, input any) *MockReleaseServiceListCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockReleaseService)(nil).List), ctx, input)
+	return &MockReleaseServiceListCall{Call: call}
+}
+
+// MockReleaseServiceListCall wrap *gomock.Call
+type MockReleaseServiceListCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockReleaseServiceListCall) Return(arg0 *service.ListReleasesOutput, arg1 error) *MockReleaseServiceListCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockReleaseServiceListCall) Do(f func(context.Context, service.ListReleasesInput) (*service.ListReleasesOutput, error)) *MockReleaseServiceListCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockReleaseServiceListCall) DoAndReturn(f func(context.Context, service.ListReleasesInput) (*service.ListReleasesOutput, error)) *MockReleaseServiceListCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockSessionResolver is a mock of SessionResolver interface.
 type MockSessionResolver struct {
 	ctrl     *gomock.Controller

--- a/internal/service/release.go
+++ b/internal/service/release.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zitadel/nextgen/internal/audit"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/storage/database"
+	"github.com/zitadel/nextgen/internal/storage/release"
 )
 
 // ---- Input / output types ---------------------------------------------------
@@ -35,8 +36,21 @@ type CreateReleaseOutput struct {
 	Created bool
 }
 
+type ListReleasesInput struct {
+	ProjectID string
+	PageToken string
+	Limit     int
+}
+
+type ListReleasesOutput struct {
+	Items         []*domain.Release
+	NextPageToken string
+}
+
 type ReleaseService interface {
 	Create(ctx context.Context, input CreateReleaseInput) (*CreateReleaseOutput, error)
+	Get(ctx context.Context, projectID, id string) (*domain.Release, error)
+	List(ctx context.Context, input ListReleasesInput) (*ListReleasesOutput, error)
 }
 
 type releaseService struct {
@@ -122,6 +136,32 @@ func (s *releaseService) Create(ctx context.Context, input CreateReleaseInput) (
 	}
 
 	return &CreateReleaseOutput{Release: entity, Created: true}, nil
+}
+
+func (s *releaseService) Get(ctx context.Context, projectID, id string) (*domain.Release, error) {
+	entity, err := s.v2Pool.Statements().GetReleaseByID(ctx, projectID, id)
+	if err != nil {
+		if _, ok := errors.AsType[*database.NoRowFoundError](err); ok {
+			return nil, domain.ErrReleaseNotFound()
+		}
+		return nil, domain.ErrInternal(err).WithMessage("failed to get release from database")
+	}
+	return entity, nil
+}
+
+func (s *releaseService) List(ctx context.Context, input ListReleasesInput) (*ListReleasesOutput, error) {
+	opts := release.ListOptions(input.ProjectID, uint32(normalizeLimit(input.Limit)))
+	opts.Pagination.Cursor = []byte(input.PageToken)
+
+	result, err := s.v2Pool.Statements().ListReleases(ctx, opts)
+	if err != nil {
+		return nil, mapListError(err, "failed to list releases")
+	}
+
+	return &ListReleasesOutput{
+		Items:         result.Items,
+		NextPageToken: string(result.NextCursor),
+	}, nil
 }
 
 // getByContentHash returns nil without an error when the project holds no

--- a/internal/service/release_test.go
+++ b/internal/service/release_test.go
@@ -272,3 +272,17 @@ func TestReleaseServiceCreateRejectsSameResourceTwice(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, domain.ErrReleaseInvalid(nil, nil).Code, domErr.Code)
 }
+
+func TestReleaseServiceGetUnknownIsNotFound(t *testing.T) {
+	svc, statements := newMockedReleaseService(t)
+	statements.EXPECT().
+		GetReleaseByID(gomock.Any(), "proj_1", "rel_gone").
+		Return(nil, new(database.NoRowFoundError))
+
+	_, err := svc.Get(t.Context(), "proj_1", "rel_gone")
+	require.Error(t, err)
+
+	domErr, ok := errors.AsType[domain.Error](err)
+	require.True(t, ok)
+	assert.Equal(t, domain.ErrReleaseNotFound().Code, domErr.Code)
+}


### PR DESCRIPTION
Implements `GET /releases` and `GET /releases/{release_id}`.

## `GET /releases`

<img width="555" height="473" alt="Screenshot 2026-09-07 at 11 44 50" src="https://github.com/user-attachments/assets/42d5320a-83f8-4f65-921c-2ac2496f9f6c" />

## `GET /releases/{release_id}`

<img width="550" height="625" alt="Screenshot 2026-09-07 at 11 44 55" src="https://github.com/user-attachments/assets/178243d1-15cd-4d8a-b3c3-fe05cbbbb4ce" />
