### PR TITLE
fix: make local claims work end to end

### DIFF
--- a/.changeset/cli-local-claim.md
+++ b/.changeset/cli-local-claim.md
@@ -1,0 +1,9 @@
+---
+"@zitadel/cli": minor
+---
+
+`zitadel start` now provisions the platform project in the local runtime, so the console's own sign-in and `zitadel claim` work against a local server the same way they do on Zitadel Cloud. Before, the claim page signed in against the app's own project and stopped on an origin error while the CLI waited out the link.
+
+`zitadel claim --json` now writes the claim link and its expiry to stderr (stdout stays the single JSON envelope), so an agent driving the command can hand the link to a human instead of blocking silently until it expires.
+
+`zitadel status` and `zitadel doctor` now report a recorded owning team on any server, not only on Zitadel Cloud; only the "attach it to a team" nudge stays cloud-only.

--- a/.changeset/cli-local-claim.md
+++ b/.changeset/cli-local-claim.md
@@ -2,7 +2,7 @@
 "@zitadel/cli": minor
 ---
 
-`zitadel start` now provisions the platform project in the local runtime, so the console's own sign-in and `zitadel claim` work against a local server the same way they do on Zitadel Cloud. Before, the claim page signed in against the app's own project and stopped on an origin error while the CLI waited out the link.
+`zitadel start` now provisions the platform project in the local runtime, so the console's own sign-in and `zitadel claim` work against a local server the same way they do on Zitadel Cloud. Before, the claim page signed in against the app's own project and stopped on an origin error while the CLI waited out the link. A local runtime started by an older CLI is restarted (its data is kept) the next time you run `zitadel start`, so an upgrade does not leave a server without the platform project running.
 
 `zitadel claim --json` now writes the claim link and its expiry to stderr (stdout stays the single JSON envelope), so an agent driving the command can hand the link to a human instead of blocking silently until it expires.
 

--- a/apps/cli/SKILLS.md
+++ b/apps/cli/SKILLS.md
@@ -236,7 +236,10 @@ the CLI's help layer, not the envelope.
   under `.zitadel/local/runtime.json`. The binary runtime defaults to SQLite
   under `.zitadel/local/nextgen-data/`. The local runtime provisions the
   built-in platform project, so the console's own sign-in and `zitadel claim`
-  work against it the same way they do on Zitadel Cloud. Runtime metadata
+  work against it the same way they do on Zitadel Cloud. A healthy runtime is
+  reused only when it was launched by a CLI that hands the server the same
+  environment; one started by an older CLI is restarted on the next `start`,
+  keeping its data. Runtime metadata
   reports the published server package version; the repository contributor
   wrapper reports the `dev+<short-commit>` source build it launched. That
   label names the revision the binary was built from, which after a Moon cache

--- a/apps/cli/SKILLS.md
+++ b/apps/cli/SKILLS.md
@@ -209,7 +209,10 @@ the CLI's help layer, not the envelope.
   `status: "skipped"` with `reason: "already-claimed"`, so agents can retry
   safely. The link is always printed before any browser opens, so a headless
   machine, an SSH session, or `--no-open` needs no special handling — copy it
-  and open it anywhere. Links last 10 minutes; once one lapses the command
+  and open it anywhere. Under `--json` the link and its expiry go to **stderr**
+  (stdout stays the single envelope), so capture stderr and hand the link to a
+  human; the command keeps blocking until they finish or the link lapses.
+  Links last 10 minutes; once one lapses the command
   exits `E_VALIDATION` and points at a fresh run. `--dry-run` stops before
   anything is minted and reports `status: "skipped"`, `reason: "dry-run"` —
   there is nothing to preview, because a claim is decided in a browser.
@@ -223,19 +226,22 @@ the CLI's help layer, not the envelope.
   `claim` check. A project with no team is only ever a **warning**, never a
   failure — it works exactly like one with a team, so `doctor` still exits 0
   and `--fix` deliberately does nothing (a claim needs a human in a browser).
-  All three stay silent about teams when the project's `server` in
-  `zitadel.json` is local or self-hosted, where there is nothing to attach.
+  A recorded team is reported wherever the project lives; the nudge for a
+  missing one is only raised when the project's `server` in `zitadel.json` is
+  Zitadel Cloud, since a local or self-hosted project is not temporary.
 - `status` — summarize the local runtime and project state.
 - `eject` (alias `uninstall`) — remove managed files and local Zitadel state;
   requires `--force` when non-interactive.
 - `start` — start the managed local Zitadel server and persist runtime metadata
   under `.zitadel/local/runtime.json`. The binary runtime defaults to SQLite
-  under `.zitadel/local/nextgen-data/`. Runtime metadata reports the published
-  server package version; the repository contributor wrapper reports the
-  `dev+<short-commit>` source build it launched. That label names the revision
-  the binary was built from, which after a Moon cache hit can be an earlier
-  commit whose server sources are byte-identical. Use `--runtime docker` or
-  `--image` for the Docker backend.
+  under `.zitadel/local/nextgen-data/`. The local runtime provisions the
+  built-in platform project, so the console's own sign-in and `zitadel claim`
+  work against it the same way they do on Zitadel Cloud. Runtime metadata
+  reports the published server package version; the repository contributor
+  wrapper reports the `dev+<short-commit>` source build it launched. That
+  label names the revision the binary was built from, which after a Moon cache
+  hit can be an earlier commit whose server sources are byte-identical. Use
+  `--runtime docker` or `--image` for the Docker backend.
 - `stop` — stop the managed runtime while preserving
   `.zitadel/local/nextgen-data`. Use `stop --all` to sweep all discovered
   host-wide CLI-managed local runtime processes, including healthy runtimes

--- a/apps/cli/src/commands/claim.ts
+++ b/apps/cli/src/commands/claim.ts
@@ -150,25 +150,42 @@ export default class Claim extends BaseCommand {
       now: Date.now(),
     });
 
+    // `--json` silences consola so stdout stays one parseable envelope. The
+    // narration below is not decoration, though: the link is the whole
+    // instruction, and an agent driving this command has nothing to hand the
+    // human without it — the command would just block until the link died.
+    // stderr is the documented home for narration under `--json`, so the
+    // link and the one warning that can change where it should point go
+    // there instead of vanishing.
+    const json = this.jsonEnabled();
+
     // A local server left on the default public base advertises a claim page
     // on a remote origin — the exact confusion this warning names. Cloud
     // servers legitimately use a console origin different from the API one,
     // so only a loopback API paired with a non-loopback claim page warns.
     if (isLoopbackUrl(this.meta.source) && !isLoopbackUrl(challenge.claim_url)) {
-      consola.warn(
+      const warning =
         `The server at ${this.meta.source} advertised a claim page on ${new URL(challenge.claim_url).origin}. ` +
-          "If you started that server yourself, set NEXTGEN_SERVER_PUBLIC_BASE to its reachable origin (e.g. http://localhost:8080).",
-      );
+        "If you started that server yourself, set NEXTGEN_SERVER_PUBLIC_BASE to its reachable origin (e.g. http://localhost:8080).";
+      if (json) {
+        process.stderr.write(`Warning: ${warning}\n`);
+      } else {
+        consola.warn(warning);
+      }
     }
 
     // Always show the link first, before attempting anything: it is the whole
     // instruction on its own, so a launch that never happens (headless box,
     // no `xdg-open`, `--no-open`, an agent) needs no separate path.
-    consola.box({
-      title: "Finish in your browser",
-      message: `${challenge.claim_url}\n\nSign in there to attach this project to your team.`,
-      style: { padding: 1, borderStyle: "rounded", borderColor: "cyan" },
-    });
+    if (json) {
+      process.stderr.write(claimLinkNarration(challenge));
+    } else {
+      consola.box({
+        title: "Finish in your browser",
+        message: `${challenge.claim_url}\n\nSign in there to attach this project to your team.`,
+        style: { padding: 1, borderStyle: "rounded", borderColor: "cyan" },
+      });
+    }
 
     const skipLaunch = flags["no-open"] || nonInteractive;
     const opened = skipLaunch ? false : (await openInBrowser(challenge.claim_url)).opened;
@@ -277,6 +294,22 @@ export default class Claim extends BaseCommand {
       data: { title: "Zitadel project already belongs to a team.", ...data },
     });
   }
+}
+
+/**
+ * The link as `--json` mode narrates it on stderr: one line an agent can
+ * forward verbatim, plus the expiry so it knows how long the line stays true.
+ * Plain text rather than a JSON line on purpose — stdout is the single
+ * envelope, and a second machine format on stderr would only invite parsing
+ * what is meant to be read.
+ */
+export function claimLinkNarration(challenge: { claim_url: string; expires_at?: string }): string {
+  const expiry =
+    typeof challenge.expires_at === "string" ? ` The link expires at ${challenge.expires_at}.` : "";
+  return (
+    `Finish in your browser: ${challenge.claim_url}\n` +
+    `Sign in there to attach this project to your team.${expiry}\n`
+  );
 }
 
 /**

--- a/apps/cli/src/commands/claim.ts
+++ b/apps/cli/src/commands/claim.ts
@@ -165,7 +165,7 @@ export default class Claim extends BaseCommand {
     // so only a loopback API paired with a non-loopback claim page warns.
     if (isLoopbackUrl(this.meta.source) && !isLoopbackUrl(challenge.claim_url)) {
       const warning =
-        `The server at ${this.meta.source} advertised a claim page on ${new URL(challenge.claim_url).origin}. ` +
+        `The server at ${this.meta.source} advertised a claim page on ${originOf(challenge.claim_url)}. ` +
         "If you started that server yourself, set NEXTGEN_SERVER_PUBLIC_BASE to its reachable origin (e.g. http://localhost:8080).";
       if (json) {
         process.stderr.write(`Warning: ${warning}\n`);
@@ -302,14 +302,35 @@ export default class Claim extends BaseCommand {
  * Plain text rather than a JSON line on purpose — stdout is the single
  * envelope, and a second machine format on stderr would only invite parsing
  * what is meant to be read.
+ *
+ * The expiry is only narrated when it parses, and then in the same ISO form
+ * the poll deadline is derived from: {@link claimDeadline} falls back to the
+ * documented TTL for an unparseable `expires_at`, so echoing the raw value
+ * would promise a time the CLI itself does not honour.
  */
 export function claimLinkNarration(challenge: { claim_url: string; expires_at?: string }): string {
-  const expiry =
-    typeof challenge.expires_at === "string" ? ` The link expires at ${challenge.expires_at}.` : "";
+  const parsed = typeof challenge.expires_at === "string" ? Date.parse(challenge.expires_at) : NaN;
+  const expiry = Number.isNaN(parsed)
+    ? ""
+    : ` The link expires at ${new Date(parsed).toISOString()}.`;
   return (
     `Finish in your browser: ${challenge.claim_url}\n` +
     `Sign in there to attach this project to your team.${expiry}\n`
   );
+}
+
+/**
+ * The origin of a URL for the wrong-origin warning, or the value itself when
+ * it does not parse: the warning exists to show where a link points, and a
+ * malformed link is still worth naming rather than a reason to crash a
+ * command that could otherwise print it and carry on.
+ */
+export function originOf(value: string): string {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return value;
+  }
 }
 
 /**

--- a/apps/cli/src/commands/doctor/checks/claim.ts
+++ b/apps/cli/src/commands/doctor/checks/claim.ts
@@ -63,9 +63,9 @@ export class ClaimCheck implements SanityCheck {
       message:
         state.kind === "attached"
           ? `Project is attached to team ${state.team_id}`
-          : // Local and self-hosted servers have no team to attach to, so the
-            // check passes rather than warning about an impossible action.
-            "Project is not on a server where teams apply",
+          : // Off the cloud a missing team carries no urgency (nothing expires),
+            // so the check passes rather than nudging for the life of the project.
+            "No owning team recorded; the claim nudge applies to Zitadel Cloud projects only",
       path: this.path,
     };
   }

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -29,6 +29,7 @@ import {
   defaultLocalServerImageForCliVersion,
   ensureContainerIdentity,
   ensureLocalState,
+  hasCurrentLaunchContract,
   localContainerName,
   localServerUrl,
   readRuntimeMetadata,
@@ -101,9 +102,14 @@ export default class Start extends BaseCommand {
     const existingRuntime = await readRuntimeMetadata(this.meta.cwd);
 
     if (runtimeBackend === "binary") {
+      // Healthy is not enough to reuse: a runtime launched by an older CLI
+      // answers /healthz just fine while missing the environment this CLI
+      // hands the server (the launch contract), and a running process cannot
+      // pick that up. Such a runtime is restarted below, keeping its data dir.
       if (
         existingRuntime?.backend === "binary" &&
         existingRuntime.port === port &&
+        hasCurrentLaunchContract(existingRuntime) &&
         isProcessRunning(existingRuntime.pid) &&
         (await checkLocalServerHealth(serverUrl))
       ) {
@@ -155,10 +161,17 @@ export default class Start extends BaseCommand {
       await stopBinaryRuntime(existingRuntime.pid);
     }
     const existing = await inspectContainer(containerName);
+    // Same rule as the binary runtime: a container that matches the image is
+    // reused only when its runtime record shows it was created under the
+    // current launch contract. A record from an older CLI, or none at all,
+    // means the container's environment is unknown, so it is recreated on the
+    // same data volume.
     if (
       existing.exists &&
       existing.running &&
       existing.image === image &&
+      existingRuntime?.backend === "docker" &&
+      hasCurrentLaunchContract(existingRuntime) &&
       (await checkLocalServerHealth(serverUrl))
     ) {
       const metadata = metadataFromStart({

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -138,8 +138,9 @@ type ProjectStatus =
       issuer?: string;
       /**
        * Whether the project is attached to a team, from the local
-       * `.zitadel/secret`. Omitted entirely off the cloud, where there is
-       * nothing to attach and the field would only invite agents to act on it.
+       * `.zitadel/secret`. A recorded team is reported on any server; a
+       * missing one is omitted entirely off the cloud, where the nudge does
+       * not apply and the field would only invite agents to act on it.
        */
       claim?: ClaimState;
     };

--- a/apps/cli/src/lib/claim-state.ts
+++ b/apps/cli/src/lib/claim-state.ts
@@ -42,10 +42,16 @@ export function isAttached(
  * stay fast and work offline. `zitadel claim` reaches the same conclusion the
  * same way before it decides to skip.
  *
- * **Why cloud only.** Claiming attaches a project to a team on the platform.
- * A local or self-hosted server has no such platform, and `--server local` is
- * the documented dev loop, so an ungated nudge would advertise an impossible
- * action for the entire life of a local project.
+ * **Why the nudge is cloud only.** The nudge frames a project with no team as
+ * temporary, which is only true on the cloud; `--server local` is the
+ * documented dev loop, so an ungated nudge would advertise urgency that does
+ * not exist for the entire life of a local project.
+ *
+ * **Why an attached record is not.** The record is a fact about this project
+ * wherever it lives: the local runtime `zitadel start` launches carries the
+ * platform project and can take a claim, and `zitadel claim` writes this very
+ * file when it does. Answering `not-applicable` to a claim the CLI recorded a
+ * moment earlier would contradict its own output.
  *
  * The local record can be stale in one direction: a project claimed from
  * another machine, or a `.zitadel/secret` restored from a backup, reads as
@@ -57,15 +63,15 @@ export function claimState(input: {
   secret: Pick<ZitadelSecret, "claimed_at" | "team_id">;
   server: string;
 }): ClaimState {
-  if (serverKind.value(input.server) !== "cloud") {
-    return { kind: "not-applicable" };
-  }
   if (isAttached(input.secret)) {
     return {
       kind: "attached",
       team_id: input.secret.team_id,
       claimed_at: input.secret.claimed_at,
     };
+  }
+  if (serverKind.value(input.server) !== "cloud") {
+    return { kind: "not-applicable" };
   }
   return { kind: "detached" };
 }

--- a/apps/cli/src/lib/local-server/binary.ts
+++ b/apps/cli/src/lib/local-server/binary.ts
@@ -7,6 +7,7 @@ import { dirname, join } from "node:path";
 import { ZitadelError } from "../errors";
 import {
   type BinaryRuntimeMetadata,
+  LAUNCH_CONTRACT,
   type RuntimeMetadata,
   checkLocalServerHealth,
 } from "./runtime";
@@ -64,10 +65,16 @@ export async function startBinaryRuntime(spec: BinaryRunSpec): Promise<BinaryRun
   await mkdir(dirname(spec.logPath), { recursive: true, mode: 0o700 });
   const log = await open(spec.logPath, "a", 0o600);
   try {
+    // The platform config below is the CLI's to own for its managed runtime:
+    // an ambient project pin (`platform.project_id`) combined with the forced
+    // bootstrap would fail the server's config validation for any id other
+    // than the built-in one, and there is no reason to pin anything on a
+    // data dir only this CLI provisions.
+    const { NEXTGEN_PLATFORM_PROJECT_ID: _inheritedProjectPin, ...inheritedEnv } = process.env;
     const child = spawn(command.command, command.args, {
       detached: true,
       env: {
-        ...process.env,
+        ...inheritedEnv,
         NEXTGEN_SERVER_ADDRESS: `:${String(spec.port)}`,
         NEXTGEN_SERVER_DATA_DIR: spec.dataDir,
         // Browser-facing URLs (claim, dashboard) must point at this local
@@ -89,6 +96,7 @@ export async function startBinaryRuntime(spec: BinaryRunSpec): Promise<BinaryRun
     }
     return {
       schema_version: 1,
+      launch_contract: LAUNCH_CONTRACT,
       backend: "binary",
       pid: child.pid,
       command: [command.command, ...command.args].join(" "),

--- a/apps/cli/src/lib/local-server/binary.ts
+++ b/apps/cli/src/lib/local-server/binary.ts
@@ -73,6 +73,13 @@ export async function startBinaryRuntime(spec: BinaryRunSpec): Promise<BinaryRun
         // Browser-facing URLs (claim, dashboard) must point at this local
         // server, not the cloud default the server config falls back to.
         NEXTGEN_SERVER_PUBLIC_BASE: spec.serverUrl,
+        // The platform project hosts the console's own sign-in and the
+        // personal teams a claim attaches to. Without it the console falls
+        // back to the app's own project: the claim page's sign-in is then
+        // rejected on origin and `claim/complete` refuses every session, while
+        // the CLI waits out the link. A CLI-owned data dir is the one place
+        // enabling it is safe — nothing else provisions projects there.
+        NEXTGEN_PLATFORM_BOOTSTRAP_PROJECT: "true",
       },
       stdio: ["ignore", log.fd, log.fd],
     });

--- a/apps/cli/src/lib/local-server/docker.ts
+++ b/apps/cli/src/lib/local-server/docker.ts
@@ -40,6 +40,11 @@ export function dockerRunArgs(spec: DockerRunSpec): string[] {
     // published above, not the cloud default the server config falls back to.
     "--env",
     `NEXTGEN_SERVER_PUBLIC_BASE=http://localhost:${spec.port}`,
+    // The platform project hosts the console's own sign-in and the personal
+    // teams a claim attaches to; the binary launcher explains why the
+    // CLI-owned runtime is the one place to enable it.
+    "--env",
+    "NEXTGEN_PLATFORM_BOOTSTRAP_PROJECT=true",
   ];
 
   if (spec.identity) {

--- a/apps/cli/src/lib/local-server/docker.ts
+++ b/apps/cli/src/lib/local-server/docker.ts
@@ -5,6 +5,7 @@ import {
   CONTAINER_DATA_DIR,
   CONTAINER_HTTP_PORT,
   type ContainerIdentity,
+  LAUNCH_CONTRACT,
   type RuntimeMetadata,
 } from "./runtime";
 
@@ -214,6 +215,7 @@ export function metadataFromStart(input: {
 }): RuntimeMetadata {
   return {
     schema_version: 1,
+    launch_contract: LAUNCH_CONTRACT,
     backend: "docker",
     container_name: input.containerName,
     container_id: input.containerId,

--- a/apps/cli/src/lib/local-server/runtime.ts
+++ b/apps/cli/src/lib/local-server/runtime.ts
@@ -21,6 +21,22 @@ export const CONTAINER_HTTP_PORT = 8080;
 
 export type RuntimeBackend = "binary" | "docker";
 
+/**
+ * The launch contract: the environment the CLI hands the server when it
+ * starts a runtime, versioned so `start` can tell a runtime that is merely
+ * healthy from one that is healthy *and* launched the way the current CLI
+ * launches it. A running process cannot pick up a new variable, so a change
+ * to that environment is invisible to the health probe alone — the runtime
+ * keeps answering `/healthz` while the feature that needed the variable stays
+ * broken. Bump this whenever the launch environment changes in a way an
+ * already-running runtime must be restarted to receive; `start` then restarts
+ * runtimes recorded under an older (or no) contract, keeping their data dir.
+ *
+ * 1 — `NEXTGEN_PLATFORM_BOOTSTRAP_PROJECT=true`: the platform project the
+ *     console's sign-in and `zitadel claim` need.
+ */
+export const LAUNCH_CONTRACT = 1;
+
 type RuntimeMetadataBase = {
   schema_version: 1;
   backend: RuntimeBackend;
@@ -29,6 +45,12 @@ type RuntimeMetadataBase = {
   data_dir: string;
   created_at: string;
   cli_version: string;
+  /**
+   * The {@link LAUNCH_CONTRACT} the runtime was started under. Absent on
+   * records written by CLIs that predate the marker, which is exactly what
+   * makes those runtimes restart on the next `start`.
+   */
+  launch_contract?: number;
 };
 
 export type BinaryRuntimeMetadata = RuntimeMetadataBase & {
@@ -280,6 +302,13 @@ function normalizeRuntimeMetadata(input: Record<string, unknown>): RuntimeMetada
     data_dir: input.data_dir,
     created_at: input.created_at,
     cli_version: input.cli_version,
+    // Optional so records from older CLIs still parse; anything that is not
+    // a positive integer reads as "no contract", i.e. restart on `start`.
+    ...(typeof input.launch_contract === "number" &&
+    Number.isInteger(input.launch_contract) &&
+    input.launch_contract > 0
+      ? { launch_contract: input.launch_contract }
+      : {}),
   };
 
   if (backend === "binary") {
@@ -390,6 +419,17 @@ export function runtimeSummary(metadata: RuntimeMetadata | undefined): Record<st
 
 export function isRuntimeObject(value: unknown): value is RuntimeMetadata {
   return isObject(value) && value.schema_version === 1;
+}
+
+/**
+ * Whether a recorded runtime was launched under the current
+ * {@link LAUNCH_CONTRACT}, and so may be reused by `start` rather than
+ * restarted. A record without the marker was written by a CLI that predates
+ * it; a higher value comes from a newer CLI and is treated the same way, since
+ * this CLI cannot know what that launch environment contained.
+ */
+export function hasCurrentLaunchContract(metadata: RuntimeMetadata | undefined): boolean {
+  return metadata?.launch_contract === LAUNCH_CONTRACT;
 }
 
 function isValidPort(value: number): boolean {

--- a/apps/cli/tests/unit/commands/claim-deadline.test.ts
+++ b/apps/cli/tests/unit/commands/claim-deadline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { claimDeadline } from "../../../src/commands/claim";
+import { claimDeadline, claimLinkNarration, originOf } from "../../../src/commands/claim";
 
 const NOW = Date.parse("2026-08-04T12:00:00.000Z");
 const TEN_MINUTES = 10 * 60 * 1000;
@@ -50,5 +50,41 @@ describe("claimDeadline", () => {
     for (const input of cases) {
       expect(Number.isFinite(claimDeadline(input))).toBe(true);
     }
+  });
+});
+
+describe("claim link narration", () => {
+  const claimUrl = "https://console.example/claim?challenge_id=ch_1&project_id=proj_1";
+
+  it("carries the link and a parsed expiry", () => {
+    const text = claimLinkNarration({ claim_url: claimUrl, expires_at: "2026-09-03T22:54:42Z" });
+    expect(text).toContain(`Finish in your browser: ${claimUrl}`);
+    expect(text).toContain("The link expires at 2026-09-03T22:54:42.000Z.");
+  });
+
+  // `claimDeadline` falls back to the documented TTL for an unparseable
+  // `expires_at`; echoing the raw value would promise a time the poll does
+  // not honour, so the narration drops it instead.
+  it("omits an expiry the poll would not honour", () => {
+    for (const expiresAt of ["soon", "", undefined]) {
+      const text = claimLinkNarration({ claim_url: claimUrl, expires_at: expiresAt });
+      expect(text).toContain(claimUrl);
+      expect(text).not.toContain("expires at");
+    }
+  });
+});
+
+describe("origin of a claim link", () => {
+  it("names the origin of a well-formed link", () => {
+    expect(originOf("https://nextgen.zitadel.cloud/ui/console/claim?x=1")).toBe(
+      "https://nextgen.zitadel.cloud",
+    );
+  });
+
+  // The wrong-origin warning must never be the reason a claim run crashes:
+  // a link that does not parse is named as-is and the command carries on.
+  it("falls back to the raw value when the link does not parse", () => {
+    expect(originOf("/claim?challenge_id=ch_1")).toBe("/claim?challenge_id=ch_1");
+    expect(originOf("not a url")).toBe("not a url");
   });
 });

--- a/apps/cli/tests/unit/commands/claim.test.ts
+++ b/apps/cli/tests/unit/commands/claim.test.ts
@@ -164,6 +164,26 @@ describe("claim", () => {
     expect(`${res.stdout}${res.stderr}`).toContain("/claim/ch_");
   });
 
+  // The agent contract mandates `--json`, which silences consola — and the
+  // link is the one thing the human needs from this command. It has to reach
+  // them somewhere, and stderr is the only stream the envelope leaves free.
+  it("surfaces the link on stderr under --json, keeping stdout to the envelope", async () => {
+    const { cwd, project } = await makeProject();
+
+    const [res] = await Promise.all([
+      claim(cwd, ["--no-open"]),
+      onChallengeMinted((challengeId) => completeClaimChallenge(challengeId, project.id)),
+    ]);
+
+    expect(res.exitCode).toBe(0);
+    expect(res.stderr).toContain("Finish in your browser: ");
+    expect(res.stderr).toContain("/claim/ch_");
+    expect(res.stderr).toContain("The link expires at ");
+    expect(res.stdout).not.toContain("/claim/ch_");
+    const json = parseJson(res.stdout) as { status: string };
+    expect(json.status).toBe("ok");
+  });
+
   it("skips without a network call when the secret already records a team", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "zitadel-claim-"));
     tempDirs.push(cwd);
@@ -330,6 +350,32 @@ describe("claim", () => {
 
       expect(res.exitCode).toBe(0);
       expect(`${res.stdout}${res.stderr}`).toContain("NEXTGEN_SERVER_PUBLIC_BASE");
+    });
+
+    // Under `--json` the warning would otherwise be silenced with the rest of
+    // consola, but an agent is exactly who needs to learn that the link it is
+    // about to forward points at the wrong origin.
+    it("keeps the warning on stderr under --json", async () => {
+      const { cwd } = await makeProject();
+      const serverUrl = await startClaimServer(
+        "https://nextgen.zitadel.cloud/ui/console/claim?challenge_id=ch_localstub",
+      );
+      await writeRuntimeMetadata(cwd, runtimeFor(cwd, serverUrl));
+
+      const res = await runCliForTest([
+        "claim",
+        "--cwd",
+        cwd,
+        "--json",
+        "--server",
+        "local",
+        "--no-open",
+      ]);
+
+      expect(res.exitCode).toBe(0);
+      expect(res.stderr).toContain("NEXTGEN_SERVER_PUBLIC_BASE");
+      expect(res.stdout).not.toContain("NEXTGEN_SERVER_PUBLIC_BASE");
+      expect((parseJson(res.stdout) as { status: string }).status).toBe("ok");
     });
 
     it("does not warn when the claim page is on the local server itself", async () => {

--- a/apps/cli/tests/unit/commands/doctor/checks.test.ts
+++ b/apps/cli/tests/unit/commands/doctor/checks.test.ts
@@ -1039,7 +1039,20 @@ describe("ClaimCheck", () => {
     expect(outcome.message).toContain("team-001");
   });
 
-  // Local and self-hosted servers have no platform team, so there is nothing to
+  // The record is the fact: the local runtime can take a claim, and the team
+  // it recorded is reported wherever the project lives.
+  it("names the team once attached, on any server", async () => {
+    for (const server of ["http://localhost:8080", "https://zitadel.example.com"]) {
+      const cwd = await makeProject();
+      await writeServer(cwd, server);
+      await writeSecret(cwd, { claimed_at: "2026-01-02T00:00:00.000Z", team_id: "team-001" });
+      const outcome = await new ClaimCheck().run(ctxFor(cwd));
+      expect(outcome.status).toBe("pass");
+      expect(outcome.message).toContain("team-001");
+    }
+  });
+
+  // Off the cloud a missing team carries no urgency, so there is nothing to
   // nudge toward and a warning would be permanent noise.
   it("passes without a nudge off the cloud", async () => {
     for (const server of ["http://localhost:8080", "https://zitadel.example.com"]) {

--- a/apps/cli/tests/unit/commands/local-runtime.test.ts
+++ b/apps/cli/tests/unit/commands/local-runtime.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   CONTAINER_DATA_DIR,
+  LAUNCH_CONTRACT,
   defaultLocalServerImageForCliVersion,
   localContainerName,
   localRuntimePaths,
@@ -377,6 +378,116 @@ describe("local runtime commands", () => {
 
     const stop = await runCliForTest(["stop", "--cwd", cwd, "--json"]);
     expect(stop.exitCode).toBe(0);
+  });
+
+  // A runtime launched by an older CLI keeps answering /healthz while missing
+  // the environment this CLI hands the server, and a running process cannot
+  // pick that up. `start` must restart it rather than report it as running —
+  // otherwise upgrading the CLI leaves the platform-project fix unreachable
+  // until someone stops the server by hand.
+  it("start restarts a healthy binary runtime recorded under an older launch contract", async () => {
+    const cwd = await tempProject("zitadel-start-contract-");
+    const fake = await fakeServerBinary();
+    const port = await freePort();
+    const env = { ZITADEL_SERVER_BINARY: fake.binPath };
+    const args = ["start", "--cwd", cwd, "--json", "--port", String(port)];
+
+    const first = await runCliForTest(args, env);
+    expect(first.exitCode).toBe(0);
+    const firstPid = runtimePidOf(first.stdout);
+    binaryPids.push(firstPid);
+    expect((await readRuntimeMetadata(cwd))?.launch_contract).toBe(LAUNCH_CONTRACT);
+
+    // Same contract: the healthy runtime is reused, not restarted.
+    const again = await runCliForTest(args, env);
+    expect(again.exitCode).toBe(0);
+    expect(parseJson(again.stdout)).toMatchObject({
+      data: { title: "Local Zitadel server is already running.", runtime: { pid: firstPid } },
+    });
+
+    // The record an older CLI would have written: healthy, same port, no
+    // contract marker.
+    const recorded = await readRuntimeMetadata(cwd);
+    if (!recorded) {
+      throw new Error("runtime metadata missing after start");
+    }
+    const { launch_contract: _contract, ...legacy } = recorded;
+    await writeRuntimeMetadata(cwd, legacy);
+
+    const restarted = await runCliForTest(args, env);
+    expect(restarted.exitCode).toBe(0);
+    const envelope = parseJson(restarted.stdout) as {
+      data: { title: string; runtime: { pid: number } };
+    };
+    expect(envelope.data.title).toBe("Local Zitadel server is ready.");
+    expect(envelope.data.runtime.pid).not.toBe(firstPid);
+    binaryPids.push(envelope.data.runtime.pid);
+    expect(() => process.kill(firstPid, 0)).toThrow();
+    expect((await readRuntimeMetadata(cwd))?.launch_contract).toBe(LAUNCH_CONTRACT);
+
+    const stop = await runCliForTest(["stop", "--cwd", cwd, "--json"]);
+    expect(stop.exitCode).toBe(0);
+  });
+
+  it("start recreates a matching container whose record predates the launch contract", async () => {
+    const cwd = await tempProject("zitadel-start-container-contract-");
+    const image = await expectedDefaultImage();
+    const fake = await fakeDocker({ existingContainerImage: image });
+    const port = await freePort();
+    const serverUrl = `http://localhost:${String(port)}`;
+    const containerName = localContainerName(cwd);
+    // `runtimeFor` writes the record shape an older CLI produced: no marker.
+    await writeRuntimeMetadata(cwd, { ...runtimeFor(cwd, serverUrl), image });
+
+    const result = await runCliForTest(
+      ["start", "--cwd", cwd, "--json", "--runtime", "docker", "--port", String(port)],
+      {
+        PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
+        DOCKER_LOG: fake.logPath,
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(parseJson(result.stdout)).toMatchObject({
+      data: { title: "Local Zitadel server is ready." },
+    });
+    const dockerCalls = await readDockerCalls(fake.logPath);
+    expect(dockerCalls).toContainEqual(["stop", containerName]);
+    expect(dockerCalls).toContainEqual(["rm", containerName]);
+    expect(dockerCalls.find((args) => args[0] === "run")).toContain(
+      "NEXTGEN_PLATFORM_BOOTSTRAP_PROJECT=true",
+    );
+    expect((await readRuntimeMetadata(cwd))?.launch_contract).toBe(LAUNCH_CONTRACT);
+  });
+
+  it("start reuses a healthy matching container recorded under the current launch contract", async () => {
+    const cwd = await tempProject("zitadel-start-container-reuse-");
+    const image = await expectedDefaultImage();
+    const fake = await fakeDocker({ existingContainerImage: image });
+    // The "container" answering /healthz on the port the record names.
+    const serverUrl = await startHealthServer();
+    const port = Number(new URL(serverUrl).port);
+    await writeRuntimeMetadata(cwd, {
+      ...runtimeFor(cwd, serverUrl),
+      image,
+      launch_contract: LAUNCH_CONTRACT,
+    });
+
+    const result = await runCliForTest(
+      ["start", "--cwd", cwd, "--json", "--runtime", "docker", "--port", String(port)],
+      {
+        PATH: `${fake.binDir}:${process.env.PATH ?? ""}`,
+        DOCKER_LOG: fake.logPath,
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(parseJson(result.stdout)).toMatchObject({
+      data: { title: "Local Zitadel server is already running." },
+    });
+    const dockerCalls = await readDockerCalls(fake.logPath);
+    expect(dockerCalls.some((args) => args[0] === "run")).toBe(false);
+    expect(dockerCalls.some((args) => args[0] === "rm")).toBe(false);
   });
 
   it("start fails with E_PORT_IN_USE when a foreign listener owns the requested port", async () => {

--- a/apps/cli/tests/unit/commands/status.test.ts
+++ b/apps/cli/tests/unit/commands/status.test.ts
@@ -53,13 +53,13 @@ afterEach(async () => {
   }
 });
 
-async function configuredProject(): Promise<string> {
+async function configuredProject(server = "https://api.zitadel.cloud"): Promise<string> {
   const cwd = await makeProject();
   await writeFile(
     join(cwd, "zitadel.json"),
     JSON.stringify({
       project: "proj-001",
-      server: "https://api.zitadel.cloud",
+      server,
       environments: { development: { issuer: "http://localhost:3000" } },
     }),
   );
@@ -130,6 +130,29 @@ describe("status command", () => {
     });
     expect(json.data.next_actions.join("\n")).not.toContain("temporary until you attach");
     expect(json.data.next_commands).not.toContain(expectedPublicCliCommand("claim"));
+  });
+
+  // The local runtime carries the platform project and can take a claim. The
+  // team `zitadel claim` recorded is a fact wherever the project lives; only
+  // the nudge for a missing team is cloud-only.
+  it("reports the owning team on a local server too", async () => {
+    const cwd = await configuredProject("http://localhost:8080");
+    await writeFile(
+      join(cwd, ".zitadel/secret"),
+      JSON.stringify({ ...SECRET, claimed_at: "2026-01-02T00:00:00.000Z", team_id: "team-001" }),
+    );
+
+    const res = await status(cwd);
+
+    const json = parseJson(res.stdout) as {
+      data: { project: { claim?: { kind: string; team_id?: string } }; next_actions: string[] };
+    };
+    expect(json.data.project.claim).toEqual({
+      kind: "attached",
+      team_id: "team-001",
+      claimed_at: "2026-01-02T00:00:00.000Z",
+    });
+    expect(json.data.next_actions.join("\n")).not.toContain("temporary until you attach");
   });
 
   // The project lives wherever `zitadel.json` says, not wherever this

--- a/apps/cli/tests/unit/lib/claim-state.test.ts
+++ b/apps/cli/tests/unit/lib/claim-state.test.ts
@@ -35,10 +35,22 @@ describe("claim state", () => {
     ).toEqual({ kind: "detached" });
   });
 
-  it("is not applicable off the cloud, attached or not", () => {
+  it("is not applicable off the cloud while nothing is attached", () => {
     for (const server of ["http://localhost:8080", "https://zitadel.example.com"]) {
       expect(claimState({ secret: DETACHED, server })).toEqual({ kind: "not-applicable" });
-      expect(claimState({ secret: ATTACHED, server })).toEqual({ kind: "not-applicable" });
+    }
+  });
+
+  // The local runtime carries the platform project and can take a claim, and
+  // `zitadel claim` writes this record when it does. Only the nudge is
+  // cloud-only; the record is reported wherever the project lives.
+  it("reports an attached project on any server", () => {
+    for (const server of ["http://localhost:8080", "https://zitadel.example.com"]) {
+      expect(claimState({ secret: ATTACHED, server })).toEqual({
+        kind: "attached",
+        team_id: "team-001",
+        claimed_at: "2026-08-01T10:00:00.000Z",
+      });
     }
   });
 

--- a/apps/cli/tests/unit/lib/local-server/binary.test.ts
+++ b/apps/cli/tests/unit/lib/local-server/binary.test.ts
@@ -23,7 +23,7 @@ describe("local server binary helpers", () => {
     vi.unstubAllEnvs();
   });
 
-  it("spawns the server with the address, data dir, and public base env", async () => {
+  it("spawns the server with the address, data dir, public base, and platform bootstrap env", async () => {
     vi.stubEnv("ZITADEL_SERVER_BINARY", "/tmp/fake-nextgen-server");
     const dir = await mkdtemp(join(tmpdir(), "zitadel-binary-test-"));
 
@@ -42,6 +42,9 @@ describe("local server binary helpers", () => {
     ];
     expect(options.env.NEXTGEN_SERVER_ADDRESS).toBe(":8091");
     expect(options.env.NEXTGEN_SERVER_PUBLIC_BASE).toBe("http://localhost:8091");
+    // Without the platform project the claim page cannot sign anyone in and
+    // `claim/complete` refuses every session, so a local claim never lands.
+    expect(options.env.NEXTGEN_PLATFORM_BOOTSTRAP_PROJECT).toBe("true");
   });
 
   it("records an explicit source build version with a binary override", () => {

--- a/apps/cli/tests/unit/lib/local-server/binary.test.ts
+++ b/apps/cli/tests/unit/lib/local-server/binary.test.ts
@@ -10,6 +10,7 @@ import {
   startBinaryRuntime,
   stopBinaryRuntime,
 } from "../../../../src/lib/local-server/binary";
+import { LAUNCH_CONTRACT } from "../../../../src/lib/local-server/runtime";
 
 vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
@@ -45,6 +46,35 @@ describe("local server binary helpers", () => {
     // Without the platform project the claim page cannot sign anyone in and
     // `claim/complete` refuses every session, so a local claim never lands.
     expect(options.env.NEXTGEN_PLATFORM_BOOTSTRAP_PROJECT).toBe("true");
+  });
+
+  // The server rejects `platform.bootstrap_project` combined with a foreign
+  // `platform.project_id`, so an ambient pin in the caller's shell would turn
+  // `zitadel start` into a startup failure. The managed runtime owns its
+  // platform config; the pin must not leak into it.
+  it("does not pass an inherited platform project pin to the managed server", async () => {
+    vi.stubEnv("ZITADEL_SERVER_BINARY", "/tmp/fake-nextgen-server");
+    vi.stubEnv("NEXTGEN_PLATFORM_PROJECT_ID", "proj_custom");
+    const dir = await mkdtemp(join(tmpdir(), "zitadel-binary-test-"));
+
+    const metadata = await startBinaryRuntime({
+      cliVersion: "0.0.0-test",
+      dataDir: join(dir, "data"),
+      logPath: join(dir, "logs", "server.log"),
+      port: 8092,
+      serverUrl: "http://localhost:8092",
+    });
+
+    const [, , options] = vi.mocked(spawn).mock.calls.at(-1) as unknown as [
+      string,
+      string[],
+      { env: NodeJS.ProcessEnv },
+    ];
+    expect(options.env.NEXTGEN_PLATFORM_PROJECT_ID).toBeUndefined();
+    expect(options.env.NEXTGEN_PLATFORM_BOOTSTRAP_PROJECT).toBe("true");
+    // The record says which launch contract the process got, so a later
+    // `start` can tell it apart from a runtime that predates the marker.
+    expect(metadata.launch_contract).toBe(LAUNCH_CONTRACT);
   });
 
   it("records an explicit source build version with a binary override", () => {

--- a/apps/cli/tests/unit/lib/local-server/docker.test.ts
+++ b/apps/cli/tests/unit/lib/local-server/docker.test.ts
@@ -49,6 +49,8 @@ describe("local server Docker helpers", () => {
       `NEXTGEN_SERVER_DATA_DIR=${CONTAINER_DATA_DIR}`,
       "--env",
       "NEXTGEN_SERVER_PUBLIC_BASE=http://localhost:8090",
+      "--env",
+      "NEXTGEN_PLATFORM_BOOTSTRAP_PROJECT=true",
       "--volume",
       "/tmp/app/.zitadel/local/container-passwd:/etc/passwd:ro",
       "--volume",

--- a/apps/cli/tests/unit/lib/local-server/docker.test.ts
+++ b/apps/cli/tests/unit/lib/local-server/docker.test.ts
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
-import { CONTAINER_DATA_DIR } from "../../../../src/lib/local-server/runtime";
-import { dockerRunArgs } from "../../../../src/lib/local-server/docker";
+import { dockerRunArgs, metadataFromStart } from "../../../../src/lib/local-server/docker";
+import { CONTAINER_DATA_DIR, LAUNCH_CONTRACT } from "../../../../src/lib/local-server/runtime";
 
 describe("local server Docker helpers", () => {
   // The server derives its default data dir next to the entrypoint, which lives
@@ -60,5 +60,20 @@ describe("local server Docker helpers", () => {
       "ghcr.io/zitadel/nextgen:test",
     ]);
     expect(args.join(" ")).not.toContain("NEXTGEN_SERVER_ENCRYPTION_KEY");
+  });
+
+  // The record must say which launch contract the container got, or a later
+  // `start` cannot tell it from a container created by an older CLI.
+  it("records the current launch contract for a started container", () => {
+    const metadata = metadataFromStart({
+      cwdDataDir: "/tmp/app/.zitadel/local/nextgen-data",
+      cliVersion: "0.0.0-test",
+      containerName: "zitadel-server-test",
+      containerId: "container-test-id",
+      image: "ghcr.io/zitadel/nextgen:test",
+      port: 8090,
+      serverUrl: "http://localhost:8090",
+    });
+    expect(metadata.launch_contract).toBe(LAUNCH_CONTRACT);
   });
 });

--- a/apps/cli/tests/unit/lib/local-server/runtime.test.ts
+++ b/apps/cli/tests/unit/lib/local-server/runtime.test.ts
@@ -79,6 +79,30 @@ describe("local server runtime metadata", () => {
     await expect(readRuntimeMetadata(cwd)).resolves.toEqual(metadata);
   });
 
+  // The marker is what lets `start` tell a runtime it may reuse from one it
+  // must restart, so it has to survive the write/read cycle unchanged.
+  it("round-trips the launch contract", async () => {
+    const metadata: RuntimeMetadata = { ...runtimeFor(cwd), launch_contract: 1 };
+
+    await writeRuntimeMetadata(cwd, metadata);
+
+    await expect(readRuntimeMetadata(cwd)).resolves.toEqual(metadata);
+  });
+
+  // A record from an older CLI carries no marker, and a corrupt one must read
+  // the same way: "no contract", which `start` treats as a restart.
+  it("drops a launch contract that is not a positive integer", async () => {
+    const paths = await ensureLocalState(cwd);
+    const metadata = runtimeFor(cwd);
+    for (const junk of ["1", 0, -1, 1.5, null]) {
+      await writeFile(
+        paths.runtimeFile,
+        `${JSON.stringify({ ...metadata, launch_contract: junk }, null, 2)}\n`,
+      );
+      await expect(readRuntimeMetadata(cwd)).resolves.toEqual(metadata);
+    }
+  });
+
   it("treats legacy runtime metadata without backend as Docker metadata", async () => {
     const paths = await ensureLocalState(cwd);
     const metadata = runtimeFor(cwd);


### PR DESCRIPTION
## Summary

Three fixes found by running the published `@zitadel/cli@1.0.0-alpha.21` claim flow against the local runtime.

- `zitadel start` now sets `NEXTGEN_PLATFORM_BOOTSTRAP_PROJECT=true` for the binary and Docker runtimes. Without the platform project the console falls back to the app's own project, the claim page's sign-in is rejected on origin (`origin "http://localhost:8080" is not allowed for this project`), and `claim/complete` refuses every session while the CLI waits out the link. A CLI-owned data dir is the one place enabling it is safe.
- `zitadel claim --json` writes the claim link and its expiry to stderr; stdout stays the single JSON envelope. `--json` silences consola, so the documented agent invocation (`--non-interactive --json`) never surfaced the link at all: zero bytes on either stream until the timeout envelope. The wrong-origin warning reaches stderr the same way.
- `claimState()` reports a recorded owning team on any server; only the detached nudge stays cloud-only, because its "temporary" framing is only true on the cloud. Before, `status` omitted `data.project.claim` and `doctor` said "not on a server where teams apply" right after the CLI itself wrote `team_id` and `claimed_at` for a local claim.

SKILLS.md documents all three.

## Validation

- `moon run cli:lint` — 0 errors (27 pre-existing warnings)
- `moon run cli:test` — 113 files, 1108 tests pass; new or changed: launcher env (binary + Docker), link on stderr under `--json`, warning on stderr under `--json`, attached-on-local for `claimState`, `status`, and `doctor`
- Manual round trip with the source-built CLI driving the published alpha.21 server binary: `start` created the platform project with no env from the caller, `claim --json` printed the link on stderr with stdout empty until the envelope, the browser leg registered and completed the claim, and `status` / `doctor` reported the team on the local server
- oxfmt is not enforced in CI and none of the touched files were clean at HEAD, so the formatter was not run over whole files; every added line was checked to be oxfmt-clean on its own

## Release notes / changeset

- Changeset: `.changeset/cli-local-claim.md` — `zitadel start` provisions the platform project in the local runtime so the console sign-in and `zitadel claim` work locally; `zitadel claim --json` writes the link and expiry to stderr; `status` and `doctor` report a recorded team on any server, with only the nudge staying cloud-only. `@zitadel/cli` minor (fixed group).

## Notes

- Behavior change to be aware of: a CLI-started server now resolves `proj_platform` as its default project, so the embedded console signs into the platform project instead of the app's project. That is the shape Console ADR 0004 describes; the scaffolded app is unaffected because it carries its own publishable key, and nothing in the journey e2e reads the hosted login shell.
- Follow-ups from the same test run, not in this PR: `claim/init` should refuse on a deployment without a platform project instead of letting the CLI poll for ten minutes; the embedded console shows dev-proxy copy (`CONSOLE_PROJECT_SECRET`) on every management 401 until session-derived authorization (ADR 053) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pep3j1rKFMZ7GaGwujmGr