### PR TITLE
test(api): cover grant and user-query session principal

### DIFF
--- a/internal/api/authz_internal_test.go
+++ b/internal/api/authz_internal_test.go
@@ -245,6 +245,22 @@ func TestRequireExpandScope(t *testing.T) {
 			t.Fatalf("code %q, want %q", de.Code, domain.ErrTeamPermissionDenied().Code)
 		}
 	})
+	t.Run("session user does not skip users-query expand ceilings", func(t *testing.T) {
+		ctx := WithScopeContext(context.Background(), ScopeContext{
+			ProjectID:     "proj_platform",
+			PrincipalType: domain.AuthzPrincipalTypeUser,
+			PrincipalID:   "user_alice",
+		})
+		if hasGranularOrOperator(ctx, "user.read") || hasGranularOrOperator(ctx, "team.read") {
+			t.Fatal("empty-scope user must not satisfy hasGranularOrOperator")
+		}
+		if err := requireMembershipRead(ctx); err == nil {
+			t.Fatal("session users must still need team_membership.read")
+		}
+		if err := requireTeamRead(ctx); err == nil {
+			t.Fatal("session users must still need team.read")
+		}
+	})
 }
 
 func TestMapAuthzDecision(t *testing.T) {
@@ -399,6 +415,13 @@ func TestRequireProjectAccess_UserPrincipalCrossProject(t *testing.T) {
 		stmts := stubAuthzStmts{allowCheck: &deny, foothold: &foothold}
 		err := requireProjectAccess(human, stmts, "proj_customer", grantAccess, opDelete)
 		assertDomainCode(t, err, domain.ErrGrantPermissionDenied().Code)
+		var de domain.Error
+		if !errors.As(err, &de) {
+			t.Fatalf("error is not a domain.Error: %v", err)
+		}
+		if de.Message != "insufficient permissions to manage grants" {
+			t.Fatalf("grant denial copy = %q, want credential-neutral message", de.Message)
+		}
 	})
 
 	t.Run("missing home project fails closed", func(t *testing.T) {
@@ -450,6 +473,33 @@ func TestCredentialCeiling(t *testing.T) {
 		}, "proj_a")
 		if !errors.Is(err, errAuthzPreviewDenied) {
 			t.Fatalf("got %v, want preview denied", err)
+		}
+	})
+
+	t.Run("write-bearing secret with home is allowed on own and foreign targets", func(t *testing.T) {
+		scope := ScopeContext{
+			ProjectID:     "proj_a",
+			Scope:         []string{"project.write", "project.read"},
+			PrincipalType: domain.AuthzPrincipalTypeSKProj,
+			PrincipalID:   "proj_a",
+		}
+		if err := credentialCeiling(scope, "proj_a"); err != nil {
+			t.Fatalf("own project: %v", err)
+		}
+		if err := credentialCeiling(scope, "proj_b"); err != nil {
+			t.Fatalf("foreign project: %v", err)
+		}
+	})
+
+	t.Run("preview on a foreign project is anti-oracle", func(t *testing.T) {
+		err := credentialCeiling(ScopeContext{
+			ProjectID:     "proj_a",
+			Scope:         []string{"project.read"},
+			PrincipalType: domain.AuthzPrincipalTypeSKProj,
+			PrincipalID:   "proj_a",
+		}, "proj_b")
+		if !errors.Is(err, errAuthzNoScope) {
+			t.Fatalf("got %v, want no scope", err)
 		}
 	})
 }
@@ -511,6 +561,70 @@ func TestRequireProjectListAccess(t *testing.T) {
 
 	_, err = requireProjectListAccess(context.Background(), stmts, "proj_a", userAccess, domain.ResourceKindUser)
 	assertDomainCode(t, err, domain.ErrUserNotFound().Code)
+}
+
+// QueryUsers authorizes session callers through requireProjectListAccess on the
+// credential home. Lists must not 404 a Forbidden foothold (that's an empty
+// page) and must still fail closed without home or without any foothold.
+func TestRequireProjectListAccess_UserPrincipal(t *testing.T) {
+	human := WithScopeContext(context.Background(), ScopeContext{
+		ProjectID:     "proj_home",
+		PrincipalType: domain.AuthzPrincipalTypeUser,
+		PrincipalID:   "user_alice",
+	})
+
+	t.Run("allow stamps skip", func(t *testing.T) {
+		allow := true
+		foothold := true
+		ctx, err := requireProjectListAccess(human, stubAuthzStmts{allowCheck: &allow, foothold: &foothold}, "proj_home", userAccess, domain.ResourceKindUser)
+		if err != nil {
+			t.Fatalf("session user with Check Allow should proceed: %v", err)
+		}
+		if !service.AuthzListSkipOncePending(ctx) {
+			t.Fatal("Allow must stamp a one-shot EXISTS skip")
+		}
+		if _, ok := service.AuthzListFilterFromContext(ctx); ok {
+			t.Fatal("Allow must not attach EXISTS")
+		}
+	})
+
+	t.Run("foothold without permission is an empty-page filter", func(t *testing.T) {
+		deny := false
+		foothold := true
+		ctx, err := requireProjectListAccess(human, stubAuthzStmts{allowCheck: &deny, foothold: &foothold}, "proj_home", userAccess, domain.ResourceKindUser)
+		if err != nil {
+			t.Fatalf("Forbidden with foothold should proceed for partial-view lists: %v", err)
+		}
+		filter, ok := service.AuthzListFilterFromContext(ctx)
+		if !ok {
+			t.Fatal("Forbidden must attach the EXISTS list filter")
+		}
+		if filter.ResourceKind != domain.ResourceKindUser {
+			t.Fatalf("filter kind = %q, want user", filter.ResourceKind)
+		}
+		if filter.PrincipalHomeProjectID != "proj_home" {
+			t.Fatalf("PrincipalHomeProjectID = %q, want credential home", filter.PrincipalHomeProjectID)
+		}
+		if service.AuthzListSkipOncePending(ctx) {
+			t.Fatal("Forbidden must not stamp the project-wide skip")
+		}
+	})
+
+	t.Run("no foothold is not found", func(t *testing.T) {
+		deny := false
+		foothold := false
+		_, err := requireProjectListAccess(human, stubAuthzStmts{allowCheck: &deny, foothold: &foothold}, "proj_home", userAccess, domain.ResourceKindUser)
+		assertDomainCode(t, err, domain.ErrUserNotFound().Code)
+	})
+
+	t.Run("missing home project fails closed", func(t *testing.T) {
+		orphan := WithScopeContext(context.Background(), ScopeContext{
+			PrincipalType: domain.AuthzPrincipalTypeUser,
+			PrincipalID:   "user_alice",
+		})
+		_, err := requireProjectListAccess(orphan, stubAuthzStmts{}, "proj_home", userAccess, domain.ResourceKindUser)
+		assertDomainCode(t, err, domain.ErrUserNotFound().Code)
+	})
 }
 
 func TestWithAuthzListFilterCopiesConstraintTeamID(t *testing.T) {

--- a/internal/api/error_handler_test.go
+++ b/internal/api/error_handler_test.go
@@ -224,6 +224,54 @@ func TestOgenErrorHandlerQueryUsersSecurityStaysCredentialNeutral(t *testing.T) 
 	})
 }
 
+func TestOgenErrorHandlerDualSchemeInvalidCookieStaysCredentialNeutral(t *testing.T) {
+	t.Parallel()
+
+	const want = `{"code":"auth.unauthorized","message":"The request lacks valid authentication credentials."}`
+	for _, op := range []api.OperationName{
+		api.CreateGrantOperation,
+		api.GetGrantOperation,
+		api.DeleteGrantOperation,
+		api.QueryGrantsOperation,
+		api.QueryUsersOperation,
+	} {
+		require.False(t, sessionCookieOperations[op], "%s must stay off the session-only 401 rewrite", op)
+	}
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"grant create", http.MethodPost, "/grants?project_id=proj_1", `{"principal_type":"user","principal_id":"user_1","relation":"viewer"}`},
+		{"grant get", http.MethodGet, "/grants/asgn_1?project_id=proj_1", ""},
+		{"grant delete", http.MethodDelete, "/grants/asgn_1?project_id=proj_1", ""},
+		{"grant query", http.MethodPost, "/grants/query?project_id=proj_1", `{}`},
+		{"users query", http.MethodPost, "/users/query", `{}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mock := gomock.NewController(t)
+			tokenService := mocks.NewMockTokenService(mock)
+			tokenService.EXPECT().IntrospectToken(gomock.Any(), "garbage").Return(nil, errors.New("bad token"))
+			srv := newErrorHandlerTestServer(t, tokenService)
+
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+			if tc.method == http.MethodPost {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "garbage"})
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusUnauthorized, rec.Code)
+			require.JSONEq(t, want, rec.Body.String())
+		})
+	}
+}
+
 func TestDomainErrorDetailsOmitsDiagnostics(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/grant_internal_test.go
+++ b/internal/api/grant_internal_test.go
@@ -1,12 +1,18 @@
 package api
 
 import (
+	"context"
 	"errors"
+	"net/http"
 	"testing"
+
+	"go.uber.org/mock/gomock"
 
 	api "github.com/zitadel/nextgen/api/generated"
 	"github.com/zitadel/nextgen/internal/domain"
 	"github.com/zitadel/nextgen/internal/service"
+	servicemocks "github.com/zitadel/nextgen/internal/service/mocks"
+	"github.com/zitadel/nextgen/internal/storage/database"
 )
 
 func TestMapQueryGrantsToService_Expand(t *testing.T) {
@@ -67,4 +73,98 @@ func TestGrantResponse_Principal(t *testing.T) {
 			t.Fatalf("error = %v, want grant not found", err)
 		}
 	})
+}
+
+func TestGrantErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  domain.Error
+		want int
+	}{
+		{"invalid", domain.ErrGrantInvalid(), http.StatusBadRequest},
+		{"not_found", domain.ErrGrantNotFound(), http.StatusNotFound},
+		{"principal_not_found", domain.ErrGrantPrincipalNotFound(), http.StatusNotFound},
+		{"already_exists", domain.ErrGrantAlreadyExists(), http.StatusConflict},
+		{"permission_denied", domain.ErrGrantPermissionDenied(), http.StatusForbidden},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := grantErrorResponse(tt.err); got.StatusCode != tt.want {
+				t.Fatalf("grantErrorResponse(%q) status = %d, want %d", tt.err.Code, got.StatusCode, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryGrants_PrincipalExpandCeiling(t *testing.T) {
+	params := api.QueryGrantsParams{ProjectID: api.ProjectID("proj_customer")}
+	expand := &api.QueryGrantsRequest{Expand: []api.GrantExpand{api.GrantExpandPrincipal}}
+	userCtx := WithScopeContext(context.Background(), ScopeContext{
+		ProjectID:     "proj_platform",
+		PrincipalType: domain.AuthzPrincipalTypeUser,
+		PrincipalID:   "user_alice",
+	})
+	secretCtx := WithScopeContext(context.Background(), ScopeContext{
+		ProjectID:     "proj_customer",
+		Scope:         []string{"project.write", "project.read"},
+		PrincipalType: domain.AuthzPrincipalTypeSKProj,
+		PrincipalID:   "proj_customer",
+	})
+
+	t.Run("session user without read scopes may expand", func(t *testing.T) {
+		h := queryGrantsHandler(t, true, true, true)
+		resp, err := h.QueryGrants(userCtx, expand, params)
+		if err != nil {
+			t.Fatalf("user expand: %v", err)
+		}
+		if _, ok := resp.(*api.QueryGrantsResponse); !ok {
+			t.Fatalf("got %T, want QueryGrantsResponse", resp)
+		}
+	})
+
+	t.Run("operator secret may expand via project.write", func(t *testing.T) {
+		h := queryGrantsHandler(t, true, true, true)
+		resp, err := h.QueryGrants(secretCtx, expand, params)
+		if err != nil {
+			t.Fatalf("secret expand: %v", err)
+		}
+		if _, ok := resp.(*api.QueryGrantsResponse); !ok {
+			t.Fatalf("got %T, want QueryGrantsResponse", resp)
+		}
+	})
+
+	t.Run("session user still needs Check before expand skip", func(t *testing.T) {
+		h := queryGrantsHandler(t, false, true, false)
+		_, err := h.QueryGrants(userCtx, expand, params)
+		assertDomainCode(t, err, domain.ErrGrantPermissionDenied().Code)
+	})
+
+	t.Run("session user without foothold is not found", func(t *testing.T) {
+		h := queryGrantsHandler(t, false, false, false)
+		_, err := h.QueryGrants(userCtx, expand, params)
+		assertDomainCode(t, err, domain.ErrGrantNotFound().Code)
+	})
+}
+
+func queryGrantsHandler(t *testing.T, allowed, foothold, expectList bool) Handler {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	pool := servicemocks.NewMockPool(ctrl)
+	stmts := servicemocks.NewMockAllStatements(ctrl)
+	pool.EXPECT().Statements().Return(stmts).AnyTimes()
+	stmts.EXPECT().ActiveSystemCatalogID(gomock.Any()).Return(domain.SystemCatalogID, nil).AnyTimes()
+	stmts.EXPECT().CheckAuthz(gomock.Any(), gomock.Any()).Return(allowed, foothold, nil).AnyTimes()
+	if expectList {
+		stmts.EXPECT().ListManagedGrants(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			&database.ListResult[*domain.AuthzAssignment]{}, nil)
+	}
+	db := service.NewPool(pool)
+	return Handler{
+		pool:         db,
+		grantService: service.NewGrantService(db, nil, "proj_platform"),
+	}
 }

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -156,27 +156,45 @@ func TestHandleNextgenSession(t *testing.T) {
 	t.Run("user-bound session mints user ScopeContext", func(t *testing.T) {
 		t.Parallel()
 
-		token := &domain.Token{
-			ProjectID: "project-1",
-			TokenID:   "token-1",
-			UserID:    "user-1",
-			Type:      domain.TokenTypeSessionToken,
-			SessionID: new("session-1"),
+		for _, tc := range []struct {
+			name  string
+			scope []string
+		}{
+			{"empty scope", nil},
+			{"write scopes still user", []string{"project.write", "project.read"}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				token := &domain.Token{
+					ProjectID: "project-1",
+					TokenID:   "token-1",
+					UserID:    "user-1",
+					Type:      domain.TokenTypeSessionToken,
+					Scope:     tc.scope,
+					SessionID: new("session-1"),
+				}
+
+				mock := gomock.NewController(t)
+				tokenService := mocks.NewMockTokenService(mock)
+				tokenService.EXPECT().IntrospectToken(gomock.Any(), "raw-cookie").Return(token, nil)
+
+				handler := NewSecurityHandler(tokenService)
+				ctx, err := handler.HandleNextgenSession(t.Context(), api.GetMySessionOperation, api.NextgenSession{APIKey: "raw-cookie"})
+				require.NoError(t, err)
+
+				scope, ok := GetScopeContext(ctx)
+				require.True(t, ok)
+				require.Equal(t, "project-1", scope.ProjectID)
+				require.Equal(t, domain.AuthzPrincipalTypeUser, scope.PrincipalType)
+				require.Equal(t, "user-1", scope.PrincipalID)
+				if len(tc.scope) == 0 {
+					require.Empty(t, scope.Scope, "session tokens mint an empty Scope; the user skip must not depend on project.write")
+				} else {
+					require.Equal(t, tc.scope, scope.Scope)
+				}
+			})
 		}
-
-		mock := gomock.NewController(t)
-		tokenService := mocks.NewMockTokenService(mock)
-		tokenService.EXPECT().IntrospectToken(gomock.Any(), "raw-cookie").Return(token, nil)
-
-		handler := NewSecurityHandler(tokenService)
-		ctx, err := handler.HandleNextgenSession(t.Context(), api.GetMySessionOperation, api.NextgenSession{APIKey: "raw-cookie"})
-		require.NoError(t, err)
-
-		scope, ok := GetScopeContext(ctx)
-		require.True(t, ok)
-		require.Equal(t, "project-1", scope.ProjectID)
-		require.Equal(t, domain.AuthzPrincipalTypeUser, scope.PrincipalType)
-		require.Equal(t, "user-1", scope.PrincipalID)
 	})
 
 	t.Run("invalid token is an unsatisfied requirement", func(t *testing.T) {

--- a/internal/api/user_internal_test.go
+++ b/internal/api/user_internal_test.go
@@ -1,9 +1,17 @@
 package api
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
+	"go.uber.org/mock/gomock"
+
 	api "github.com/zitadel/nextgen/api/generated"
+	"github.com/zitadel/nextgen/internal/domain"
+	"github.com/zitadel/nextgen/internal/service"
+	servicemocks "github.com/zitadel/nextgen/internal/service/mocks"
 )
 
 // The membership gate on POST /users/query keys off this, so a field that reads
@@ -64,3 +72,132 @@ func TestMapQueryUsersToService_Expand(t *testing.T) {
 		})
 	}
 }
+
+func TestQueryUsers_SessionCaller(t *testing.T) {
+	userCtx := WithScopeContext(context.Background(), ScopeContext{
+		ProjectID:     "proj_home",
+		PrincipalType: domain.AuthzPrincipalTypeUser,
+		PrincipalID:   "user_alice",
+	})
+
+	t.Run("lists credential home", func(t *testing.T) {
+		users := &stubQueryUsersService{}
+		h := queryUsersHandler(t, true, true, users)
+		resp, err := h.QueryUsers(userCtx, &api.QueryUsersRequest{})
+		if err != nil {
+			t.Fatalf("session list: %v", err)
+		}
+		if _, ok := resp.(*api.QueryUsersResponse); !ok {
+			t.Fatalf("got %T, want QueryUsersResponse", resp)
+		}
+		if len(users.listProjectIDs) != 1 || users.listProjectIDs[0] != "proj_home" {
+			t.Fatalf("ListUsers projects = %v, want [proj_home]", users.listProjectIDs)
+		}
+	})
+
+	t.Run("no foothold is not found", func(t *testing.T) {
+		users := &stubQueryUsersService{}
+		h := queryUsersHandler(t, false, false, users)
+		_, err := h.QueryUsers(userCtx, &api.QueryUsersRequest{})
+		assertDomainCode(t, err, domain.ErrUserNotFound().Code)
+		if len(users.listProjectIDs) != 0 {
+			t.Fatalf("ListUsers must not run before Check, got %v", users.listProjectIDs)
+		}
+	})
+
+	t.Run("expand and membership filter still need read scopes", func(t *testing.T) {
+		tests := []struct {
+			name string
+			req  *api.QueryUsersRequest
+			want string
+		}{
+			{
+				name: "expand teams",
+				req:  &api.QueryUsersRequest{Expand: []api.UserExpand{api.UserExpandTeams}},
+				want: "team_membership.read",
+			},
+			{
+				name: "team_id filter",
+				req: &api.QueryUsersRequest{Filter: []api.QueryUsersRequestFilterItem{{
+					Field: api.UserFilterFieldTeamID,
+				}}},
+				want: "team_membership.read",
+			},
+			{
+				name: "expand owner team",
+				req:  &api.QueryUsersRequest{Expand: []api.UserExpand{api.UserExpandLifecycleOwnerTeam}},
+				want: "team.read",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				users := &stubQueryUsersService{}
+				h := queryUsersHandler(t, true, true, users)
+				_, err := h.QueryUsers(userCtx, tt.req)
+				assertDomainCode(t, err, domain.ErrUserPermissionDenied().Code)
+				var de domain.Error
+				if !errors.As(err, &de) {
+					t.Fatalf("error is not a domain.Error: %v", err)
+				}
+				if !strings.Contains(de.Message, tt.want) {
+					t.Fatalf("message %q does not name %q", de.Message, tt.want)
+				}
+				if len(users.listProjectIDs) != 0 {
+					t.Fatalf("ListUsers must not run after expand/filter deny, got %v", users.listProjectIDs)
+				}
+			})
+		}
+	})
+}
+
+func queryUsersHandler(t *testing.T, allowed, foothold bool, users *stubQueryUsersService) Handler {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	pool := servicemocks.NewMockPool(ctrl)
+	stmts := servicemocks.NewMockAllStatements(ctrl)
+	pool.EXPECT().Statements().Return(stmts).AnyTimes()
+	stmts.EXPECT().ActiveSystemCatalogID(gomock.Any()).Return(domain.SystemCatalogID, nil).AnyTimes()
+	stmts.EXPECT().CheckAuthz(gomock.Any(), gomock.Any()).Return(allowed, foothold, nil).AnyTimes()
+	if users == nil {
+		users = &stubQueryUsersService{}
+	}
+	return Handler{
+		pool:        service.NewPool(pool),
+		userService: users,
+	}
+}
+
+type stubQueryUsersService struct {
+	listProjectIDs []string
+}
+
+func (s *stubQueryUsersService) ApplyActions(context.Context, ...service.UserAction) error {
+	return errors.New("unexpected ApplyActions")
+}
+func (s *stubQueryUsersService) CreateUser(context.Context, service.CreateUserInput) (*domain.User, error) {
+	return nil, errors.New("unexpected CreateUser")
+}
+func (s *stubQueryUsersService) DeleteUser(context.Context, service.DeleteUserInput) error {
+	return errors.New("unexpected DeleteUser")
+}
+func (s *stubQueryUsersService) ListUsers(_ context.Context, input service.ListUsersInput) (*service.ListUsersOutput, error) {
+	s.listProjectIDs = append(s.listProjectIDs, input.ProjectID)
+	return &service.ListUsersOutput{}, nil
+}
+func (s *stubQueryUsersService) ListPasskeys(context.Context, service.ListPasskeysInput) ([]*domain.UserPasskey, string, error) {
+	return nil, "", errors.New("unexpected ListPasskeys")
+}
+func (s *stubQueryUsersService) ListUserTeams(context.Context, service.ListUserTeamsInput) (*service.ListUserTeamsOutput, error) {
+	return nil, errors.New("unexpected ListUserTeams")
+}
+func (s *stubQueryUsersService) GetUserByID(context.Context, service.GetUserInput) (*domain.User, error) {
+	return nil, errors.New("unexpected GetUserByID")
+}
+func (s *stubQueryUsersService) SetPassword(context.Context, service.SetPasswordInput) error {
+	return errors.New("unexpected SetPassword")
+}
+func (s *stubQueryUsersService) GetMyUser(context.Context, service.GetMyUserInput) (*domain.User, error) {
+	return nil, errors.New("unexpected GetMyUser")
+}
+
+var _ service.UserService = (*stubQueryUsersService)(nil)

--- a/internal/service/grant_test.go
+++ b/internal/service/grant_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ func TestGrantService_Create(t *testing.T) {
 	t.Parallel()
 
 	future := time.Now().Add(time.Hour)
+	past := time.Now().Add(-time.Minute)
 	userID := "user_grant01"
 	teamID := "team_grant01"
 
@@ -168,6 +170,70 @@ func TestGrantService_Create(t *testing.T) {
 			},
 			wantErr: domain.ErrGrantInvalid(),
 		},
+		{
+			name: "expires_at in the past",
+			input: service.CreateGrantInput{
+				ProjectID:     "proj_customer",
+				PrincipalType: domain.AuthzPrincipalTypeUser,
+				PrincipalID:   userID,
+				Relation:      "viewer",
+				ExpiresAt:     &past,
+			},
+			wantErr: domain.ErrGrantInvalid(),
+		},
+		{
+			name: "principal kind mismatch",
+			input: service.CreateGrantInput{
+				ProjectID:     "proj_customer",
+				PrincipalType: domain.AuthzPrincipalTypeUser,
+				PrincipalID:   userID,
+				Relation:      "viewer",
+			},
+			setupStmt: func(s *servicemocks.MockAllStatements) {
+				s.EXPECT().GetResourceScope(gomock.Any(), userID).Return(&domain.ResourceScope{
+					ResourceID:   userID,
+					ResourceKind: domain.ResourceKindTeam,
+					ProjectID:    grantPlatformProjID,
+				}, nil)
+			},
+			wantErr: domain.ErrGrantPrincipalNotFound(),
+		},
+		{
+			name: "principal home is not the platform project",
+			input: service.CreateGrantInput{
+				ProjectID:     "proj_customer",
+				PrincipalType: domain.AuthzPrincipalTypeUser,
+				PrincipalID:   userID,
+				Relation:      "viewer",
+			},
+			setupStmt: func(s *servicemocks.MockAllStatements) {
+				s.EXPECT().GetResourceScope(gomock.Any(), userID).Return(&domain.ResourceScope{
+					ResourceID:   userID,
+					ResourceKind: domain.ResourceKindUser,
+					ProjectID:    "proj_other",
+				}, nil)
+			},
+			wantErr: domain.ErrGrantPrincipalNotFound(),
+		},
+		{
+			name: "inactive team",
+			input: service.CreateGrantInput{
+				ProjectID:     "proj_customer",
+				PrincipalType: domain.AuthzPrincipalTypeTeam,
+				PrincipalID:   teamID,
+				Relation:      "editor",
+			},
+			setupStmt: func(s *servicemocks.MockAllStatements) {
+				s.EXPECT().GetResourceScope(gomock.Any(), teamID).Return(&domain.ResourceScope{
+					ResourceID:   teamID,
+					ResourceKind: domain.ResourceKindTeam,
+					ProjectID:    grantPlatformProjID,
+				}, nil)
+				s.EXPECT().GetTeam(gomock.Any(), gomock.Any()).
+					Return(nil, database.NewNoRowFoundError(nil))
+			},
+			wantErr: domain.ErrGrantPrincipalNotFound(),
+		},
 	}
 
 	for _, tc := range tests {
@@ -252,9 +318,7 @@ func TestGrantService_Create_EventUsesAssignmentProject(t *testing.T) {
 		Relation:      "viewer",
 	})
 	require.NoError(t, err)
-	require.NotNil(t, got)
-	assert.Equal(t, "proj_customer", got.ProjectID)
-	assert.Nil(t, got.TeamID)
+	assertManagedGrantEvent(t, got, domain.EventTypeAuthzGranted, "asgn_test01")
 }
 
 func TestGrantService_Get(t *testing.T) {
@@ -383,19 +447,24 @@ func TestGrantService_Revoke(t *testing.T) {
 
 	t.Run("ok emits authz.revoked", func(t *testing.T) {
 		t.Parallel()
-		var emitted domain.EventType
+		homeTeam := "team_home"
+		ctx := audit.WithActorContext(t.Context(), audit.ActorContext{
+			ProjectID: "proj_platform",
+			TeamID:    &homeTeam,
+		})
+		var got *domain.Event
 		svc := newMockedGrantService(t, grantPlatformProjID, func(s *servicemocks.MockAllStatements) {
 			s.EXPECT().GetAuthzAssignment(gomock.Any(), "proj_customer", "asgn_1").Return(
 				testManagedGrant("asgn_1", "user_grant01"), nil)
 			s.EXPECT().RevokeAuthzAssignment(gomock.Any(), "proj_customer", "asgn_1").Return(nil)
 			s.EXPECT().InsertEvent(gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ context.Context, e *domain.Event) error {
-					emitted = e.EventType
+					got = e
 					return nil
 				})
 		})
-		require.NoError(t, svc.Revoke(t.Context(), "proj_customer", "asgn_1"))
-		assert.Equal(t, domain.EventTypeAuthzRevoked, emitted)
+		require.NoError(t, svc.Revoke(ctx, "proj_customer", "asgn_1"))
+		assertManagedGrantEvent(t, got, domain.EventTypeAuthzRevoked, "asgn_1")
 	})
 
 	t.Run("already revoked is not found", func(t *testing.T) {
@@ -478,6 +547,27 @@ func testManagedGrant(id, principalID string) *domain.AuthzAssignment {
 		Relation:      "viewer",
 		ScopeKind:     domain.AuthzScopeKindProject,
 	}
+}
+
+func assertManagedGrantEvent(t *testing.T, got *domain.Event, typ domain.EventType, entityID string) {
+	t.Helper()
+	require.NotNil(t, got)
+	assert.Equal(t, typ, got.EventType)
+	assert.Equal(t, domain.EventCategoryAdmin, got.Category)
+	assert.Equal(t, "proj_customer", got.ProjectID)
+	assert.Nil(t, got.TeamID)
+	require.NotNil(t, got.EntityType)
+	assert.Equal(t, "authz_assignment", *got.EntityType)
+	require.NotNil(t, got.EntityID)
+	assert.Equal(t, entityID, *got.EntityID)
+
+	var payload domain.AuthzGrantedPayload
+	require.NoError(t, json.Unmarshal(got.Payload, &payload))
+	assert.Equal(t, domain.AuthzGrantedPayload{
+		PrincipalType: "user",
+		PrincipalID:   "user_grant01",
+		Relation:      "viewer",
+	}, payload)
 }
 
 func expectActiveUserPrincipal(s *servicemocks.MockAllStatements, userID string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Collapses the unique unit tests from #1157, #1159, #1173, and #1174 into one PR stacked on #1142. No production behavior changes.

### Risky behavior now covered

From #1157:

- `credentialCeiling` allow / anti-oracle complements (write-bearing secret with home; preview on a foreign project).
- Session cookies that carry `project.write` still mint a **user** principal, not `sk_proj`.
- Create rejects past `expires_at`, kind-mismatched principals, non-platform homes, and inactive teams.
- Grant error codes keep their HTTP shapes (`principal_not_found` → 404, `permission_denied` → 403).

From #1159:

- Grant create and revoke audit events stamp `authz_assignment` entity id plus `AuthzGranted`/`AuthzRevoked` payload on the assignment project, with empty `team_id`.
- `grant.permission_denied` copy stays credential-neutral.

From #1173:

- A Console session user who already passed project Check may `expand: ["principal"]` without `user.read` / `team.read`. Check still gates first (403 vs 404). The skip does not leak into users-query expand helpers.

From #1174:

- QueryUsers lists the credential home only. No foothold is `user.not_found` before `ListUsers`. Expand/filter still need `team_membership.read` / `team.read`.

Shared overlap resolved once:

- Dual-scheme grant create/get/delete/query and `POST /users/query` with an invalid `__nextgen_session` cookie stay the default `auth.unauthorized` copy, not the session-only rewrite.

### Test files added/updated

- `internal/api/authz_internal_test.go`
- `internal/api/error_handler_test.go`
- `internal/api/grant_internal_test.go`
- `internal/api/security_test.go`
- `internal/api/user_internal_test.go`
- `internal/service/grant_test.go`

### Why these tests materially reduce regression risk

These are permission, validation, audit, and dual-scheme 401 paths. A ceiling invert, a session minted as `sk_proj`, QueryGrants expand skip leaking into QueryUsers, or a dual-scheme 401 rewrite would leak credential type or access. #1142 stated those contracts; this PR locks the edges its happy-path tests left open.

Stacked on #1142 (`cursor/session-grant-principal-910a`); retarget after that merges. Replaces #1157, #1159, #1173, and #1174.

## Validation

- `gofmt -w` on the six test files — clean
- `node scripts/check-pr-title.mjs --title "test(api): cover grant and user-query session principal"` — ok
- `go test ./internal/api ./internal/service -count=1 -timeout 180s` — pass
- Focused `-run` of the new cases — pass

`moon run server:format` was not run (`moon` not on PATH); equivalent `gofmt -l` on the touched files was clean. Postgres/Spanner `TestGrantSessionCaller` / `TestQueryUsersSessionCaller` were not re-run. These additions are deterministic unit tests only.

## Release notes / changeset

- No changeset required — no shipped behavior changed.

## Notes

- Reviewer: @adlerhurst
- Does not change production code.
- Does not redo #1142 happy-path tests (`TestGrantSessionCaller`, `TestQueryUsersSessionCaller`).
- Does not include #1175 (that stays on #1117).
- Closes #1157, #1159, #1173, and #1174 as superseded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40f5de0c-dd23-4c7b-abf0-6d501293f0c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40f5de0c-dd23-4c7b-abf0-6d501293f0c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

