### PR TITLE
fix(console): one next step after a claim, and actionable copy when a session blocks it

### DIFF
--- a/.changeset/claim-followups.md
+++ b/.changeset/claim-followups.md
@@ -1,0 +1,11 @@
+---
+"@zitadel/server": patch
+---
+
+Say what a claimed project means, and what to do when an app session blocks the claim.
+
+The claim success screen offered two competing next steps; it now offers one, and states the outcome rather than the mechanics: your project is permanent, open the console. The claim-window badge disappears once the project is claimed, where a countdown no longer means anything.
+
+A developer who follows the CLI's own journey signs into the scaffolded app first, and that session then blocks the claim on the same address. The screen that follows named the deployment's missing platform project, which is not something they can act on; it now says the session belongs to another project and to sign out of the app and reopen the claim link.
+
+The console's theme switcher is icon-only, so its options carry tooltips — a monitor glyph reads as "display", not "follow the operating system".

--- a/apps/console/src/components/app-shell/AppShell.tsx
+++ b/apps/console/src/components/app-shell/AppShell.tsx
@@ -35,6 +35,8 @@ import type { NavGroup } from "../../nav";
 import { type ThemePreference, useTheme } from "../../theme";
 import { ContextSwitcher } from "./ContextSwitcher";
 import { ZitadelLogo } from "./icons";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
 import { useNavItems } from "./use-nav-items";
 
 /**
@@ -411,10 +413,13 @@ function ContextBar() {
   );
 }
 
-const THEME_OPTIONS: { value: ThemePreference; label: string; icon: typeof Sun }[] = [
-  { value: "light", label: "Light", icon: Sun },
-  { value: "dark", label: "Dark", icon: Moon },
-  { value: "system", label: "System", icon: Monitor },
+// `hint` is what the icon cannot say on its own — a monitor glyph reads as
+// "display", not "follow the operating system". The label stays the short
+// name so the radio's accessible name is not a sentence.
+const THEME_OPTIONS: { value: ThemePreference; label: string; hint: string; icon: typeof Sun }[] = [
+  { value: "light", label: "Light", hint: "Light theme", icon: Sun },
+  { value: "dark", label: "Dark", hint: "Dark theme", icon: Moon },
+  { value: "system", label: "System", hint: "Match system theme", icon: Monitor },
 ];
 
 function ThemeToggle() {
@@ -459,28 +464,33 @@ function ThemeToggle() {
       aria-label="Theme"
       className="hidden shrink-0 items-center gap-0.5 rounded-md border border-border p-0.5 sm:inline-flex"
     >
-      {THEME_OPTIONS.map(({ value, label, icon: Icon }, index) => {
+      {THEME_OPTIONS.map(({ value, label, hint, icon: Icon }, index) => {
         const active = preference === value;
         return (
-          <button
-            key={value}
-            ref={(node) => {
-              optionRefs.current[index] = node;
-            }}
-            type="button"
-            role="radio"
-            aria-checked={active}
-            aria-label={label}
-            title={label}
-            tabIndex={active ? 0 : -1}
-            onClick={() => setPreference(value)}
-            onKeyDown={(event) => onOptionKeyDown(event, index)}
-            className={`inline-flex size-7 items-center justify-center rounded-sm ${
-              active ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            <Icon size={15} aria-hidden />
-          </button>
+          <Tooltip key={value}>
+            <TooltipTrigger asChild>
+              <button
+                ref={(node) => {
+                  optionRefs.current[index] = node;
+                }}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                aria-label={label}
+                tabIndex={active ? 0 : -1}
+                onClick={() => setPreference(value)}
+                onKeyDown={(event) => onOptionKeyDown(event, index)}
+                className={`inline-flex size-7 items-center justify-center rounded-sm ${
+                  active
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                <Icon size={15} aria-hidden />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{hint}</TooltipContent>
+          </Tooltip>
         );
       })}
     </div>

--- a/apps/console/src/routes/claim/claim.spec.tsx
+++ b/apps/console/src/routes/claim/claim.spec.tsx
@@ -135,9 +135,10 @@ describe("claim page", () => {
     // The challenge is single-use (first-claim-wins): one visit must spend it
     // exactly once, whatever React re-renders happen around the effect.
     expect(bodies).toEqual([{ challenge_id: CHALLENGE_ID }]);
-    // The CLI is polling `claim/status`; the page says so instead of
-    // pretending the browser is the end of the story.
-    expect(screen.getByText(/terminal/i)).toBeInTheDocument();
+    // One next step, not two: the console is where the developer goes, and the
+    // CLI picks the claim up on its own without being told to.
+    expect(screen.getByRole("link", { name: "Open the console" })).toBeInTheDocument();
+    expect(screen.queryByText(/terminal/i)).not.toBeInTheDocument();
   });
 
   it("shows the owning team's dashboard when the project is already claimed", async () => {
@@ -267,7 +268,7 @@ describe("claim page", () => {
     await renderAt(CLAIM_PATH);
 
     expect(
-      await screen.findByRole("heading", { name: "Your session can't complete this claim" }),
+      await screen.findByRole("heading", { name: "This account can't claim the project" }),
     ).toBeInTheDocument();
     expect(screen.queryByTestId("zitadel-login")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
@@ -349,6 +350,19 @@ describe("claim window countdown", () => {
 
     // A read that only decorates must never gate the claim itself.
     expect(await screen.findByTestId("zitadel-login")).toBeInTheDocument();
+    expect(screen.queryByText(/^Expires in/)).not.toBeInTheDocument();
+  });
+
+  it("drops the badge once the project is claimed", async () => {
+    fetchSession.mockResolvedValue(makeTestSession());
+    stubWindow(9);
+    stubComplete(() =>
+      HttpResponse.json({ project_id: PROJECT_ID, team_id: "team_1", claimed_at: "2026-08-24T10:00:00Z" }),
+    );
+
+    await renderAt(CLAIM_PATH);
+
+    expect(await screen.findByText("Project claimed")).toBeInTheDocument();
     expect(screen.queryByText(/^Expires in/)).not.toBeInTheDocument();
   });
 

--- a/apps/console/src/routes/claim/index.tsx
+++ b/apps/console/src/routes/claim/index.tsx
@@ -147,8 +147,9 @@ function StateCard({ title, children }: { title: string; children: ReactNode }) 
  * It is about the *project*, not the link in the address bar: an unclaimed
  * project can be claimed for 14 days after it is created (ADR 046), while the
  * link itself lapses in minutes. Both can therefore be true at once — an
- * expired link with eleven days still on the window — which is why it renders
- * beside every outcome rather than instead of one.
+ * expired link with eleven days still on the window — so it renders beside a
+ * failed outcome rather than instead of one. A claimed project is the
+ * exception: nothing is left to count down, and `CompleteClaim` drops it.
  *
  * Days, not a ticking clock: the window is two weeks long, so a
  * second-by-second timer would be motion that never tells the reader anything.

--- a/apps/console/src/routes/claim/index.tsx
+++ b/apps/console/src/routes/claim/index.tsx
@@ -105,18 +105,17 @@ function ClaimScreen() {
         the spent-once state and show the previous outcome. The key remounts it
         instead, which resets the gate without weakening it.
       */}
+      {/*
+        No widget on this leg, so no trustmark row to slot into — the badge
+        stands under the outcome instead, which is why CompleteClaim renders
+        it: only the outcome knows whether a countdown still means anything.
+      */}
       <CompleteClaim
         key={`${project_id}:${challenge_id}`}
         projectId={project_id}
         challengeId={challenge_id}
+        window={window}
       />
-      {/*
-        No widget on this leg, so no trustmark row to slot into — the badge
-        stands under the outcome instead. It still belongs here: "your link
-        expired" and "the project has nine days left" are both true, and the
-        page has to say so.
-      */}
-      {window && <ClaimWindowBadge window={window} />}
     </ClaimShell>
   );
 }
@@ -259,7 +258,15 @@ function ClaimLogin({
  * re-renders and double-mounts, and only the explicit `Try again` button can
  * start another attempt.
  */
-function CompleteClaim({ projectId, challengeId }: { projectId: string; challengeId: string }) {
+function CompleteClaim({
+  projectId,
+  challengeId,
+  window,
+}: {
+  projectId: string;
+  challengeId: string;
+  window?: ClaimWindow;
+}) {
   const [outcome, setOutcome] = useState<ClaimOutcome | null>(null);
   const startedRef = useRef(false);
 
@@ -283,13 +290,31 @@ function CompleteClaim({ projectId, challengeId }: { projectId: string; challeng
     );
   }
 
+  // The window says how long is left to claim. Once the project is claimed —
+  // by this attempt or an earlier one — there is nothing left to count down,
+  // so the badge goes rather than contradicting the outcome above it.
+  const settled = outcome.kind === "claimed" || outcome.kind === "already_claimed";
+  const card = outcomeCard(outcome, run);
+  return (
+    <>
+      {card}
+      {window && !settled && <ClaimWindowBadge window={window} />}
+    </>
+  );
+}
+
+/**
+ * The screen for one completion outcome. Every branch is a state the contract
+ * enumerates (`claim/complete` in the OpenAPI source), not an exception.
+ */
+function outcomeCard(outcome: ClaimOutcome, run: () => void) {
   switch (outcome.kind) {
     case "claimed":
       return (
         <StateCard title="Project claimed">
           <p className={BODY_TEXT}>
-            The project now belongs to your personal team. You can return to your terminal — the CLI
-            picks the claim up on its own.
+            Your project is now permanent. Open the console to manage it and start collaborating
+            with your team.
           </p>
           <Button asChild className="mx-auto w-fit">
             <Link to="/">Open the console</Link>
@@ -349,19 +374,22 @@ function CompleteClaim({ projectId, challengeId }: { projectId: string; challeng
         </StateCard>
       );
     case "unauthenticated":
-      // NOT the sign-in widget again. The loader confirmed an active session
-      // moments ago, so this 401 is almost never a lost cookie — it is the
-      // server's deliberately opaque verdict for a session that cannot claim
-      // (most often: it does not belong to the platform project, e.g. a
-      // deployment running without `platform.bootstrap_project`, which is how
-      // the local testkit boots today). Re-running sign-in mints the same
-      // session and loops forever; an honest dead-end beats a treadmill.
+      // NOT the sign-in widget again: the server collapses "wrong project" and
+      // "no platform project" into one opaque 401, so the page cannot tell
+      // which it is, and re-running sign-in against the same project mints the
+      // same session. Signing out is what the developer can act on, and it is
+      // the common case — a session left over from the app they just scaffolded
+      // on this origin. Offering the account a choice is the account-picker
+      // story, not this screen.
       return (
-        <StateCard title="Your session can't complete this claim">
+        <StateCard title="This account can't claim the project">
           <p className={BODY_TEXT}>
-            The server did not accept the signed-in session for this claim. On a deployment without
-            a platform project, claims cannot complete; otherwise your session may have expired
-            mid-claim — reopen the link from your terminal and sign in again.
+            You are signed in with an account from a different project — most likely the app you
+            just set up, which shares this address.
+          </p>
+          <p className={BODY_TEXT}>
+            Sign out of that app, then reopen the claim link from your terminal to create an account
+            or sign in for this project.
           </p>
           <Button onClick={run} variant="outline" className="mx-auto w-fit">
             Try again

--- a/apps/console/src/routes/claim/index.tsx
+++ b/apps/console/src/routes/claim/index.tsx
@@ -384,12 +384,12 @@ function outcomeCard(outcome: ClaimOutcome, run: () => void) {
       return (
         <StateCard title="This account can't claim the project">
           <p className={BODY_TEXT}>
-            You are signed in with an account from a different project — most likely the app you
-            just set up, which shares this address.
+            The account you are signed in with belongs to a different project.
           </p>
           <p className={BODY_TEXT}>
-            Sign out of that app, then reopen the claim link from your terminal to create an account
-            or sign in for this project.
+            If you signed in to the app you just set up, sign out of it — it shares this address.
+            Then reopen the claim link from your terminal to create an account or sign in for this
+            project.
           </p>
           <Button onClick={run} variant="outline" className="mx-auto w-fit">
             Try again


### PR DESCRIPTION
## Summary

Round-2 QA follow-ups on the claim page, plus one console polish item. Copy and UI only; no contract or flow changes.

- **One next step after a claim.** The success screen pointed at the terminal and the console at once. It now states the outcome and offers the console alone: your project is permanent, open the console to manage it.
- **The window badge stops at the claim.** It kept counting down after the project became permanent. `CompleteClaim` now owns the badge so the outcome decides whether a countdown still means anything.
- **Actionable copy when an app session blocks the claim.** A developer following the CLI's own journey signs into the scaffolded app first, and that session then blocks the claim on the same address. The screen named the deployment's missing platform project, which is not something they can act on. It now says the session belongs to another project, and to sign out of the app and reopen the claim link.
- **The theme switcher's options carry tooltips.** They are icons alone, and a monitor glyph reads as "display" rather than "follow the operating system".

## Validation

- `moon run console:typecheck`
- `pnpm --filter console test`
- `pnpm exec oxlint apps/console/src`

## Release notes / changeset

Changeset: `.changeset/claim-followups.md` — claim success copy, the badge stopping at the claim, actionable copy when a session blocks it, and theme-switcher tooltips. Lists `@zitadel/server`.

## Notes

**The 401 asserts one of two causes.** The server collapses "session belongs to another project" and "deployment has no platform project" into one opaque verdict, so the page cannot distinguish them. The copy now names the first, because it is the one a developer reaches by following the documented journey and the only one they can act on. On a deployment with no platform project the text is wrong, but the old copy covered both and was unreadable for it.

**The account picker is deliberately not here.** Letting the developer keep the current account or switch is the right answer and is its own story — it went to design review rather than into this PR. This is the fallback QA asked for in the meantime: say what happened and what to do.

**Not in scope, and owned elsewhere:** the CLI copy blocks from the same QA round, the setup summary naming the wrong SDK package, and the console project-secret error (#1022/#1023). The Teams landing that QA also asked for is in #1167.
