### PR TITLE
feat(console): add a dev loop for the claim page

### DIFF
--- a/apps/console/AGENTS.md
+++ b/apps/console/AGENTS.md
@@ -80,11 +80,42 @@ rule).
 
 ```sh
 moon run console:dev-real   # seeded real backend + dev server (default loop)
+moon run console:dev-claim  # same, but for the claim page (see below)
 moon run console:dev        # dev server only on http://localhost:5174
 moon run console:typecheck
 moon run console:test
 moon run console:build
 ```
+
+## The claim page needs `dev-claim`, not `dev-real`
+
+`dev-real` boots one ordinary project and signs the console into it. The claim
+page is the console acting as the *platform's* claim surface, and
+`claim/complete` only accepts a session belonging to the platform project — so
+on `dev-real` the page renders but the claim always fails with "This account
+can't claim the project". That is the harness, not a defect.
+
+`moon run console:dev-claim` boots the platform project, pins the console to it,
+and prints a ready claim link. The trade-off is why it is opt-in: pinning the
+console to `proj_platform` changes the standalone semantics the demo and
+embedded suites rely on, and the seeded users live in the project being claimed
+rather than the platform one, so list screens read empty and you register on the
+claim page instead of signing in with the seeded credentials.
+
+Three things that break either loop before it starts, none of which say so
+clearly:
+
+- **Build the CLI first** (`moon run cli:build`). Both loops shell out to it to
+  start the server; without a built bundle the server starts unmigrated and dies
+  with `no such table: projects`.
+- **Reinstall after a rebase** (`pnpm install`). A stale `node_modules` fails the
+  built CLI on a missing transitive dependency, not on anything you changed.
+- **A raw binary needs `--migrate`.** Migrations are opt-in since #1152; the CLI
+  passes the flag for you, so this only bites when launching `dist/server/nextgen`
+  by hand.
+
+`CONSOLE_DEV_ORIGIN` sets the console's port for both loops, so a second worktree
+can run beside the first.
 
 ## Develop against real data, not the mock
 

--- a/apps/console/moon.yml
+++ b/apps/console/moon.yml
@@ -67,6 +67,16 @@ tasks:
       persistent: true
       runInCI: false
 
+  # The claim page is the console acting as the *platform's* claim surface, not
+  # as a project's admin console, so it needs the platform project that
+  # `dev-real` deliberately does not boot. Opt-in for that one screen; every
+  # other screen is better served by `dev-real`.
+  dev-claim:
+    command: "corepack pnpm run dev:claim"
+    options:
+      persistent: true
+      runInCI: false
+
   preview:
     command: "corepack pnpm run preview"
     deps:

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -8,7 +8,8 @@
     "preview": "vite preview --host 0.0.0.0",
     "typecheck": "tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.spec.json",
     "test": "vitest run",
-    "dev:real": "tsx --conditions=@zitadel/source scripts/dev-real.mts"
+    "dev:real": "tsx --conditions=@zitadel/source scripts/dev-real.mts",
+    "dev:claim": "tsx --conditions=@zitadel/source scripts/dev-real.mts --claim"
   },
   "dependencies": {
     "@fontsource/arimo": "catalog:",

--- a/apps/console/scripts/dev-real.mts
+++ b/apps/console/scripts/dev-real.mts
@@ -193,13 +193,17 @@ async function mintClaimUrl(): Promise<string | null> {
       method: "POST",
       headers: { authorization: `Bearer ${projectSecret}`, "content-type": "application/json" },
       body: "{}",
+      // A hung endpoint must not hold the dev server hostage for a
+      // convenience link.
+      signal: AbortSignal.timeout(5_000),
     });
     if (!response.ok) return null;
     const { challenge_id } = (await response.json()) as { challenge_id?: string };
     if (!challenge_id) return null;
     // The server builds claim_url from its configured console base, which is
     // not this dev server; rebuild it against the origin actually being served.
-    return `${consoleOrigin}/claim?challenge_id=${challenge_id}&project_id=${projectId}`;
+    const query = new URLSearchParams({ challenge_id, project_id: projectId });
+    return `${consoleOrigin}/claim?${query.toString()}`;
   } catch {
     return null;
   }
@@ -258,9 +262,11 @@ if (seedOnly) {
 } else {
   // `--port` from the origin: everything else here honours CONSOLE_DEV_ORIGIN,
   // and without this vite stays pinned to its config's 5174 and a second
-  // worktree collides with the first.
+  // worktree collides with the first. Passed to the `dev` script rather than
+  // around it, so future flags on that script still apply here. No `--`
+  // separator: pnpm swallows the args with one and vite never sees them.
   const consolePort = new URL(consoleOrigin).port;
-  const viteArgs = ["pnpm", "--filter", "@zitadel/console", "exec", "vite"];
+  const viteArgs = ["pnpm", "--filter", "@zitadel/console", "dev"];
   if (consolePort) viteArgs.push("--port", consolePort);
   const vite = spawn("corepack", viteArgs, {
     cwd: workspaceRoot,

--- a/apps/console/scripts/dev-real.mts
+++ b/apps/console/scripts/dev-real.mts
@@ -49,6 +49,24 @@ const configuredServerBinary = process.env.ZITADEL_SERVER_BINARY;
 const serverBinary =
   configuredServerBinary || join(workspaceRoot, "dist", "server", "nextgen");
 const seedOnly = process.argv.includes("--seed-only");
+/**
+ * Claim mode boots the deployment's *platform* project and points the console
+ * at it, which is what `claim/complete` authenticates against — without it the
+ * claim page can render but never finish, because the console's session belongs
+ * to the seeded project instead. Opt-in, not the default: pinning the console
+ * to `proj_platform` is exactly the standalone-semantics change the demo and
+ * embedded suites must not see (see `cli-journey-e2e/scripts/run-local.mjs`).
+ */
+const claimMode = process.argv.includes("--claim");
+
+/** The well-known platform project id (`domain.PlatformProjectID`). */
+const PLATFORM_PROJECT_ID = "proj_platform";
+
+if (claimMode) {
+  // Read by the server through the CLI's `start`, which inherits this process's
+  // environment (`packages/testing/src/cli.ts` merges `process.env`).
+  process.env["NEXTGEN_PLATFORM_BOOTSTRAP_PROJECT"] = "true";
+}
 
 /**
  * The account you sign in as. Fixed rather than random so the credentials stay
@@ -157,6 +175,38 @@ try {
 }
 
 const { baseUrl, projectId, projectSecret } = zitadel.handle;
+
+// Claim mode signs in against the platform project, because that is the only
+// session `claim/complete` accepts. The seeded users stay in the project being
+// claimed — they are its app's users, not the human doing the claiming, who
+// registers through the claim page itself.
+const consoleProjectId = claimMode ? PLATFORM_PROJECT_ID : projectId;
+
+/**
+ * A claim link for the seeded project, so claim mode lands on something
+ * openable instead of leaving the reader to mint one. Best-effort: a failure
+ * costs the link, not the instance.
+ */
+async function mintClaimUrl(): Promise<string | null> {
+  try {
+    const response = await fetch(`${baseUrl}/projects/${projectId}/claim/init`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${projectSecret}`, "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!response.ok) return null;
+    const { challenge_id } = (await response.json()) as { challenge_id?: string };
+    if (!challenge_id) return null;
+    // The server builds claim_url from its configured console base, which is
+    // not this dev server; rebuild it against the origin actually being served.
+    return `${consoleOrigin}/claim?challenge_id=${challenge_id}&project_id=${projectId}`;
+  } catch {
+    return null;
+  }
+}
+
+const claimUrl = claimMode ? await mintClaimUrl() : null;
+
 console.log(
   [
     "",
@@ -168,6 +218,18 @@ console.log(
     `  │  sign in at ${consoleOrigin}/login`,
     `  │    email     ${DEV_USER.email}`,
     `  │    password  ${DEV_USER.password}`,
+    ...(claimMode
+      ? [
+          "  │",
+          `  │  claim mode: console is pinned to ${PLATFORM_PROJECT_ID}, so the`,
+          "  │  seeded credentials above do not exist there — register on the",
+          "  │  claim page instead. List screens will look empty; that is the",
+          "  │  platform project, not the seeded one.",
+          ...(claimUrl
+            ? ["  │", `  │  claim       ${claimUrl}`]
+            : ["  │", "  │  claim       could not mint a link; see claim/init"]),
+        ]
+      : []),
     "  └───────────────────────────────────────────────────────────",
     "",
   ].join("\n"),
@@ -194,14 +256,20 @@ if (seedOnly) {
     /* keep the event loop alive */
   }, 60_000);
 } else {
-  const vite = spawn("corepack", ["pnpm", "--filter", "@zitadel/console", "dev"], {
+  // `--port` from the origin: everything else here honours CONSOLE_DEV_ORIGIN,
+  // and without this vite stays pinned to its config's 5174 and a second
+  // worktree collides with the first.
+  const consolePort = new URL(consoleOrigin).port;
+  const viteArgs = ["pnpm", "--filter", "@zitadel/console", "exec", "vite"];
+  if (consolePort) viteArgs.push("--port", consolePort);
+  const vite = spawn("corepack", viteArgs, {
     cwd: workspaceRoot,
     stdio: "inherit",
     env: {
       ...process.env,
       CONSOLE_BACKEND_URL: baseUrl,
       CONSOLE_PROJECT_SECRET: projectSecret,
-      VITE_CONSOLE_PROJECT_ID: projectId,
+      VITE_CONSOLE_PROJECT_ID: consoleProjectId,
     },
   });
   vite.on("exit", (code) => void shutdown(code ?? 0));


### PR DESCRIPTION
## Summary

`moon run console:dev-claim` — a dev loop for the claim page, which `dev-real` structurally cannot serve.

`dev-real` boots one ordinary project and signs the console into it. The claim page is the console acting as the *platform's* claim surface, and `claim/complete` only accepts a session belonging to the platform project, so on `dev-real` the page renders and the claim always fails with "This account can't claim the project" — a harness limit that reads like a product defect. Working on that page today means booting the server by hand.

`dev-claim` boots the platform project, pins the console to it, and prints a ready claim link.

Opt-in rather than the default, for the reason `cli-journey-e2e/scripts/run-local.mjs` already records: pinning the console to `proj_platform` changes the standalone semantics the demo and embedded suites prove. The seeded users also stay in the project being claimed, so list screens read empty in this mode and you register through the claim page — which is the real journey anyway. Every other screen is still better served by `dev-real`.

Two things came along with it:

- **Vite takes its port from `CONSOLE_DEV_ORIGIN`.** The rest of the script already honours that variable; vite alone stayed pinned to its config's 5174, so a second worktree could not run beside the first without editing a checked-in file.
- **`apps/console/AGENTS.md`** gains the claim-loop section and three traps that break either loop before it starts, none of which say so clearly: the CLI must be built first (an unbuilt one starts the server unmigrated and dies with `no such table: projects`), a stale `node_modules` after a rebase fails the built CLI on a missing transitive dependency, and a raw `dist/server/nextgen` needs `--migrate` since #1152.

## Validation

- `moon run console:dev-claim` — booted, platform project pinned, link minted and resolvable through `claim/window`
- `moon run console:typecheck`
- `pnpm --filter console test`
- `pnpm exec oxlint apps/console` (2 warnings, both pre-existing)

## Release notes / changeset

No changeset required — no shipped behavior changed. Developer tooling and docs only.

## Notes

Prompted by round-2 QA on the claim flow: verifying those fixes by hand needed a server booted by hand, and the first attempt failed on each of the three traps above in turn.
