### PR TITLE
build: fail fast on a stale pnpm install in the CLI dev wrapper

### DIFF
--- a/apps/cli/tests/unit/scripts/run-cli.test.ts
+++ b/apps/cli/tests/unit/scripts/run-cli.test.ts
@@ -1,12 +1,17 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 type RunCliModule = {
+  assertFreshInstall: (
+    root?: string,
+    statFn?: (path: string) => Promise<{ mtimeMs: number }>,
+  ) => Promise<void>;
   cliCwdFor: (env?: Record<string, string | undefined>, fallback?: string) => string;
   commandName: (args: string[]) => string | undefined;
   main: (options: {
     args?: string[];
     cwd?: string;
     env?: Record<string, string | undefined>;
+    assertFreshInstall?: () => Promise<void>;
     buildCli?: (options: { env: Record<string, string | undefined> }) => Promise<void>;
     buildLocalServerBinary?: (options: {
       env: Record<string, string | undefined>;
@@ -135,6 +140,47 @@ describe("run-cli wrapper", () => {
     ).toBe(false);
   });
 
+  it("flags a stale or missing install and stays quiet on a fresh one", async () => {
+    const statFor = (mtimes: Record<string, number>) => async (path: string) => {
+      const mtimeMs = mtimes[path];
+      if (mtimeMs === undefined) {
+        throw new Error(`ENOENT: ${path}`);
+      }
+      return { mtimeMs };
+    };
+    const lockfile = "/repo/pnpm-lock.yaml";
+    const installed = "/repo/node_modules/.pnpm/lock.yaml";
+    const remedy = "corepack pnpm install --frozen-lockfile";
+
+    await expect(
+      runCli.assertFreshInstall("/repo", statFor({ [lockfile]: 2000, [installed]: 1000 })),
+    ).rejects.toThrow(remedy);
+    await expect(
+      runCli.assertFreshInstall("/repo", statFor({ [lockfile]: 2000 })),
+    ).rejects.toThrow(remedy);
+    await expect(
+      runCli.assertFreshInstall("/repo", statFor({ [lockfile]: 2000, [installed]: 2000 })),
+    ).resolves.toBeUndefined();
+    await expect(runCli.assertFreshInstall("/repo", statFor({}))).resolves.toBeUndefined();
+  });
+
+  it("fails before building anything when the install is stale", async () => {
+    const buildCli = vi.fn(noop);
+
+    await expect(
+      runCli.main({
+        args: ["doctor"],
+        env: { PATH: "/bin" },
+        assertFreshInstall: async () => {
+          throw new Error("Run: corepack pnpm install --frozen-lockfile");
+        },
+        buildCli,
+        run: vi.fn(noop),
+      }),
+    ).rejects.toThrow("corepack pnpm install --frozen-lockfile");
+    expect(buildCli).not.toHaveBeenCalled();
+  });
+
   it("builds and injects a local server binary for the default binary start runtime", async () => {
     const calls: string[] = [];
     const env = { PATH: "/bin" };
@@ -143,6 +189,7 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["start"],
       env,
+      assertFreshInstall: noop,
       buildCli: async (options) => {
         calls.push("build-cli");
         expect(options.env).toBe(env);
@@ -185,6 +232,7 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["start", "--runtime", "docker"],
       env,
+      assertFreshInstall: noop,
       buildCli: async (options) => {
         calls.push("build-cli");
         expect(options.env).toBe(env);
@@ -226,6 +274,7 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["start", "--image", "custom:tag"],
       env: { PATH: "/bin" },
+      assertFreshInstall: noop,
       buildCli: vi.fn(noop),
       buildLocalServerBinary,
       buildLocalRuntimeImage,
@@ -249,6 +298,7 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["start"],
       env: { PATH: "/bin", ZITADEL_LOCAL_IMAGE: "custom:tag" },
+      assertFreshInstall: noop,
       buildCli: vi.fn(noop),
       buildLocalServerBinary,
       buildLocalRuntimeImage,
@@ -271,6 +321,7 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["start", "--runtime", "binary"],
       env: { PATH: "/bin", ZITADEL_SERVER_BINARY: "/tmp/custom-nextgen" },
+      assertFreshInstall: noop,
       buildCli: vi.fn(noop),
       buildLocalServerBinary,
       buildLocalRuntimeImage: vi.fn(noop),
@@ -291,6 +342,7 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["start", "--dry-run"],
       env: { PATH: "/bin" },
+      assertFreshInstall: noop,
       buildCli: vi.fn(noop),
       buildLocalServerBinary,
       buildLocalRuntimeImage: vi.fn(noop),
@@ -310,6 +362,7 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["doctor"],
       env: { PATH: "/bin" },
+      assertFreshInstall: noop,
       buildCli: vi.fn(noop),
       buildLocalServerBinary,
       buildLocalRuntimeImage,
@@ -326,6 +379,7 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["setup", "--server", "local", "--skip-install"],
       env: { INIT_CWD: "/tmp/myapp", PATH: "/bin" },
+      assertFreshInstall: noop,
       buildCli: vi.fn(noop),
       buildLocalRuntimeImage: vi.fn(noop),
       run,
@@ -362,6 +416,7 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["setup", "--server", "local"],
       env: { INIT_CWD: "/tmp/myapp", PATH: "/bin" },
+      assertFreshInstall: noop,
       buildCli: vi.fn(noop),
       buildLocalRuntimeImage: vi.fn(noop),
       prepareLocalRegistry,
@@ -399,6 +454,7 @@ describe("run-cli wrapper", () => {
     await runCli.main({
       args: ["setup", "--server", "local", "--json"],
       env: { INIT_CWD: "/tmp/myapp", PATH: "/bin" },
+      assertFreshInstall: noop,
       buildCli: vi.fn(noop),
       buildLocalRuntimeImage: vi.fn(noop),
       prepareLocalRegistry,

--- a/apps/cli/tests/unit/scripts/run-cli.test.ts
+++ b/apps/cli/tests/unit/scripts/run-cli.test.ts
@@ -144,7 +144,7 @@ describe("run-cli wrapper", () => {
     const statFor = (mtimes: Record<string, number>) => async (path: string) => {
       const mtimeMs = mtimes[path];
       if (mtimeMs === undefined) {
-        throw new Error(`ENOENT: ${path}`);
+        throw Object.assign(new Error(`ENOENT: ${path}`), { code: "ENOENT" });
       }
       return { mtimeMs };
     };
@@ -162,6 +162,11 @@ describe("run-cli wrapper", () => {
       runCli.assertFreshInstall("/repo", statFor({ [lockfile]: 2000, [installed]: 2000 })),
     ).resolves.toBeUndefined();
     await expect(runCli.assertFreshInstall("/repo", statFor({}))).resolves.toBeUndefined();
+    await expect(
+      runCli.assertFreshInstall("/repo", async () => {
+        throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      }),
+    ).rejects.toThrow("EACCES");
   });
 
   it("fails before building anything when the install is stale", async () => {

--- a/scripts/run-cli.mjs
+++ b/scripts/run-cli.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import { stat } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,6 +24,7 @@ export async function main(options = {}) {
   const args = options.args ?? forwardedArgs();
   const env = options.env ?? process.env;
   const runFn = options.run ?? run;
+  const assertFreshInstallFn = options.assertFreshInstall ?? assertFreshInstall;
   const runCaptureFn = options.runCapture ?? runCapture;
   const buildCliFn = options.buildCli ?? buildCli;
   const buildLocalServerBinaryFn = options.buildLocalServerBinary ?? buildLocalServerBinary;
@@ -34,6 +36,7 @@ export async function main(options = {}) {
   const cliCwd = options.cwd ?? cliCwdFor(env);
   let registryProcess;
 
+  await assertFreshInstallFn();
   await buildCliFn({ env });
 
   if (shouldUseLocalServerBinary(args, env)) {
@@ -77,6 +80,26 @@ export async function main(options = {}) {
     if (registryProcess) {
       await stopLocalRegistryFn(registryProcess);
     }
+  }
+}
+
+// A stale install (lockfile changed since the last `pnpm install`) makes the
+// task chain behind every CLI command fail deep inside cli:test with
+// misleading module-resolution errors, so fail fast with the remedy instead.
+// mtime is a heuristic: a branch switch can rewrite an unchanged lockfile and
+// report stale, but the remedy is then a fast no-op install.
+export async function assertFreshInstall(root = repoRoot, statFn = stat) {
+  const lockfile = await statFn(join(root, "pnpm-lock.yaml")).catch(() => undefined);
+  if (!lockfile) {
+    return;
+  }
+  const installed = await statFn(join(root, "node_modules", ".pnpm", "lock.yaml")).catch(
+    () => undefined,
+  );
+  if (!installed || installed.mtimeMs < lockfile.mtimeMs) {
+    throw new Error(
+      "workspace dependencies are missing or older than pnpm-lock.yaml. Run: corepack pnpm install --frozen-lockfile",
+    );
   }
 }
 

--- a/scripts/run-cli.mjs
+++ b/scripts/run-cli.mjs
@@ -89,13 +89,23 @@ export async function main(options = {}) {
 // mtime is a heuristic: a branch switch can rewrite an unchanged lockfile and
 // report stale, but the remedy is then a fast no-op install.
 export async function assertFreshInstall(root = repoRoot, statFn = stat) {
-  const lockfile = await statFn(join(root, "pnpm-lock.yaml")).catch(() => undefined);
+  // Only "not there" counts as missing; EACCES and friends are real problems
+  // the guard must not silently shrug off.
+  const statIfExists = async (path) => {
+    try {
+      return await statFn(path);
+    } catch (error) {
+      if (error?.code === "ENOENT" || error?.code === "ENOTDIR") {
+        return undefined;
+      }
+      throw error;
+    }
+  };
+  const lockfile = await statIfExists(join(root, "pnpm-lock.yaml"));
   if (!lockfile) {
     return;
   }
-  const installed = await statFn(join(root, "node_modules", ".pnpm", "lock.yaml")).catch(
-    () => undefined,
-  );
+  const installed = await statIfExists(join(root, "node_modules", ".pnpm", "lock.yaml"));
   if (!installed || installed.mtimeMs < lockfile.mtimeMs) {
     throw new Error(
       "workspace dependencies are missing or older than pnpm-lock.yaml. Run: corepack pnpm install --frozen-lockfile",


### PR DESCRIPTION
## Summary

Running the onboarding journey (`moon run workspace:cli -- setup ...`) from a checkout whose `node_modules` predate the current `pnpm-lock.yaml` fails deep inside the setup task chain: `release:pack` runs `cli:test`, where suites fail to load newly added dependencies and every test that spawns the built CLI exits 127 (tsdown keeps deps external, so oclif treats the unloadable command module as unknown and hides it). Concretely: #1147 added `wrap-ansi` to `apps/cli`, and a checkout installed before that commit produced ~40 misleading test failures instead of one actionable message.

This adds a fail-fast guard at the choke point every `workspace:cli` invocation flows through:

- `scripts/run-cli.mjs`: new `assertFreshInstall()` runs at the top of `main()`. If `node_modules/.pnpm/lock.yaml` is missing or older (mtime) than `pnpm-lock.yaml`, it throws with the same remedy line the workspace doctor uses: `Run: corepack pnpm install --frozen-lockfile`. The mtime comparison is a heuristic (a branch switch can rewrite an unchanged lockfile and report stale), but the remedy is then a fast no-op install.
- Injectable via the options object, matching the existing `buildCli` pattern.

The workspace doctor already fails when dependencies are not installed at all, but nothing guarded "installed but stale", and moon's native auto-install (`pipeline.installDependencies`) was deliberately disabled in #305.

## Validation

- `moon run cli:test` green (1125 tests, including the new guard coverage in `apps/cli/tests/unit/scripts/run-cli.test.ts`)
- `moon run cli:lint` and `moon run workspace:test` green
- Pointed `assertFreshInstall` at a real stale checkout (installed Aug 28, lockfile from Sep 7): rejects with the remedy; passes on a freshly installed worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnnpUjDZy9iom5aojj7AaT