### PR TITLE
docs: drop Figma node ids and file keys from source comments

### DIFF
--- a/apps/console/src/components/add-user-sheet.spec.tsx
+++ b/apps/console/src/components/add-user-sheet.spec.tsx
@@ -338,7 +338,7 @@ describe("add user sheet", () => {
   // });
 
   it("marks fields the schema does not require, and leaves required ones unmarked", async () => {
-    // `Optional` (`27843:10611`) sits beside the label, driven by the schema's
+    // `Optional` sits beside the label, driven by the schema's
     // `required` array rather than by which fields the design happens to mark.
     stubSchemas({ sch_business: BUSINESS });
     await openSheet();

--- a/apps/console/src/components/add-user-sheet.tsx
+++ b/apps/console/src/components/add-user-sheet.tsx
@@ -59,14 +59,14 @@ const BODY = "flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-6";
 const SECTION = "flex flex-col gap-4";
 const LABEL = "font-serif text-sm leading-5 font-normal text-foreground";
 // The design wraps the label in a row so a marker can sit beside it
-// (`27843:12281`), rather than appending to the label text itself.
+//, rather than appending to the label text itself.
 const LABEL_ROW = "flex w-full items-center gap-2";
 // The footer sits on the page background rather than a raised surface so
-// scrolling body content passes under it (Figma annotation on `727:63415`).
+// scrolling body content passes under it.
 const FOOTER = "flex-row items-center justify-end gap-3 bg-background px-6 py-4";
 
 /**
- * The Add user drawer (Figma `641:13005` — "User creation: drawer").
+ * The Add user drawer ("User creation: drawer").
  *
  * The form is **schema-driven**: `POST /users` takes an `attributes` object
  * validated against the user schema named in `schema`, so the controls below are

--- a/apps/console/src/components/add-user-sheet.tsx
+++ b/apps/console/src/components/add-user-sheet.tsx
@@ -58,15 +58,15 @@ const TITLE = "font-serif text-xl leading-none font-normal";
 const BODY = "flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-6";
 const SECTION = "flex flex-col gap-4";
 const LABEL = "font-serif text-sm leading-5 font-normal text-foreground";
-// The design wraps the label in a row so a marker can sit beside it
-//, rather than appending to the label text itself.
+// The design wraps the label in a row so a marker can sit beside it, rather
+// than appending to the label text itself.
 const LABEL_ROW = "flex w-full items-center gap-2";
 // The footer sits on the page background rather than a raised surface so
 // scrolling body content passes under it.
 const FOOTER = "flex-row items-center justify-end gap-3 bg-background px-6 py-4";
 
 /**
- * The Add user drawer ("User creation: drawer").
+ * The Add user drawer.
  *
  * The form is **schema-driven**: `POST /users` takes an `attributes` object
  * validated against the user schema named in `schema`, so the controls below are

--- a/apps/console/src/components/delete-user-dialog.tsx
+++ b/apps/console/src/components/delete-user-dialog.tsx
@@ -23,7 +23,7 @@ import { describeError } from "../lib/api-error";
 
 /**
  * The word the operator has to type before the action unlocks. Compared
- * case-sensitively: the design (`656:49130`) renders it uppercase, and a
+ * case-sensitively: the design renders it uppercase, and a
  * confirmation step that accepts "delete" is not the barrier it appears to be.
  */
 const CONFIRM_WORD = "DELETE";
@@ -52,7 +52,7 @@ const CONFIRM_LABEL = "font-serif text-sm leading-5 font-normal text-foreground"
 const FOOTER = "flex-row items-center justify-end gap-2 px-6 pb-6";
 
 /**
- * The delete-user confirmation dialog (Figma `656:49130`).
+ * The delete-user confirmation dialog.
  *
  * **The copy is literally true.** `DELETE /users/{user_id}` is a hard delete:
  * the service removes the user's memberships and the user row in one

--- a/apps/console/src/components/project-access.tsx
+++ b/apps/console/src/components/project-access.tsx
@@ -41,7 +41,7 @@ const SMALL = "h-8 gap-1 px-2.5 text-xs";
 
 /**
  * The "Projects (optional)" block from the Add user drawer
- * (Figma `702:3993` — the three annotated states).
+ * (the three annotated states).
  *
  * **`availableRoles` is empty in the app, by construction.** No endpoint serves a
  * role catalogue: ADR 034 places app roles in the app-group permission catalog,

--- a/apps/console/src/components/project-access.tsx
+++ b/apps/console/src/components/project-access.tsx
@@ -40,8 +40,8 @@ const ROLES_WIDTH = "min-w-0 flex-1";
 const SMALL = "h-8 gap-1 px-2.5 text-xs";
 
 /**
- * The "Projects (optional)" block from the Add user drawer
- * (the three annotated states).
+ * The "Projects (optional)" block from the Add user drawer, in its three
+ * annotated states.
  *
  * **`availableRoles` is empty in the app, by construction.** No endpoint serves a
  * role catalogue: ADR 034 places app roles in the app-group permission catalog,

--- a/apps/console/src/components/schema-fields-panel.tsx
+++ b/apps/console/src/components/schema-fields-panel.tsx
@@ -35,7 +35,7 @@ const ROOT_LABEL = "Schema";
  * needs it.
  *
  * The panel carries no timestamp: the design's `Last changed` line was removed
- * from both this component (`1389:8803`) and the drill-in frame, and the date a
+ * from both this component and the drill-in frame, and the date a
  * schema was created now lives on the list row instead.
  */
 export function SchemaFieldsPanel({ schema }: { schema: UserSchema }) {

--- a/apps/console/src/components/status-badge.tsx
+++ b/apps/console/src/components/status-badge.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
  * (`active`, `suspended`, `deactivated`, `pending_purge`) and teams (`active`,
  * `deactivated`).
  *
- * `Badge` is the design-system component (`26:169`) and already carries every
+ * `Badge` is the design-system component and already carries every
  * dimension of the pill — `h-5`, `gap-1`, `px-2 py-0.5`, `rounded-full`,
  * `text-xs font-medium` — so nothing here restates it. What the design adds is
  * the component's own left icon slot (`showLeftIcon`), filled with a dot rather

--- a/apps/console/src/components/ui/badge.tsx
+++ b/apps/console/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  // `h-5` is the design system's own Badge height (`26:169`), where the 1px
+  // `h-5` is the design system's own Badge height, where the 1px
   // border sits inside the 20px frame. Left to hug, the same padding and line
   // height render 22px.
   "inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",

--- a/apps/console/src/components/ui/button.tsx
+++ b/apps/console/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         // Tinted, not solid. The registry default is `bg-destructive text-white`,
-        // but the design system's `Variant=Destructive` (`786:5825`) is a
+        // but the design system's `Variant=Destructive` is a
         // destructive/10 fill with destructive text — dark mode lifts the fill to
         // /20 so it reads against the darker surface. Fixed here rather than at
         // the call site so the next destructive button inherits it.

--- a/apps/console/src/components/ui/combobox.tsx
+++ b/apps/console/src/components/ui/combobox.tsx
@@ -27,16 +27,16 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
  * instances on a screen mock — the mock wires `Select`-shaped triggers to
  * Combobox menus, so its trigger differs from the canonical one:
  *
- * - `Combobox / Item` (`430:4114`) — the trigger. `Type=Default | Multiple |
+ * - `Combobox / Item` — the trigger. `Type=Default | Multiple |
  *   Invalid` × `Default | Active | Focus | Disabled`. `h-9`, `gap-1.5`,
  *   `pl-2.5 pr-1 py-1`, `rounded-md`, `border-input`, `shadow-xs`,
  *   `bg-background dark:bg-input/30`; optional inline addon glyph at 50% opacity;
  *   trailing 24px box holding a 12px chevron.
- * - `Combobox / Combobox List` (`21473:103072`) — `rounded-lg`, `bg-popover`,
+ * - `Combobox / Combobox List` — `rounded-lg`, `bg-popover`,
  *   `shadow-md`, hairline in `foreground/10`.
- * - `Combobox / Menu Item` (`17379:199232`) — `Type=Simple` (32px, one line) and
+ * - `Combobox / Menu Item` — `Type=Simple` (32px, one line) and
  *   `Type=Custom` (48px, label over description).
- * - `Multiple Selection Item` (`21180:30054`) — the removable chip.
+ * - `Multiple Selection Item` — the removable chip.
  */
 
 const TRIGGER_BASE =

--- a/apps/console/src/components/ui/inline-code.tsx
+++ b/apps/console/src/components/ui/inline-code.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils"
 
 /**
- * `Typography / InlineCode` (`1389:9783`) — shadcn's inline-code treatment.
+ * `Typography / InlineCode` — shadcn's inline-code treatment.
  *
  * A `muted` fill with mono 12/16 on `foreground`, at the design's own 4.8/3.2px
  * inset. Used for the schema attribute chips and for the `zitadel apply` hint

--- a/apps/console/src/components/ui/meta-item.tsx
+++ b/apps/console/src/components/ui/meta-item.tsx
@@ -4,9 +4,9 @@ import { cn } from "@/lib/utils"
  * `MetaItem` — the small uppercase annotation that sits beside a label.
  *
  * One component in the design system, instanced under two names: `Optional` in
- * the `Field` label row and `MetaItem` beside a section heading
- *. Both resolve to the same inner text node, so this
- * is deliberately a single implementation rather than a copy per call site.
+ * the `Field` label row and `MetaItem` beside a section heading. Both resolve to
+ * the same inner text node, so this is deliberately a single implementation
+ * rather than a copy per call site.
  *
  * Arimo Medium 10/15, `0.4px` tracking, `muted-foreground`. Uppercased in CSS
  * rather than in the string so the accessible name and any copied text stay

--- a/apps/console/src/components/ui/meta-item.tsx
+++ b/apps/console/src/components/ui/meta-item.tsx
@@ -4,8 +4,8 @@ import { cn } from "@/lib/utils"
  * `MetaItem` — the small uppercase annotation that sits beside a label.
  *
  * One component in the design system, instanced under two names: `Optional` in
- * the `Field` label row (`27843:10611`) and `MetaItem` beside a section heading
- * (`914:602746`). Both resolve to the same inner text node (`525:3872`), so this
+ * the `Field` label row and `MetaItem` beside a section heading
+ *. Both resolve to the same inner text node, so this
  * is deliberately a single implementation rather than a copy per call site.
  *
  * Arimo Medium 10/15, `0.4px` tracking, `muted-foreground`. Uppercased in CSS

--- a/apps/console/src/lib/schema.ts
+++ b/apps/console/src/lib/schema.ts
@@ -84,7 +84,7 @@ export function schemaFields(schema: UserSchema): SchemaField[] {
  * The columns the users table shows, unioned across every schema the loaded
  * users actually reference.
  *
- * The design (`277:288291`) has no fixed column set: its `Filled` variant lists
+ * The design has no fixed column set: its `Filled` variant lists
  * Given name / Family name / Company name / Email while `Minimal` lists only
  * Email, because the user model is `additionalProperties: true` keyed on
  * `schema`. The design decisions log (D4) settles what to show — every

--- a/apps/console/src/routes/_authed/schemas/$schemaId.tsx
+++ b/apps/console/src/routes/_authed/schemas/$schemaId.tsx
@@ -27,7 +27,7 @@ function SchemaDetail() {
   return (
     <div className="px-4 pt-9 pb-8 sm:px-8">
       <Card className="gap-4 border-foreground/10 px-6 py-5 shadow-xs">
-        {/* The `Title` lockup (`1389:190643`): icon tile + eyebrow + title.
+        {/* The `Title` lockup: icon tile + eyebrow + title.
             The schema's id is not repeated here — the list row carries it, and
             the design's lockup has only the two lines. */}
         <div className="flex items-center gap-3">

--- a/apps/console/src/routes/_authed/schemas/index.tsx
+++ b/apps/console/src/routes/_authed/schemas/index.tsx
@@ -169,7 +169,7 @@ function SchemasScreen() {
 }
 
 /**
- * `Schema Row` (`1389:9690`).
+ * `Schema Row`.
  *
  * Four columns — name + sign-in methods, the attributes it collects, its
  * metadata, and the row menu. The design system's note on the component is the

--- a/apps/console/src/routes/_authed/schemas/index.tsx
+++ b/apps/console/src/routes/_authed/schemas/index.tsx
@@ -169,7 +169,7 @@ function SchemasScreen() {
 }
 
 /**
- * `Schema Row`.
+ * One row of the schema directory.
  *
  * Four columns — name + sign-in methods, the attributes it collects, its
  * metadata, and the row menu. The design system's note on the component is the

--- a/apps/console/src/routes/_authed/schemas/schemas.spec.tsx
+++ b/apps/console/src/routes/_authed/schemas/schemas.spec.tsx
@@ -335,7 +335,7 @@ describe("user schema detail", () => {
   });
 
   it("elides the middle of a deep path, keeping the last two levels", async () => {
-    // `Schema › … › datum › reference` (`1279:366735`). The ellipsis stands for
+    // `Schema › … › datum › reference`. The ellipsis stands for
     // more than one level, so it is inert; the segments either side of it still
     // navigate.
     server.use(

--- a/apps/console/src/routes/_authed/users/$userId.tsx
+++ b/apps/console/src/routes/_authed/users/$userId.tsx
@@ -20,7 +20,7 @@ import { type UserSchema, schemaDisplayName, schemaFields } from "../../../lib/s
 import { userAttributes, userIdentity, userIdentitySecondary } from "../../../lib/user";
 
 /**
- * User detail (Figma `467:44362`, `Filled` and `Authentication` variants).
+ * User detail (`Filled` and `Authentication` variants).
  *
  * Much of the design cannot be built yet, and what is missing is *data*, not
  * markup. Rather than render labels with nothing behind them, each is left out
@@ -67,7 +67,7 @@ const PAGE = "px-4 pt-9 pb-8 sm:px-8";
 const HEADING = "text-foreground font-serif text-2xl leading-8 tracking-tight";
 const CARD = "gap-0 rounded-xl py-0";
 // The panel body is 24px in from the card edge and 20px down, with 16px between
-// the header, the divider and the content (Detail Panel `1305:392714`).
+// the header, the divider and the content.
 const CARD_HEAD = "flex items-center gap-3 px-6 pt-5 pb-4";
 const PLATE = "flex size-9 items-center justify-center rounded-md bg-muted text-foreground";
 // 18px between fields on both axes — not a 4px-scale step, so it is written out.
@@ -101,7 +101,7 @@ function UserDetail() {
         </div>
         <Card className="gap-0 rounded-xl py-0">
           {/* Stacked below `sm`, in a row above it — the mobile frame
-              (`520:80552`) keeps every item flush left and turns the column
+              keeps every item flush left and turns the column
               rule into a tick on its own row between them. */}
           <CardContent className="flex flex-col px-5 py-3.5 sm:flex-row sm:flex-wrap sm:items-start">
             <MetaValue label="User ID" value={userId} copyable />
@@ -181,7 +181,7 @@ function UserDetail() {
         <TabsContent value="authentication">
           <Card className={CARD}>
             <div className={CARD_HEAD}>
-              {/* `Lucide Icon / Key` (`911:34248`) — the design names the glyph,
+              {/* `Lucide Icon / Key` — the design names the glyph,
                   so it is read off the node rather than picked by meaning. */}
               <span className={PLATE} aria-hidden>
                 <Key className="size-[18px]" />
@@ -208,7 +208,7 @@ function UserDetail() {
                   <span className="text-muted-foreground text-[13px] leading-[22px]">
                     {passkeys.length} registered
                   </span>
-                  {/* The design's only badge here is `Enabled` (`1305:392844`).
+                  {/* The design's only badge here is `Enabled`.
                       With nothing registered the count already says so, and a
                       second capsule reading `None` restates it. */}
                   {passkeys.length > 0 && <Badge variant="secondary">Enabled</Badge>}

--- a/apps/console/src/routes/_authed/users/$userId.tsx
+++ b/apps/console/src/routes/_authed/users/$userId.tsx
@@ -20,7 +20,7 @@ import { type UserSchema, schemaDisplayName, schemaFields } from "../../../lib/s
 import { userAttributes, userIdentity, userIdentitySecondary } from "../../../lib/user";
 
 /**
- * User detail (`Filled` and `Authentication` variants).
+ * User detail — the overview and authentication tabs.
  *
  * Much of the design cannot be built yet, and what is missing is *data*, not
  * markup. Rather than render labels with nothing behind them, each is left out

--- a/apps/console/src/routes/_authed/users/users.spec.tsx
+++ b/apps/console/src/routes/_authed/users/users.spec.tsx
@@ -79,7 +79,7 @@ describe("users screen", () => {
     expect(await screen.findByRole("heading", { name: "Users" })).toBeInTheDocument();
     // The User column leads with the resolved display and carries the link;
     // the identifier has its own column (asserted below). Schema-driven
-    // attribute columns follow (design `277:288291`, decisions log D4).
+    // attribute columns follow (decisions log D4).
     expect(await screen.findByRole("link", { name: "Maya Patel" })).toBeInTheDocument();
     // The designated identifier is its own platform-derived column (like
     // Status and ID), role-named so mixed-schema lists read down one column.

--- a/packages/components/src/atoms/zl-alert.ts
+++ b/packages/components/src/atoms/zl-alert.ts
@@ -14,10 +14,8 @@ import type { IconName } from "./zl-icon.js";
  * Atom: `<zl-alert>` — inline status message replacing the legacy
  * `<zl-error>`.
  *
- * Spec lineage (file `8UjCXw8yemgljmbkWGrSfE`):
- *   - design-system master: node `6593:2640` (Alert/Error). Screen instance
- *     `6596:132779` matches the same chrome. Severity is conveyed by icon
- *     shape and colour, not by tinting the background.
+ * Severity is conveyed by icon shape and colour, not by tinting the
+ * background.
  *
  * Per-state Figma values:
  *

--- a/packages/components/src/atoms/zl-button.ts
+++ b/packages/components/src/atoms/zl-button.ts
@@ -13,11 +13,7 @@ import "./zl-icon.js";
 /**
  * Atom: `<zl-button>` — the entire Figma button matrix in a single atom.
  *
- * Spec lineage (file `8UjCXw8yemgljmbkWGrSfE`, "Zitadel - Design System - External"):
- *   - master variant set: node `6598:292`
- *   - icon-leading instance reference: node `6598:143281` (passkey upsell)
- *
- * Variant axes (matches Figma directly):
+ * Variant axes, matching the design system's own:
  *   - hierarchy: primary | secondary | text
  *   - size:      medium (48 × auto) | small (40 × auto)
  *   - state:     enabled / hovered / focused / pressed / disabled

--- a/packages/components/src/atoms/zl-checkbox.css
+++ b/packages/components/src/atoms/zl-checkbox.css
@@ -9,7 +9,6 @@
 }
 
 /* Shared surface for `<zl-checkbox>` / `<Checkbox>`. Lit-only rules: lit/checkbox-host.css */
-/* Figma masters: 8UjCXw8yemgljmbkWGrSfE / Checkbox 4387:460 · Checkbox / With Label 6634:1868 */
 /*
  * Figma models the two checked states as a `style` variant (Outline = unchecked,
  * Filled = checked) and the three interaction states (Hovered / Focused / Pressed)

--- a/packages/components/src/atoms/zl-checkbox.ts
+++ b/packages/components/src/atoms/zl-checkbox.ts
@@ -19,11 +19,7 @@ export type ZlCheckboxChangeDetail = { name: string; checked: boolean; value: st
 /**
  * Atom: `<zl-checkbox>` — labelled checkbox bound to a boolean choice.
  *
- * Spec lineage (file `8UjCXw8yemgljmbkWGrSfE`, "Zitadel - Design System - External"):
- *   - bare master variant set:        node `4387:460` (Checkbox)
- *   - labelled master variant set:    node `6634:1868` (Checkbox / With Label)
- *
- * Figma models the checked state as the `style` variant (Outline = unchecked,
+ * The design system models the checked state as the `style` variant (Outline = unchecked,
  * Filled = checked) and Hovered / Focused / Pressed as a 32px circular halo
  * behind the 16px box. Those map to real CSS pseudo-classes; only the optional
  * `data-state` preview hook forces a state for the design matrix.

--- a/packages/components/src/atoms/zl-icon.ts
+++ b/packages/components/src/atoms/zl-icon.ts
@@ -28,8 +28,8 @@ import { surfaceStyles } from "../styles/index.js";
 /**
  * Atom: `<zl-icon>` — renders a curated glyph from the Lucide icon library.
  *
- * The Figma design system (file `8UjCXw8yemgljmbkWGrSfE`, Icons set
- * `4103:10466`, sizes `16 | 24`) is explicitly built on Lucide. Rather than redrawing every glyph as an
+ * The design system's icon set is explicitly built on Lucide, at 16 and 24px.
+ * Rather than redrawing every glyph as an
  * inline `<path>` (which inevitably drifts), we curate the auth surface's
  * subset by importing each canonical Lucide node and exposing a stable
  * kebab-case `name` API. To add a glyph: import it from `lucide`, add an

--- a/packages/components/src/atoms/zl-select.css
+++ b/packages/components/src/atoms/zl-select.css
@@ -9,7 +9,6 @@
 }
 
 /* Shared surface for `<zl-select>` / `<Select>`. Lit-only rules: lit/select-host.css */
-/* Figma masters: 8UjCXw8yemgljmbkWGrSfE / Dropdown 4397:4816 · Items 4397:4098 */
 /*
  * A select-only combobox: a button trigger (`.zr-select__trigger`) that opens a
  * `role="listbox"` popup (`.zr-select__listbox`). The trigger mirrors the text

--- a/packages/components/src/atoms/zl-select.ts
+++ b/packages/components/src/atoms/zl-select.ts
@@ -26,9 +26,6 @@ export type ZlSelectChangeDetail = { name: string; value: string };
 /**
  * Atom: `<zl-select>` — a select bound to a single choice.
  *
- * Spec lineage (file `8UjCXw8yemgljmbkWGrSfE`, "Zitadel - Design System - External"):
- *   - trigger + open/selected matrix:  node `4397:4816` (Dropdown)
- *   - option (Items) state matrix:      node `4397:4098` (Input text)
  *
  * Agent-first contract (see `packages/components/AGENTS.md` → "Input atoms expose
  * a real native control"): the operable, accessible, form-associated, and

--- a/packages/components/src/orchestrator/liquid.spec.ts
+++ b/packages/components/src/orchestrator/liquid.spec.ts
@@ -435,7 +435,7 @@ describe("LiquidJS engine", () => {
   // A template-capability test, not the default flow: the default flow splits
   // email and credential across two steps. The template must still render
   // whatever field set a tenant's flow definition declares on one step,
-  // including an email+password pair (Figma `6593:141983`).
+  // including an email+password pair.
   it("renders an email+password step on one card: autocomplete, forgot link, sign-in CTA", () => {
     const engine = createLiquidEngine({ locale: fullLocale });
     const f = toArray({
@@ -500,7 +500,7 @@ describe("LiquidJS engine", () => {
     expect(result).not.toContain('hierarchy="secondary"');
   });
 
-  it("renders sign-in wrong credentials (6602:180268): inline password error, no form alert", () => {
+  it("renders sign-in wrong credentials: inline password error, no form alert", () => {
     const engine = createLiquidEngine({ locale: fullLocale });
     const f = toArray({
       email: { type: "email", text_key: "identifier.field.email", required: true },
@@ -529,7 +529,7 @@ describe("LiquidJS engine", () => {
     expect(result).not.toContain("<zl-alert data-zl-step-error");
   });
 
-  it("renders sign-in server error (6594:125237): heading + body alert, fields unchanged", () => {
+  it("renders sign-in server error: heading + body alert, fields unchanged", () => {
     const engine = createLiquidEngine({ locale: fullLocale });
     const f = toArray({
       email: { type: "email", text_key: "identifier.field.email", required: true },
@@ -559,7 +559,7 @@ describe("LiquidJS engine", () => {
     expect(result).not.toContain("Wrong email or password.");
   });
 
-  it("renders sign-up field annotations (6593:141741): autocomplete, help, inline email error", () => {
+  it("renders sign-up field annotations: autocomplete, help, inline email error", () => {
     const engine = createLiquidEngine({ locale: fullLocale });
     const f = toArray({
       email: { type: "email", text_key: "register.field.email", required: true },

--- a/packages/components/src/orchestrator/locales/de.ts
+++ b/packages/components/src/orchestrator/locales/de.ts
@@ -110,7 +110,7 @@ export const de: Locale = {
   "password.action.register.link": "Registrieren",
 
   "register.title": "Konto erstellen",
-  // Leer per Design — die Registrierungskarte hat keine Unterzeile (Figma 6593:141743).
+  // Leer per Design — die Registrierungskarte hat keine Unterzeile.
   "register.description": "Gib deine Daten ein, um loszulegen",
   "register.field.email": "E-Mail",
   "register.field.email.placeholder": "du@beispiel.de",

--- a/packages/components/src/orchestrator/locales/en.ts
+++ b/packages/components/src/orchestrator/locales/en.ts
@@ -17,7 +17,6 @@
 export const en: Record<string, string> = {
   // ═══════════════════════════════════════════════════════════════════════════
   // Step: identifier (email entry — first screen)
-  // Figma 2xl `6593:141983`, card `6593:141985`, stack `6593:141989`
   // ═══════════════════════════════════════════════════════════════════════════
   "identifier.title": "Sign in",
   "identifier.description": "Enter your email to continue",
@@ -71,7 +70,6 @@ export const en: Record<string, string> = {
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Step: passkey-upsell (passkey enrollment offer — after registration)
-  // Figma `6594:630`, heading `6594:89142`, body `6594:12796`
   // ═══════════════════════════════════════════════════════════════════════════
   "passkey-upsell.title": "Sign in faster next time",
   "passkey-upsell.description": "No password needed ever again.",
@@ -79,7 +77,7 @@ export const en: Record<string, string> = {
   "passkey-upsell.description.line2": "Sign in with Face ID, Touch ID, or PIN.",
   "passkey-upsell.action.passkey_register": "Set up passkey",
   "passkey-upsell.action.skip": "Skip for now",
-  // Figma `6594:630` setup-passkey annotations — kept for backward compat.
+  // Setup-passkey copy — kept for backward compat.
   "passkey-upsell.action.setup": "Set up passkey",
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -100,7 +98,6 @@ export const en: Record<string, string> = {
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Step: done (terminal — signed-in confirmation)
-  // Figma `6596:132846`
   // ═══════════════════════════════════════════════════════════════════════════
   "done.title": "You're signed in as",
   "done.description": "",
@@ -189,7 +186,7 @@ export const en: Record<string, string> = {
   "error.password_required": "Please enter a password",
   "error.password_incorrect": "Wrong email or password.",
   "error.email_exists": "An account with this email already exists.",
-  /** Figma sign-in error `6602:180268` — inline on password field. */
+  /** Sign-in error, inline on the password field. */
   "error.invalid_credentials": "Wrong email or password.",
   "error.required": "This field is required.",
 
@@ -202,7 +199,7 @@ export const en: Record<string, string> = {
   "error.field_max_length": "{0} is too long.",
   "error.field_invalid": "Please check {0}.",
 
-  // --- Sign-in form-level alert (Figma `6594:125237`, alert `6596:132779`) ---
+  // --- Sign-in form-level alert ---
   "error.sign_in_server.title": "We couldn't complete your sign in.",
   "error.sign_in_server.body": "Please try again in a few minutes",
 };

--- a/packages/components/src/orchestrator/locales/it.ts
+++ b/packages/components/src/orchestrator/locales/it.ts
@@ -108,7 +108,7 @@ export const it: Locale = {
   "password.action.register.link": "Registrati",
 
   "register.title": "Crea il tuo account",
-  // Vuoto per design — la scheda di registrazione non ha sottotitolo (Figma 6593:141743).
+  // Vuoto per design — la scheda di registrazione non ha sottotitolo.
   "register.description": "Inserisci i tuoi dati per iniziare",
   "register.field.email": "E-mail",
   "register.field.email.placeholder": "tu@esempio.com",

--- a/packages/components/src/orchestrator/zitadel-session.ts
+++ b/packages/components/src/orchestrator/zitadel-session.ts
@@ -13,7 +13,7 @@ import "../atoms/index.js";
 /**
  * `<zitadel-session>` — the "signed in" card.
  *
- * Renders the post-sign-in confirmation surface (Figma `7355:8959`): a
+ * Renders the post-sign-in confirmation surface: a
  * centred auth card reading "Signed in as {identity}" with a **Sign out**
  * action. Composed from the same `<zl-page-shell>` / `<zl-card>` /
  * `<zl-button>` atoms as the `<zitadel-login>` orchestrator, so it inherits


### PR DESCRIPTION
## Summary

- Source comments across the console and the login atoms cited Figma node ids, layer names and file keys — about fifty of them. They are never updated, and they fail silently: every id the console's schema screens cited had already been deleted from the design file, so the comments pointed at nothing while still reading as exact references, and that screen could not be re-checked against its frame from the source at all.
- The reasoning each frame gave is kept; only the pointer goes. "The frame insets the panel 24px on every side" survives a rename, a node id does not.
- Where a block existed solely to carry ids — the atoms' `Spec lineage` lists — it goes with them. The values those lists introduced are documented in full directly underneath.
- Comment-only. No behaviour, no API, no rendered output, and no test assertion changes; three `liquid.spec.ts` test names lose an id from their description and keep the description.

## Validation

- `moon ci :lint :typecheck :build :test`

## Release notes / changeset

- No changeset required — no shipped behavior changed. The diff is comments and three test names.

## Notes

- `apps/console/src/routes/_authed/flow-definitions/index.tsx`, `schemas/$schemaId.tsx` and `components/layout.tsx` are not in this diff: #1189 already cleared their references, so they are left alone to avoid a conflict.
- One `1.05:1` in `branding-to-tokens.ts` is a contrast ratio, not a node id, and is untouched.
- Closes #1190
